### PR TITLE
Make more fns/macros const, update MSRV to 1.61.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         # See `INTERNAL.md` for an explanation of these pinned toolchain
         # versions.
-        channel: [ "1.56.1", "1.64.0", "nightly-2022-09-26" ]
+        channel: [ "1.61.0", "1.64.0", nightly-2022-09-26 ]
         target: [ "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "wasm32-wasi" ]
         features: [ "" , "alloc,simd", "alloc,simd,simd-nightly" ]
         exclude:
           # Exclude any combination which uses a non-nightly toolchain but
           # enables nightly features.
-          - channel: "1.56.1"
+          - channel: "1.61.0"
             features: "alloc,simd,simd-nightly"
           - channel: "1.64.0"
             features: "alloc,simd,simd-nightly"

--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -9,12 +9,12 @@ locations.
 ## CI and toolchain versions
 
 In CI (`.github/workflows/ci.yml`), we pin to specific versions or dates of the
-stable and nightly toolchains. The reason is twofold: First, `zerocopy-derive`'s
-UI tests (see `zerocopy-derive/tests/trybuild.rs`) depend on the format of
-rustc's error messages, and that format can change between toolchain versions
-(we also maintain multiple copies of our UI tests - one for each toolchain
-version pinned in CI - for this reason). Second, not all nightlies have a
-working Miri, so we need to pin to one that does (see
+stable and nightly toolchains. The reason is twofold: First, our UI tests (see
+`tests/trybuild.rs` and `zerocopy-derive/tests/trybuild.rs`) depend on the
+format of rustc's error messages, and that format can change between toolchain
+versions (we also maintain multiple copies of our UI tests - one for each
+toolchain version pinned in CI - for this reason). Second, not all nightlies
+have a working Miri, so we need to pin to one that does (see
 https://rust-lang.github.io/rustup-components-history/).
 
 Updating the versions pinned in CI may cause the UI tests to break. In order to

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ packed SIMD vectors][simd-layout].
 which are only available on nightly. Since these types are unstable, support
 for any type may be removed at any point in the future.
 
+## Minimum Supported Rust Version (MSRV)
+
+zerocopy's MSRV is 1.61.0.
+
 [simd-layout]: https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
 
 ## Dislcaimer

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -1,9 +1,29 @@
-// Copyright 2022 The Fuchsia Authors. All rights reserved.
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// UI tests depend on the exact error messages emitted by rustc, but those error
+// messages are not stable, and sometimes change between Rust versions. Thus, we
+// maintain one set of UI tests for each Rust version that we test in CI, and we
+// pin to specific versions in CI (a specific stable version, a specific date of
+// the nightly compiler, and a specific MSRV). Updating those pinned versions
+// may also require updating these tests.
+// - `tests/ui` - Contains the source of truth for our UI test source files
+//   (`.rs`), and contains `.err` and `.out` files for nightly and beta
+// - `tests/ui-stable` - Contains symlinks to the `.rs` files in `tests/ui`, and
+//   contains `.err` and `.out` files for stable
+// - `tests/ui-msrv` - Contains symlinks to the `.rs` files in `tests/ui`, and
+//   contains `.err` and `.out` files for MSRV
+
+#[rustversion::any(nightly, beta)]
+const SOURCE_FILES_GLOB: &str = "tests/ui/*.rs";
+#[rustversion::all(stable, not(stable(1.61.0)))]
+const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
+#[rustversion::stable(1.61.0)]
+const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
 
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/*.rs");
+    t.compile_fail(SOURCE_FILES_GLOB);
 }

--- a/tests/ui-msrv/transmute-illegal.rs
+++ b/tests/ui-msrv/transmute-illegal.rs
@@ -1,0 +1,1 @@
+../ui/transmute-illegal.rs

--- a/tests/ui-msrv/transmute-illegal.stderr
+++ b/tests/ui-msrv/transmute-illegal.stderr
@@ -1,0 +1,24 @@
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui-msrv/transmute-illegal.rs:8:76
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui-msrv/transmute-illegal.rs`
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+ --> tests/ui-msrv/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+  |
+  = help: the following implementations were found:
+            <usize as AsBytes>
+            <f32 as AsBytes>
+            <f64 as AsBytes>
+            <i128 as AsBytes>
+          and 10 others
+note: required by a bound in `POINTER_VALUE::transmute`
+ --> tests/ui-msrv/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-illegal.rs
+++ b/tests/ui-stable/transmute-illegal.rs
@@ -1,0 +1,1 @@
+../ui/transmute-illegal.rs

--- a/tests/ui-stable/transmute-illegal.stderr
+++ b/tests/ui-stable/transmute-illegal.stderr
@@ -1,0 +1,28 @@
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui-stable/transmute-illegal.rs:8:76
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui-stable/transmute-illegal.rs`
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+ --> tests/ui-stable/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+  |
+  = help: the following other types implement trait `AsBytes`:
+            f32
+            f64
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+          and 6 others
+note: required by a bound in `POINTER_VALUE::transmute`
+ --> tests/ui-stable/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/transmute-illegal.rs
+++ b/tests/ui/transmute-illegal.rs
@@ -1,0 +1,8 @@
+// Copyright 2022 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+// It is unsound to inspect the usize value of a pointer during const eval.
+const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);

--- a/tests/ui/transmute-illegal.stderr
+++ b/tests/ui/transmute-illegal.stderr
@@ -1,0 +1,31 @@
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/transmute-illegal.rs:8:76
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui/transmute-illegal.rs`
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+ --> tests/ui/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                              |
+  |                              the trait `AsBytes` is not implemented for `*const usize`
+  |                              required by a bound introduced by this call
+  |
+  = help: the following other types implement trait `AsBytes`:
+            f32
+            f64
+            i128
+            i16
+            i32
+            i64
+            i8
+            isize
+          and 6 others
+note: required by a bound in `POINTER_VALUE::transmute`
+ --> tests/ui/transmute-illegal.rs:8:30
+  |
+8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -17,9 +17,9 @@
 
 #[rustversion::any(nightly, beta)]
 const SOURCE_FILES_GLOB: &str = "tests/ui/*.rs";
-#[rustversion::all(stable, not(stable(1.56.1)))]
+#[rustversion::all(stable, not(stable(1.61.0)))]
 const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
-#[rustversion::stable(1.56.1)]
+#[rustversion::stable(1.61.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
 
 #[test]

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -32,6 +32,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 38 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:38:10
    |
@@ -45,6 +48,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 46 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:46:10
    |
@@ -58,6 +64,9 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
 53 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `u16`
    |
+   = help: the following implementations were found:
+             <i8 as Unaligned>
+             <u8 as Unaligned>
 note: required by a bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
   --> tests/ui-msrv/late_compile_pass.rs:53:10
    |


### PR DESCRIPTION
Make more functions and the `transmute!` macro const. This requires updating our MSRV to 1.61.0.

While we're doing this, document our MSRV in the crate root and our `README.md`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
