### PR TITLE
[0.6.x] Remove byteorder feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ pinned-stable = "1.64.0"
 pinned-nightly = "nightly-2022-10-17"
 
 [features]
-default = ["byteorder"]
-
 alloc = []
 simd = []
 simd-nightly = ["simd"]
@@ -45,7 +43,6 @@ zerocopy-derive = { version = "=0.6.2", path = "zerocopy-derive" }
 [dependencies.byteorder]
 version = "1.3"
 default-features = false
-optional = true
 
 [dev-dependencies]
 rand = "0.6"

--- a/README.md
+++ b/README.md
@@ -34,15 +34,6 @@ types, see the `byteorder` module.
 enabled, the `alloc` crate is added as a dependency, and some
 allocation-related functionality is added.
 
-`byteorder` (enabled by default): Adds the `byteorder` module and a
-dependency on the `byteorder` crate. The `byteorder` module provides byte
-order-aware equivalents of the multi-byte primitive numerical types. Unlike
-their primitive equivalents, the types in this module have no alignment
-requirement and support byte order conversions. This can be useful in
-handling file formats, network packet layouts, etc which don't provide
-alignment guarantees and which may use a byte order different from that of
-the execution platform.
-
 `simd`: When the `simd` feature is enabled, `FromBytes` and `AsBytes` impls
 are emitted for all stable SIMD types which exist on the target platform.
 Note that the layout of SIMD types is not yet stabilized, so these impls may

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,15 +33,6 @@
 //! enabled, the `alloc` crate is added as a dependency, and some
 //! allocation-related functionality is added.
 //!
-//! `byteorder` (enabled by default): Adds the [`byteorder`] module and a
-//! dependency on the `byteorder` crate. The `byteorder` module provides byte
-//! order-aware equivalents of the multi-byte primitive numerical types. Unlike
-//! their primitive equivalents, the types in this module have no alignment
-//! requirement and support byte order conversions. This can be useful in
-//! handling file formats, network packet layouts, etc which don't provide
-//! alignment guarantees and which may use a byte order different from that of
-//! the execution platform.
-//!
 //! `simd`: When the `simd` feature is enabled, `FromBytes` and `AsBytes` impls
 //! are emitted for all stable SIMD types which exist on the target platform.
 //! Note that the layout of SIMD types is not yet stabilized, so these impls may
@@ -134,12 +125,10 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "simd-nightly", feature(stdsimd))]
 
-#[cfg(feature = "byteorder")]
 pub mod byteorder;
 #[doc(hidden)]
 pub mod derive_util;
 
-#[cfg(feature = "byteorder")]
 pub use crate::byteorder::*;
 pub use zerocopy_derive::*;
 


### PR DESCRIPTION
This feature caused breakage in 0.6.2 (see [1] for details). This commit removes the feature and makes the `byteorder` module present unconditionally. This will not be ported to 0.7.0, which will contain the `byteorder` feature.

[1] https://github.com/google/zerocopy/issues/228#issuecomment-1668506529

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
