### PR TITLE
Migrate UI tests to `ui-test` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly
   # toolchain.
   ZC_NIGHTLY_RUSTFLAGS: -Zrandomize-layout
-  ZC_NIGHTLY_MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-strict-provenance"
+  ZC_NIGHTLY_MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-disable-isolation"
 
 jobs:
   build_test:
@@ -79,10 +79,10 @@ jobs:
             ZC_TOOLCHAIN="$(pkg-meta rust_version)"
             ;;
           stable)
-            ZC_TOOLCHAIN="$(pkg-meta 'metadata.ci."pinned-stable"')"
+            ZC_TOOLCHAIN="$(pkg-meta 'metadata."pinned-stable"')"
             ;;
           nightly)
-            ZC_TOOLCHAIN="$(pkg-meta 'metadata.ci."pinned-nightly"')"
+            ZC_TOOLCHAIN="$(pkg-meta 'metadata."pinned-nightly"')"
             ;;
           *)
             echo 'Unrecognized toolchain: ${{ matrix.toolchain }}' | tee -a $GITHUB_STEP_SUMMARY >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ guidelines on how to test code in zerocopy:
    any potential [undefined behavior][undefined_behavior] so that Miri can catch
    it.
 1. If there's some user code that should be impossible to compile, add a
-   [trybuild test][trybuild] to ensure that it's properly rejected.
+   [UI test][uitest] to ensure that it's properly rejected.
 
 ### Source Control Best Practices
 
@@ -207,5 +207,5 @@ Guidelines][google_open_source_guidelines].
 [google_open_source_guidelines]: https://opensource.google/conduct/
 [magic_number]: https://en.wikipedia.org/wiki/Magic_number_(programming)
 [miri]: https://github.com/rust-lang/miri
-[trybuild]: https://crates.io/crates/trybuild
+[uitest]: https://crates.io/crates/ui-test
 [undefined_behavior]: https://raphlinus.github.io/programming/rust/2018/08/17/undefined-behavior.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ exclude = [".*"]
 [package.metadata.docs.rs]
 all-features = true
 
-[package.metadata.ci]
-# The versions of the stable and nightly compiler toolchains to use in CI.
+[package.metadata]
+# The versions of the stable and nightly compiler toolchains to use for UI testing.
 pinned-stable = "1.69.0"
 pinned-nightly = "nightly-2023-05-25"
 
@@ -49,10 +49,9 @@ optional = true
 
 [dev-dependencies]
 rand = "0.6"
-rustversion = "1.0"
 static_assertions = "1.1"
-# Pinned to a specific version so that the version used for local development
-# and the version used in CI are guaranteed to be the same. Future versions
-# sometimes change the output format slightly, so a version mismatch can cause
-# CI test failures.
-trybuild = "=1.0.80"
+test-util = { path = "./test-util" }
+
+[[test]]
+name = "ui"
+harness = false

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright 2023 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+[package]
+name = "test-util"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rustversion = "1.0"
+cargo_toml = "0.15.3"
+serde = "1.0"
+static_assertions = "1.1"
+toml = "0.7.5"
+zerocopy = { path = "../", version = "=0.7.0-alpha.4" }
+
+# Pinned to a specific version so that the version used for local development
+# and the version used in CI are guaranteed to be the same. Future versions
+# sometimes change the output format slightly, so a version mismatch can cause
+# CI test failures.
+ui_test = "=0.11.7"

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+pub use static_assertions::*;
+pub use ui_test::*;
+
+#[rustversion::nightly(2023-05-24)]
+pub static TOOLCHAIN: &str = "nightly-2023-05-25";
+
+#[rustversion::stable(1.69.0)]
+pub static TOOLCHAIN: &str = "1.69.0";
+
+#[rustversion::stable(1.65.0)]
+pub static TOOLCHAIN: &str = "1.65.0";
+
+macro_rules! manifest_path {
+    () => {
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../Cargo.toml")
+    };
+}
+
+static MANIFEST: &str = include_str!(manifest_path!());
+
+pub struct PinnedToolchains {
+    pub msrv: String,
+    pub stable: String,
+    pub nightly: String,
+}
+
+pub fn pinned_toolchains() -> color_eyre::eyre::Result<PinnedToolchains> {
+    use cargo_toml::Manifest;
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    struct Metadata {
+        pinned_stable: String,
+        pinned_nightly: String,
+    }
+
+    let manifest = Manifest::<Metadata>::from_slice_with_metadata(MANIFEST.as_bytes())?;
+    let package = manifest.package.expect("expected `package` section");
+    let package_metadata = package.metadata.expect("expected `package.metadata` section");
+
+    let msrv = package.rust_version.expect("`package.rust-version` is unset");
+    let msrv = msrv.get()?.to_string();
+    let stable = package_metadata.pinned_stable;
+    let nightly = package_metadata.pinned_nightly;
+
+    Ok(PinnedToolchains { msrv, stable, nightly })
+}
+
+/// Bless tests with `cargo test -- -- --bless`.
+pub fn should_bless() -> bool {
+    std::env::args().any(|arg| arg == "--bless")
+}
+
+/// Run (and optionally bless) UI tests in a given folder, within a given toolchain.
+pub fn ui_test(toolchain: &str, folder: &str, bless: bool) -> color_eyre::eyre::Result<()> {
+    let toolchain = String::from("+") + toolchain;
+
+    // // Make sure we can depend on zerocopy in ui tests.
+    // let dependencies_crate_manifest_path =
+    //     Some(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml").into());
+
+    // let mut config = ui_test::Config { dependencies_crate_manifest_path, ..Default::default() };
+
+    // if bless {
+    //     config.output_conflict_handling = OutputConflictHandling::Bless;
+    // }
+
+    // // Place the build artifacts in the `target/ui` directory instead of in the
+    // // crate root.
+    // config.out_dir = Some("target/ui.rs".into());
+
+    // config.program = CommandBuilder::rustc();
+    // config.root_dir = folder.into();
+    // config.program.args.insert(0, toolchain.into());
+
+    let mut config = ui_test::Config::rustc(folder.into());
+    if bless {
+        config.output_conflict_handling = OutputConflictHandling::Bless;
+    }
+
+    // Make sure we can depend on zerocopy in ui tests.
+    config.dependencies_crate_manifest_path = Some(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml").into());
+    config.out_dir = "target/ui.rs".into();
+    config.program.args.insert(0, toolchain.into());
+
+    run_tests(config)
+}

--- a/tests/ui-msrv/transmute-illegal.stderr
+++ b/tests/ui-msrv/transmute-illegal.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
-  --> tests/ui-msrv/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              the trait `AsBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
@@ -16,10 +16,84 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
              i64
              i8
              isize
-           and $N others
+           and 6 others
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> tests/ui-msrv/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
-   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 51 others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: FromBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 37 others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:23:29
+   |
+23 | const INCREASE_SIZE: AU16 = transmute!(0u8);
+   |                             ^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `AU16` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:26:27
+   |
+26 | const DECREASE_SIZE: u8 = transmute!(AU16(0));
+   |                           ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AU16` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0512.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-nightly/transmute-illegal.rs
+++ b/tests/ui-nightly/transmute-illegal.rs
@@ -2,9 +2,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+include!("../../zerocopy-derive/tests/util.rs");
+
 extern crate zerocopy;
+
+use zerocopy::transmute;
 
 fn main() {}
 
-// It is unsound to inspect the usize value of a pointer during const eval.
-const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+// It is unsupported to inspect the usize value of a pointer during const eval.
+const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+//~^ ERROR: the trait bound `*const usize: AsBytes` is not satisfied
+
+const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+//~^ ERROR: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+
+const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+//~^ ERROR: the trait bound `NotZerocopy<AU16>: FromBytes` is not satisfied
+
+const INCREASE_SIZE: AU16 = transmute!(0u8);
+//~^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
+
+const DECREASE_SIZE: u8 = transmute!(AU16(0));
+//~^ ERROR: cannot transmute between types of different sizes, or dependently-sized types

--- a/tests/ui-nightly/transmute-illegal.stderr
+++ b/tests/ui-nightly/transmute-illegal.stderr
@@ -1,16 +1,90 @@
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
-  --> tests/ui-nightly/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              the trait `AsBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
    |
    = help: the trait `AsBytes` is implemented for `usize`
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> tests/ui-nightly/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 51 others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: FromBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 37 others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:23:29
+   |
+23 | const INCREASE_SIZE: AU16 = transmute!(0u8);
+   |                             ^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `AU16` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:26:27
+   |
+26 | const DECREASE_SIZE: u8 = transmute!(AU16(0));
+   |                           ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AU16` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0512.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-stable/transmute-illegal.stderr
+++ b/tests/ui-stable/transmute-illegal.stderr
@@ -1,16 +1,90 @@
 error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
-  --> tests/ui-stable/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              the trait `AsBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
    |
    = help: the trait `AsBytes` is implemented for `usize`
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> tests/ui-stable/transmute-illegal.rs:10:30
+  --> $DIR/transmute-illegal.rs:14:30
    |
-10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+14 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 51 others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:17:32
+   |
+17 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: FromBytes` is not satisfied
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AU16
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+             I32<O>
+             I64<O>
+           and 37 others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> $DIR/transmute-illegal.rs:20:47
+   |
+20 | const DST_NOT_FROM_BYTES: NotZerocopy<AU16> = transmute!(AU16(0));
+   |                                               ^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:23:29
+   |
+23 | const INCREASE_SIZE: AU16 = transmute!(0u8);
+   |                             ^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `AU16` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute-illegal.rs:26:27
+   |
+26 | const DECREASE_SIZE: u8 = transmute!(AU16(0));
+   |                           ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AU16` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0512.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -15,15 +15,26 @@
 // - `tests/ui-msrv` - Contains symlinks to the `.rs` files in
 //   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
 
-#[rustversion::any(nightly)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-nightly/*.rs";
-#[rustversion::all(stable, not(stable(1.65.0)))]
-const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
-#[rustversion::stable(1.65.0)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
+use test_util::*;
 
-#[test]
-fn ui() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail(SOURCE_FILES_GLOB);
+fn main() -> color_eyre::eyre::Result<()> {
+    let bless = should_bless();
+
+    let PinnedToolchains { msrv, stable, nightly } = test_util::pinned_toolchains()?;
+
+    let folder = if TOOLCHAIN == msrv {
+        "tests/ui-msrv"
+    } else if TOOLCHAIN == stable {
+        "tests/ui-stable"
+    } else if TOOLCHAIN == nightly {
+        "tests/ui-nightly"
+    } else {
+        unreachable!(
+            "UI tests must be runned with the MSRV ({msrv}),\
+            pinned stable ({stable}), \
+            or pinned nightly ({nightly}) toolchains."
+        );
+    };
+
+    ui_test(TOOLCHAIN, folder, bless)
 }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -25,9 +25,9 @@ syn = { version = "2", features = ["visit"] }
 [dev-dependencies]
 rustversion = "1.0"
 static_assertions = "1.1"
-# Pinned to a specific version so that the version used for local development
-# and the version used in CI are guaranteed to be the same. Future versions
-# sometimes change the output format slightly, so a version mismatch can cause
-# CI test failures.
-trybuild = "=1.0.80"
+test-util = { path = "../test-util" }
 zerocopy = { path = "../" }
+
+[[test]]
+name = "ui"
+harness = false

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,5 +1,13 @@
+warning: unused import: `test_util::*`
+ --> $DIR/derive_transparent.rs:8:5
+  |
+8 | use test_util::*;
+  |     ^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:33:18
+  --> $DIR/derive_transparent.rs:33:18
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
@@ -13,23 +21,23 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 41 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
-  --> tests/ui-msrv/derive_transparent.rs:23:19
+  --> $DIR/derive_transparent.rs:23:19
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-msrv/derive_transparent.rs:33:1
+  --> $DIR/derive_transparent.rs:33:1
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:34:18
+  --> $DIR/derive_transparent.rs:35:18
    |
-34 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
@@ -41,23 +49,23 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 38 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-msrv/derive_transparent.rs:23:31
+  --> $DIR/derive_transparent.rs:23:31
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                               ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-msrv/derive_transparent.rs:34:1
+  --> $DIR/derive_transparent.rs:35:1
    |
-34 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:35:18
+  --> $DIR/derive_transparent.rs:37:18
    |
-35 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
@@ -69,23 +77,23 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 52 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
-  --> tests/ui-msrv/derive_transparent.rs:23:10
+  --> $DIR/derive_transparent.rs:23:10
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |          ^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-msrv/derive_transparent.rs:35:1
+  --> $DIR/derive_transparent.rs:37:1
    |
-35 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:36:18
+  --> $DIR/derive_transparent.rs:39:18
    |
-36 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -97,15 +105,19 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 19 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-msrv/derive_transparent.rs:23:42
+  --> $DIR/derive_transparent.rs:23:42
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                                          ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-msrv/derive_transparent.rs:36:1
+  --> $DIR/derive_transparent.rs:39:1
    |
-36 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -1,201 +1,209 @@
 error: unrecognized representation hint
-  --> tests/ui-msrv/enum.rs:15:8
+  --> $DIR/enum.rs:15:8
    |
 15 | #[repr("foo")]
    |        ^^^^^
 
 error: unrecognized representation hint
-  --> tests/ui-msrv/enum.rs:21:8
+  --> $DIR/enum.rs:23:8
    |
-21 | #[repr(foo)]
+23 | #[repr(foo)]
    |        ^^^
 
 error: unsupported representation for deriving FromBytes, AsBytes, or Unaligned on an enum
-  --> tests/ui-msrv/enum.rs:27:8
+  --> $DIR/enum.rs:31:8
    |
-27 | #[repr(transparent)]
+31 | #[repr(transparent)]
    |        ^^^^^^^^^^^
 
 error: conflicting representation hints
-  --> tests/ui-msrv/enum.rs:33:1
+  --> $DIR/enum.rs:38:1
    |
-33 | #[repr(u8, u16)]
+38 | #[repr(u8, u16)]
    | ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-  --> tests/ui-msrv/enum.rs:38:22
+  --> $DIR/enum.rs:45:22
    |
-38 | #[derive(FromZeroes, FromBytes)]
+45 | #[derive(FromZeroes, FromBytes)]
    |                      ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only C-like enums can implement FromZeroes
-  --> tests/ui-msrv/enum.rs:48:1
+  --> $DIR/enum.rs:56:1
    |
-48 | / enum FromZeroes1 {
-49 | |     A(u8),
-50 | | }
+56 | / enum FromZeroes1 {
+57 | |
+58 | |     A(u8),
+59 | | }
    | |_^
 
 error: only C-like enums can implement FromZeroes
-  --> tests/ui-msrv/enum.rs:53:1
+  --> $DIR/enum.rs:62:1
    |
-53 | / enum FromZeroes2 {
-54 | |     A,
-55 | |     B(u8),
-56 | | }
+62 | / enum FromZeroes2 {
+63 | |
+64 | |     A,
+65 | |     B(u8),
+66 | | }
    | |_^
 
 error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
-  --> tests/ui-msrv/enum.rs:59:1
+  --> $DIR/enum.rs:69:1
    |
-59 | / enum FromZeroes3 {
-60 | |     A = 1,
-61 | |     B,
-62 | | }
+69 | / enum FromZeroes3 {
+70 | |
+71 | |     A = 1,
+72 | |     B,
+73 | | }
    | |_^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:69:8
+  --> $DIR/enum.rs:80:8
    |
-69 | #[repr(C)]
+80 | #[repr(C)]
    |        ^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:75:8
+  --> $DIR/enum.rs:87:8
    |
-75 | #[repr(usize)]
+87 | #[repr(usize)]
    |        ^^^^^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:81:8
+  --> $DIR/enum.rs:94:8
    |
-81 | #[repr(isize)]
+94 | #[repr(isize)]
    |        ^^^^^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:87:8
-   |
-87 | #[repr(u32)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:93:8
-   |
-93 | #[repr(i32)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-msrv/enum.rs:99:8
-   |
-99 | #[repr(u64)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:105:8
+   --> $DIR/enum.rs:101:8
     |
-105 | #[repr(i64)]
+101 | #[repr(u32)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:108:8
+    |
+108 | #[repr(i32)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:115:8
+    |
+115 | #[repr(u64)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:122:8
+    |
+122 | #[repr(i64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:115:8
+   --> $DIR/enum.rs:133:8
     |
-115 | #[repr(C)]
+133 | #[repr(C)]
     |        ^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:121:8
+   --> $DIR/enum.rs:140:8
     |
-121 | #[repr(u16)]
+140 | #[repr(u16)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:127:8
+   --> $DIR/enum.rs:147:8
     |
-127 | #[repr(i16)]
+147 | #[repr(i16)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:133:8
+   --> $DIR/enum.rs:154:8
     |
-133 | #[repr(u32)]
+154 | #[repr(u32)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:139:8
+   --> $DIR/enum.rs:161:8
     |
-139 | #[repr(i32)]
+161 | #[repr(i32)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:145:8
+   --> $DIR/enum.rs:168:8
     |
-145 | #[repr(u64)]
+168 | #[repr(u64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:151:8
+   --> $DIR/enum.rs:175:8
     |
-151 | #[repr(i64)]
+175 | #[repr(i64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:157:8
+   --> $DIR/enum.rs:182:8
     |
-157 | #[repr(usize)]
+182 | #[repr(usize)]
     |        ^^^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:163:8
+   --> $DIR/enum.rs:189:8
     |
-163 | #[repr(isize)]
+189 | #[repr(isize)]
     |        ^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:169:12
+   --> $DIR/enum.rs:196:12
     |
-169 | #[repr(u8, align(2))]
+196 | #[repr(u8, align(2))]
     |            ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:175:12
+   --> $DIR/enum.rs:203:12
     |
-175 | #[repr(i8, align(2))]
+203 | #[repr(i8, align(2))]
     |            ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:181:18
+   --> $DIR/enum.rs:210:18
     |
-181 | #[repr(align(1), align(2))]
+210 | #[repr(align(1), align(2))]
     |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:187:8
+   --> $DIR/enum.rs:217:8
     |
-187 | #[repr(align(2), align(4))]
+217 | #[repr(align(2), align(4))]
     |        ^^^^^^^^
 
 error[E0565]: meta item in `repr` must be an identifier
-  --> tests/ui-msrv/enum.rs:15:8
+  --> $DIR/enum.rs:15:8
    |
 15 | #[repr("foo")]
    |        ^^^^^
 
 error[E0552]: unrecognized representation hint
-  --> tests/ui-msrv/enum.rs:21:8
+  --> $DIR/enum.rs:23:8
    |
-21 | #[repr(foo)]
+23 | #[repr(foo)]
    |        ^^^
    |
    = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
 error[E0566]: conflicting representation hints
-  --> tests/ui-msrv/enum.rs:33:8
+  --> $DIR/enum.rs:38:8
    |
-33 | #[repr(u8, u16)]
+38 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
    = note: `#[deny(conflicting_repr_hints)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
+
+error: aborting due to 31 previous errors
+
+Some errors have detailed explanations: E0552, E0565, E0566.
+For more information about an error, try `rustc --explain E0552`.

--- a/zerocopy-derive/tests/ui-msrv/enum_from_bytes_u8_too_few.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum_from_bytes_u8_too_few.stderr
@@ -1,11 +1,14 @@
 error: FromBytes only supported on repr(u8) enum with 256 variants
-   --> tests/ui-msrv/enum_from_bytes_u8_too_few.rs:11:1
+   --> $DIR/enum_from_bytes_u8_too_few.rs:11:1
     |
 11  | / #[repr(u8)]
-12  | | enum Foo {
-13  | |     Variant0,
-14  | |     Variant1,
+12  | |
+13  | | enum Foo {
+14  | |     Variant0,
 ...   |
-267 | |     Variant254,
-268 | | }
+268 | |     Variant254,
+269 | | }
     | |_^
+
+error: aborting due to previous error
+

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:23:10
+  --> $DIR/late_compile_pass.rs:23:10
    |
 23 | #[derive(FromZeroes)]
    |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
@@ -13,14 +13,14 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 41 others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeroes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:32:10
+  --> $DIR/late_compile_pass.rs:33:10
    |
-32 | #[derive(FromBytes)]
+33 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
@@ -32,37 +32,37 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 38 others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `FromBytes1: FromZeroes` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:32:10
-   |
-32 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `FromBytes1`
-   |
-   = help: the following other types implement trait `FromZeroes`:
-             ()
-             AU16
-             F32<O>
-             F64<O>
-             FromZeroes1
-             I128<O>
-             I16<O>
-             I32<O>
-           and $N others
+   --> $DIR/late_compile_pass.rs:33:10
+    |
+33  | #[derive(FromBytes)]
+    |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `FromBytes1`
+    |
+    = help: the following other types implement trait `FromZeroes`:
+              ()
+              AU16
+              F32<O>
+              F64<O>
+              FromZeroes1
+              I128<O>
+              I16<O>
+              I32<O>
+            and 41 others
 note: required by a bound in `FromBytes`
-  --> $WORKSPACE/src/lib.rs
-   |
-   | pub unsafe trait FromBytes: FromZeroes {
-   |                             ^^^^^^^^^^ required by this bound in `FromBytes`
-   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> /home/ubuntu/projects/zerocopy/src/lib.rs:449:29
+    |
+449 | pub unsafe trait FromBytes: FromZeroes {
+    |                             ^^^^^^^^^^ required by this bound in `FromBytes`
+    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:41:10
+  --> $DIR/late_compile_pass.rs:44:10
    |
-41 | #[derive(AsBytes)]
+44 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
@@ -74,14 +74,14 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 52 others
    = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:51:10
+  --> $DIR/late_compile_pass.rs:55:10
    |
-51 | #[derive(Unaligned)]
+55 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -93,14 +93,14 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:59:10
+  --> $DIR/late_compile_pass.rs:64:10
    |
-59 | #[derive(Unaligned)]
+64 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -112,14 +112,14 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/late_compile_pass.rs:66:10
+  --> $DIR/late_compile_pass.rs:72:10
    |
-66 | #[derive(Unaligned)]
+72 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -131,6 +131,10 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -1,5 +1,5 @@
 error: unsupported on generic structs that are not repr(transparent) or repr(packed)
-  --> tests/ui-msrv/struct.rs:19:10
+  --> $DIR/struct.rs:19:10
    |
 19 | #[derive(AsBytes)]
    |          ^^^^^^^
@@ -7,47 +7,52 @@ error: unsupported on generic structs that are not repr(transparent) or repr(pac
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:35:11
+  --> $DIR/struct.rs:37:11
    |
-35 | #[repr(C, align(2))]
+37 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:39:21
+  --> $DIR/struct.rs:42:21
    |
-39 | #[repr(transparent, align(2))]
+42 | #[repr(transparent, align(2))]
    |                     ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:45:16
+  --> $DIR/struct.rs:50:16
    |
-45 | #[repr(packed, align(2))]
+50 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:49:18
+  --> $DIR/struct.rs:55:18
    |
-49 | #[repr(align(1), align(2))]
+55 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:53:8
+  --> $DIR/struct.rs:60:8
    |
-53 | #[repr(align(2), align(4))]
+60 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> tests/ui-msrv/struct.rs:39:8
+  --> $DIR/struct.rs:42:8
    |
-39 | #[repr(transparent, align(2))]
+42 | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
-  --> tests/ui-msrv/struct.rs:23:10
+  --> $DIR/struct.rs:24:10
    |
-23 | #[derive(AsBytes)]
+24 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
    |
    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
    = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0277, E0692.
+For more information about an error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -1,5 +1,5 @@
 error: unsupported on types with type parameters
-  --> tests/ui-msrv/union.rs:20:10
+  --> $DIR/union.rs:20:10
    |
 20 | #[derive(AsBytes)]
    |          ^^^^^^^
@@ -7,35 +7,39 @@ error: unsupported on types with type parameters
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/union.rs:38:11
+  --> $DIR/union.rs:40:11
    |
-38 | #[repr(C, align(2))]
+40 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/union.rs:54:16
+  --> $DIR/union.rs:57:16
    |
-54 | #[repr(packed, align(2))]
+57 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/union.rs:60:18
+  --> $DIR/union.rs:64:18
    |
-60 | #[repr(align(1), align(2))]
+64 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/union.rs:66:8
+  --> $DIR/union.rs:71:8
    |
-66 | #[repr(align(2), align(4))]
+71 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
-  --> tests/ui-msrv/union.rs:26:10
+  --> $DIR/union.rs:27:10
    |
-26 | #[derive(AsBytes)]
+27 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
    |
    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
    = help: see issue #48214
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-extern crate zerocopy;
-
 #[path = "../util.rs"]
 mod util;
+
+use test_util::*;
 
 use core::marker::PhantomData;
 
@@ -31,6 +31,10 @@ struct TransparentStruct<T> {
 // must also ensure the traits are only implemented when the inner type
 // implements them.
 assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
+//~^ ERROR: the trait bound `NotZerocopy: FromZeroes` is not satisfied
 assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+//~^ ERROR: the trait bound `NotZerocopy: FromBytes` is not satisfied
 assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+//~^ ERROR: the trait bound `NotZerocopy: AsBytes` is not satisfied
 assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+//~^ ERROR: the trait bound `NotZerocopy: Unaligned` is not satisfied

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -1,5 +1,13 @@
+warning: unused import: `test_util::*`
+ --> $DIR/derive_transparent.rs:8:5
+  |
+8 | use test_util::*;
+  |     ^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:33:18
+  --> $DIR/derive_transparent.rs:33:18
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
@@ -13,23 +21,23 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 41 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
-  --> tests/ui-nightly/derive_transparent.rs:23:19
+  --> $DIR/derive_transparent.rs:23:19
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                   ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:33:1
+  --> $DIR/derive_transparent.rs:33:1
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:34:18
+  --> $DIR/derive_transparent.rs:35:18
    |
-34 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
@@ -41,23 +49,23 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 38 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-nightly/derive_transparent.rs:23:31
+  --> $DIR/derive_transparent.rs:23:31
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                               ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:34:1
+  --> $DIR/derive_transparent.rs:35:1
    |
-34 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+35 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:35:18
+  --> $DIR/derive_transparent.rs:37:18
    |
-35 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
@@ -69,23 +77,23 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              I16<O>
              I32<O>
              I64<O>
-           and $N others
+           and 52 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
-  --> tests/ui-nightly/derive_transparent.rs:23:10
+  --> $DIR/derive_transparent.rs:23:10
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:35:1
+  --> $DIR/derive_transparent.rs:37:1
    |
-35 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:36:18
+  --> $DIR/derive_transparent.rs:39:18
    |
-36 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -97,15 +105,19 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 19 others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-nightly/derive_transparent.rs:23:42
+  --> $DIR/derive_transparent.rs:23:42
    |
 23 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
    |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:36:1
+  --> $DIR/derive_transparent.rs:39:1
    |
-36 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-nightly/enum.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum.rs
@@ -13,29 +13,37 @@ fn main() {}
 
 #[derive(FromZeroes, FromBytes)]
 #[repr("foo")]
+//~^ ERROR: meta item in `repr` must be an identifier
+//~| ERROR: unrecognized representation hint
 enum Generic1 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(foo)]
+//~^ ERROR: unrecognized representation hint
+//~| ERROR: unrecognized representation hint
 enum Generic2 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(transparent)]
+//~^ ERROR: unsupported representation for deriving FromBytes, AsBytes, or Unaligned on an enum
 enum Generic3 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(u8, u16)]
+//~^ ERROR: conflicting representation hints
+//~| ERROR: conflicting representation hints
 enum Generic4 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
+//~^ ERROR: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
 enum Generic5 {
     A,
 }
@@ -46,17 +54,20 @@ enum Generic5 {
 
 #[derive(FromZeroes)]
 enum FromZeroes1 {
+    //~^ ERROR: only C-like enums can implement FromZeroes
     A(u8),
 }
 
 #[derive(FromZeroes)]
 enum FromZeroes2 {
+    //~^ ERROR: only C-like enums can implement FromZeroes
     A,
     B(u8),
 }
 
 #[derive(FromZeroes)]
 enum FromZeroes3 {
+    //~^ ERROR: FromZeroes only supported on enums with a variant that has a discriminant of `0`
     A = 1,
     B,
 }
@@ -67,42 +78,49 @@ enum FromZeroes3 {
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(C)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes1 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(usize)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes2 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(isize)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes3 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(u32)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes4 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(i32)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes5 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(u64)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes6 {
     A,
 }
 
 #[derive(FromZeroes, FromBytes)]
 #[repr(i64)]
+//~^ ERROR: FromBytes requires repr of "u8", "u16", "i8", or "i16"
 enum FromBytes7 {
     A,
 }
@@ -113,78 +131,91 @@ enum FromBytes7 {
 
 #[derive(Unaligned)]
 #[repr(C)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment
 enum Unaligned1 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(u16)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned2 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(i16)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned3 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(u32)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned4 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(i32)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned5 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(u64)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned6 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(i64)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned7 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(usize)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned8 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(isize)]
+//~^ ERROR: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
 enum Unaligned9 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(u8, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 enum Unaligned10 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(i8, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 enum Unaligned11 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(align(1), align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 enum Unaligned12 {
     A,
 }
 
 #[derive(Unaligned)]
 #[repr(align(2), align(4))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 enum Unaligned13 {
     A,
 }

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -1,201 +1,209 @@
 error: unrecognized representation hint
-  --> tests/ui-nightly/enum.rs:15:8
+  --> $DIR/enum.rs:15:8
    |
 15 | #[repr("foo")]
    |        ^^^^^
 
 error: unrecognized representation hint
-  --> tests/ui-nightly/enum.rs:21:8
+  --> $DIR/enum.rs:23:8
    |
-21 | #[repr(foo)]
+23 | #[repr(foo)]
    |        ^^^
 
 error: unsupported representation for deriving FromBytes, AsBytes, or Unaligned on an enum
-  --> tests/ui-nightly/enum.rs:27:8
+  --> $DIR/enum.rs:31:8
    |
-27 | #[repr(transparent)]
+31 | #[repr(transparent)]
    |        ^^^^^^^^^^^
 
 error: conflicting representation hints
-  --> tests/ui-nightly/enum.rs:33:8
+  --> $DIR/enum.rs:38:8
    |
-33 | #[repr(u8, u16)]
+38 | #[repr(u8, u16)]
    |        ^^^^^^^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-  --> tests/ui-nightly/enum.rs:38:22
+  --> $DIR/enum.rs:45:22
    |
-38 | #[derive(FromZeroes, FromBytes)]
+45 | #[derive(FromZeroes, FromBytes)]
    |                      ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: only C-like enums can implement FromZeroes
-  --> tests/ui-nightly/enum.rs:48:1
+  --> $DIR/enum.rs:56:1
    |
-48 | / enum FromZeroes1 {
-49 | |     A(u8),
-50 | | }
+56 | / enum FromZeroes1 {
+57 | |
+58 | |     A(u8),
+59 | | }
    | |_^
 
 error: only C-like enums can implement FromZeroes
-  --> tests/ui-nightly/enum.rs:53:1
+  --> $DIR/enum.rs:62:1
    |
-53 | / enum FromZeroes2 {
-54 | |     A,
-55 | |     B(u8),
-56 | | }
+62 | / enum FromZeroes2 {
+63 | |
+64 | |     A,
+65 | |     B(u8),
+66 | | }
    | |_^
 
 error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
-  --> tests/ui-nightly/enum.rs:59:1
+  --> $DIR/enum.rs:69:1
    |
-59 | / enum FromZeroes3 {
-60 | |     A = 1,
-61 | |     B,
-62 | | }
+69 | / enum FromZeroes3 {
+70 | |
+71 | |     A = 1,
+72 | |     B,
+73 | | }
    | |_^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:69:8
+  --> $DIR/enum.rs:80:8
    |
-69 | #[repr(C)]
+80 | #[repr(C)]
    |        ^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:75:8
+  --> $DIR/enum.rs:87:8
    |
-75 | #[repr(usize)]
+87 | #[repr(usize)]
    |        ^^^^^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:81:8
+  --> $DIR/enum.rs:94:8
    |
-81 | #[repr(isize)]
+94 | #[repr(isize)]
    |        ^^^^^
 
 error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:87:8
-   |
-87 | #[repr(u32)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:93:8
-   |
-93 | #[repr(i32)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-  --> tests/ui-nightly/enum.rs:99:8
-   |
-99 | #[repr(u64)]
-   |        ^^^
-
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:105:8
+   --> $DIR/enum.rs:101:8
     |
-105 | #[repr(i64)]
+101 | #[repr(u32)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:108:8
+    |
+108 | #[repr(i32)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:115:8
+    |
+115 | #[repr(u64)]
+    |        ^^^
+
+error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
+   --> $DIR/enum.rs:122:8
+    |
+122 | #[repr(i64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:115:8
+   --> $DIR/enum.rs:133:8
     |
-115 | #[repr(C)]
+133 | #[repr(C)]
     |        ^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:121:8
+   --> $DIR/enum.rs:140:8
     |
-121 | #[repr(u16)]
+140 | #[repr(u16)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:127:8
+   --> $DIR/enum.rs:147:8
     |
-127 | #[repr(i16)]
+147 | #[repr(i16)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:133:8
+   --> $DIR/enum.rs:154:8
     |
-133 | #[repr(u32)]
+154 | #[repr(u32)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:139:8
+   --> $DIR/enum.rs:161:8
     |
-139 | #[repr(i32)]
+161 | #[repr(i32)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:145:8
+   --> $DIR/enum.rs:168:8
     |
-145 | #[repr(u64)]
+168 | #[repr(u64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:151:8
+   --> $DIR/enum.rs:175:8
     |
-151 | #[repr(i64)]
+175 | #[repr(i64)]
     |        ^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:157:8
+   --> $DIR/enum.rs:182:8
     |
-157 | #[repr(usize)]
+182 | #[repr(usize)]
     |        ^^^^^
 
 error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:163:8
+   --> $DIR/enum.rs:189:8
     |
-163 | #[repr(isize)]
+189 | #[repr(isize)]
     |        ^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:169:12
+   --> $DIR/enum.rs:196:12
     |
-169 | #[repr(u8, align(2))]
+196 | #[repr(u8, align(2))]
     |            ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:175:12
+   --> $DIR/enum.rs:203:12
     |
-175 | #[repr(i8, align(2))]
+203 | #[repr(i8, align(2))]
     |            ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:181:18
+   --> $DIR/enum.rs:210:18
     |
-181 | #[repr(align(1), align(2))]
+210 | #[repr(align(1), align(2))]
     |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:187:8
+   --> $DIR/enum.rs:217:8
     |
-187 | #[repr(align(2), align(4))]
+217 | #[repr(align(2), align(4))]
     |        ^^^^^^^^
 
 error[E0565]: meta item in `repr` must be an identifier
-  --> tests/ui-nightly/enum.rs:15:8
+  --> $DIR/enum.rs:15:8
    |
 15 | #[repr("foo")]
    |        ^^^^^
 
 error[E0552]: unrecognized representation hint
-  --> tests/ui-nightly/enum.rs:21:8
+  --> $DIR/enum.rs:23:8
    |
-21 | #[repr(foo)]
+23 | #[repr(foo)]
    |        ^^^
    |
    = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
 error[E0566]: conflicting representation hints
-  --> tests/ui-nightly/enum.rs:33:8
+  --> $DIR/enum.rs:38:8
    |
-33 | #[repr(u8, u16)]
+38 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
    = note: `#[deny(conflicting_repr_hints)]` on by default
+
+error: aborting due to 31 previous errors
+
+Some errors have detailed explanations: E0552, E0565, E0566.
+For more information about an error, try `rustc --explain E0552`.

--- a/zerocopy-derive/tests/ui-nightly/enum_from_bytes_u8_too_few.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum_from_bytes_u8_too_few.rs
@@ -9,6 +9,7 @@ fn main() {}
 
 #[derive(FromBytes)]
 #[repr(u8)]
+//~^ ERROR: FromBytes only supported on repr(u8) enum with 256 variants
 enum Foo {
     Variant0,
     Variant1,

--- a/zerocopy-derive/tests/ui-nightly/enum_from_bytes_u8_too_few.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum_from_bytes_u8_too_few.stderr
@@ -1,11 +1,14 @@
 error: FromBytes only supported on repr(u8) enum with 256 variants
-   --> tests/ui-nightly/enum_from_bytes_u8_too_few.rs:11:1
+   --> $DIR/enum_from_bytes_u8_too_few.rs:11:1
     |
 11  | / #[repr(u8)]
-12  | | enum Foo {
-13  | |     Variant0,
-14  | |     Variant1,
+12  | |
+13  | | enum Foo {
+14  | |     Variant0,
 ...   |
-267 | |     Variant254,
-268 | | }
+268 | |     Variant254,
+269 | | }
     | |_^
+
+error: aborting due to previous error
+

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.rs
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.rs
@@ -21,6 +21,7 @@ fn main() {}
 //
 
 #[derive(FromZeroes)]
+//~^ ERROR: the trait bound `NotZerocopy: FromZeroes` is not satisfied
 struct FromZeroes1 {
     value: NotZerocopy,
 }
@@ -30,6 +31,8 @@ struct FromZeroes1 {
 //
 
 #[derive(FromBytes)]
+//~^ ERROR: the trait bound `NotZerocopy: FromBytes` is not satisfied
+//~| ERROR: the trait bound `FromBytes1: FromZeroes` is not satisfied
 struct FromBytes1 {
     value: NotZerocopy,
 }
@@ -39,6 +42,7 @@ struct FromBytes1 {
 //
 
 #[derive(AsBytes)]
+//~^ ERROR: the trait bound `NotZerocopy: AsBytes` is not satisfied
 #[repr(C)]
 struct AsBytes1 {
     value: NotZerocopy,
@@ -49,6 +53,7 @@ struct AsBytes1 {
 //
 
 #[derive(Unaligned)]
+//~^ ERROR: the trait bound `AU16: Unaligned` is not satisfied
 #[repr(C)]
 struct Unaligned1 {
     aligned: AU16,
@@ -57,6 +62,7 @@ struct Unaligned1 {
 // This specifically tests a bug we had in an old version of the code in which
 // the trait bound would only be enforced for the first field's type.
 #[derive(Unaligned)]
+//~^ ERROR: the trait bound `AU16: Unaligned` is not satisfied
 #[repr(C)]
 struct Unaligned2 {
     unaligned: u8,
@@ -64,6 +70,7 @@ struct Unaligned2 {
 }
 
 #[derive(Unaligned)]
+//~^ ERROR: the trait bound `AU16: Unaligned` is not satisfied
 #[repr(transparent)]
 struct Unaligned3 {
     aligned: AU16,

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:23:10
+  --> $DIR/late_compile_pass.rs:23:10
    |
 23 | #[derive(FromZeroes)]
    |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
@@ -13,15 +13,15 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 41 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromZeroes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:32:10
+  --> $DIR/late_compile_pass.rs:33:10
    |
-32 | #[derive(FromBytes)]
+33 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
@@ -33,38 +33,38 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 38 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `FromBytes1: FromZeroes` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:32:10
-   |
-32 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `FromBytes1`
-   |
-   = help: the following other types implement trait `FromZeroes`:
-             ()
-             AU16
-             F32<O>
-             F64<O>
-             FromZeroes1
-             I128<O>
-             I16<O>
-             I32<O>
-           and $N others
+   --> $DIR/late_compile_pass.rs:33:10
+    |
+33  | #[derive(FromBytes)]
+    |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `FromBytes1`
+    |
+    = help: the following other types implement trait `FromZeroes`:
+              ()
+              AU16
+              F32<O>
+              F64<O>
+              FromZeroes1
+              I128<O>
+              I16<O>
+              I32<O>
+            and 41 others
 note: required by a bound in `FromBytes`
-  --> $WORKSPACE/src/lib.rs
-   |
-   | pub unsafe trait FromBytes: FromZeroes {
-   |                             ^^^^^^^^^^ required by this bound in `FromBytes`
-   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> /home/ubuntu/projects/zerocopy/src/lib.rs:449:29
+    |
+449 | pub unsafe trait FromBytes: FromZeroes {
+    |                             ^^^^^^^^^^ required by this bound in `FromBytes`
+    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:41:10
+  --> $DIR/late_compile_pass.rs:44:10
    |
-41 | #[derive(AsBytes)]
+44 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
@@ -76,15 +76,15 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              I128<O>
              I16<O>
              I32<O>
-           and $N others
+           and 52 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:51:10
+  --> $DIR/late_compile_pass.rs:55:10
    |
-51 | #[derive(Unaligned)]
+55 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -96,15 +96,15 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:59:10
+  --> $DIR/late_compile_pass.rs:64:10
    |
-59 | #[derive(Unaligned)]
+64 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -116,15 +116,15 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-nightly/late_compile_pass.rs:66:10
+  --> $DIR/late_compile_pass.rs:72:10
    |
-66 | #[derive(Unaligned)]
+72 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
    = help: the following other types implement trait `Unaligned`:
@@ -136,7 +136,11 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              I32<O>
              I64<O>
              ManuallyDrop<T>
-           and $N others
+           and 21 others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -17,10 +17,12 @@ fn main() {}
 //
 
 #[derive(AsBytes)]
+//~^ ERROR: unsupported on generic structs that are not repr(transparent) or repr(packed)
 #[repr(C)]
 struct AsBytes1<T>(T);
 
 #[derive(AsBytes)]
+//~^ ERROR: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
 #[repr(C)]
 struct AsBytes2 {
     foo: u8,
@@ -33,22 +35,28 @@ struct AsBytes2 {
 
 #[derive(Unaligned)]
 #[repr(C, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned1;
 
 #[derive(Unaligned)]
 #[repr(transparent, align(2))]
+//~^ ERROR: transparent struct cannot have other repr hints
+//~| ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned2 {
     foo: u8,
 }
 
 #[derive(Unaligned)]
 #[repr(packed, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned3;
 
 #[derive(Unaligned)]
 #[repr(align(1), align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned4;
 
 #[derive(Unaligned)]
 #[repr(align(2), align(4))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned5;

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -1,5 +1,5 @@
 error: unsupported on generic structs that are not repr(transparent) or repr(packed)
-  --> tests/ui-nightly/struct.rs:19:10
+  --> $DIR/struct.rs:19:10
    |
 19 | #[derive(AsBytes)]
    |          ^^^^^^^
@@ -7,48 +7,53 @@ error: unsupported on generic structs that are not repr(transparent) or repr(pac
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:35:11
+  --> $DIR/struct.rs:37:11
    |
-35 | #[repr(C, align(2))]
+37 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:39:21
+  --> $DIR/struct.rs:42:21
    |
-39 | #[repr(transparent, align(2))]
+42 | #[repr(transparent, align(2))]
    |                     ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:45:16
+  --> $DIR/struct.rs:50:16
    |
-45 | #[repr(packed, align(2))]
+50 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:49:18
+  --> $DIR/struct.rs:55:18
    |
-49 | #[repr(align(1), align(2))]
+55 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:53:8
+  --> $DIR/struct.rs:60:8
    |
-53 | #[repr(align(2), align(4))]
+60 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> tests/ui-nightly/struct.rs:39:8
+  --> $DIR/struct.rs:42:8
    |
-39 | #[repr(transparent, align(2))]
+42 | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
-  --> tests/ui-nightly/struct.rs:23:10
+  --> $DIR/struct.rs:24:10
    |
-23 | #[derive(AsBytes)]
+24 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
    |
    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0277, E0692.
+For more information about an error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui-nightly/union.rs
+++ b/zerocopy-derive/tests/ui-nightly/union.rs
@@ -18,12 +18,14 @@ fn main() {}
 //
 
 #[derive(AsBytes)]
+//~^ ERROR: unsupported on types with type parameters
 #[repr(C)]
 union AsBytes1<T> {
     foo: ManuallyDrop<T>,
 }
 
 #[derive(AsBytes)]
+//~^ ERROR: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
 #[repr(C)]
 union AsBytes2 {
     foo: u8,
@@ -36,6 +38,7 @@ union AsBytes2 {
 
 #[derive(Unaligned)]
 #[repr(C, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 union Unaligned1 {
     foo: i16,
     bar: AU16,
@@ -52,18 +55,21 @@ union Unaligned1 {
 
 #[derive(Unaligned)]
 #[repr(packed, align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 union Unaligned3 {
     foo: u8,
 }
 
 #[derive(Unaligned)]
 #[repr(align(1), align(2))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned4 {
     foo: u8,
 }
 
 #[derive(Unaligned)]
 #[repr(align(2), align(4))]
+//~^ ERROR: cannot derive Unaligned with repr(align(N > 1))
 struct Unaligned5 {
     foo: u8,
 }

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -1,5 +1,5 @@
 error: unsupported on types with type parameters
-  --> tests/ui-nightly/union.rs:20:10
+  --> $DIR/union.rs:20:10
    |
 20 | #[derive(AsBytes)]
    |          ^^^^^^^
@@ -7,36 +7,40 @@ error: unsupported on types with type parameters
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:38:11
+  --> $DIR/union.rs:40:11
    |
-38 | #[repr(C, align(2))]
+40 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:54:16
+  --> $DIR/union.rs:57:16
    |
-54 | #[repr(packed, align(2))]
+57 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:60:18
+  --> $DIR/union.rs:64:18
    |
-60 | #[repr(align(1), align(2))]
+64 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:66:8
+  --> $DIR/union.rs:71:8
    |
-66 | #[repr(align(2), align(4))]
+71 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is not satisfied
-  --> tests/ui-nightly/union.rs:26:10
+  --> $DIR/union.rs:27:10
    |
-26 | #[derive(AsBytes)]
+27 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
    |
    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui.rs
+++ b/zerocopy-derive/tests/ui.rs
@@ -15,15 +15,26 @@
 // - `tests/ui-msrv` - Contains symlinks to the `.rs` files in
 //   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
 
-#[rustversion::any(nightly)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-nightly/*.rs";
-#[rustversion::all(stable, not(stable(1.65.0)))]
-const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
-#[rustversion::stable(1.65.0)]
-const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
+use test_util::*;
 
-#[test]
-fn ui() {
-    let t = trybuild::TestCases::new();
-    t.compile_fail(SOURCE_FILES_GLOB);
+fn main() -> color_eyre::eyre::Result<()> {
+    let bless = should_bless();
+
+    let PinnedToolchains { msrv, stable, nightly } = test_util::pinned_toolchains()?;
+
+    let folder = if TOOLCHAIN == msrv {
+        "tests/ui-msrv"
+    } else if TOOLCHAIN == stable {
+        "tests/ui-stable"
+    } else if TOOLCHAIN == nightly {
+        "tests/ui-nightly"
+    } else {
+        unreachable!(
+            "UI tests must be runned with the MSRV ({msrv}),\
+            pinned stable ({stable}), \
+            or pinned nightly ({nightly}) toolchains."
+        );
+    };
+
+    ui_test(TOOLCHAIN, folder, bless)
 }

--- a/zerocopy-derive/tests/util.rs
+++ b/zerocopy-derive/tests/util.rs
@@ -5,7 +5,7 @@
 use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 /// A type that doesn't implement any zerocopy traits.
-pub struct NotZerocopy(());
+pub struct NotZerocopy<T: ?Sized = ()>(T);
 
 /// A `u16` with alignment 2.
 ///


### PR DESCRIPTION
The `ui-test` crate allows for annotating the tests themselves with the expected error message. This will make changes to zerocopy or its tests that alter error messages easier to review, as the .stderr file can be merely skimmed.

This is a fork of #194 in order to try to get tests passing.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
