### PR TITLE
Rename LayoutVerified to Ref

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -30,7 +30,7 @@
 //! UDP:
 //!
 //! ```edition2021
-//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeroes, LayoutVerified, Unaligned};
+//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeroes, Ref, Unaligned};
 //! use zerocopy::byteorder::network_endian::U16;
 //!
 //! #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -43,13 +43,13 @@
 //! }
 //!
 //! struct UdpPacket<B: ByteSlice> {
-//!     header: LayoutVerified<B, UdpHeader>,
+//!     header: Ref<B, UdpHeader>,
 //!     body: B,
 //! }
 //!
 //! impl<B: ByteSlice> UdpPacket<B> {
 //!     fn parse(bytes: B) -> Option<UdpPacket<B>> {
-//!         let (header, body) = LayoutVerified::new_from_prefix(bytes)?;
+//!         let (header, body) = Ref::new_from_prefix(bytes)?;
 //!         Some(UdpPacket { header, body })
 //!     }
 //!


### PR DESCRIPTION
While `LayoutVerified` is technically a descriptive name, it doesn't give much of a hint as to what the type's intended use is. The way it is used in practice is as a sort of "smart" reference - the only difference from a native reference (`&` or `&mut`) is that it is generic over the mutability of the byte slice from which it was constructed. Thus, `Ref` is a more helpful and informative name.

Closes #68

cc @kupiakos

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
