### PR TITLE
Put the byteorder module behind a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         # versions.
         toolchain: [ "msrv", "stable", "nightly" ]
         target: [ "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "wasm32-wasi" ]
-        features: [ "" , "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]
+        features: [ "--no-default-features", "" , "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]
         crate: [ "zerocopy", "zerocopy-derive" ]
         exclude:
           # Exclude any combination which uses a non-nightly toolchain but
@@ -35,6 +35,8 @@ jobs:
             features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
+          - crate: "zerocopy-derive"
+            features: "--no-default-features"
           - crate: "zerocopy-derive"
             features: "--features __internal_use_only_features_that_work_on_stable"
           - crate: "zerocopy-derive"
@@ -158,7 +160,7 @@ jobs:
       # scope without the `alloc` feature. This isn't a big deal because we care
       # primarily about `cargo doc` working for `docs.rs`, which enables the
       # `alloc` feature.
-      if: ${{ matrix.features != '' }}
+      if: ${{ matrix.features != '' && matrix.features != '--no-default-features' }}
 
   check_fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha.3"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause"
@@ -29,6 +29,8 @@ pinned-stable = "1.65.0"
 pinned-nightly = "nightly-2022-11-04"
 
 [features]
+default = ["byteorder"]
+
 alloc = []
 simd = []
 simd-nightly = ["simd"]
@@ -38,11 +40,12 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.0-alpha.2", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.0-alpha.3", path = "zerocopy-derive" }
 
 [dependencies.byteorder]
 version = "1.3"
 default-features = false
+optional = true
 
 [dev-dependencies]
 rand = "0.6"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ types, see the `byteorder` module.
 enabled, the `alloc` crate is added as a dependency, and some
 allocation-related functionality is added.
 
+`byteorder` (enabled by default): Adds the `byteorder` module and a
+dependency on the `byteorder` crate. The `byteorder` module provides byte
+order-aware equivalents of the multi-byte primitive numerical types. Unlike
+their primitive equivalents, the types in this module have no alignment
+requirement and support byte order conversions. This can be useful in
+handling file formats, network packet layouts, etc which don't provide
+alignment guarantees and which may use a byte order different from that of
+the execution platform.
+
 `simd`: When the `simd` feature is enabled, `FromZeroes`, `FromBytes`, and
 `AsBytes` impls are emitted for all stable SIMD types which exist on the
 target platform. Note that the layout of SIMD types is not yet stabilized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,15 @@
 //! enabled, the `alloc` crate is added as a dependency, and some
 //! allocation-related functionality is added.
 //!
+//! `byteorder` (enabled by default): Adds the [`byteorder`] module and a
+//! dependency on the `byteorder` crate. The `byteorder` module provides byte
+//! order-aware equivalents of the multi-byte primitive numerical types. Unlike
+//! their primitive equivalents, the types in this module have no alignment
+//! requirement and support byte order conversions. This can be useful in
+//! handling file formats, network packet layouts, etc which don't provide
+//! alignment guarantees and which may use a byte order different from that of
+//! the execution platform.
+//!
 //! `simd`: When the `simd` feature is enabled, `FromZeroes`, `FromBytes`, and
 //! `AsBytes` impls are emitted for all stable SIMD types which exist on the
 //! target platform. Note that the layout of SIMD types is not yet stabilized,
@@ -123,10 +132,12 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "simd-nightly", feature(stdsimd))]
 
+#[cfg(feature = "byteorder")]
 pub mod byteorder;
 #[doc(hidden)]
 pub mod derive_util;
 
+#[cfg(feature = "byteorder")]
 pub use crate::byteorder::*;
 pub use zerocopy_derive::*;
 
@@ -2939,7 +2950,7 @@ pub use alloc_support::*;
 mod tests {
     #![allow(clippy::unreadable_literal)]
 
-    use core::{convert::TryInto, ops::Deref};
+    use core::ops::Deref;
 
     use static_assertions::assert_impl_all;
 
@@ -3003,7 +3014,7 @@ mod tests {
 
     // Converts an `AU64` to bytes using this platform's endianness.
     fn au64_to_bytes(u: AU64) -> [u8; 8] {
-        U64::<NativeEndian>::new(u.0).as_bytes().try_into().unwrap()
+        transmute!(u)
     }
 
     // An unsized type.

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha.3"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license-file = "../LICENSE"


### PR DESCRIPTION
The feature is on by default, but allows consumers to avoid the dependency on the `byteorder` crate if they wish.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
