### PR TITLE
[byteorder] Add submodules with byte order aliases

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -9,35 +9,37 @@
 //!
 //! For each native multi-byte integer type - `u16`, `i16`, `u32`, etc - and
 //! floating point type - `f32` and `f64` - an equivalent type is defined by
-//! this module - [`U16`], [`I16`], [`U32`], [`F64`], etc.
-//! Unlike their native counterparts, these types have alignment 1, and take a
-//! type parameter specifying the byte order in which the bytes are stored in
-//! memory. Each type implements the [`FromBytes`], [`AsBytes`], and
-//! [`Unaligned`] traits.
+//! this module - [`U16`], [`I16`], [`U32`], [`F64`], etc. Unlike their native
+//! counterparts, these types have alignment 1, and take a type parameter
+//! specifying the byte order in which the bytes are stored in memory. Each type
+//! implements the [`FromBytes`], [`AsBytes`], and [`Unaligned`] traits.
 //!
-//! These two properties, taken together, make these types very useful for
-//! defining data structures whose memory layout matches a wire format such as
-//! that of a network protocol or a file format. Such formats often have
-//! multi-byte values at offsets that do not respect the alignment requirements
-//! of the equivalent native types, and stored in a byte order not necessarily
-//! the same as that of the target platform.
+//! These two properties, taken together, make these types useful for defining
+//! data structures whose memory layout matches a wire format such as that of a
+//! network protocol or a file format. Such formats often have multi-byte values
+//! at offsets that do not respect the alignment requirements of the equivalent
+//! native types, and stored in a byte order not necessarily the same as that of
+//! the target platform.
+//!
+//! Type aliases are provided for common byte orders in the [`big_endian`],
+//! [`little_endian`], [`network_endian`], and [`native_endian`] submodules.
 //!
 //! # Example
 //!
 //! One use of these types is for representing network packet formats, such as
 //! UDP:
 //!
-//! ```edition2018
-//! # use zerocopy::*;
-//! use ::byteorder::NetworkEndian;
+//! ```edition2021
+//! use zerocopy::{AsBytes, ByteSlice, FromBytes, LayoutVerified, Unaligned};
+//! use zerocopy::byteorder::network_endian::U16;
 //!
 //! #[derive(FromBytes, AsBytes, Unaligned)]
 //! #[repr(C)]
 //! struct UdpHeader {
-//!     src_port: U16<NetworkEndian>,
-//!     dst_port: U16<NetworkEndian>,
-//!     length: U16<NetworkEndian>,
-//!     checksum: U16<NetworkEndian>,
+//!     src_port: U16,
+//!     dst_port: U16,
+//!     length: U16,
+//!     checksum: U16,
 //! }
 //!
 //! struct UdpPacket<B: ByteSlice> {
@@ -444,6 +446,41 @@ define_type!(
     []
 );
 define_type!(An, F64, f64, 64, 8, read_f64, write_f64, "floating point number", [], [], [], []);
+
+macro_rules! module {
+    ($name:ident, $trait:ident, $endianness_str:expr) => {
+        /// Numeric primitives stored in
+        #[doc = $endianness_str]
+        /// byte order.
+        pub mod $name {
+            use byteorder::$trait;
+
+            module!(@ty U16,  $trait, "16-bit unsigned integer", $endianness_str);
+            module!(@ty U32,  $trait, "32-bit unsigned integer", $endianness_str);
+            module!(@ty U64,  $trait, "64-bit unsigned integer", $endianness_str);
+            module!(@ty U128, $trait, "128-bit unsigned integer", $endianness_str);
+            module!(@ty I16,  $trait, "16-bit signed integer", $endianness_str);
+            module!(@ty I32,  $trait, "32-bit signed integer", $endianness_str);
+            module!(@ty I64,  $trait, "64-bit signed integer", $endianness_str);
+            module!(@ty I128, $trait, "128-bit signed integer", $endianness_str);
+            module!(@ty F32,  $trait, "32-bit floating point number", $endianness_str);
+            module!(@ty F64,  $trait, "64-bit floating point number", $endianness_str);
+        }
+    };
+    (@ty $ty:ident, $trait:ident, $desc_str:expr, $endianness_str:expr) => {
+        /// A
+        #[doc = $desc_str]
+        /// stored in
+        #[doc = $endianness_str]
+        /// byte order.
+        pub type $ty = crate::byteorder::$ty<$trait>;
+    };
+}
+
+module!(big_endian, BigEndian, "big-endian");
+module!(little_endian, LittleEndian, "little-endian");
+module!(network_endian, NetworkEndian, "network-endian");
+module!(native_endian, NativeEndian, "native-endian");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Add submodules which define type aliases for the `byteorder::*` types with a specific byte order type argument. This allows us to go from the somewhat clunky:

```rust
  use byteorder::NetworkEndian;
  use zerocopy::byteorder::U16;

  #[derive(FromBytes, AsBytes, Unaligned)]
  #[repr(C)]
  struct UdpHeader {
      src_port: U16<NetworkEndian>,
      dst_port: U16<NetworkEndian>,
      length: U16<NetworkEndian>,
      checksum: U16<NetworkEndian>,
  }
```

...to the less clunky:

```rust
  use zerocopy::byteorder::network_endian::U16;

  #[derive(FromBytes, AsBytes, Unaligned)]
  #[repr(C)]
  struct UdpHeader {
      src_port: U16,
      dst_port: U16,
      length: U16,
      checksum: U16,
  }
```

Closes #100

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
