### PR TITLE
Move field type bounds into where clauses

### DIFF
--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -4,11 +4,7 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
 18 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `&'static str`
    |
-note: required by a bound in `ImplementsFromBytes`
-  --> tests/ui-msrv/late_compile_pass.rs:18:10
-   |
-18 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ required by this bound in `ImplementsFromBytes`
+   = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
@@ -17,11 +13,7 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
 30 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
    |
-note: required by a bound in `ImplementsAsBytes`
-  --> tests/ui-msrv/late_compile_pass.rs:30:10
-   |
-30 | #[derive(AsBytes)]
-   |          ^^^^^^^ required by this bound in `ImplementsAsBytes`
+   = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -33,11 +25,7 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following implementations were found:
              <i8 as Unaligned>
              <u8 as Unaligned>
-note: required by a bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-msrv/late_compile_pass.rs:40:10
-   |
-40 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -49,11 +37,7 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following implementations were found:
              <i8 as Unaligned>
              <u8 as Unaligned>
-note: required by a bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-msrv/late_compile_pass.rs:48:10
-   |
-48 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -65,9 +49,5 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following implementations were found:
              <i8 as Unaligned>
              <u8 as Unaligned>
-note: required by a bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-msrv/late_compile_pass.rs:55:10
-   |
-55 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -14,11 +14,7 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required by a bound in `ImplementsFromBytes`
-  --> tests/ui-stable/late_compile_pass.rs:18:10
-   |
-18 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ required by this bound in `ImplementsFromBytes`
+   = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
@@ -37,11 +33,7 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required by a bound in `ImplementsAsBytes`
-  --> tests/ui-stable/late_compile_pass.rs:30:10
-   |
-30 | #[derive(AsBytes)]
-   |          ^^^^^^^ required by this bound in `ImplementsAsBytes`
+   = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -53,11 +45,7 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-stable/late_compile_pass.rs:40:10
-   |
-40 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -69,11 +57,7 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-stable/late_compile_pass.rs:48:10
-   |
-48 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -85,9 +69,5 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui-stable/late_compile_pass.rs:55:10
-   |
-55 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui/late_compile_pass.stderr
@@ -14,11 +14,8 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required by a bound in `ImplementsFromBytes`
-  --> tests/ui/late_compile_pass.rs:18:10
-   |
-18 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ required by this bound in `ImplementsFromBytes`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
@@ -37,11 +34,8 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required by a bound in `ImplementsAsBytes`
-  --> tests/ui/late_compile_pass.rs:30:10
-   |
-30 | #[derive(AsBytes)]
-   |          ^^^^^^^ required by this bound in `ImplementsAsBytes`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -53,11 +47,8 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui/late_compile_pass.rs:40:10
-   |
-40 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned1 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -69,11 +60,8 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui/late_compile_pass.rs:48:10
-   |
-48 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned2 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u16: Unaligned` is not satisfied
@@ -85,9 +73,6 @@ error[E0277]: the trait bound `u16: Unaligned` is not satisfied
    = help: the following other types implement trait `Unaligned`:
              i8
              u8
-note: required by a bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
-  --> tests/ui/late_compile_pass.rs:55:10
-   |
-55 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ required by this bound in `<Unaligned3 as Unaligned>::only_derive_is_allowed_to_implement_this_trait::ImplementsUnaligned`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This cleans up some of the error messages without introducing any functional changes. This will also make it easier to enable deriving on generic types in the future.
