### PR TITLE
Have zerocopy depend exactly on derive version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,53 @@ jobs:
           ver_zerocopy_derive=$(msrv zerocopy-derive $path_zerocopy_derive)
 
           if [[ "$ver_zerocopy" == "$ver_zerocopy_derive" ]]; then
-            echo "Same MSRV ($ver_zerocopy) found in '$path_zerocopy' and '$path_zerocopy_derve'." | tee -a $GITHUB_STEP_SUMMARY
+            echo "Same MSRV ($ver_zerocopy) found in '$path_zerocopy' and '$path_zerocopy_derive'." | tee -a $GITHUB_STEP_SUMMARY
             exit 0
           else
-            echo "Different MSRVs found in '$path_zerocopy' ($ver_zerocopy) and '$path_zerocopy_derve' ($ver_zerocopy_derive)." \
+            echo "Different MSRVs found in '$path_zerocopy' ($ver_zerocopy) and '$path_zerocopy_derive' ($ver_zerocopy_derive)." \
+              | tee -a $GITHUB_STEP_SUMMARY >&2
+            exit 1
+          fi
+
+  check_versions:
+    runs-on: ubuntu-latest
+    name: Check crate versions match
+    steps:
+      - uses: actions/checkout@v3
+      # Make sure that both crates are at the same version, and that zerocopy
+      # depends exactly upon the current version of zerocopy-derive. See
+      # `INTERNAL.md` for an explanation of why we do this.
+      - name: Check crate versions match
+        run: |
+          set -e
+
+          # Usage: version <crate-name> <manifest-path>
+          function version {
+            cargo metadata --manifest-path $2 --format-version 1 | jq -r ".packages[] | select(.name == \"$1\").version"
+          }
+
+          path_zerocopy=Cargo.toml
+          ver_zerocopy=$(version zerocopy $path_zerocopy)
+
+          path_zerocopy_derive=zerocopy-derive/Cargo.toml
+          ver_zerocopy_derive=$(version zerocopy-derive $path_zerocopy_derive)
+
+          zerocopy_derive_dep_ver=$(cargo metadata --manifest-path Cargo.toml --format-version 1 \
+            | jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select(.name == \"zerocopy-derive\").req")
+
+          if [[ "$ver_zerocopy" == "$ver_zerocopy_derive" ]]; then
+            echo "Same crate version ($ver_zerocopy) found in '$path_zerocopy' and '$path_zerocopy_derive'." | tee -a $GITHUB_STEP_SUMMARY
+          else
+            echo "Different crate versions found in '$path_zerocopy' ($ver_zerocopy) and '$path_zerocopy_derive' ($ver_zerocopy_derive)." \
+              | tee -a $GITHUB_STEP_SUMMARY >&2
+            exit 1
+          fi
+
+          # Note the leading `=` sign - the dependency needs to be an exact one.
+          if [[ "=$ver_zerocopy_derive" == "$zerocopy_derive_dep_ver" ]]; then
+            echo "zerocopy depends upon same version of zerocopy-derive in-tree ($zerocopy_derive_dep_ver)." | tee -a $GITHUB_STEP_SUMMARY
+          else
+            echo "zerocopy depends upon different version of zerocopy-derive ($zerocopy_derive_dep_ver) than the one in-tree ($ver_zerocopy_derive)." \
               | tee -a $GITHUB_STEP_SUMMARY >&2
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "0.3.1", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.0-alpha.1", path = "zerocopy-derive" }
 
 [dependencies.byteorder]
 version = "1.3"

--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -20,3 +20,14 @@ https://rust-lang.github.io/rustup-components-history/).
 Updating the versions pinned in CI may cause the UI tests to break. In order to
 fix UI tests after a version update, set the environment variable
 `TRYBUILD=overwrite` while running `cargo test`.
+
+## Crate versions
+
+We ensure that the crate versions of zerocopy and zerocopy-derive are always the
+same in-tree, and that zerocopy depends upon zerocopy-derive using an exact
+version match to the current version in-tree. This has the result that, even
+when published on crates.io, both crates effectively constitute a single atomic
+version. So long as the code in zerocopy is compatible with the code in
+zerocopy-derive in the same Git commit, then publishing them both is fine. This
+frees us from the normal task of reasoning about compatibility with a range of
+semver-compatible versions of different crates.

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -7,7 +7,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.3.2"
+version = "0.7.0-alpha.1"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license-file = "../LICENSE"


### PR DESCRIPTION
Have zerocopy depend on an exact version of zerocopy-derive. See the note added to `INTERNAL.md` in this commit for a justification.

Closes #107

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
