### PR TITLE
Switch from actions-rs/toolchain to dtolnay/rust-toolchain.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Build & Tests
 
 on:
-  push:
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
         fi
 
     - name: Install Rust with toolchain ${{ env.ZC_TOOLCHAIN }} and target ${{ matrix.target }}
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
           toolchain: ${{ env.ZC_TOOLCHAIN }}
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
           # Only nightly has a working Miri, so we skip installing on all other
           # toolchains. This expression is effectively a ternary expression -
           # see [1] for details.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Build & Tests
 
 on:
+  push:
   pull_request:
 
 env:


### PR DESCRIPTION
[`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) is not actively maintained and a number of warnings are thrown when ran. Some community efforts are made to revive the project but nothing has really materialized as of yet. [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) does essentially the same thing except it is actively maintained and `dtolnay` is a very reputable member of the Rust community.

The switch is frictionless. 

For more information, you can take a look at [this](https://github.com/actions-rs/toolchain/issues/216) issue.