### PR TITLE
Cargo.toml: use `license` instead of `license-file`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "zerocopy"
 version = "0.7.0-alpha.1"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
-license-file = "LICENSE"
+license = "BSD-2-Clause"
 repository = "https://github.com/google/zerocopy"
 rust-version = "1.61.0"
 

--- a/generate-readme.sh
+++ b/generate-readme.sh
@@ -30,7 +30,7 @@ EOF
 #
 # These links don't work in a Markdown file, and so we remove the `[` and `]`
 # characters to convert them to non-link code snippets.
-cargo readme | sed 's/\[\(`[^`]*`\)]/\1/g' > $BODY
+cargo readme --no-license | sed 's/\[\(`[^`]*`\)]/\1/g' > $BODY
 
 cat > $DISCLAIMER_FOOTER <<'EOF'
 


### PR DESCRIPTION
When using a standard SPDX license, Cargo.toml should only have the license field. `license-file` is for use when the license being used is nonstandard, per:
https://doc.rust-lang.org/cargo/reference/manifest.html

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
