### PR TITLE
Clean up trait impls, add some safety comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ default-features = false
 [dev-dependencies]
 rand = "0.6"
 rustversion = "1.0"
+static_assertions = "1.1"
 # Required for "and $N others" normalization
 trybuild = ">=1.0.70"


### PR DESCRIPTION
Previously, impls of the `FromBytes`, `AsBytes`, and `Unaligned` traits were spread across a number of inconsistent and hard-to-follow macro invocations. This commit cleans that up by introducing a single macro and a single section of `lib.rs` to hold macro invocations.

This commit also adds some safety comments, but there are still some left as TODOs. Note that, since this commit does not add or remove any trait impls (see `test_impls` for a confirmation that the exact set of impls are tested), these TODOs are acceptable to add in this commit; this commit moves us strictly forward in terms of safety comment coverage.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
