### PR TITLE
Fix bug that made a static assertion a no-op

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,11 +590,11 @@ macro_rules! unsafe_impl {
         unsafe impl Unaligned for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
     };
     // Implement `$trait` for `$ty` with no bounds.
-    ($ty:ty: $trait:ty) => {
+    ($ty:ty: $trait:tt) => {
         unsafe impl $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
     };
     // Implement all `$traits` for `$ty` with no bounds.
-    ($ty:ty: $($traits:ty),*) => {
+    ($ty:ty: $($traits:tt),*) => {
         $( unsafe_impl!($ty: $traits); )*
     };
     // For all `$tyvar` with no bounds, implement `$trait` for `$ty`.


### PR DESCRIPTION
The `unsafe_impl!` macro has a branch that special-cases `Unaligned` and adds an extra static assertion that the type's alignment is 1. It turns out that this branch is unreachable when the macro is invoked with multiple traits like:

  unsafe_impl!(ty: TraitA, TraitB, Unaligned);

This commit fixes the bug by marking the macro item matching trait names as a `tt` rather than a `ty`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
