### PR TITLE
[derive] Clean up AsBytes support on repr(packed)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3253,20 +3253,31 @@ mod tests {
     }
 
     #[test]
-    fn test_transparent_generic_struct() {
+    fn test_transparent_packed_generic_struct() {
         #[derive(AsBytes, FromBytes, Unaligned)]
         #[repr(transparent)]
         struct Foo<T> {
-            _bar: T,
+            _t: T,
             _phantom: PhantomData<()>,
         }
 
-        fn assert_impls_asbytes<T: AsBytes>() {}
-        fn assert_impls_frombytes<T: FromBytes>() {}
+        fn assert_impls_as_bytes<T: AsBytes>() {}
+        fn assert_impls_from_bytes<T: FromBytes>() {}
         fn assert_impls_unaligned<T: Unaligned>() {}
 
-        assert_impls_asbytes::<Foo<f32>>();
-        assert_impls_frombytes::<Foo<u32>>();
+        assert_impls_as_bytes::<Foo<f32>>();
+        assert_impls_from_bytes::<Foo<u32>>();
         assert_impls_unaligned::<Foo<u8>>();
+
+        #[derive(AsBytes, FromBytes, Unaligned)]
+        #[repr(packed)]
+        struct Bar<T, U> {
+            _t: T,
+            _u: U,
+        }
+
+        assert_impls_as_bytes::<Bar<u8, AU64>>();
+        assert_impls_from_bytes::<Bar<u8, AU64>>();
+        assert_impls_unaligned::<Bar<u8, AU64>>();
     }
 }

--- a/zerocopy-derive/tests/struct_as_bytes.rs
+++ b/zerocopy-derive/tests/struct_as_bytes.rs
@@ -7,9 +7,11 @@
 #[macro_use]
 mod util;
 
-use self::util::AU16;
 use std::{marker::PhantomData, option::IntoIter};
+
 use zerocopy::AsBytes;
+
+use self::util::AU16;
 
 // A struct is `AsBytes` if:
 // - all fields are `AsBytes`
@@ -43,6 +45,15 @@ struct Transparent {
 assert_is_as_bytes!(Transparent);
 
 #[derive(AsBytes)]
+#[repr(transparent)]
+struct TransparentGeneric<T> {
+    a: T,
+    b: CZst,
+}
+
+assert_is_as_bytes!(TransparentGeneric<u64>);
+
+#[derive(AsBytes)]
 #[repr(C, packed)]
 struct CZstPacked;
 
@@ -63,3 +74,37 @@ struct CPacked {
 }
 
 assert_is_as_bytes!(CPacked);
+
+#[derive(AsBytes)]
+#[repr(C, packed)]
+struct CPackedGeneric<T, U> {
+    t: T,
+    u: U,
+}
+
+assert_is_as_bytes!(CPackedGeneric<u8, AU16>);
+
+#[derive(AsBytes)]
+#[repr(packed)]
+struct Packed {
+    a: u8,
+    // NOTE: The `u16` type is not guaranteed to have alignment 2, although it
+    // does on many platforms. However, to fix this would require a custom type
+    // with a `#[repr(align(2))]` attribute, and `#[repr(packed)]` types are not
+    // allowed to transitively contain `#[repr(align(...))]` types. Thus, we
+    // have no choice but to use `u16` here. Luckily, these tests run in CI on
+    // platforms on which `u16` has alignment 2, so this isn't that big of a
+    // deal.
+    b: u16,
+}
+
+assert_is_as_bytes!(Packed);
+
+#[derive(AsBytes)]
+#[repr(packed)]
+struct PackedGeneric<T, U> {
+    t: T,
+    u: U,
+}
+
+assert_is_as_bytes!(PackedGeneric<u8, AU16>);

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -1,4 +1,4 @@
-error: unsupported on generic structs that are not repr(transparent)
+error: unsupported on generic structs that are not repr(transparent) or repr(packed)
   --> tests/ui-msrv/struct.rs:19:10
    |
 19 | #[derive(AsBytes)]

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -1,4 +1,4 @@
-error: unsupported on generic structs that are not repr(transparent)
+error: unsupported on generic structs that are not repr(transparent) or repr(packed)
   --> tests/ui-stable/struct.rs:19:10
    |
 19 | #[derive(AsBytes)]

--- a/zerocopy-derive/tests/ui/struct.stderr
+++ b/zerocopy-derive/tests/ui/struct.stderr
@@ -1,4 +1,4 @@
-error: unsupported on generic structs that are not repr(transparent)
+error: unsupported on generic structs that are not repr(transparent) or repr(packed)
   --> tests/ui/struct.rs:19:10
    |
 19 | #[derive(AsBytes)]


### PR DESCRIPTION
Unify our handling of `repr(packed)` and `repr(transparent)` when deriving `AsBytes`, and bring error messages up to date with the fact that we support both of these reprs on generic structs.

Closes #127

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
