### PR TITLE
Publish 0.7.0-alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 edition = "2018"
 name = "zerocopy"
-version = "0.6.1"
+version = "0.7.0-alpha"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license-file = "LICENSE"


### PR DESCRIPTION
This is nowhere near ready for 0.7.0, but releasing an alpha release allows Fuchsia to vendor zerocopy and remove their in-tree copy (zerocopy used to live in the Fuchsia tree before it migrated to GitHub).

Closes #52

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
