### PR TITLE
Disable incremental compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly


### PR DESCRIPTION
> compiling a crate for the first time in incremental mode can be slower than compiling it in non-incremental mode

This should speed up your CI runs by a 1-2 minutes :)