### PR TITLE
Add `transmute_ref!` macro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,13 +122,17 @@ jobs:
       with:
           toolchain: ${{ env.ZC_TOOLCHAIN }}
           targets: ${{ matrix.target }}
+          # We require the `rust-src` component to ensure that the compiler
+          # error output generated during UI tests matches that generated on
+          # local developer machines; see
+          # https://github.com/rust-lang/rust/issues/116433.
+          #
           # Only nightly has a working Miri, so we skip installing on all other
           # toolchains. This expression is effectively a ternary expression -
           # see [1] for details.
           #
-          # [1]
-          # https://github.com/actions/runner/issues/409#issuecomment-752775072
-          components: clippy ${{ matrix.toolchain == 'nightly' && ', miri' || '' }}
+          # [1] https://github.com/actions/runner/issues/409#issuecomment-752775072
+          components: clippy, rust-src ${{ matrix.toolchain == 'nightly' && ', miri' || '' }}
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause"
@@ -41,7 +41,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.7", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.7.8", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -52,7 +52,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.7", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.8", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -67,4 +67,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.7", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.8", path = "zerocopy-derive" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1652,7 +1652,7 @@ macro_rules! transmute {
             // `AsBytes` and that the type of this macro invocation expression
             // is `FromBytes`.
             const fn transmute<T: $crate::AsBytes, U: $crate::FromBytes>(_t: T) -> U {
-                unreachable!()
+                loop {}
             }
             transmute(e)
         } else {
@@ -1669,7 +1669,154 @@ macro_rules! transmute {
             // `core::mem::transmute`, this macro would not work in `std`
             // contexts in which `core` was not manually imported. This is not a
             // problem for 2018 edition crates.
-            unsafe { $crate::macro_util::core_reexport::mem::transmute(e) }
+            unsafe {
+                // Clippy: It's okay to transmute a type to itself.
+                #[allow(clippy::useless_transmute)]
+                $crate::macro_util::core_reexport::mem::transmute(e)
+            }
+        }
+    }}
+}
+
+/// Safely transmutes a mutable or immutable reference of one type to an
+/// immutable reference of another type of the same size.
+///
+/// The expression `$e` must have a concrete type, `&T` or `&mut T`, where `T:
+/// Sized + AsBytes`. The `transmute_ref!` expression must also have a concrete
+/// type, `&U` (`U` is inferred from the calling context), where `U: Sized +
+/// FromBytes`. It must be the case that `align_of::<T>() >= align_of::<U>()`.
+///
+/// The lifetime of the input type, `&T` or `&mut T`, must be the same as or
+/// outlive the lifetime of the output type, `&U`.
+///
+/// # Alignment increase error message
+///
+/// Because of limitations on macros, the error message generated when
+/// `transmute_ref!` is used to transmute from a type of lower alignment to a
+/// type of higher alignment is somewhat confusing. For example, the following
+/// code:
+///
+/// ```compile_fail
+/// const INCREASE_ALIGNMENT: &u16 = zerocopy::transmute_ref!(&[0u8; 2]);
+/// ```
+///
+/// ...generates the following error:
+///
+/// ```text
+/// error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+///  --> src/lib.rs:1524:34
+///   |
+/// 5 | const INCREASE_ALIGNMENT: &u16 = zerocopy::transmute_ref!(&[0u8; 2]);
+///   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+///   |
+///   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+///   = note: target type: `MaxAlignsOf<[u8; 2], u16>` (16 bits)
+///   = note: this error originates in the macro `zerocopy::transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+/// ```
+///
+/// This is saying that `max(align_of::<T>(), align_of::<U>()) !=
+/// align_of::<T>()`, which is equivalent to `align_of::<T>() <
+/// align_of::<U>()`.
+#[macro_export]
+macro_rules! transmute_ref {
+    ($e:expr) => {{
+        // NOTE: This must be a macro (rather than a function with trait bounds)
+        // because there's no way, in a generic context, to enforce that two
+        // types have the same size or alignment.
+
+        // Reborrow so that mutable references are supported too.
+        //
+        // In the rest of the comments, we refer only to `&T` since this
+        // reborrow ensures that `e` is an immutable reference.
+        let e = &*$e;
+
+        #[allow(unused, clippy::diverging_sub_expression)]
+        if false {
+            // This branch, though never taken, ensures that the type of `e` is
+            // `&T` where `T: 't + Sized + AsBytes`, that the type of this macro
+            // expression is `&U` where `U: 'u + Sized + FromBytes`, and that
+            // `'t` outlives `'u`.
+            const fn transmute<'u, 't: 'u, T: 't + Sized + $crate::AsBytes, U: 'u + Sized + $crate::FromBytes>(_t: &'t T) -> &'u U {
+                loop {}
+            }
+            transmute(e)
+        } else if false {
+            // This branch, though never taken, ensures that `size_of::<T>() ==
+            // size_of::<U>()`.
+
+            // `t` is inferred to have type `T` because it's assigned to `e` (of
+            // type `&T`) as `&t`.
+            let mut t = unreachable!();
+            e = &t;
+
+            // `u` is inferred to have type `U` because it's used as `&u` as the
+            // value returned from this branch.
+            //
+            // SAFETY: This code is never run.
+            let u = unsafe {
+                 // Clippy: It's okay to transmute a type to itself.
+                #[allow(clippy::useless_transmute)]
+                $crate::macro_util::core_reexport::mem::transmute(t)
+            };
+            &u
+        } else if false {
+            // This branch, though never taken, ensures that the alignment of
+            // `T` is greater than or equal to to the alignment of `U`.
+
+            // `t` is inferred to have type `T` because it's assigned to `e` (of
+            // type `&T`) as `&t`.
+            let mut t = unreachable!();
+            e = &t;
+
+            // `u` is inferred to have type `U` because it's used as `&u` as the
+            // value returned from this branch.
+            let mut u = unreachable!();
+
+            // The type wildcard in this bound is inferred to be `T` because
+            // `align_of.into_t()` is assigned to `t` (which has type `T`).
+            let align_of: $crate::macro_util::AlignOf<_> = unreachable!();
+            t = align_of.into_t();
+            // `max_aligns` is inferred to have type `MaxAlignsOf<T, U>` because
+            // of the inferred types of `t` and `u`.
+            let mut max_aligns = $crate::macro_util::MaxAlignsOf::new(t, u);
+
+            // This transmute will only compile successfully if
+            // `align_of::<T>() == max(align_of::<T>(), align_of::<U>())` - in
+            // other words, if `align_of::<T>() >= align_of::<U>()`.
+            //
+            // SAFETY: This code is never run.
+            max_aligns = unsafe { $crate::macro_util::core_reexport::mem::transmute(align_of) };
+
+            &u
+        } else {
+            // SAFETY:
+            // - We know that the input and output types are both `Sized` (ie,
+            //   thin) references thanks to the trait bounds on `transmute`
+            //   above, and thanks to the fact that transmute takes and returns
+            //   references.
+            // - We know that it is sound to view the target type of the input
+            //   reference (`T`) as the target type of the output reference
+            //   (`U`) because `T: AsBytes` and `U: FromBytes` (guaranteed by
+            //   trait bounds on `transmute`) and because `size_of::<T>() ==
+            //   size_of::<U>()` (guaranteed by the first `core::mem::transmute`
+            //   above).
+            // - We know that alignment is not increased thanks to the second
+            //   `core::mem::transmute` above (the one which transmutes
+            //   `MaxAlignsOf` into `AlignOf`).
+            //
+            // We use this reexport of `core::mem::transmute` because we know it
+            // will always be available for crates which are using the 2015
+            // edition of Rust. By contrast, if we were to use
+            // `std::mem::transmute`, this macro would not work for such crates
+            // in `no_std` contexts, and if we were to use
+            // `core::mem::transmute`, this macro would not work in `std`
+            // contexts in which `core` was not manually imported. This is not a
+            // problem for 2018 edition crates.
+            unsafe {
+                // Clippy: It's okay to transmute a type to itself.
+                #[allow(clippy::useless_transmute)]
+                $crate::macro_util::core_reexport::mem::transmute(e)
+            }
         }
     }}
 }
@@ -3808,6 +3955,58 @@ mod tests {
         const ARRAY_OF_ARRAYS: [[u8; 2]; 4] = [[0, 1], [2, 3], [4, 5], [6, 7]];
         const X: [[u8; 2]; 4] = transmute!(ARRAY_OF_U8S);
         assert_eq!(X, ARRAY_OF_ARRAYS);
+    }
+
+    #[test]
+    fn test_transmute_ref() {
+        // Test that memory is transmuted as expected.
+        let array_of_u8s = [0u8, 1, 2, 3, 4, 5, 6, 7];
+        let array_of_arrays = [[0, 1], [2, 3], [4, 5], [6, 7]];
+        let x: &[[u8; 2]; 4] = transmute_ref!(&array_of_u8s);
+        assert_eq!(*x, array_of_arrays);
+        let x: &[u8; 8] = transmute_ref!(&array_of_arrays);
+        assert_eq!(*x, array_of_u8s);
+
+        // Test that `transmute_ref!` is legal in a const context.
+        const ARRAY_OF_U8S: [u8; 8] = [0u8, 1, 2, 3, 4, 5, 6, 7];
+        const ARRAY_OF_ARRAYS: [[u8; 2]; 4] = [[0, 1], [2, 3], [4, 5], [6, 7]];
+        #[allow(clippy::redundant_static_lifetimes)]
+        const X: &'static [[u8; 2]; 4] = transmute_ref!(&ARRAY_OF_U8S);
+        assert_eq!(*X, ARRAY_OF_ARRAYS);
+
+        // Test that it's legal to transmute a reference while shrinking the
+        // lifetime (note that `X` has the lifetime `'static`).
+        let x: &[u8; 8] = transmute_ref!(X);
+        assert_eq!(*x, ARRAY_OF_U8S);
+
+        // Test that `transmute_ref!` supports decreasing alignment.
+        let u = AU64(0);
+        let array = [0, 0, 0, 0, 0, 0, 0, 0];
+        let x: &[u8; 8] = transmute_ref!(&u);
+        assert_eq!(*x, array);
+
+        // Test that a mutable reference can be turned into an immutable one.
+        let mut x = 0u8;
+        #[allow(clippy::useless_transmute)]
+        let y: &u8 = transmute_ref!(&mut x);
+        assert_eq!(*y, 0);
+    }
+
+    #[test]
+    fn test_macros_evaluate_args_once() {
+        let mut ctr = 0;
+        let _: usize = transmute!({
+            ctr += 1;
+            0usize
+        });
+        assert_eq!(ctr, 1);
+
+        let mut ctr = 0;
+        let _: &usize = transmute_ref!({
+            ctr += 1;
+            &0usize
+        });
+        assert_eq!(ctr, 1);
     }
 
     #[test]

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -13,7 +13,7 @@
 
 #![allow(missing_debug_implementations)]
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, mem::ManuallyDrop};
 
 /// A compile-time check that should be one particular value.
 pub trait ShouldBe<const VALUE: bool> {}
@@ -22,6 +22,40 @@ pub trait ShouldBe<const VALUE: bool> {}
 pub struct HasPadding<T: ?Sized, const VALUE: bool>(PhantomData<T>);
 
 impl<T: ?Sized, const VALUE: bool> ShouldBe<VALUE> for HasPadding<T, VALUE> {}
+
+/// A type whose size is equal to `align_of::<T>()`.
+#[repr(C)]
+pub struct AlignOf<T> {
+    // This field ensures that:
+    // - The size is always at least 1 (the minimum possible alignment).
+    // - If the alignment is greater than 1, Rust has to round up to the next
+    //   multiple of it in order to make sure that `Align`'s size is a multiple
+    //   of that alignment. Without this field, its size could be 0, which is a
+    //   valid multiple of any alignment.
+    _u: u8,
+    _a: [T; 0],
+}
+
+impl<T> AlignOf<T> {
+    #[inline(never)] // Make `missing_inline_in_public_items` happy.
+    pub fn into_t(self) -> T {
+        unreachable!()
+    }
+}
+
+/// A type whose size is equal to `max(align_of::<T>(), align_of::<U>())`.
+#[repr(C)]
+pub union MaxAlignsOf<T, U> {
+    _t: ManuallyDrop<AlignOf<T>>,
+    _u: ManuallyDrop<AlignOf<U>>,
+}
+
+impl<T, U> MaxAlignsOf<T, U> {
+    #[inline(never)] // Make `missing_inline_in_public_items` happy.
+    pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+        unreachable!()
+    }
+}
 
 /// Does the struct type `$t` have padding?
 ///
@@ -71,7 +105,60 @@ pub mod core_reexport {
 
 #[cfg(test)]
 mod tests {
+    use core::mem;
+
+    use super::*;
     use crate::util::testutil::*;
+
+    #[test]
+    fn test_align_of() {
+        macro_rules! test {
+            ($ty:ty) => {
+                assert_eq!(mem::size_of::<AlignOf<$ty>>(), mem::align_of::<$ty>());
+            };
+        }
+
+        test!(());
+        test!(u8);
+        test!(AU64);
+        test!([AU64; 2]);
+    }
+
+    #[test]
+    fn test_max_aligns_of() {
+        macro_rules! test {
+            ($t:ty, $u:ty) => {
+                assert_eq!(
+                    mem::size_of::<MaxAlignsOf<$t, $u>>(),
+                    core::cmp::max(mem::align_of::<$t>(), mem::align_of::<$u>())
+                );
+            };
+        }
+
+        test!(u8, u8);
+        test!(u8, AU64);
+        test!(AU64, u8);
+    }
+
+    #[test]
+    fn test_typed_align_check() {
+        // Test that the type-based alignment check used in `transmute_ref!`
+        // behaves as expected.
+
+        macro_rules! assert_t_align_gteq_u_align {
+            ($t:ty, $u:ty, $gteq:expr) => {
+                assert_eq!(
+                    mem::size_of::<MaxAlignsOf<$t, $u>>() == mem::size_of::<AlignOf<$t>>(),
+                    $gteq
+                );
+            };
+        }
+
+        assert_t_align_gteq_u_align!(u8, u8, true);
+        assert_t_align_gteq_u_align!(AU64, AU64, true);
+        assert_t_align_gteq_u_align!(AU64, u8, true);
+        assert_t_align_gteq_u_align!(u8, AU64, false);
+    }
 
     #[test]
     fn test_struct_has_padding() {

--- a/tests/ui-msrv/transmute-ref-alignment-increase.rs
+++ b/tests/ui-msrv/transmute-ref-alignment-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-alignment-increase.rs

--- a/tests/ui-msrv/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-alignment-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-alignment-increase.rs:15:35
+   |
+15 | const INCREASE_ALIGNMENT: &AU16 = transmute_ref!(&[0u8; 2]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-generic.rs
+++ b/tests/ui-msrv/transmute-ref-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-generic.rs

--- a/tests/ui-msrv/transmute-ref-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-mutable.rs
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-mutable.rs

--- a/tests/ui-msrv/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.rs
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-a-reference.rs

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui-msrv/transmute-ref-dst-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-frombytes.rs

--- a/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-unsized.rs
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-unsized.rs

--- a/tests/ui-msrv/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.stderr
@@ -1,0 +1,91 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                         ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-illegal-lifetime.rs
+++ b/tests/ui-msrv/transmute-ref-illegal-lifetime.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-illegal-lifetime.rs

--- a/tests/ui-msrv/transmute-ref-illegal-lifetime.stderr
+++ b/tests/ui-msrv/transmute-ref-illegal-lifetime.stderr
@@ -1,0 +1,9 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-msrv/transmute-ref-illegal-lifetime.rs:10:52
+   |
+10 |     let _: &'static u64 = zerocopy::transmute_ref!(&x);
+   |            ------------                            ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+11 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-msrv/transmute-ref-size-decrease.rs
+++ b/tests/ui-msrv/transmute-ref-size-decrease.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-size-decrease.rs

--- a/tests/ui-msrv/transmute-ref-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-ref-size-decrease.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-size-decrease.rs:13:28
+   |
+13 | const DECREASE_SIZE: &u8 = transmute_ref!(&[0u8; 2]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-size-increase.rs
+++ b/tests/ui-msrv/transmute-ref-size-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-size-increase.rs

--- a/tests/ui-msrv/transmute-ref-size-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-size-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-size-increase.rs:13:33
+   |
+13 | const INCREASE_SIZE: &[u8; 2] = transmute_ref!(&0u8);
+   |                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-generic.rs
+++ b/tests/ui-msrv/transmute-ref-src-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-generic.rs

--- a/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.rs
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-not-references.rs

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
@@ -1,0 +1,37 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.rs
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-unsized.rs

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
@@ -1,0 +1,175 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_DST_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                      ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-generic.rs
+++ b/tests/ui-msrv/transmute-ref-src-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-generic.rs

--- a/tests/ui-msrv/transmute-ref-src-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-not-a-reference.rs
+++ b/tests/ui-msrv/transmute-ref-src-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-a-reference.rs

--- a/tests/ui-msrv/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-a-reference.stderr
@@ -1,0 +1,7 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-msrv/transmute-ref-src-not-a-reference.rs:13:34
+   |
+13 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-not-asbytes.rs
+++ b/tests/ui-msrv/transmute-ref-src-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-asbytes.rs

--- a/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-unsized.rs
+++ b/tests/ui-msrv/transmute-ref-src-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-unsized.rs

--- a/tests/ui-msrv/transmute-ref-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-unsized.stderr
@@ -1,0 +1,153 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                      ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-alignment-increase.rs
+++ b/tests/ui-nightly/transmute-ref-alignment-increase.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting from a type of smaller
+// alignment to one of larger alignment.
+const INCREASE_ALIGNMENT: &AU16 = transmute_ref!(&[0u8; 2]);

--- a/tests/ui-nightly/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-nightly/transmute-ref-alignment-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-alignment-increase.rs:15:35
+   |
+15 | const INCREASE_ALIGNMENT: &AU16 = transmute_ref!(&[0u8; 2]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-dst-generic.rs
@@ -1,0 +1,14 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_ref, FromBytes};
+
+fn main() {}
+
+fn transmute_ref<T: FromBytes>(u: &u8) -> &T {
+    // `transmute_ref!` requires the destination type to be concrete.
+    transmute_ref!(u)
+}

--- a/tests/ui-nightly/transmute-ref-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-mutable.rs
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+fn ref_dst_mutable() {
+    // `transmute_ref!` requires that its destination type be an immutable
+    // reference.
+    let _: &mut u8 = transmute_ref!(&0u8);
+}

--- a/tests/ui-nightly/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting into a non-reference
+// destination type.
+const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
@@ -1,0 +1,14 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref` requires that the destination type implements `FromBytes`
+const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-unsized.rs
+++ b/tests/ui-nightly/transmute-ref-dst-unsized.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting into an unsized destination
+// type.
+const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);

--- a/tests/ui-nightly/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-unsized.stderr
@@ -1,0 +1,97 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-illegal-lifetime.rs
+++ b/tests/ui-nightly/transmute-ref-illegal-lifetime.rs
@@ -1,0 +1,11 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+fn main() {}
+
+fn increase_lifetime() {
+    let x = 0u64;
+    // It is illegal to increase the lifetime scope.
+    let _: &'static u64 = zerocopy::transmute_ref!(&x);
+}

--- a/tests/ui-nightly/transmute-ref-illegal-lifetime.stderr
+++ b/tests/ui-nightly/transmute-ref-illegal-lifetime.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-nightly/transmute-ref-illegal-lifetime.rs:10:52
+   |
+8  |     let x = 0u64;
+   |         - binding `x` declared here
+9  |     // It is illegal to increase the lifetime scope.
+10 |     let _: &'static u64 = zerocopy::transmute_ref!(&x);
+   |            ------------                            ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+11 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-nightly/transmute-ref-size-decrease.rs
+++ b/tests/ui-nightly/transmute-ref-size-decrease.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// Although this is not a soundness requirement, we currently require that the
+// size of the destination type is not smaller than the size of the source type.
+const DECREASE_SIZE: &u8 = transmute_ref!(&[0u8; 2]);

--- a/tests/ui-nightly/transmute-ref-size-decrease.stderr
+++ b/tests/ui-nightly/transmute-ref-size-decrease.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-size-decrease.rs:13:28
+   |
+13 | const DECREASE_SIZE: &u8 = transmute_ref!(&[0u8; 2]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-size-increase.rs
+++ b/tests/ui-nightly/transmute-ref-size-increase.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting from a smaller type to a larger
+// one.
+const INCREASE_SIZE: &[u8; 2] = transmute_ref!(&0u8);

--- a/tests/ui-nightly/transmute-ref-size-increase.stderr
+++ b/tests/ui-nightly/transmute-ref-size-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-size-increase.rs:13:33
+   |
+13 | const INCREASE_SIZE: &[u8; 2] = transmute_ref!(&0u8);
+   |                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-dst-generic.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_ref, AsBytes, FromBytes};
+
+fn main() {}
+
+fn transmute_ref<T: AsBytes, U: FromBytes>(t: &T) -> &U {
+    // `transmute_ref!` requires the source and destination types to be
+    // concrete.
+    transmute_ref!(t)
+}

--- a/tests/ui-nightly/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.rs
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting between non-reference source
+// and destination types.
+const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -1,0 +1,37 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-unsized.rs
+++ b/tests/ui-nightly/transmute-ref-src-dst-unsized.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting between unsized source and
+// destination types.
+const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);

--- a/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
@@ -1,0 +1,214 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-generic.rs
@@ -1,0 +1,14 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_ref, AsBytes};
+
+fn main() {}
+
+fn transmute_ref<T: AsBytes>(t: &T) -> &u8 {
+    // `transmute_ref!` requires the source type to be concrete.
+    transmute_ref!(t)
+}

--- a/tests/ui-nightly/transmute-ref-src-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-src-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-not-a-reference.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-a-reference.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting from a non-reference source
+// type.
+const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);

--- a/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
@@ -1,0 +1,7 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:13:34
+   |
+13 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-asbytes.rs
@@ -1,0 +1,14 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref` requires that the source type implements `AsBytes`
+const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));

--- a/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                 required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-unsized.rs
+++ b/tests/ui-nightly/transmute-ref-src-unsized.rs
@@ -1,0 +1,12 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+// `transmute_ref!` does not support transmuting from an unsized source type.
+const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);

--- a/tests/ui-nightly/transmute-ref-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-unsized.stderr
@@ -1,0 +1,144 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-size-increase.rs
+++ b/tests/ui-nightly/transmute-size-increase.rs
@@ -10,6 +10,6 @@ use zerocopy::transmute;
 
 fn main() {}
 
-// Although this is not a soundness requirement, we currently require that the
-// size of the destination type is not larger than the size of the source type.
+// `transmute!` does not support transmuting from a smaller type to a larger
+// one.
 const INCREASE_SIZE: AU16 = transmute!(0u8);

--- a/tests/ui-stable/transmute-ref-alignment-increase.rs
+++ b/tests/ui-stable/transmute-ref-alignment-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-alignment-increase.rs

--- a/tests/ui-stable/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-stable/transmute-ref-alignment-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-alignment-increase.rs:15:35
+   |
+15 | const INCREASE_ALIGNMENT: &AU16 = transmute_ref!(&[0u8; 2]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-generic.rs
+++ b/tests/ui-stable/transmute-ref-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-generic.rs

--- a/tests/ui-stable/transmute-ref-dst-generic.stderr
+++ b/tests/ui-stable/transmute-ref-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-dst-generic.rs:13:5
+   |
+13 |     transmute_ref!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-mutable.rs
+++ b/tests/ui-stable/transmute-ref-dst-mutable.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-mutable.rs

--- a/tests/ui-stable/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-stable/transmute-ref-dst-mutable.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:14:22
+   |
+14 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.rs
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-a-reference.rs

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:13:36
+   |
+13 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-frombytes.rs

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
@@ -1,0 +1,22 @@
+error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:14:42
+   |
+14 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-unsized.rs
+++ b/tests/ui-stable/transmute-ref-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-unsized.rs

--- a/tests/ui-stable/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-dst-unsized.stderr
@@ -1,0 +1,80 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:13:28
+   |
+13 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-illegal-lifetime.rs
+++ b/tests/ui-stable/transmute-ref-illegal-lifetime.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-illegal-lifetime.rs

--- a/tests/ui-stable/transmute-ref-illegal-lifetime.stderr
+++ b/tests/ui-stable/transmute-ref-illegal-lifetime.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-stable/transmute-ref-illegal-lifetime.rs:10:52
+   |
+8  |     let x = 0u64;
+   |         - binding `x` declared here
+9  |     // It is illegal to increase the lifetime scope.
+10 |     let _: &'static u64 = zerocopy::transmute_ref!(&x);
+   |            ------------                            ^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+11 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-stable/transmute-ref-size-decrease.rs
+++ b/tests/ui-stable/transmute-ref-size-decrease.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-size-decrease.rs

--- a/tests/ui-stable/transmute-ref-size-decrease.stderr
+++ b/tests/ui-stable/transmute-ref-size-decrease.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-size-decrease.rs:13:28
+   |
+13 | const DECREASE_SIZE: &u8 = transmute_ref!(&[0u8; 2]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-size-increase.rs
+++ b/tests/ui-stable/transmute-ref-size-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-size-increase.rs

--- a/tests/ui-stable/transmute-ref-size-increase.stderr
+++ b/tests/ui-stable/transmute-ref-size-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-size-increase.rs:13:33
+   |
+13 | const INCREASE_SIZE: &[u8; 2] = transmute_ref!(&0u8);
+   |                                 ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-generic.rs
+++ b/tests/ui-stable/transmute-ref-src-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-generic.rs

--- a/tests/ui-stable/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-src-dst-generic.rs:14:5
+   |
+14 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.rs
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-not-references.rs

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
@@ -1,0 +1,37 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:13:39
+   |
+13 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-unsized.rs
+++ b/tests/ui-stable/transmute-ref-src-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-dst-unsized.rs

--- a/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
@@ -1,0 +1,205 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:13:32
+   |
+13 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-generic.rs
+++ b/tests/ui-stable/transmute-ref-src-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-generic.rs

--- a/tests/ui-stable/transmute-ref-src-generic.stderr
+++ b/tests/ui-stable/transmute-ref-src-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-ref-src-generic.rs:13:5
+   |
+13 |     transmute_ref!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-not-a-reference.rs
+++ b/tests/ui-stable/transmute-ref-src-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-a-reference.rs

--- a/tests/ui-stable/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-a-reference.stderr
@@ -1,0 +1,7 @@
+error[E0614]: type `usize` cannot be dereferenced
+  --> tests/ui-stable/transmute-ref-src-not-a-reference.rs:13:34
+   |
+13 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-not-asbytes.rs
+++ b/tests/ui-stable/transmute-ref-src-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-asbytes.rs

--- a/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                 required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and $N others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:14:33
+   |
+14 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-unsized.rs
+++ b/tests/ui-stable/transmute-ref-src-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-unsized.rs

--- a/tests/ui-stable/transmute-ref-src-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-unsized.stderr
@@ -1,0 +1,138 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:12:31
+   |
+12 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause"


### PR DESCRIPTION
This macro is like the existing `transmute!`, but it transmutes immutable references rather than values.

Issue #159