### PR TITLE
Add deprecated LayoutVerified type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1571,6 +1571,11 @@ macro_rules! transmute {
 /// ```
 pub struct Ref<B, T: ?Sized>(B, PhantomData<T>);
 
+/// Deprecated: prefer [`Ref`] instead.
+#[deprecated(since = "0.7.0", note = "LayoutVerified has been renamed to Ref")]
+#[doc(hidden)]
+pub type LayoutVerified<B, T> = Ref<B, T>;
+
 impl<B, T> Ref<B, T>
 where
     B: ByteSlice,


### PR DESCRIPTION
This should help make the transition to 0.7.0 easier, as code which currently uses `LayoutVerified` will get a deprecation warning instead of a (much less helpful) "not found" error.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
