### PR TITLE
Refactor zeroing for loops with the [u8]::fill method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,9 +1041,7 @@ fn map_zeroed<B: ByteSliceMut, T: ?Sized>(
 ) -> Option<LayoutVerified<B, T>> {
     match opt {
         Some(mut lv) => {
-            for b in lv.0.iter_mut() {
-                *b = 0;
-            }
+            lv.0.fill(0);
             Some(lv)
         }
         None => None,
@@ -1055,9 +1053,7 @@ fn map_prefix_tuple_zeroed<B: ByteSliceMut, T: ?Sized>(
 ) -> Option<(LayoutVerified<B, T>, B)> {
     match opt {
         Some((mut lv, rest)) => {
-            for b in lv.0.iter_mut() {
-                *b = 0;
-            }
+            lv.0.fill(0);
             Some((lv, rest))
         }
         None => None,


### PR DESCRIPTION
Refactored map_zeroed & map_prefix_tuple_zeroed's for-loops with the [u8]::fill method.

Resolves #38

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
