### PR TITLE
Add `fn main` to UI test files

### DIFF
--- a/tests/ui-msrv/transmute-illegal.stderr
+++ b/tests/ui-msrv/transmute-illegal.stderr
@@ -1,24 +1,18 @@
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui-msrv/transmute-illegal.rs:8:76
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui-msrv/transmute-illegal.rs`
-
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
- --> tests/ui-msrv/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
-  |
-  = help: the following implementations were found:
-            <usize as AsBytes>
-            <f32 as AsBytes>
-            <f64 as AsBytes>
-            <i128 as AsBytes>
-          and 10 others
+  --> tests/ui-msrv/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |
+   = help: the following implementations were found:
+             <usize as AsBytes>
+             <f32 as AsBytes>
+             <f64 as AsBytes>
+             <i128 as AsBytes>
+           and $N others
 note: required by a bound in `POINTER_VALUE::transmute`
- --> tests/ui-msrv/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
-  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/ui-msrv/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-illegal.stderr
+++ b/tests/ui-stable/transmute-illegal.stderr
@@ -1,28 +1,22 @@
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui-stable/transmute-illegal.rs:8:76
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui-stable/transmute-illegal.rs`
-
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
- --> tests/ui-stable/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
-  |
-  = help: the following other types implement trait `AsBytes`:
-            f32
-            f64
-            i128
-            i16
-            i32
-            i64
-            i8
-            isize
-          and 6 others
+  --> tests/ui-stable/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             f32
+             f64
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+           and $N others
 note: required by a bound in `POINTER_VALUE::transmute`
- --> tests/ui-stable/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
-  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/ui-stable/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/transmute-illegal.rs
+++ b/tests/ui/transmute-illegal.rs
@@ -4,5 +4,7 @@
 
 extern crate zerocopy;
 
+fn main() {}
+
 // It is unsound to inspect the usize value of a pointer during const eval.
 const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);

--- a/tests/ui/transmute-illegal.stderr
+++ b/tests/ui/transmute-illegal.stderr
@@ -1,31 +1,25 @@
-error[E0601]: `main` function not found in crate `$CRATE`
- --> tests/ui/transmute-illegal.rs:8:76
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                                                                            ^ consider adding a `main` function to `$DIR/tests/ui/transmute-illegal.rs`
-
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
- --> tests/ui/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                              |
-  |                              the trait `AsBytes` is not implemented for `*const usize`
-  |                              required by a bound introduced by this call
-  |
-  = help: the following other types implement trait `AsBytes`:
-            f32
-            f64
-            i128
-            i16
-            i32
-            i64
-            i8
-            isize
-          and 6 others
+  --> tests/ui/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              the trait `AsBytes` is not implemented for `*const usize`
+   |                              required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             f32
+             f64
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+           and $N others
 note: required by a bound in `POINTER_VALUE::transmute`
- --> tests/ui/transmute-illegal.rs:8:30
-  |
-8 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
-  = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/ui/transmute-illegal.rs:10:30
+   |
+10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This removes one source of errors which clutters the `.stderr` files and is a source of noise when the compiler's error output changes.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
