### PR TITLE
Fix unsoundness in FromBytes::new_box_slice_zeroed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,5 @@ default-features = false
 
 [dev-dependencies]
 rand = "0.6"
+rustversion = "1.0"
 trybuild = "1.0"


### PR DESCRIPTION
Previously, `FromBytes::new_box_slice_zeroed` called `Layout::from_size_align_unchecked` with arguments that could overflow `isize`, which would violate its safety preconditions. In this change, we use the safe variant, which returns a `Result` which we can `.expect()`. Though I haven't benchmarked it, this likely has little impact on performance over the optimal code since optimal code would still need to perform the same bounds check that `from_size_align` is performing.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
