### PR TITLE
Make zerocopy-derive an optional dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         # versions.
         toolchain: [ "msrv", "stable", "nightly" ]
         target: [ "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "arm-unknown-linux-gnueabi", "aarch64-unknown-linux-gnu", "powerpc-unknown-linux-gnu", "powerpc64-unknown-linux-gnu", "wasm32-wasi" ]
-        features: [ "--no-default-features", "" , "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]
+        features: [ "--no-default-features", "", "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]
         crate: [ "zerocopy", "zerocopy-derive" ]
         exclude:
           # Exclude any combination which uses a non-nightly toolchain but
@@ -166,6 +166,20 @@ jobs:
       # TODO(#22): Re-enable testing on wasm32-wasi once it works.
       if: matrix.toolchain == 'nightly' && matrix.target != 'wasm32-wasi'
 
+    - name: Run doc tests
+      # We explicitly pass `--doc` here because doc tests are disabled by
+      # default in zerocopy's `Cargo.toml`. This is because some doc examples
+      # make use of derives, and so would fail without the `derive` feature
+      # enabled. We skip this step for `zerocopy` when the `derive` feature is
+      # omitted for that reason.
+      run: cargo +${{ env.ZC_TOOLCHAIN }} test --doc --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      # Only run tests when targetting x86 (32- or 64-bit) - we're executing on
+      # x86_64, so we can't run tests for any non-x86 target.
+      #
+      # TODO(https://github.com/dtolnay/trybuild/issues/184#issuecomment-1269097742):
+      # Run compile tests when building for other targets.
+      if: ${{ (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686')) && !(matrix.crate == 'zerocopy' && !contains(matrix.features, 'derive')) }}
+
     - name: Clippy check
       run: cargo +${{ env.ZC_TOOLCHAIN }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --tests --verbose
 
@@ -255,8 +269,14 @@ jobs:
           ver_zerocopy=$(version zerocopy)
           ver_zerocopy_derive=$(version zerocopy-derive)
 
+          # The non-dev dependency version (`.kind == null` filters out the dev
+          # dependency).
           zerocopy_derive_dep_ver=$(cargo metadata --format-version 1 \
-            | jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select(.name == \"zerocopy-derive\").req")
+            | jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select((.name == \"zerocopy-derive\") and .kind == null).req")
+          # The dev dependency version (`.kind == \"dev\"` selects only the dev
+          # dependency).
+          zerocopy_derive_dev_dep_ver=$(cargo metadata --format-version 1 \
+            | jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select((.name == \"zerocopy-derive\") and .kind == \"dev\").req")
 
           if [[ "$ver_zerocopy" == "$ver_zerocopy_derive" ]]; then
             echo "Same crate version ($ver_zerocopy) found for zerocopy and zerocopy-derive." | tee -a $GITHUB_STEP_SUMMARY
@@ -271,6 +291,14 @@ jobs:
             echo "zerocopy depends upon same version of zerocopy-derive in-tree ($zerocopy_derive_dep_ver)." | tee -a $GITHUB_STEP_SUMMARY
           else
             echo "zerocopy depends upon different version of zerocopy-derive ($zerocopy_derive_dep_ver) than the one in-tree ($ver_zerocopy_derive)." \
+              | tee -a $GITHUB_STEP_SUMMARY >&2
+            exit 1
+          fi
+
+          if [[ "=$ver_zerocopy_derive" == "$zerocopy_derive_dev_dep_ver" ]]; then
+            echo "In dev mode, zerocopy depends upon same version of zerocopy-derive in-tree ($zerocopy_derive_dev_dep_ver)." | tee -a $GITHUB_STEP_SUMMARY
+          else
+            echo "In dev mode, zerocopy depends upon different version of zerocopy-derive ($zerocopy_derive_dev_dep_ver) than the one in-tree ($ver_zerocopy_derive)." \
               | tee -a $GITHUB_STEP_SUMMARY >&2
             exit 1
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,24 @@ all-features = true
 pinned-stable = "1.69.0"
 pinned-nightly = "nightly-2023-05-25"
 
+# Don't run doctests during `cargo test` without the `--doc` flag (the `--doc`
+# flag will still cause doctests to run despite this directive). Running
+# doctests without the `derive` feature fails because our doc examples make use
+# of zerocopy-derive, which is an optional dependency and is disabled by
+# default. Unfortunately, there's no way to automatically include
+# zerocopy-derive as a dependency during doctests, so we have to do it manually
+# by passing the appropriate flags in CI.
+[lib]
+doctest = false
+# Not technically necessary - this is the default value for `path` - but if a
+# `lib` section is present, then `cargo readme` expects it to have a `path`
+# field, and will fail if it's missing.
+path = "src/lib.rs"
+
 [features]
 default = ["byteorder"]
 
+derive = ["zerocopy-derive"]
 alloc = []
 simd = []
 simd-nightly = ["simd"]
@@ -40,7 +55,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.0-alpha.5", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.0-alpha.5", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -56,3 +71,5 @@ static_assertions = "1.1"
 # sometimes change the output format slightly, so a version mismatch can cause
 # CI test failures.
 trybuild = "=1.0.80"
+# In tests, unlike in production, zerocopy-derive is not optional
+zerocopy-derive = { version = "=0.7.0-alpha.5", path = "zerocopy-derive" }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ handling file formats, network packet layouts, etc which don't provide
 alignment guarantees and which may use a byte order different from that of
 the execution platform.
 
+`derive`: Provides derives for the core marker traits via the
+`zerocopy-derive` crate. These derives are re-exported from `zerocopy`, so
+it is not necessary to depend on `zerocopy-derive` directly.
+
 `simd`: When the `simd` feature is enabled, `FromZeroes`, `FromBytes`, and
 `AsBytes` impls are emitted for all stable SIMD types which exist on the
 target platform. Note that the layout of SIMD types is not yet stabilized,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Documents multiple unsafe blocks with a single safety comment.
+///
+/// Invoked as:
+///
+/// ```rust,ignore
+/// safety_comment! {
+///     // Non-doc comments come first.
+///     /// SAFETY:
+///     /// Safety comment starts on its own line.
+///     macro_1!(args);
+///     macro_2! { args };
+/// }
+/// ```
+///
+/// The macro invocations are emitted, each decorated with the following
+/// attribute: `#[allow(clippy::undocumented_unsafe_blocks)]`.
+macro_rules! safety_comment {
+    (#[doc = r" SAFETY:"] $(#[doc = $_doc:literal])* $($macro:ident!$args:tt;)*) => {
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        const _: () = { $($macro!$args;)* };
+    }
+}
+
+/// Unsafely implements trait(s) for a type.
+macro_rules! unsafe_impl {
+    // Implement `$trait` for `$ty` with no bounds.
+    ($ty:ty: $trait:ty) => {
+        unsafe impl $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    };
+    // Implement all `$traits` for `$ty` with no bounds.
+    ($ty:ty: $($traits:ty),*) => {
+        $( unsafe_impl!($ty: $traits); )*
+    };
+    // For all `$tyvar` with no bounds, implement `$trait` for `$ty`.
+    ($tyvar:ident => $trait:ident for $ty:ty) => {
+        unsafe impl<$tyvar> $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    };
+    // For all `$tyvar: ?Sized` with no bounds, implement `$trait` for `$ty`.
+    ($tyvar:ident: ?Sized => $trait:ident for $ty:ty) => {
+        unsafe impl<$tyvar: ?Sized> $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    };
+    // For all `$tyvar: $bound`, implement `$trait` for `$ty`.
+    ($tyvar:ident: $bound:path => $trait:ident for $ty:ty) => {
+        unsafe impl<$tyvar: $bound> $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    };
+    // For all `$tyvar: $bound + ?Sized`, implement `$trait` for `$ty`.
+    ($tyvar:ident: ?Sized + $bound:path => $trait:ident for $ty:ty) => {
+        unsafe impl<$tyvar: ?Sized + $bound> $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    };
+    // For all `$tyvar: $bound` and for all `const $constvar: $constty`,
+    // implement `$trait` for `$ty`.
+    ($tyvar:ident: $bound:path, const $constvar:ident: $constty:ty => $trait:ident for $ty:ty) => {
+        unsafe impl<$tyvar: $bound, const $constvar: $constty> $trait for $ty {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+        }
+    };
+}
+
+/// Implements trait(s) for a type or verifies the given implementation by
+/// referencing an existing (derived) implementation.
+///
+/// This macro exists so that we can provide zerocopy-derive as an optional
+/// dependency and still get the benefit of using its derives to validate that
+/// our trait impls are sound.
+///
+/// When compiling without `--cfg 'feature = "derive"` and without `--cfg test`,
+/// `impl_or_verify!` emits the provided trait impl. When compiling with either
+/// of those cfgs, it is expected that the type in question is deriving the
+/// traits instead. In this case, `impl_or_verify!` emits code which validates
+/// that the given trait impl is at least as restrictive as the the impl emitted
+/// by the custom derive. This has the effect of confirming that the impl which
+/// is emitted when the `derive` feature is disabled is actually sound (on the
+/// assumption that the impl emitted by the custom derive is sound).
+///
+/// The caller is still required to provide a safety comment (e.g. using the
+/// `safety_comment!` macro) . The reason for this restriction is that, while
+/// `impl_or_verify!` can guarantee that the provided impl is sound when it is
+/// compiled with the appropriate cfgs, there is no way to guarantee that it is
+/// ever compiled with those cfgs. In particular, it would be possible to
+/// accidentally place an `impl_or_verify!` call in a context that is only ever
+/// compiled when the `derive` feature is disabled. If that were to happen,
+/// there would be nothing to prevent an unsound trait impl from being emitted.
+/// Requiring a safety comment reduces the likelihood of emitting an unsound
+/// impl in this case, and also provides useful documentation for readers of the
+/// code.
+///
+/// ## Example
+///
+/// ```rust,ignore
+/// // Note that these derives are gated by `feature = "derive"`
+/// #[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+/// #[repr(transparent)]
+/// struct Wrapper<T>(T);
+///
+/// safety_comment! {
+///     /// SAFETY:
+///     /// `Wrapper<T>` is `repr(transparent)`, so it is sound to implement any
+///     /// zerocopy trait if `T` implements that trait.
+///     impl_or_verify!(T: FromZeroes => FromZeroes for Wrapper<T>);
+///     impl_or_verify!(T: FromBytes => FromBytes for Wrapper<T>);
+///     impl_or_verify!(T: AsBytes => AsBytes for Wrapper<T>);
+///     impl_or_verify!(T: Unaligned => Unaligned for Wrapper<T>);
+/// }
+/// ```
+macro_rules! impl_or_verify {
+    // Implement `$trait` for `$ty` with no bounds.
+    ($ty:ty: $trait:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($ty: $trait); });
+        impl_or_verify!(@verify $trait, { impl Subtrait for $ty {} });
+    };
+    // Implement all `$traits` for `$ty` with no bounds.
+    ($ty:ty: $($traits:ty),*) => {
+        $( foobar!($ty: $traits); )*
+    };
+    // For all `$tyvar` with no bounds, implement `$trait` for `$ty`.
+    ($tyvar:ident => $trait:ident for $ty:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($tyvar => $trait for $ty); });
+        impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
+    };
+    // For all `$tyvar: ?Sized` with no bounds, implement `$trait` for `$ty`.
+    ($tyvar:ident: ?Sized => $trait:ident for $ty:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($tyvar: ?Sized => $trait for $ty); });
+        impl_or_verify!(@verify $trait, { impl<$tyvar: ?Sized> Subtrait for $ty {} });
+    };
+    // For all `$tyvar: $bound`, implement `$trait` for `$ty`.
+    ($tyvar:ident: $bound:path => $trait:ident for $ty:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($tyvar: $bound => $trait for $ty); });
+        impl_or_verify!(@verify $trait, { impl<$tyvar: $bound> Subtrait for $ty {} });
+    };
+    // For all `$tyvar: $bound + ?Sized`, implement `$trait` for `$ty`.
+    ($tyvar:ident: ?Sized + $bound:path => $trait:ident for $ty:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($tyvar: ?Sized + $bound => $trait for $ty); });
+        impl_or_verify!(@verify $trait, { impl<$tyvar: ?Sized + $bound> Subtrait for $ty {} });
+    };
+    // For all `$tyvar: $bound` and for all `const $constvar: $constty`,
+    // implement `$trait` for `$ty`.
+    ($tyvar:ident: $bound:path, const $constvar:ident: $constty:ty => $trait:ident for $ty:ty) => {
+        impl_or_verify!(@impl { unsafe_impl!($tyvar: $bound, const $constvar: $constty => $trait for $ty); });
+        impl_or_verify!(@verify $trait, { impl<$tyvar: $bound, const $constvar: $constty> Subtrait for $ty {} });
+    };
+    (@impl $impl_block:tt) => {
+        #[cfg(not(any(feature = "derive", test)))]
+        const _: () = { $impl_block };
+    };
+    (@verify $trait:ident, $impl_block:tt) => {
+        #[cfg(any(feature = "derive", test))]
+        const _: () = {
+            trait Subtrait: $trait {}
+            $impl_block
+        };
+    };
+}
+
+/// Uses `align_of` to confirm that a type or set of types have alignment 1.
+///
+/// Note that `align_of<T>` requires `T: Sized`, so this macro doesn't work for
+/// unsized types.
+macro_rules! assert_unaligned {
+    ($ty:ty) => {
+        // We only compile this assertion under `cfg(test)` to avoid taking an
+        // extra non-dev dependency (and making this crate more expensive to
+        // compile for our dependents).
+        #[cfg(test)]
+        static_assertions::const_assert_eq!(core::mem::align_of::<$ty>(), 1);
+    };
+    ($($ty:ty),*) => {
+        $(assert_unaligned!($ty);)*
+    };
+}

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -16,14 +16,28 @@
 //   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
 
 #[rustversion::nightly]
-const SOURCE_FILES_GLOB: &str = "tests/ui-nightly/*.rs";
+const SOURCE_FILES_DIR: &str = "tests/ui-nightly";
 #[rustversion::stable(1.69.0)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
+const SOURCE_FILES_DIR: &str = "tests/ui-stable";
 #[rustversion::stable(1.61.0)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
+const SOURCE_FILES_DIR: &str = "tests/ui-msrv";
 
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();
-    t.compile_fail(SOURCE_FILES_GLOB);
+    t.compile_fail(format!("{SOURCE_FILES_DIR}/*.rs"));
+}
+
+// The file `invalid-impls.rs` directly includes `src/macros.rs` in order to
+// test the `impl_or_verify!` macro which is defined in that file. Specifically,
+// it tests the verification portion of that macro, which is enabled when
+// `cfg(any(feature = "derive", test))`. While `--cfg test` is of course passed
+// to the code in the file you're reading right now, `trybuild` does not pass
+// `--cfg test` when it invokes Cargo. As a result, this `trybuild` test only
+// tests the correct behavior when the "derive" feature is enabled.
+#[cfg(feature = "derive")]
+#[test]
+fn ui_invalid_impls() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail(format!("{SOURCE_FILES_DIR}/invalid-impls/*.rs"));
 }

--- a/tests/ui-msrv/invalid-impls/invalid-impls.rs
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.rs
@@ -1,0 +1,1 @@
+../../ui-nightly/invalid-impls/invalid-impls.rs

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -1,0 +1,131 @@
+error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
+   |                                                        ^^^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:22:1
+   |
+22 | impl_or_verify!(T => FromZeroes for Foo<T>);
+   | ------------------------------------------- in this macro invocation
+   |
+note: required for `Foo<T>` to implement `zerocopy::FromZeroes`
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:10
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |          ^^^^^^^^^^
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `_::Subtrait`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:22:1
+   |
+22 | impl_or_verify!(T => FromZeroes for Foo<T>);
+   | ------------------------------------------- in this macro invocation
+   = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
+    |
+    | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
+    |                  ++++++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
+   |                                                        ^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:23:1
+   |
+23 | impl_or_verify!(T => FromBytes for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   |
+note: required for `Foo<T>` to implement `zerocopy::FromBytes`
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:22
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                      ^^^^^^^^^
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `_::Subtrait`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:23:1
+   |
+23 | impl_or_verify!(T => FromBytes for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
+    |
+    | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+    |                  +++++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
+   |                                                        ^^^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:24:1
+   |
+24 | impl_or_verify!(T => AsBytes for Foo<T>);
+   | ---------------------------------------- in this macro invocation
+   |
+note: required for `Foo<T>` to implement `zerocopy::AsBytes`
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:33
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                                 ^^^^^^^
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `_::Subtrait`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:24:1
+   |
+24 | impl_or_verify!(T => AsBytes for Foo<T>);
+   | ---------------------------------------- in this macro invocation
+   = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
+    |
+    | impl_or_verify!(T: zerocopy::AsBytes => AsBytes for Foo<T>);
+    |                  +++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
+   |                                                        ^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:25:1
+   |
+25 | impl_or_verify!(T => Unaligned for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   |
+note: required for `Foo<T>` to implement `zerocopy::Unaligned`
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:42
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                                          ^^^^^^^^^
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `_::Subtrait`
+   |
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:25:1
+   |
+25 | impl_or_verify!(T => Unaligned for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
+    |
+    | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+    |                  +++++++++++++++++++++

--- a/tests/ui-nightly/invalid-impls/invalid-impls.rs
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.rs
@@ -1,0 +1,25 @@
+// Copyright 2022 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Since some macros from `macros.rs` are unused.
+#![allow(unused)]
+
+extern crate zerocopy;
+extern crate zerocopy_derive;
+
+include!("../../../src/macros.rs");
+
+use zerocopy::*;
+use zerocopy_derive::*;
+
+fn main() {}
+
+#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[repr(transparent)]
+struct Foo<T>(T);
+
+impl_or_verify!(T => FromZeroes for Foo<T>);
+impl_or_verify!(T => FromBytes for Foo<T>);
+impl_or_verify!(T => AsBytes for Foo<T>);
+impl_or_verify!(T => Unaligned for Foo<T>);

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -1,0 +1,107 @@
+error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:37
+   |
+22 | impl_or_verify!(T => FromZeroes for Foo<T>);
+   |                                     ^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+   |
+note: required for `Foo<T>` to implement `zerocopy::FromZeroes`
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:18:10
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |          ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `Subtrait`
+   |
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:22:1
+   |
+22 | impl_or_verify!(T => FromZeroes for Foo<T>);
+   | ------------------------------------------- in this macro invocation
+   = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+    |
+22  | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
+    |                  ++++++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:23:36
+   |
+23 | impl_or_verify!(T => FromBytes for Foo<T>);
+   |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+   |
+note: required for `Foo<T>` to implement `zerocopy::FromBytes`
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:18:22
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                      ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `Subtrait`
+   |
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:23:1
+   |
+23 | impl_or_verify!(T => FromBytes for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+    |
+23  | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+    |                  +++++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:24:34
+   |
+24 | impl_or_verify!(T => AsBytes for Foo<T>);
+   |                                  ^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
+   |
+note: required for `Foo<T>` to implement `zerocopy::AsBytes`
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:18:33
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                                 ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `Subtrait`
+   |
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:24:1
+   |
+24 | impl_or_verify!(T => AsBytes for Foo<T>);
+   | ---------------------------------------- in this macro invocation
+   = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+    |
+24  | impl_or_verify!(T: zerocopy::AsBytes => AsBytes for Foo<T>);
+    |                  +++++++++++++++++++
+
+error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:25:36
+   |
+25 | impl_or_verify!(T => Unaligned for Foo<T>);
+   |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+   |
+note: required for `Foo<T>` to implement `zerocopy::Unaligned`
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:18:42
+   |
+18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+   |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::Subtrait`
+  --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
+   |
+   |             trait Subtrait: $trait {}
+   |                             ^^^^^^ required by this bound in `Subtrait`
+   |
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:25:1
+   |
+25 | impl_or_verify!(T => Unaligned for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+    |
+25  | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+    |                  +++++++++++++++++++++

--- a/tests/ui-stable/invalid-impls/invalid-impls.rs
+++ b/tests/ui-stable/invalid-impls/invalid-impls.rs
@@ -1,0 +1,1 @@
+../../ui-nightly/invalid-impls/invalid-impls.rs

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -30,4 +30,4 @@ static_assertions = "1.1"
 # sometimes change the output format slightly, so a version mismatch can cause
 # CI test failures.
 trybuild = "=1.0.80"
-zerocopy = { path = "../" }
+zerocopy = { path = "../", features = ["default", "derive"] }


### PR DESCRIPTION
This requires a few changes to accomodate:
- We still want to be able to derive zerocopy traits on our own types so
  that we can rely on it to validate the soundness of those impls for
  us. That means that, when the `derive` feature is enabled, we still
  use custom derives, but when it's disabled, we implement traits
  manually. However, we also need to ensure that our manual trait impls
  have the correct bounds required in order for those impls to be sound.
  In order to ensure this, we introduce an `impl_or_verify!` macro
  which, when building with `derive` enabled, verifies that the manual
  impl matches the one emitted by our custom derive.
- Since some doc examples use custom derives, we can no longer run doc
  tests unconditionally in CI - when the `derive` feature is disabled,
  doc tests fail. Instead, we disable doc tests by default (in order to
  run them, `cargo test` must be run with the `--doc` flag). We
  introduce a separate "Run doc tests" step in CI - this step only runs
  when the `derive` feature is enabled.

Closes #169

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
