### PR TITLE
Add check_msrv job to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,30 +153,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check MSRV
         run: |
-          # Allow commands to fail without terminating the script
-          set +e
+          set -e
 
-          vers=$(mktemp)
-          ver_regex='\d+\.\d+.\d+'
+          ver_ci=$(<.github/workflows/ci.yml yq '.jobs.build_test.strategy.matrix.channel[0] // ""' | grep .)
+          ver_lib=$(<src/lib.rs grep "//! zerocopy's MSRV is" | grep -Po '\d+\.\d+.\d+')
 
-          <.github/workflows/ci.yml yq '.jobs.build_test.strategy.matrix.channel[0] // ""' | grep . | tee -a $vers
-          <src/lib.rs grep "//! zerocopy's MSRV is"                           | grep -Po $ver_regex | tee -a $vers
-          <tests/trybuild.rs                 grep' #\[rustversion::stable'    | grep -Po $ver_regex | tee -a $vers
-          <tests/trybuild.rs                 grep' #\[rustversion::all'       | grep -Po $ver_regex | tee -a $vers
-          <zerocopy-derive/tests/trybuild.rs grep '#\[rustversion::stable'    | grep -Po $ver_regex | tee -a $vers
-          <zerocopy-derive/tests/trybuild.rs grep '#\[rustversion::all'       | grep -Po $ver_regex | tee -a $vers
-
-          number_of_uniq_vers=$(<$vers uniq | wc -l)
-
-          if (( $number_of_uniq_vers == 0 )); then
-            echo "No MSRV found in checked places."       | tee -a $GITHUB_STEP_SUMMARY
+          if [[ "$ver_ci" == "$ver_lib" ]]; then
+            echo "Same MSRV found in both places." | tee -a $GITHUB_STEP_SUMMARY
+            exit 0
+          else
+            echo "Different MSRVs found in checked places." | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
-
-          if (( $number_of_uniq_vers == 1 )); then
-            echo "Same MSRV found in all checked places." | tee -a $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
-
-          echo "Different MSRVs found in checked places." | tee -a $GITHUB_STEP_SUMMARY
-          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,38 @@ jobs:
           cargo install cargo-readme --version 3.2.0
           diff <(./generate-readme.sh) README.md
           exit $?
+
+  check_msrv:
+    runs-on: ubuntu-latest
+    name: Check MSRV
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check MSRV
+        run: |
+          # Allow commands to fail without terminating the script
+          set +e
+
+          vers=$(mktemp)
+          ver_regex='\d+\.\d+.\d+'
+
+          <.github/workflows/ci.yml yq '.jobs.build_test.strategy.matrix.channel[0] // ""' | grep . | tee -a $vers
+          <src/lib.rs grep "//! zerocopy's MSRV is"                           | grep -Po $ver_regex | tee -a $vers
+          <tests/trybuild.rs                 grep' #\[rustversion::stable'    | grep -Po $ver_regex | tee -a $vers
+          <tests/trybuild.rs                 grep' #\[rustversion::all'       | grep -Po $ver_regex | tee -a $vers
+          <zerocopy-derive/tests/trybuild.rs grep '#\[rustversion::stable'    | grep -Po $ver_regex | tee -a $vers
+          <zerocopy-derive/tests/trybuild.rs grep '#\[rustversion::all'       | grep -Po $ver_regex | tee -a $vers
+
+          number_of_uniq_vers=$(<$vers uniq | wc -l)
+
+          if (( $number_of_uniq_vers == 0 )); then
+            echo "No MSRV found in checked places."       | tee -a $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          if (( $number_of_uniq_vers == 1 )); then
+            echo "Same MSRV found in all checked places." | tee -a $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          echo "Different MSRVs found in checked places." | tee -a $GITHUB_STEP_SUMMARY
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,17 +151,22 @@ jobs:
     name: Check MSRV
     steps:
       - uses: actions/checkout@v3
+      # Make sure that the MSRV documented in our crate documentation
+      # is the same one that we test for in CI.
       - name: Check MSRV
         run: |
           set -e
 
-          ver_ci=$(<.github/workflows/ci.yml yq '.jobs.build_test.strategy.matrix.channel[0] // ""' | grep .)
-          ver_lib=$(<src/lib.rs grep "//! zerocopy's MSRV is" | grep -Po '\d+\.\d+.\d+')
+          path_ci=.github/workflows/ci.yml
+          ver_ci=$(<$path_ci yq '.jobs.build_test.strategy.matrix.channel[0] // ""' | grep .)
+
+          path_lib=src/lib.rs
+          ver_lib=$(<$path_lib grep "//! zerocopy's MSRV is" | grep -Po '\d+\.\d+.\d+')
 
           if [[ "$ver_ci" == "$ver_lib" ]]; then
-            echo "Same MSRV found in both places." | tee -a $GITHUB_STEP_SUMMARY
+            echo "Same MSRV found in '$path_ci' ($ver_ci) and '$path_lib' ($ver_lib)." | tee -a $GITHUB_STEP_SUMMARY
             exit 0
           else
-            echo "Different MSRVs found in checked places." | tee -a $GITHUB_STEP_SUMMARY
+            echo "Different MSRVs found in '$path_ci' ($ver_ci) and '$path_lib' ($ver_lib)." | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi


### PR DESCRIPTION
Add check_msrv job to ci workflow. Checking the MSRV specified in all places mentioned in #39:

- Doc comment in src/lib.rs
- .github/workflows/ci.yml
- tests/trybuild.rs (added in https://github.com/google/zerocopy/pull/60, which hasn't merged as of this writing)
- zerocopy-derive/tests/trybuild.rs

When running locally this check works against #60 as well.

Resolves #39.