### PR TITLE
Remove TODO to use rustversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,6 @@
 // `unknown_lints` is `warn` by default and we deny warnings in CI, so without
 // this attribute, any unknown lint would cause a CI failure when testing with
 // our MSRV.
-//
-// TODO(https://github.com/rust-lang/rust/issues/54726): Only allow
-// `unknown_lints` when we're compiling with the MSRV toolchain. This will
-// detect a typo'd lint name, which will go unnoticed today since it has no
-// effect and will cause no warning or error. Once that issue is resolved, we
-// can use an attribute like:
-//
-//   #![rustversion::attr(stable(<MSRV>), allow(unknown_lints))]
 #![allow(unknown_lints)]
 #![deny(renamed_and_removed_lints)]
 #![deny(

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -6,14 +6,6 @@
 // `unknown_lints` is `warn` by default and we deny warnings in CI, so without
 // this attribute, any unknown lint would cause a CI failure when testing with
 // our MSRV.
-//
-// TODO(https://github.com/rust-lang/rust/issues/54726): Only allow
-// `unknown_lints` when we're compiling with the MSRV toolchain. This will
-// detect a typo'd lint name, which will go unnoticed today since it has no
-// effect and will cause no warning or error. Once that issue is resolved, we
-// can use an attribute like:
-//
-//   #![rustversion::attr(stable(<MSRV>), allow(unknown_lints))]
 #![allow(unknown_lints)]
 #![deny(renamed_and_removed_lints)]
 #![deny(clippy::all)]


### PR DESCRIPTION
The TODO was to use `#[rustversion::stable(<MSRV>)]` to conditionally emit `allow(unknown_lints)` only on MSRV. The theory was that unconditionally doing `allow(unknown_lints)` risks someone adding an invalid or typo'd lint and thinking they're getting a lint that's not actually having any effect. This risk is real, but probably not important enough to justify either a) taking a production dependency on another crate or, b) avoiding this dependency by writing our own `build.rs` file.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
