### PR TITLE
Use static_assertions to assert trait impls

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -26,6 +26,7 @@ syn = { version = "1.0.5", features = ["visit"] }
 
 [dev-dependencies]
 rustversion = "1.0"
+static_assertions = "1.1"
 # Required for "and $N others" normalization
 trybuild = ">=1.0.70"
 zerocopy = { path = "../" }

--- a/zerocopy-derive/tests/enum_as_bytes.rs
+++ b/zerocopy-derive/tests/enum_as_bytes.rs
@@ -4,10 +4,7 @@
 
 #![allow(warnings)]
 
-#[macro_use]
-mod util;
-
-use zerocopy::AsBytes;
+use {static_assertions::assert_impl_all, zerocopy::AsBytes};
 
 // An enum is `AsBytes` if if has a defined repr.
 
@@ -17,7 +14,7 @@ enum C {
     A,
 }
 
-assert_is_as_bytes!(C);
+assert_impl_all!(C: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(u8)]
@@ -25,7 +22,7 @@ enum U8 {
     A,
 }
 
-assert_is_as_bytes!(U8);
+assert_impl_all!(U8: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(u16)]
@@ -33,7 +30,7 @@ enum U16 {
     A,
 }
 
-assert_is_as_bytes!(U16);
+assert_impl_all!(U16: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(u32)]
@@ -41,7 +38,7 @@ enum U32 {
     A,
 }
 
-assert_is_as_bytes!(U32);
+assert_impl_all!(U32: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(u64)]
@@ -49,7 +46,7 @@ enum U64 {
     A,
 }
 
-assert_is_as_bytes!(U64);
+assert_impl_all!(U64: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(usize)]
@@ -57,7 +54,7 @@ enum Usize {
     A,
 }
 
-assert_is_as_bytes!(Usize);
+assert_impl_all!(Usize: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(i8)]
@@ -65,7 +62,7 @@ enum I8 {
     A,
 }
 
-assert_is_as_bytes!(I8);
+assert_impl_all!(I8: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(i16)]
@@ -73,7 +70,7 @@ enum I16 {
     A,
 }
 
-assert_is_as_bytes!(I16);
+assert_impl_all!(I16: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(i32)]
@@ -81,7 +78,7 @@ enum I32 {
     A,
 }
 
-assert_is_as_bytes!(I32);
+assert_impl_all!(I32: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(i64)]
@@ -89,7 +86,7 @@ enum I64 {
     A,
 }
 
-assert_is_as_bytes!(I64);
+assert_impl_all!(I64: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(isize)]
@@ -97,4 +94,4 @@ enum Isize {
     A,
 }
 
-assert_is_as_bytes!(Isize);
+assert_impl_all!(Isize: AsBytes);

--- a/zerocopy-derive/tests/enum_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_from_bytes.rs
@@ -4,10 +4,9 @@
 
 #![allow(warnings)]
 
-#[macro_use]
 mod util;
 
-use zerocopy::FromBytes;
+use {static_assertions::assert_impl_all, zerocopy::FromBytes};
 
 // An enum is `FromBytes` if:
 // - `repr(uN)` or `repr(iN)`
@@ -287,7 +286,7 @@ enum FooU8 {
     Variant255,
 }
 
-assert_is_from_bytes!(FooU8);
+assert_impl_all!(FooU8: FromBytes);
 
 #[derive(FromBytes)]
 #[repr(i8)]
@@ -550,7 +549,7 @@ enum FooI8 {
     Variant255,
 }
 
-assert_is_from_bytes!(FooI8);
+assert_impl_all!(FooI8: FromBytes);
 
 #[derive(FromBytes)]
 #[repr(u8, align(2))]
@@ -813,7 +812,7 @@ enum FooU8Align {
     Variant255,
 }
 
-assert_is_from_bytes!(FooU8Align);
+assert_impl_all!(FooU8Align: FromBytes);
 
 #[derive(FromBytes)]
 #[repr(i8, align(2))]
@@ -1076,7 +1075,7 @@ enum FooI8Align {
     Variant255,
 }
 
-assert_is_from_bytes!(FooI8Align);
+assert_impl_all!(FooI8Align: FromBytes);
 
 #[derive(FromBytes)]
 #[repr(u16)]
@@ -66619,7 +66618,7 @@ enum FooU16 {
     Variant65535,
 }
 
-assert_is_from_bytes!(FooU16);
+assert_impl_all!(FooU16: FromBytes);
 
 #[derive(FromBytes)]
 #[repr(i16)]
@@ -132162,4 +132161,4 @@ enum FooI16 {
     Variant65535,
 }
 
-assert_is_from_bytes!(FooI16);
+assert_impl_all!(FooI16: FromBytes);

--- a/zerocopy-derive/tests/enum_unaligned.rs
+++ b/zerocopy-derive/tests/enum_unaligned.rs
@@ -4,10 +4,7 @@
 
 #![allow(warnings)]
 
-#[macro_use]
-mod util;
-
-use zerocopy::Unaligned;
+use {static_assertions::assert_impl_all, zerocopy::Unaligned};
 
 // An enum is `Unaligned` if:
 // - No `repr(align(N > 1))`
@@ -19,7 +16,7 @@ enum Foo {
     A,
 }
 
-assert_is_unaligned!(Foo);
+assert_impl_all!(Foo: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(i8)]
@@ -27,7 +24,7 @@ enum Bar {
     A,
 }
 
-assert_is_unaligned!(Bar);
+assert_impl_all!(Bar: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(u8, align(1))]
@@ -35,7 +32,7 @@ enum Baz {
     A,
 }
 
-assert_is_unaligned!(Baz);
+assert_impl_all!(Baz: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(i8, align(1))]
@@ -43,4 +40,4 @@ enum Blah {
     B,
 }
 
-assert_is_unaligned!(Blah);
+assert_impl_all!(Blah: Unaligned);

--- a/zerocopy-derive/tests/hygiene.rs
+++ b/zerocopy-derive/tests/hygiene.rs
@@ -11,7 +11,7 @@ extern crate zerocopy as _zerocopy;
 
 use std::{marker::PhantomData, option::IntoIter};
 
-use _zerocopy::FromBytes;
+use {_zerocopy::FromBytes, static_assertions::assert_impl_all};
 
 #[derive(FromBytes)]
 struct TypeParams<'a, T, I: Iterator> {
@@ -23,8 +23,4 @@ struct TypeParams<'a, T, I: Iterator> {
     g: PhantomData<String>,
 }
 
-const _FOO: () = {
-    let _: IsFromBytes<TypeParams<'static, (), IntoIter<()>>>;
-};
-
-struct IsFromBytes<T: FromBytes>(PhantomData<T>);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);

--- a/zerocopy-derive/tests/struct_as_bytes.rs
+++ b/zerocopy-derive/tests/struct_as_bytes.rs
@@ -4,12 +4,11 @@
 
 #![allow(warnings)]
 
-#[macro_use]
 mod util;
 
 use std::{marker::PhantomData, mem::ManuallyDrop, option::IntoIter};
 
-use zerocopy::AsBytes;
+use {static_assertions::assert_impl_all, zerocopy::AsBytes};
 
 use self::util::AU16;
 
@@ -23,7 +22,7 @@ use self::util::AU16;
 #[repr(C)]
 struct CZst;
 
-assert_is_as_bytes!(CZst);
+assert_impl_all!(CZst: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C)]
@@ -33,7 +32,7 @@ struct C {
     c: AU16,
 }
 
-assert_is_as_bytes!(C);
+assert_impl_all!(C: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(transparent)]
@@ -42,7 +41,7 @@ struct Transparent {
     b: CZst,
 }
 
-assert_is_as_bytes!(Transparent);
+assert_impl_all!(Transparent: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(transparent)]
@@ -51,14 +50,14 @@ struct TransparentGeneric<T: ?Sized> {
     b: T,
 }
 
-assert_is_as_bytes!(TransparentGeneric<u64>);
-assert_is_as_bytes!(TransparentGeneric<[u64]>);
+assert_impl_all!(TransparentGeneric<u64>: AsBytes);
+assert_impl_all!(TransparentGeneric<[u64]>: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C, packed)]
 struct CZstPacked;
 
-assert_is_as_bytes!(CZstPacked);
+assert_impl_all!(CZstPacked: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C, packed)]
@@ -74,7 +73,7 @@ struct CPacked {
     b: u16,
 }
 
-assert_is_as_bytes!(CPacked);
+assert_impl_all!(CPacked: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C, packed)]
@@ -88,8 +87,8 @@ struct CPackedGeneric<T, U: ?Sized> {
     u: ManuallyDrop<U>,
 }
 
-assert_is_as_bytes!(CPackedGeneric<u8, AU16>);
-assert_is_as_bytes!(CPackedGeneric<u8, [AU16]>);
+assert_impl_all!(CPackedGeneric<u8, AU16>: AsBytes);
+assert_impl_all!(CPackedGeneric<u8, [AU16]>: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(packed)]
@@ -105,7 +104,7 @@ struct Packed {
     b: u16,
 }
 
-assert_is_as_bytes!(Packed);
+assert_impl_all!(Packed: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(packed)]
@@ -119,8 +118,8 @@ struct PackedGeneric<T, U: ?Sized> {
     u: ManuallyDrop<U>,
 }
 
-assert_is_as_bytes!(PackedGeneric<u8, AU16>);
-assert_is_as_bytes!(PackedGeneric<u8, [AU16]>);
+assert_impl_all!(PackedGeneric<u8, AU16>: AsBytes);
+assert_impl_all!(PackedGeneric<u8, [AU16]>: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(transparent)]
@@ -128,4 +127,4 @@ struct Unsized {
     a: [u8],
 }
 
-assert_is_as_bytes!(Unsized);
+assert_impl_all!(Unsized: AsBytes);

--- a/zerocopy-derive/tests/struct_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_from_bytes.rs
@@ -4,12 +4,11 @@
 
 #![allow(warnings)]
 
-#[macro_use]
 mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
 
-use zerocopy::FromBytes;
+use {static_assertions::assert_impl_all, zerocopy::FromBytes};
 
 use crate::util::AU16;
 
@@ -19,14 +18,14 @@ use crate::util::AU16;
 #[derive(FromBytes)]
 struct Zst;
 
-assert_is_from_bytes!(Zst);
+assert_impl_all!(Zst: FromBytes);
 
 #[derive(FromBytes)]
 struct One {
     a: u8,
 }
 
-assert_is_from_bytes!(One);
+assert_impl_all!(One: FromBytes);
 
 #[derive(FromBytes)]
 struct Two {
@@ -34,14 +33,14 @@ struct Two {
     b: Zst,
 }
 
-assert_is_from_bytes!(Two);
+assert_impl_all!(Two: FromBytes);
 
 #[derive(FromBytes)]
 struct Unsized {
     a: [u8],
 }
 
-assert_is_from_bytes!(Unsized);
+assert_impl_all!(Unsized: FromBytes);
 
 #[derive(FromBytes)]
 struct TypeParams<'a, T: ?Sized, I: Iterator> {
@@ -53,6 +52,6 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
     f: T,
 }
 
-assert_is_from_bytes!(TypeParams<'static, (), IntoIter<()>>);
-assert_is_from_bytes!(TypeParams<'static, AU16, IntoIter<()>>);
-assert_is_from_bytes!(TypeParams<'static, [AU16], IntoIter<()>>);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);
+assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: FromBytes);
+assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromBytes);

--- a/zerocopy-derive/tests/struct_unaligned.rs
+++ b/zerocopy-derive/tests/struct_unaligned.rs
@@ -4,12 +4,11 @@
 
 #![allow(warnings)]
 
-#[macro_use]
 mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
 
-use zerocopy::Unaligned;
+use {static_assertions::assert_impl_all, zerocopy::Unaligned};
 
 use crate::util::AU16;
 
@@ -25,7 +24,7 @@ struct Foo {
     a: u8,
 }
 
-assert_is_unaligned!(Foo);
+assert_impl_all!(Foo: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(transparent)]
@@ -33,7 +32,7 @@ struct Bar {
     a: u8,
 }
 
-assert_is_unaligned!(Bar);
+assert_impl_all!(Bar: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(packed)]
@@ -48,7 +47,7 @@ struct Baz {
     a: u16,
 }
 
-assert_is_unaligned!(Baz);
+assert_impl_all!(Baz: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(C, align(1))]
@@ -56,7 +55,7 @@ struct FooAlign {
     a: u8,
 }
 
-assert_is_unaligned!(FooAlign);
+assert_impl_all!(FooAlign: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(transparent)]
@@ -64,7 +63,7 @@ struct Unsized {
     a: [u8],
 }
 
-assert_is_unaligned!(Unsized);
+assert_impl_all!(Unsized: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(C)]
@@ -77,6 +76,6 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
     f: T,
 }
 
-assert_is_unaligned!(TypeParams<'static, (), IntoIter<()>>);
-assert_is_unaligned!(TypeParams<'static, u8, IntoIter<()>>);
-assert_is_unaligned!(TypeParams<'static, [u8], IntoIter<()>>);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: Unaligned);
+assert_impl_all!(TypeParams<'static, u8, IntoIter<()>>: Unaligned);
+assert_impl_all!(TypeParams<'static, [u8], IntoIter<()>>: Unaligned);

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,83 +1,53 @@
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-msrv/../util.rs
-   |
-   |             const _: () = is_as_bytes::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-msrv/derive_transparent.rs:31:1
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   | --------------------------------------------------- in this macro invocation
-   |
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:21:10
-   |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |          ^^^^^^^
-note: required by a bound in `is_as_bytes`
-  --> tests/ui-msrv/../util.rs
-   |
-   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
-   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
-   |
-  ::: tests/ui-msrv/derive_transparent.rs:31:1
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   | --------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-msrv/../util.rs
+  --> tests/ui-msrv/derive_transparent.rs:33:1
    |
-   |             const _: () = is_from_bytes::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-msrv/derive_transparent.rs:32:1
-   |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   | ----------------------------------------------------- in this macro invocation
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:21:19
+  --> tests/ui-msrv/derive_transparent.rs:23:19
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `is_from_bytes`
-  --> tests/ui-msrv/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-msrv/derive_transparent.rs:33:1
    |
-   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
-   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-msrv/derive_transparent.rs:34:1
    |
-  ::: tests/ui-msrv/derive_transparent.rs:32:1
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   | ----------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:23:10
+   |
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
+   |          ^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-msrv/derive_transparent.rs:34:1
+   |
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-msrv/../util.rs
+  --> tests/ui-msrv/derive_transparent.rs:35:1
    |
-   |             const _: () = is_unaligned::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-msrv/derive_transparent.rs:33:1
-   |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   | ---------------------------------------------------- in this macro invocation
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:21:30
+  --> tests/ui-msrv/derive_transparent.rs:23:30
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `is_unaligned`
-  --> tests/ui-msrv/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-msrv/derive_transparent.rs:35:1
    |
-   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
-   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
-   |
-  ::: tests/ui-msrv/derive_transparent.rs:33:1
-   |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   | ---------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -1,51 +1,8 @@
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-stable/../util.rs
-   |
-   |             const _: () = is_as_bytes::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-stable/derive_transparent.rs:31:1
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   | --------------------------------------------------- in this macro invocation
-   |
-   = help: the following other types implement trait `AsBytes`:
-             ()
-             AU16
-             F32<O>
-             F64<O>
-             I128<O>
-             I16<O>
-             I32<O>
-             I64<O>
-           and $N others
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-stable/derive_transparent.rs:21:10
-   |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |          ^^^^^^^
-note: required by a bound in `is_as_bytes`
-  --> tests/ui-stable/../util.rs
-   |
-   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
-   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
-   |
-  ::: tests/ui-stable/derive_transparent.rs:31:1
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   | --------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-stable/../util.rs
+  --> tests/ui-stable/derive_transparent.rs:33:1
    |
-   |             const _: () = is_from_bytes::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-stable/derive_transparent.rs:32:1
-   |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   | ----------------------------------------------------- in this macro invocation
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
              ()
@@ -58,32 +15,50 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I64<O>
            and $N others
 note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-stable/derive_transparent.rs:21:19
+  --> tests/ui-stable/derive_transparent.rs:23:19
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `is_from_bytes`
-  --> tests/ui-stable/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-stable/derive_transparent.rs:33:1
    |
-   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
-   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-stable/derive_transparent.rs:34:1
    |
-  ::: tests/ui-stable/derive_transparent.rs:32:1
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   | ----------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-stable/derive_transparent.rs:23:10
+   |
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
+   |          ^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-stable/derive_transparent.rs:34:1
+   |
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-stable/../util.rs
+  --> tests/ui-stable/derive_transparent.rs:35:1
    |
-   |             const _: () = is_unaligned::<$ty>();
-   |                           ^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
-   |
-  ::: tests/ui-stable/derive_transparent.rs:33:1
-   |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   | ---------------------------------------------------- in this macro invocation
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
              ()
@@ -96,18 +71,13 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              ManuallyDrop<T>
            and $N others
 note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-stable/derive_transparent.rs:21:30
+  --> tests/ui-stable/derive_transparent.rs:23:30
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `is_unaligned`
-  --> tests/ui-stable/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-stable/derive_transparent.rs:35:1
    |
-   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
-   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
-   |
-  ::: tests/ui-stable/derive_transparent.rs:33:1
-   |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   | ---------------------------------------------------- in this macro invocation
-   = note: this error originates in the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui/derive_transparent.rs
@@ -5,12 +5,14 @@
 extern crate zerocopy;
 
 #[path = "../util.rs"]
-#[macro_use]
 mod util;
 
 use core::marker::PhantomData;
 
-use zerocopy::{AsBytes, FromBytes, Unaligned};
+use {
+    static_assertions::assert_impl_all,
+    zerocopy::{AsBytes, FromBytes, Unaligned},
+};
 
 use self::util::NotZerocopy;
 
@@ -28,6 +30,6 @@ struct TransparentStruct<T> {
 // It should be legal to derive these traits on a transparent struct, but it
 // must also ensure the traits are only implemented when the inner type
 // implements them.
-assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-assert_is_unaligned!(TransparentStruct<NotZerocopy>);
+assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);

--- a/zerocopy-derive/tests/ui/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui/derive_transparent.stderr
@@ -1,41 +1,8 @@
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui/derive_transparent.rs:31:21
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
-   |
-   = help: the following other types implement trait `AsBytes`:
-             ()
-             AU16
-             F32<O>
-             F64<O>
-             I128<O>
-             I16<O>
-             I32<O>
-             I64<O>
-           and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
-  --> tests/ui/derive_transparent.rs:21:10
-   |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |          ^^^^^^^
-note: required by a bound in `is_as_bytes`
-  --> tests/ui/../util.rs
-   |
-   |             const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
-   |                                     ^^^^^^^^^^^^^^^^^ required by this bound in `is_as_bytes`
-   |
-  ::: tests/ui/derive_transparent.rs:31:1
-   |
-31 | assert_is_as_bytes!(TransparentStruct<NotZerocopy>);
-   | --------------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_is_as_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui/derive_transparent.rs:32:23
+  --> tests/ui/derive_transparent.rs:33:18
    |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
              ()
@@ -48,27 +15,50 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I64<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui/derive_transparent.rs:21:19
+  --> tests/ui/derive_transparent.rs:23:19
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^
-note: required by a bound in `is_from_bytes`
-  --> tests/ui/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui/derive_transparent.rs:33:1
    |
-   |             const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
-   |                                       ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_from_bytes`
+33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui/derive_transparent.rs:34:18
    |
-  ::: tests/ui/derive_transparent.rs:32:1
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-32 | assert_is_from_bytes!(TransparentStruct<NotZerocopy>);
-   | ----------------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_is_from_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
+  --> tests/ui/derive_transparent.rs:23:10
+   |
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
+   |          ^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui/derive_transparent.rs:34:1
+   |
+34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui/derive_transparent.rs:33:22
+  --> tests/ui/derive_transparent.rs:35:18
    |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
              ()
@@ -81,18 +71,13 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              ManuallyDrop<T>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui/derive_transparent.rs:21:30
+  --> tests/ui/derive_transparent.rs:23:30
    |
-21 | #[derive(AsBytes, FromBytes, Unaligned)]
+23 | #[derive(AsBytes, FromBytes, Unaligned)]
    |                              ^^^^^^^^^
-note: required by a bound in `is_unaligned`
-  --> tests/ui/../util.rs
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui/derive_transparent.rs:35:1
    |
-   |             const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
-   |                                      ^^^^^^^^^^^^^^^^^^^ required by this bound in `is_unaligned`
-   |
-  ::: tests/ui/derive_transparent.rs:33:1
-   |
-33 | assert_is_unaligned!(TransparentStruct<NotZerocopy>);
-   | ---------------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_is_unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/union_as_bytes.rs
+++ b/zerocopy-derive/tests/union_as_bytes.rs
@@ -4,11 +4,9 @@
 
 #![allow(warnings)]
 
-#[macro_use]
-mod util;
-
 use std::{marker::PhantomData, option::IntoIter};
-use zerocopy::AsBytes;
+
+use {static_assertions::assert_impl_all, zerocopy::AsBytes};
 
 // A union is `AsBytes` if:
 // - all fields are `AsBytes`
@@ -22,7 +20,7 @@ union CZst {
     a: (),
 }
 
-assert_is_as_bytes!(CZst);
+assert_impl_all!(CZst: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C)]
@@ -31,7 +29,7 @@ union C {
     b: u8,
 }
 
-assert_is_as_bytes!(C);
+assert_impl_all!(C: AsBytes);
 
 // Transparent unions are unstable; see issue #60405
 // <https://github.com/rust-lang/rust/issues/60405> for more information.
@@ -51,7 +49,7 @@ union CZstPacked {
     a: (),
 }
 
-assert_is_as_bytes!(CZstPacked);
+assert_impl_all!(CZstPacked: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C, packed)]
@@ -60,7 +58,7 @@ union CPacked {
     b: i8,
 }
 
-assert_is_as_bytes!(CPacked);
+assert_impl_all!(CPacked: AsBytes);
 
 #[derive(AsBytes)]
 #[repr(C, packed)]
@@ -70,4 +68,4 @@ union CMultibytePacked {
     c: f32,
 }
 
-assert_is_as_bytes!(CMultibytePacked);
+assert_impl_all!(CMultibytePacked: AsBytes);

--- a/zerocopy-derive/tests/union_from_bytes.rs
+++ b/zerocopy-derive/tests/union_from_bytes.rs
@@ -4,11 +4,9 @@
 
 #![allow(warnings)]
 
-#[macro_use]
-mod util;
-
 use std::{marker::PhantomData, option::IntoIter};
-use zerocopy::FromBytes;
+
+use {static_assertions::assert_impl_all, zerocopy::FromBytes};
 
 // A union is `FromBytes` if:
 // - all fields are `FromBytes`
@@ -18,14 +16,14 @@ union Zst {
     a: (),
 }
 
-assert_is_from_bytes!(Zst);
+assert_impl_all!(Zst: FromBytes);
 
 #[derive(FromBytes)]
 union One {
     a: u8,
 }
 
-assert_is_from_bytes!(One);
+assert_impl_all!(One: FromBytes);
 
 #[derive(FromBytes)]
 union Two {
@@ -33,7 +31,7 @@ union Two {
     b: Zst,
 }
 
-assert_is_from_bytes!(Two);
+assert_impl_all!(Two: FromBytes);
 
 #[derive(FromBytes)]
 union TypeParams<'a, T: Copy, I: Iterator>
@@ -48,4 +46,4 @@ where
     g: PhantomData<String>,
 }
 
-assert_is_from_bytes!(TypeParams<'static, (), IntoIter<()>>);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);

--- a/zerocopy-derive/tests/union_unaligned.rs
+++ b/zerocopy-derive/tests/union_unaligned.rs
@@ -4,11 +4,9 @@
 
 #![allow(warnings)]
 
-#[macro_use]
-mod util;
-
 use std::{marker::PhantomData, option::IntoIter};
-use zerocopy::Unaligned;
+
+use {static_assertions::assert_impl_all, zerocopy::Unaligned};
 
 // A union is `Unaligned` if:
 // - `repr(align)` is no more than 1 and either
@@ -22,7 +20,7 @@ union Foo {
     a: u8,
 }
 
-assert_is_unaligned!(Foo);
+assert_impl_all!(Foo: Unaligned);
 
 // Transparent unions are unstable; see issue #60405
 // <https://github.com/rust-lang/rust/issues/60405> for more information.
@@ -48,7 +46,7 @@ union Baz {
     a: u16,
 }
 
-assert_is_unaligned!(Baz);
+assert_impl_all!(Baz: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(C, align(1))]
@@ -56,7 +54,7 @@ union FooAlign {
     a: u8,
 }
 
-assert_is_unaligned!(FooAlign);
+assert_impl_all!(FooAlign: Unaligned);
 
 #[derive(Unaligned)]
 #[repr(C)]
@@ -72,4 +70,4 @@ where
     g: PhantomData<String>,
 }
 
-assert_is_unaligned!(TypeParams<'static, (), IntoIter<()>>);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: Unaligned);

--- a/zerocopy-derive/tests/util.rs
+++ b/zerocopy-derive/tests/util.rs
@@ -14,33 +14,3 @@ pub struct NotZerocopy(());
 #[derive(FromBytes, AsBytes, Copy, Clone)]
 #[repr(C, align(2))]
 pub struct AU16(u16);
-
-#[allow(unused_macros)]
-macro_rules! assert_is_as_bytes {
-    ($ty:ty) => {
-        const _: () = {
-            const fn is_as_bytes<T: zerocopy::AsBytes + ?Sized>() {}
-            const _: () = is_as_bytes::<$ty>();
-        };
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! assert_is_from_bytes {
-    ($ty:ty) => {
-        const _: () = {
-            const fn is_from_bytes<T: zerocopy::FromBytes + ?Sized>() {}
-            const _: () = is_from_bytes::<$ty>();
-        };
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! assert_is_unaligned {
-    ($ty:ty) => {
-        const _: () = {
-            const fn is_unaligned<T: zerocopy::Unaligned + ?Sized>() {}
-            const _: () = is_unaligned::<$ty>();
-        };
-    };
-}


### PR DESCRIPTION
Use the `static_assertions` crate's `assert_impl_all!` and `assert_not_impl_any!` macros instead of our own hand-rolled code.

This also fixes a (previously unknown) bug in
`test_impls::assert_impls!` in which a missing `?Sized` bound made it so that negative impl tests would do nothing for unsized types.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
