### PR TITLE
Fix Rust Cache invalid key warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Build & Tests
 
 on:
-  push:
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
 
     - name: Set feature string for cache key
       run: |
-        features=${{matrix.features}}
-        features_key=${#features}
-        echo "FEATURES=$(echo $features_key)" >> $GITHUB_ENV
+        echo "FEATURES_HASH=$(echo ${{ matrix.features }} | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,16 @@ jobs:
           # https://github.com/actions/runner/issues/409#issuecomment-752775072
           components: ${{ contains(matrix.channel, 'nightly') && 'miri' || '' }}
 
+    - name: Set feature string for cache key
+      run: |
+        features=${{matrix.features}}
+        features_key=${#features}
+        echo "FEATURES=$(echo $features_key)" >> $GITHUB_ENV
+
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.0.0
       with:
-        key: "${{ matrix.channel }}-${{ matrix.target }}-${#${{ matrix.features }}}-${{ hashFiles('**/Cargo.lock') }}"
-  
-    - name: tmp
-      run: ${{ matrix.channel }}-${{ matrix.target }}-${#${{ matrix.features }}}-${{ hashFiles('**/Cargo.lock') }}
+        key: "${{ matrix.channel }}-${{ matrix.target }}-${{ env.FEATURES }}-${{ hashFiles('**/Cargo.lock') }}"
 
     - name: Check
       run: cargo +${{ matrix.channel }} check --target ${{ matrix.target }} --features "${{ matrix.features }}" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           # https://github.com/actions/runner/issues/409#issuecomment-752775072
           components: ${{ contains(matrix.channel, 'nightly') && 'miri' || '' }}
 
+    # The features string contains commas which cannot be part of the cache
+    # key for the Rust Cache action. Instead, we hash the features
+    # to get a string of legal characters.
     - name: Set feature string for cache key
       run: |
         echo "FEATURES_HASH=$(echo ${{ matrix.features }} | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.0.0
       with:
-        key: "${{ matrix.channel }}-${{ matrix.target }}-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}"
+        key: "${{ matrix.channel }}-${{ matrix.target }}-${#${{ matrix.features }}}-${{ hashFiles('**/Cargo.lock') }}"
 
     - name: Check
       run: cargo +${{ matrix.channel }} check --target ${{ matrix.target }} --features "${{ matrix.features }}" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       uses: Swatinem/rust-cache@v2.0.0
       with:
         key: "${{ matrix.channel }}-${{ matrix.target }}-${#${{ matrix.features }}}-${{ hashFiles('**/Cargo.lock') }}"
+  
+    - name: tmp
+      run: ${{ matrix.channel }}-${{ matrix.target }}-${#${{ matrix.features }}}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check
       run: cargo +${{ matrix.channel }} check --target ${{ matrix.target }} --features "${{ matrix.features }}" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2.0.0
       with:
-        key: "${{ matrix.channel }}-${{ matrix.target }}-${{ env.FEATURES }}-${{ hashFiles('**/Cargo.lock') }}"
+        key: "${{ matrix.channel }}-${{ matrix.target }}-${{ env.FEATURES_HASH }}-${{ hashFiles('**/Cargo.lock') }}"
 
     - name: Check
       run: cargo +${{ matrix.channel }} check --target ${{ matrix.target }} --features "${{ matrix.features }}" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build & Tests
 
 on:
+  push:
   pull_request:
 
 env:


### PR DESCRIPTION
Addresses #43 by using the length of the feature string instead of the features themselves. This avoids the commas which were causing the issues and the key should be unique so long as the feature strings are of different lengths (which for the time being is the case).