### PR TITLE
[derive] Publish 0.3.2

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 edition = "2018"
 name = "zerocopy-derive"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license-file = "../LICENSE"


### PR DESCRIPTION
This update doesn't contain much in the way of feature improvements, but it does update some Cargo.toml metadata (including the repository link, which now actually points to this repository rather than to Fuchsia's repository, where this source code used to live).

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
