### PR TITLE
[ci] Fail fast on CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # By default, this is set to `true`, which means that a single CI job
+      # failure will cause all outstanding jobs to be canceled. This slows down
+      # development because it means that errors need to be encountered and
+      # fixed one at a time.
+      fail-fast: false
       matrix:
         # See `INTERNAL.md` for an explanation of these pinned toolchain
         # versions.


### PR DESCRIPTION
Set the `jobs.build_test.strategy.fail-fast` GitHub CI configuration option to `false`, ensuring that other CI jobs continue executing even when one has failed. This helps speed up development by surfacing more errors at a time.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
