### PR TITLE
Make more fns/macros const, update MSRV to 1.61.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  ZEROCOPY_MSRV: 1.61.0
+  ZEROCOPY_CURRENT_STABLE: 1.64.0
+  ZEROCOPY_CURRENT_NIGHTLY: nightly-2022-09-26
 
 jobs:
   build_test:
@@ -14,15 +17,15 @@ jobs:
       matrix:
         # See `INTERNAL.md` for an explanation of these pinned toolchain
         # versions.
-        channel: [ "1.56.1", "1.64.0", "nightly-2022-09-26" ]
+        channel: [ ${{ env.ZEROCOPY_MSRV }}, ${{ env.ZEROCOPY_CURRENT_STABLE }}, ${{ env.ZEROCOPY_CURRENT_NIGHTLY }} ]
         target: [ "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "wasm32-wasi" ]
         features: [ "" , "alloc,simd", "alloc,simd,simd-nightly" ]
         exclude:
           # Exclude any combination which uses a non-nightly toolchain but
           # enables nightly features.
-          - channel: "1.56.1"
+          - channel: ${{ env.ZEROCOPY_MSRV }}
             features: "alloc,simd,simd-nightly"
-          - channel: "1.64.0"
+          - channel: ${{ env.ZEROCOPY_CURRENT_STABLE }}
             features: "alloc,simd,simd-nightly"
 
     name: Build & Test (${{ matrix.channel }} for ${{ matrix.target }}, features set to "${{ matrix.features }}")

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ packed SIMD vectors][simd-layout].
 which are only available on nightly. Since these types are unstable, support
 for any type may be removed at any point in the future.
 
+## Minimum Supported Rust Version (MSRV)
+
+zerocopy's MSRV is 1.61.0.
+
 [simd-layout]: https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
 
 ## Dislcaimer

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -17,9 +17,9 @@
 
 #[rustversion::any(nightly, beta)]
 const SOURCE_FILES_GLOB: &str = "tests/ui/*.rs";
-#[rustversion::all(stable, not(stable(1.56.1)))]
+#[rustversion::all(stable, not(stable(1.61.0)))]
 const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
-#[rustversion::stable(1.56.1)]
+#[rustversion::stable(1.61.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
 
 #[test]

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -32,6 +32,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 38 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:38:10
    |
@@ -45,6 +48,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 46 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:46:10
    |
@@ -58,6 +64,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 53 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:53:10
    |


### PR DESCRIPTION
Make more functions and the `transmute!` macro const. This requires updating our MSRV to 1.61.0.

While we're doing this, document our MSRV in the crate root and our `README.md`. Make `.github/workflows/ci.yml` a bit more bug-proof with respect to pinned toolchain versions.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
