### PR TITLE
[byteorder] Derive AsBytes for byteorder types

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -179,7 +179,7 @@ example of how it can be used for parsing UDP packets.
 [`FromBytes`]: crate::FromBytes
 [`AsBytes`]: crate::AsBytes
 [`Unaligned`]: crate::Unaligned"),
-            #[derive(FromBytes, Unaligned, Copy, Clone, Eq, PartialEq, Hash)]
+            #[derive(FromBytes, AsBytes, Unaligned, Copy, Clone, Eq, PartialEq, Hash)]
             #[repr(transparent)]
             pub struct $name<O>([u8; $bytes], PhantomData<O>);
         }
@@ -187,19 +187,6 @@ example of how it can be used for parsing UDP packets.
         impl<O> Default for $name<O> {
             fn default() -> $name<O> {
                 $name::ZERO
-            }
-        }
-
-        // TODO(#10): Replace this with `#[derive(AsBytes)]` once that derive
-        // supports type parameters.
-        //
-        // TODO(#61): Add a "SAFETY" comment and remove this `allow`.
-        #[allow(clippy::undocumented_unsafe_blocks)]
-        unsafe impl<O: ByteOrder> AsBytes for $name<O> {
-            fn only_derive_is_allowed_to_implement_this_trait()
-            where
-                Self: Sized,
-            {
             }
         }
 


### PR DESCRIPTION
This was previously a hand-rolled impl, but now that our `AsBytes` derive supports generic `repr(transparent)` types, we can use the derive instead.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
