### PR TITLE
[derive] document Rust changes to priv-in-pub lint

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -426,28 +426,7 @@ fn impl_block<D: DataExt>(
     // While there's no getting around this requirement for us, it does have
     // some pretty serious downsides that are worth calling out:
     //
-    // 1. You lose the ability to have fields of generic type with reduced visibility.
-    //
-    //     #[derive(Unaligned)]
-    //     #[repr(C)]
-    //     pub struct Public<T>(Private<T>);
-    //
-    //     #[derive(Unaligned)]
-    //     #[repr(C)]
-    //     struct Private<T>(T);
-    //
-    //
-    //     warning: private type `Private<T>` in public interface (error E0446)
-    //      --> src/main.rs:6:10
-    //       |
-    //     6 | #[derive(Unaligned)]
-    //       |          ^^^^^^^^^
-    //       |
-    //       = note: #[warn(private_in_public)] on by default
-    //       = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    //       = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-    //
-    // 2. When lifetimes are involved, the trait solver ties itself in knots.
+    // 1. When lifetimes are involved, the trait solver ties itself in knots.
     //
     //     #[derive(Unaligned)]
     //     #[repr(C)]

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -423,10 +423,9 @@ fn impl_block<D: DataExt>(
     // `T::Foo: !FromBytes`. It would not be sound for us to accept a type with
     // a `T::Foo` field as `FromBytes` simply because `T: FromBytes`.
     //
-    // While there's no getting around this requirement for us, it does have
-    // some pretty serious downsides that are worth calling out:
-    //
-    // 1. When lifetimes are involved, the trait solver ties itself in knots.
+    // While there's no getting around this requirement for us, it does have the
+    // pretty serious downside that, when lifetimes are involved, the trait
+    // solver ties itself in knots:
     //
     //     #[derive(Unaligned)]
     //     #[repr(C)]

--- a/zerocopy-derive/tests/priv_in_pub.rs
+++ b/zerocopy-derive/tests/priv_in_pub.rs
@@ -1,0 +1,20 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use zerocopy::{AsBytes, FromBytes, Unaligned};
+
+// These derives do not result in E0446 as of Rust 1.59.0, because of
+// https://github.com/rust-lang/rust/pull/90586
+//
+// This change eliminates one of the major downsides of emitting `where`
+// bounds for field types (i.e., the emission of E0446 for private field
+// types).
+
+#[derive(AsBytes, FromBytes, Unaligned)]
+#[repr(C)]
+pub struct Public(Private);
+
+#[derive(AsBytes, FromBytes, Unaligned)]
+#[repr(C)]
+struct Private(());

--- a/zerocopy-derive/tests/priv_in_pub.rs
+++ b/zerocopy-derive/tests/priv_in_pub.rs
@@ -5,7 +5,7 @@
 use zerocopy::{AsBytes, FromBytes, Unaligned};
 
 // These derives do not result in E0446 as of Rust 1.59.0, because of
-// https://github.com/rust-lang/rust/pull/90586
+// https://github.com/rust-lang/rust/pull/90586.
 //
 // This change eliminates one of the major downsides of emitting `where`
 // bounds for field types (i.e., the emission of E0446 for private field


### PR DESCRIPTION
This commit corrects outdated code comments in zerocopy-derive. As of Rust 1.59.0, it is no longer an error to name private types in the `where` clauses of public trait impls for public types.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
