### PR TITLE
Move now-stable aarch64 types to "simd" feature (#172)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,7 +1014,7 @@ mod simd {
         vector_signed_long,
         vector_unsigned_long
     );
-    #[cfg(all(feature = "simd-nightly", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     #[rustfmt::skip]
     simd_arch_mod!(
         aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,


### PR DESCRIPTION
<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
