### PR TITLE
Reduce MSRV to 1.61.0 (#234)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ all-features = true
 
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
-pinned-stable = "1.64.0"
-pinned-nightly = "nightly-2022-10-17"
+pinned-stable = "1.69.0"
+pinned-nightly = "nightly-2023-05-25"
 
 [features]
 alloc = []

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -15,9 +15,9 @@
 // - `tests/ui-msrv` - Contains symlinks to the `.rs` files in
 //   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
 
-#[rustversion::any(nightly)]
+#[rustversion::nightly]
 const SOURCE_FILES_GLOB: &str = "tests/ui-nightly/*.rs";
-#[rustversion::all(stable, not(stable(1.61.0)))]
+#[rustversion::stable(1.69.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
 #[rustversion::stable(1.61.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";

--- a/tests/ui-nightly/transmute-illegal.stderr
+++ b/tests/ui-nightly/transmute-illegal.stderr
@@ -7,19 +7,10 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
    |                              the trait `AsBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and $N others
+   = help: the trait `AsBytes` is implemented for `usize`
 note: required by a bound in `POINTER_VALUE::transmute`
   --> tests/ui-nightly/transmute-illegal.rs:10:30
    |
 10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
    = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-illegal.stderr
+++ b/tests/ui-stable/transmute-illegal.stderr
@@ -2,21 +2,15 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
   --> tests/ui-stable/transmute-illegal.rs:10:30
    |
 10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              the trait `AsBytes` is not implemented for `*const usize`
+   |                              required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
-             f32
-             f64
-             i128
-             i16
-             i32
-             i64
-             i8
-             isize
-           and $N others
+   = help: the trait `AsBytes` is implemented for `usize`
 note: required by a bound in `POINTER_VALUE::transmute`
   --> tests/ui-stable/transmute-illegal.rs:10:30
    |
 10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
    = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -15,9 +15,9 @@
 // - `tests/ui-msrv` - Contains symlinks to the `.rs` files in
 //   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
 
-#[rustversion::any(nightly)]
+#[rustversion::nightly]
 const SOURCE_FILES_GLOB: &str = "tests/ui-nightly/*.rs";
-#[rustversion::all(stable, not(stable(1.61.0)))]
+#[rustversion::stable(1.69.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
 #[rustversion::stable(1.61.0)]
 const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -18,12 +18,12 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
   --> tests/ui-nightly/derive_transparent.rs:23:19
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^
+   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:33:1
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
@@ -46,12 +46,12 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-nightly/derive_transparent.rs:23:10
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |          ^^^^^^^
+   |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:34:1
    |
 34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
@@ -74,10 +74,10 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
   --> tests/ui-nightly/derive_transparent.rs:23:30
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |                              ^^^^^^^^^
+   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:35:1
    |
 35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-stable/derive_transparent.rs:33:1
+  --> tests/ui-stable/derive_transparent.rs:33:18
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromBytes`:
              ()
@@ -14,23 +14,23 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
+note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
   --> tests/ui-stable/derive_transparent.rs:23:19
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^
+   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:33:1
    |
 33 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
-  --> tests/ui-stable/derive_transparent.rs:34:1
+  --> tests/ui-stable/derive_transparent.rs:34:18
    |
 34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `AsBytes`:
              ()
@@ -42,23 +42,23 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              I32<O>
              I64<O>
            and $N others
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-stable/derive_transparent.rs:23:10
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |          ^^^^^^^
+   |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:34:1
    |
 34 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-stable/derive_transparent.rs:35:1
+  --> tests/ui-stable/derive_transparent.rs:35:18
    |
 35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `Unaligned`:
              ()
@@ -70,14 +70,14 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              I64<O>
              ManuallyDrop<T>
            and $N others
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
   --> tests/ui-stable/derive_transparent.rs:23:30
    |
 23 | #[derive(AsBytes, FromBytes, Unaligned)]
-   |                              ^^^^^^^^^
+   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:35:1
    |
 35 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -161,6 +161,8 @@ error[E0552]: unrecognized representation hint
    |
 21 | #[repr(foo)]
    |        ^^^
+   |
+   = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
 error[E0566]: conflicting representation hints
   --> tests/ui-stable/enum.rs:33:8
@@ -168,6 +170,6 @@ error[E0566]: conflicting representation hints
 33 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
-   = note: `#[deny(conflicting_repr_hints)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
+   = note: `#[deny(conflicting_repr_hints)]` on by default


### PR DESCRIPTION
It turned out that there were only a few lines of code that required our MSRV to be as high as it was before this commit (1.65.0), and those lines were easy to modify to be compatible with this new MSRV.

Note that this requires introducing defensive code to `FromZeroes::new_box_slice_zeroed` in order to sidestep a bug in `Layout::from_size_align` that was present through 1.64.0.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
