### PR TITLE
[derive] Support deriving on unsized types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,5 @@ default-features = false
 [dev-dependencies]
 rand = "0.6"
 rustversion = "1.0"
-trybuild = "1.0"
+# Required for "and $N others" normalization
+trybuild = ">=1.0.70"

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -26,5 +26,6 @@ syn = { version = "1.0.5", features = ["visit"] }
 
 [dev-dependencies]
 rustversion = "1.0"
-trybuild = "1.0"
+# Required for "and $N others" normalization
+trybuild = ">=1.0.70"
 zerocopy = { path = "../" }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -602,7 +602,7 @@ fn impl_block<D: DataExt>(
     let use_concrete = if input.generics.params.is_empty() {
         Some(quote! {
             const _: () = {
-                fn must_implement_trait<T: zerocopy::#trait_ident>() {}
+                fn must_implement_trait<T: zerocopy::#trait_ident + ?Sized>() {}
                 let _ = must_implement_trait::<#type_ident>;
             };
         })
@@ -612,8 +612,7 @@ fn impl_block<D: DataExt>(
 
     quote! {
         unsafe impl < #(#params),* > zerocopy::#trait_ident for #type_ident < #(#param_idents),* > #where_clause {
-            fn only_derive_is_allowed_to_implement_this_trait() where Self: Sized {
-            }
+            fn only_derive_is_allowed_to_implement_this_trait() {}
         }
         #use_concrete
     }

--- a/zerocopy-derive/tests/struct_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_from_bytes.rs
@@ -8,7 +8,10 @@
 mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
+
 use zerocopy::FromBytes;
+
+use crate::util::AU16;
 
 // A struct is `FromBytes` if:
 // - all fields are `FromBytes`
@@ -34,13 +37,22 @@ struct Two {
 assert_is_from_bytes!(Two);
 
 #[derive(FromBytes)]
-struct TypeParams<'a, T, I: Iterator> {
-    a: T,
-    c: I::Item,
-    d: u8,
-    e: PhantomData<&'a [u8]>,
-    f: PhantomData<&'static str>,
-    g: PhantomData<String>,
+struct Unsized {
+    a: [u8],
+}
+
+assert_is_from_bytes!(Unsized);
+
+#[derive(FromBytes)]
+struct TypeParams<'a, T: ?Sized, I: Iterator> {
+    a: I::Item,
+    b: u8,
+    c: PhantomData<&'a [u8]>,
+    d: PhantomData<&'static str>,
+    e: PhantomData<String>,
+    f: T,
 }
 
 assert_is_from_bytes!(TypeParams<'static, (), IntoIter<()>>);
+assert_is_from_bytes!(TypeParams<'static, AU16, IntoIter<()>>);
+assert_is_from_bytes!(TypeParams<'static, [AU16], IntoIter<()>>);

--- a/zerocopy-derive/tests/struct_unaligned.rs
+++ b/zerocopy-derive/tests/struct_unaligned.rs
@@ -8,7 +8,10 @@
 mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
+
 use zerocopy::Unaligned;
+
+use crate::util::AU16;
 
 // A struct is `Unaligned` if:
 // - `repr(align)` is no more than 1 and either
@@ -56,14 +59,24 @@ struct FooAlign {
 assert_is_unaligned!(FooAlign);
 
 #[derive(Unaligned)]
+#[repr(transparent)]
+struct Unsized {
+    a: [u8],
+}
+
+assert_is_unaligned!(Unsized);
+
+#[derive(Unaligned)]
 #[repr(C)]
-struct TypeParams<'a, T, I: Iterator> {
-    a: T,
-    c: I::Item,
-    d: u8,
-    e: PhantomData<&'a [u8]>,
-    f: PhantomData<&'static str>,
-    g: PhantomData<String>,
+struct TypeParams<'a, T: ?Sized, I: Iterator> {
+    a: I::Item,
+    b: u8,
+    c: PhantomData<&'a [u8]>,
+    d: PhantomData<&'static str>,
+    e: PhantomData<String>,
+    f: T,
 }
 
 assert_is_unaligned!(TypeParams<'static, (), IntoIter<()>>);
+assert_is_unaligned!(TypeParams<'static, u8, IntoIter<()>>);
+assert_is_unaligned!(TypeParams<'static, [u8], IntoIter<()>>);

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,92 +1,83 @@
-error[E0432]: unresolved import `self::util::NotAsBytes`
-  --> tests/ui-msrv/derive_transparent.rs:11:18
-   |
-11 | use self::util::{NotAsBytes, AU16};
-   |                  ^^^^^^^^^^
-   |                  |
-   |                  no `NotAsBytes` in `util`
-   |                  help: a similar name exists in the module: `AsBytes`
-
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
   --> tests/ui-msrv/../util.rs
    |
-   |             const _: fn($ty) -> IsAsBytes<$ty> = IsAsBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
+   |             const _: () = is_as_bytes::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:33:1
+  ::: tests/ui-msrv/derive_transparent.rs:31:1
    |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   | --------------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotAsBytes>`
-  --> tests/ui-msrv/derive_transparent.rs:20:10
+note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:21:10
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |          ^^^^^^^
-note: required by a bound in `IsAsBytes`
+note: required by a bound in `is_as_bytes`
   --> tests/ui-msrv/../util.rs
    |
-   |             struct IsAsBytes<T: zerocopy::AsBytes>(T);
-   |                                 ^^^^^^^^^^^^^^^^^ required by this bound in `IsAsBytes`
+   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
+   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:33:1
+  ::: tests/ui-msrv/derive_transparent.rs:31:1
    |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   | --------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `char: FromBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-msrv/../util.rs
    |
-   |             const _: fn($ty) -> IsFromBytes<$ty> = IsFromBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `char`
+   |             const _: () = is_from_bytes::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:34:1
+  ::: tests/ui-msrv/derive_transparent.rs:32:1
    |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   | ----------------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<char>`
-  --> tests/ui-msrv/derive_transparent.rs:20:19
+note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:21:19
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `IsFromBytes`
+note: required by a bound in `is_from_bytes`
   --> tests/ui-msrv/../util.rs
    |
-   |             struct IsFromBytes<T: zerocopy::FromBytes>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsFromBytes`
+   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
+   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:34:1
+  ::: tests/ui-msrv/derive_transparent.rs:32:1
    |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   | ----------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
   --> tests/ui-msrv/../util.rs
    |
-   |             const _: fn($ty) -> IsUnaligned<$ty> = IsUnaligned::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |             const _: () = is_unaligned::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:35:1
+  ::: tests/ui-msrv/derive_transparent.rs:33:1
    |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   | ---------------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<AU16>`
-  --> tests/ui-msrv/derive_transparent.rs:20:30
+note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:21:30
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `IsUnaligned`
+note: required by a bound in `is_unaligned`
   --> tests/ui-msrv/../util.rs
    |
-   |             struct IsUnaligned<T: zerocopy::Unaligned>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsUnaligned`
+   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
+   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
    |
-  ::: tests/ui-msrv/derive_transparent.rs:35:1
+  ::: tests/ui-msrv/derive_transparent.rs:33:1
    |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   | ---------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -7,37 +7,37 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:35:10
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-msrv/late_compile_pass.rs:32:10
    |
-35 | #[derive(AsBytes)]
-   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
+32 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:45:10
+  --> tests/ui-msrv/late_compile_pass.rs:42:10
    |
-45 | #[derive(Unaligned)]
+42 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:53:10
+  --> tests/ui-msrv/late_compile_pass.rs:50:10
    |
-53 | #[derive(Unaligned)]
+50 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:60:10
+  --> tests/ui-msrv/late_compile_pass.rs:57:10
    |
-60 | #[derive(Unaligned)]
+57 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -1,22 +1,13 @@
-error[E0432]: unresolved import `self::util::NotAsBytes`
-  --> tests/ui-stable/derive_transparent.rs:11:18
-   |
-11 | use self::util::{NotAsBytes, AU16};
-   |                  ^^^^^^^^^^
-   |                  |
-   |                  no `NotAsBytes` in `util`
-   |                  help: a similar name exists in the module: `AsBytes`
-
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
   --> tests/ui-stable/../util.rs
    |
-   |             const _: fn($ty) -> IsAsBytes<$ty> = IsAsBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
+   |             const _: () = is_as_bytes::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-stable/derive_transparent.rs:33:1
+  ::: tests/ui-stable/derive_transparent.rs:31:1
    |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   | --------------------------------------------------- in this macro invocation
    |
    = help: the following other types implement trait `AsBytes`:
              ()
@@ -28,71 +19,71 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotAsBytes>`
-  --> tests/ui-stable/derive_transparent.rs:20:10
+note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-stable/derive_transparent.rs:21:10
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |          ^^^^^^^
-note: required by a bound in `IsAsBytes`
+note: required by a bound in `is_as_bytes`
   --> tests/ui-stable/../util.rs
    |
-   |             struct IsAsBytes<T: zerocopy::AsBytes>(T);
-   |                                 ^^^^^^^^^^^^^^^^^ required by this bound in `IsAsBytes`
+   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
+   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
    |
-  ::: tests/ui-stable/derive_transparent.rs:33:1
+  ::: tests/ui-stable/derive_transparent.rs:31:1
    |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   | --------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `char: FromBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-stable/../util.rs
    |
-   |             const _: fn($ty) -> IsFromBytes<$ty> = IsFromBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `char`
+   |             const _: () = is_from_bytes::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-stable/derive_transparent.rs:34:1
+  ::: tests/ui-stable/derive_transparent.rs:32:1
    |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   | ----------------------------------------------------- in this macro invocation
    |
    = help: the following other types implement trait `FromBytes`:
              ()
+             AU16
              F32<O>
              F64<O>
              I128<O>
              I16<O>
              I32<O>
              I64<O>
-             MaybeUninit<T>
            and $N others
-note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<char>`
-  --> tests/ui-stable/derive_transparent.rs:20:19
+note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-stable/derive_transparent.rs:21:19
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `IsFromBytes`
+note: required by a bound in `is_from_bytes`
   --> tests/ui-stable/../util.rs
    |
-   |             struct IsFromBytes<T: zerocopy::FromBytes>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsFromBytes`
+   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
+   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
    |
-  ::: tests/ui-stable/derive_transparent.rs:34:1
+  ::: tests/ui-stable/derive_transparent.rs:32:1
    |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   | ----------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
   --> tests/ui-stable/../util.rs
    |
-   |             const _: fn($ty) -> IsUnaligned<$ty> = IsUnaligned::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |             const _: () = is_unaligned::<$ty>();
+   |                           ^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
-  ::: tests/ui-stable/derive_transparent.rs:35:1
+  ::: tests/ui-stable/derive_transparent.rs:33:1
    |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   | ---------------------------------------------------- in this macro invocation
    |
    = help: the following other types implement trait `Unaligned`:
              ()
@@ -102,21 +93,21 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<AU16>`
-  --> tests/ui-stable/derive_transparent.rs:20:30
+note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-stable/derive_transparent.rs:21:30
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `IsUnaligned`
+note: required by a bound in `is_unaligned`
   --> tests/ui-stable/../util.rs
    |
-   |             struct IsUnaligned<T: zerocopy::Unaligned>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsUnaligned`
+   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
+   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
    |
-  ::: tests/ui-stable/derive_transparent.rs:35:1
+  ::: tests/ui-stable/derive_transparent.rs:33:1
    |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   | ---------------------------------------------------- in this macro invocation
    = note: this error originates in the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -6,22 +6,22 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
    |
    = help: the following other types implement trait `FromBytes`:
              ()
+             AU16
              F32<O>
              F64<O>
              FromBytes1
              I128<O>
              I16<O>
              I32<O>
-             I64<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
-  --> tests/ui-stable/late_compile_pass.rs:35:10
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-stable/late_compile_pass.rs:32:10
    |
-35 | #[derive(AsBytes)]
-   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
+32 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
              ()
@@ -37,9 +37,9 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-stable/late_compile_pass.rs:45:10
+  --> tests/ui-stable/late_compile_pass.rs:42:10
    |
-45 | #[derive(Unaligned)]
+42 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -50,15 +50,15 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-stable/late_compile_pass.rs:53:10
+  --> tests/ui-stable/late_compile_pass.rs:50:10
    |
-53 | #[derive(Unaligned)]
+50 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -69,15 +69,15 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-stable/late_compile_pass.rs:60:10
+  --> tests/ui-stable/late_compile_pass.rs:57:10
    |
-60 | #[derive(Unaligned)]
+57 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -88,7 +88,7 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui/derive_transparent.rs
@@ -8,12 +8,13 @@ extern crate zerocopy;
 #[macro_use]
 mod util;
 
-use self::util::{NotAsBytes, AU16};
+use core::marker::PhantomData;
+
+use zerocopy::{AsBytes, FromBytes, Unaligned};
+
+use self::util::NotZerocopy;
 
 fn main() {}
-
-use core::marker::PhantomData;
-use zerocopy::{AsBytes, FromBytes, Unaligned};
 
 // Test generic transparent structs
 
@@ -24,12 +25,9 @@ struct TransparentStruct<T> {
     _phantom: PhantomData<()>,
 }
 
-// A type that does not implement `AsBytes`.
-pub struct NotAsBytes;
-
 // It should be legal to derive these traits on a transparent struct, but it
 // must also ensure the traits are only implemented when the inner type
 // implements them.
-assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-assert_is_from_bytes!(TransparentStruct<char>);
-assert_is_unaligned!(TransparentStruct<AU16>);
+assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+assert_is_unaligned!(TransparentStruct<NotZerocopy>);

--- a/zerocopy-derive/tests/ui/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui/derive_transparent.stderr
@@ -1,22 +1,8 @@
-error[E0432]: unresolved import `self::util::NotAsBytes`
-  --> tests/ui/derive_transparent.rs:11:18
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui/derive_transparent.rs:31:21
    |
-11 | use self::util::{NotAsBytes, AU16};
-   |                  ^^^^^^^^^^
-   |                  |
-   |                  no `NotAsBytes` in `util`
-   |                  help: a similar name exists in the module: `AsBytes`
-
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
-  --> tests/ui/../util.rs
-   |
-   |             const _: fn($ty) -> IsAsBytes<$ty> = IsAsBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
-   |
-  ::: tests/ui/derive_transparent.rs:33:1
-   |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
              ()
@@ -28,71 +14,61 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required for `TransparentStruct<NotAsBytes>` to implement `AsBytes`
-  --> tests/ui/derive_transparent.rs:20:10
+note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
+  --> tests/ui/derive_transparent.rs:21:10
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |          ^^^^^^^
-note: required by a bound in `IsAsBytes`
+note: required by a bound in `is_as_bytes`
   --> tests/ui/../util.rs
    |
-   |             struct IsAsBytes<T: zerocopy::AsBytes>(T);
-   |                                 ^^^^^^^^^^^^^^^^^ required by this bound in `IsAsBytes`
+   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
+   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
    |
-  ::: tests/ui/derive_transparent.rs:33:1
+  ::: tests/ui/derive_transparent.rs:31:1
    |
-33 | assert_is_as_bytes!(TransparentStruct<NotAsBytes>);
-   | -------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
+   | --------------------------------------------------- in this macro invocation
+   = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `char: FromBytes` is not satisfied
-  --> tests/ui/../util.rs
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
+  --> tests/ui/derive_transparent.rs:32:23
    |
-   |             const _: fn($ty) -> IsFromBytes<$ty> = IsFromBytes::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `char`
-   |
-  ::: tests/ui/derive_transparent.rs:34:1
-   |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
              ()
+             AU16
              F32<O>
              F64<O>
              I128<O>
              I16<O>
              I32<O>
              I64<O>
-             MaybeUninit<T>
            and $N others
-note: required for `TransparentStruct<char>` to implement `FromBytes`
-  --> tests/ui/derive_transparent.rs:20:19
+note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
+  --> tests/ui/derive_transparent.rs:21:19
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `IsFromBytes`
+note: required by a bound in `is_from_bytes`
   --> tests/ui/../util.rs
    |
-   |             struct IsFromBytes<T: zerocopy::FromBytes>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsFromBytes`
+   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
+   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
    |
-  ::: tests/ui/derive_transparent.rs:34:1
+  ::: tests/ui/derive_transparent.rs:32:1
    |
-34 | assert_is_from_bytes!(TransparentStruct<char>);
-   | ---------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
+   | ----------------------------------------------------- in this macro invocation
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui/../util.rs
+error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+  --> tests/ui/derive_transparent.rs:33:22
    |
-   |             const _: fn($ty) -> IsUnaligned<$ty> = IsUnaligned::<$ty>;
-   |                                 ^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
-   |
-  ::: tests/ui/derive_transparent.rs:35:1
-   |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
              ()
@@ -102,21 +78,21 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
-note: required for `TransparentStruct<AU16>` to implement `Unaligned`
-  --> tests/ui/derive_transparent.rs:20:30
+note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
+  --> tests/ui/derive_transparent.rs:21:30
    |
-20 | #[derive(AsBytes, FromBytes, Unaligned)]
+21 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `IsUnaligned`
+note: required by a bound in `is_unaligned`
   --> tests/ui/../util.rs
    |
-   |             struct IsUnaligned<T: zerocopy::Unaligned>(T);
-   |                                   ^^^^^^^^^^^^^^^^^^^ required by this bound in `IsUnaligned`
+   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
+   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
    |
-  ::: tests/ui/derive_transparent.rs:35:1
+  ::: tests/ui/derive_transparent.rs:33:1
    |
-35 | assert_is_unaligned!(TransparentStruct<AU16>);
-   | --------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+   | ---------------------------------------------------- in this macro invocation
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui/late_compile_pass.rs
+++ b/zerocopy-derive/tests/ui/late_compile_pass.rs
@@ -8,7 +8,7 @@ extern crate zerocopy;
 #[path = "../util.rs"]
 mod util;
 
-use self::util::AU16;
+use self::util::{NotZerocopy, AU16};
 
 fn main() {}
 
@@ -29,13 +29,10 @@ struct FromBytes1 {
 // AsBytes errors
 //
 
-#[repr(C)]
-struct NotAsBytes(u32);
-
 #[derive(AsBytes)]
 #[repr(C)]
 struct AsBytes1 {
-    value: NotAsBytes,
+    value: NotZerocopy,
 }
 
 //

--- a/zerocopy-derive/tests/ui/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui/late_compile_pass.stderr
@@ -6,23 +6,23 @@ error[E0277]: the trait bound `&'static str: FromBytes` is not satisfied
    |
    = help: the following other types implement trait `FromBytes`:
              ()
+             AU16
              F32<O>
              F64<O>
              FromBytes1
              I128<O>
              I16<O>
              I32<O>
-             I64<O>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
-  --> tests/ui/late_compile_pass.rs:35:10
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui/late_compile_pass.rs:32:10
    |
-35 | #[derive(AsBytes)]
-   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotAsBytes`
+32 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
              ()
@@ -39,9 +39,9 @@ error[E0277]: the trait bound `NotAsBytes: AsBytes` is not satisfied
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui/late_compile_pass.rs:45:10
+  --> tests/ui/late_compile_pass.rs:42:10
    |
-45 | #[derive(Unaligned)]
+42 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -52,16 +52,16 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui/late_compile_pass.rs:53:10
+  --> tests/ui/late_compile_pass.rs:50:10
    |
-53 | #[derive(Unaligned)]
+50 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -72,16 +72,16 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui/late_compile_pass.rs:60:10
+  --> tests/ui/late_compile_pass.rs:57:10
    |
-60 | #[derive(Unaligned)]
+57 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -92,7 +92,7 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-             PhantomData<T>
+             ManuallyDrop<T>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/util.rs
+++ b/zerocopy-derive/tests/util.rs
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes};
 
-// A `u16` with alignment 2.
-//
-// Though `u16` has alignment 2 on some platforms, it's not guaranteed.
-// By contrast, `AU16` is guaranteed to have alignment 2.
-#[derive(AsBytes, Copy, Clone)]
+/// A type that doesn't implement any zerocopy traits.
+pub struct NotZerocopy(());
+
+/// A `u16` with alignment 2.
+///
+/// Though `u16` has alignment 2 on some platforms, it's not guaranteed. By
+/// contrast, `AU16` is guaranteed to have alignment 2.
+#[derive(FromBytes, AsBytes, Copy, Clone)]
 #[repr(C, align(2))]
 pub struct AU16(u16);
 
@@ -16,8 +19,8 @@ pub struct AU16(u16);
 macro_rules! assert_is_as_bytes {
     ($ty:ty) => {
         const _: () = {
-            struct IsAsBytes<T: zerocopy::AsBytes>(T);
-            const _: fn($ty) -> IsAsBytes<$ty> = IsAsBytes::<$ty>;
+            const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
+            const _: () = is_as_bytes::<$ty>();
         };
     };
 }
@@ -26,8 +29,8 @@ macro_rules! assert_is_as_bytes {
 macro_rules! assert_is_from_bytes {
     ($ty:ty) => {
         const _: () = {
-            struct IsFromBytes<T: zerocopy::FromBytes>(T);
-            const _: fn($ty) -> IsFromBytes<$ty> = IsFromBytes::<$ty>;
+            const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
+            const _: () = is_from_bytes::<$ty>();
         };
     };
 }
@@ -36,8 +39,8 @@ macro_rules! assert_is_from_bytes {
 macro_rules! assert_is_unaligned {
     ($ty:ty) => {
         const _: () = {
-            struct IsUnaligned<T: zerocopy::Unaligned>(T);
-            const _: fn($ty) -> IsUnaligned<$ty> = IsUnaligned::<$ty>;
+            const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
+            const _: () = is_unaligned::<$ty>();
         };
     };
 }


### PR DESCRIPTION
In order to test this support, add a new `Unsized` type in zerocopy's
`test` module. Use this to test the derive and also to test `AsBytes`'s
methods in `test_as_bytes_methods`. These tests supersede the previous
unsized tests, which used slices, and have been removed.
    
While we're here, expand `test_as_bytes_methods` to test the `write_to`,
`write_to_prefix`, and `write_to_suffix` methods, which were not
previously tested.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
