### PR TITLE
Fix tests crashing with miri due to misalignment.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2924,27 +2924,28 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let buf = [0u8; 8];
-        let lv1 = LayoutVerified::<_, u64>::new(&buf[..]).unwrap();
-        let lv2 = LayoutVerified::<_, u64>::new(&buf[..]).unwrap();
+        let buf1 = 0_u64;
+        let lv1 = LayoutVerified::<_, u64>::new(buf1.as_bytes()).unwrap();
+        let buf2 = 0_u64;
+        let lv2 = LayoutVerified::<_, u64>::new(buf2.as_bytes()).unwrap();
         assert_eq!(lv1, lv2);
     }
 
     #[test]
     fn test_ne() {
-        let buf1 = [0u8; 8];
-        let lv1 = LayoutVerified::<_, u64>::new(&buf1[..]).unwrap();
-        let buf2 = [1u8; 8];
-        let lv2 = LayoutVerified::<_, u64>::new(&buf2[..]).unwrap();
+        let buf1 = 0_u64;
+        let lv1 = LayoutVerified::<_, u64>::new(buf1.as_bytes()).unwrap();
+        let buf2 = 1_u64;
+        let lv2 = LayoutVerified::<_, u64>::new(buf2.as_bytes()).unwrap();
         assert_ne!(lv1, lv2);
     }
 
     #[test]
     fn test_ord() {
-        let buf1 = [0u8; 8];
-        let lv1 = LayoutVerified::<_, u64>::new(&buf1[..]).unwrap();
-        let buf2 = [1u8; 8];
-        let lv2 = LayoutVerified::<_, u64>::new(&buf2[..]).unwrap();
+        let buf1 = 0_u64;
+        let lv1 = LayoutVerified::<_, u64>::new(buf1.as_bytes()).unwrap();
+        let buf2 = 1_u64;
+        let lv2 = LayoutVerified::<_, u64>::new(buf2.as_bytes()).unwrap();
         assert!(lv1 < lv2);
     }
 


### PR DESCRIPTION
Currently, three tests are failing with the latest nightly version of miri: `test_eq`, `test_ne`, `test_ord`.

Example output:
```bash
➜  zerocopy git:(main) ✗ cargo miri test -- test_ord
Preparing a sysroot for Miri (target: x86_64-unknown-linux-gnu)... done
    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/miri/x86_64-unknown-linux-gnu/debug/deps/zerocopy-3f8b570858445ddd)

running 1 test
test tests::test_ord ... FAILED

failures:

---- tests::test_ord stdout ----
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/lib.rs:2945:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_ord

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 31 filtered out

error: test failed, to rerun pass `--lib`
➜  zerocopy git:(main) ✗ 
```

This happens because of these lines:
```rust
let buf1 = [0u8; 8];
let lv1 = LayoutVerified::<_, u64>::new(&buf1[..]).unwrap();
```

Since a `[u8; N]` array is unaligned, its stack addr isn't necessarily aligned to 8 (as `u64` requires). I'm not sure where the exact semantics are documented, but I think miri randomized the layout of data to catch these types of errors? Not sure, but it seems that the tests are passing when run not under miri "by accident", i.e. they rely on the fact that the memory happens to be aligned correctly.

My fix simply stores `u64`s on the stack, instead of `[u8; 8]`s, and uses `AsBytes::as_bytes()` to use them as a buffer for the creation of the `LayoutVerified`s. Since the stack memory is now guaranteed to be properly aligned, this seems to appease miri.