### PR TITLE
Don’t compile derive_util unless needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ mod macros;
 
 #[cfg(feature = "byteorder")]
 pub mod byteorder;
+#[cfg(any(feature = "derive", test))]
 #[doc(hidden)]
 pub mod derive_util;
 


### PR DESCRIPTION

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
