### PR TITLE
Cargo check before get the metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
     - name: Configure environment variables
       run: |
-        set -e
+        set -eo pipefail
         if [[ '${{ matrix.toolchain }}' == 'nightly' ]]; then
           RUSTFLAGS="$RUSTFLAGS $ZC_NIGHTLY_RUSTFLAGS"
           MIRIFLAGS="$MIRIFLAGS $ZC_NIGHTLY_MIRIFLAGS"
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Check Rust formatting
         run: |
-          set -e
+          set -eo pipefail
           cargo fmt --check -p zerocopy
           cargo fmt --check -p zerocopy-derive
           shopt -s globstar
@@ -231,7 +231,7 @@ jobs:
         uses: Swatinem/rust-cache@e207df5d269b42b69c8bc5101da26f7d31feddb4 # v2.6.2
       - name: Check README.md
         run: |
-          set -e
+          set -eo pipefail
           cargo install cargo-readme --version 3.2.0
           diff <(./generate-readme.sh) README.md
           exit $?
@@ -245,7 +245,7 @@ jobs:
       # files are the same.
       - name: Check MSRVs match
         run: |
-          set -e
+          set -eo pipefail
 
           # Usage: msrv <crate-name>
           function msrv {
@@ -274,7 +274,7 @@ jobs:
       # `INTERNAL.md` for an explanation of why we do this.
       - name: Check crate versions match
         run: |
-          set -e
+          set -eo pipefail
 
           # Usage: version <crate-name>
           function version {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,8 @@ jobs:
     # actually compatible with.
     - name: Set toolchain version
       run: |
-        set -e
+        set -eo pipefail
 
-        cargo check
         function pkg-meta {
           cargo metadata --format-version 1 | jq -r ".packages[] | select(.name == \"zerocopy\").$1"
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
       run: |
         set -e
 
+        cargo check
         function pkg-meta {
           cargo metadata --format-version 1 | jq -r ".packages[] | select(.name == \"zerocopy\").$1"
         }

--- a/generate-readme.sh
+++ b/generate-readme.sh
@@ -4,7 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-set -e
+set -eo pipefail
 
 COPYRIGHT_HEADER=$(mktemp)
 BODY=$(mktemp)


### PR DESCRIPTION
Fixes #225
The reason `set -e` failed to interrupt the workflow is due to the output redirection to `jq`. Since `jq` returns a value of 0, indicating success, the script continues to execute. You can try running these scripts locally to gain insight into the issue.

To illustrate:

Script without interruption:
```sh
set -e

function pkg-meta {
  cargo metadata --format-version 1 | jq -r ".packages[] | select(.name\
  == \"zerocopy\").$1"
}

ZC_TOOLCHAIN=\"$(pkg-meta 'metadata.ci.\"pinned-nightly\"')\"

echo \"Discovered that the nightly toolchain is $ZC_TOOLCHAIN\"
echo \"ZC_TOOLCHAIN=$ZC_TOOLCHAIN\"
```

Script with interruption:
```sh
set -e

function pkg-meta {
  cargo metadata --format-version 1"
}

ZC_TOOLCHAIN=\"$(pkg-meta 'metadata.ci.\"pinned-nightly\"')\"

echo \"Discovered that the nightly toolchain is $ZC_TOOLCHAIN\"
echo \"ZC_TOOLCHAIN=$ZC_TOOLCHAIN\"
```

Additionally, you can display the return value after the command execution. This output will confirm the successful execution of the command.

```sh
set -e

function pkg-meta {
  cargo metadata --format-version 1 | jq -r \".packages[] | select(\
  .name == \"zerocopy\").$1\"
  echo
  echo \$?
}

ZC_TOOLCHAIN=\"$(pkg-meta 'metadata.ci.\"pinned-nightly\"')\"

echo \"Discovered that the nightly toolchain is $ZC_TOOLCHAIN\"
echo \"ZC_TOOLCHAIN=$ZC_TOOLCHAIN\"
```

Therefore, I've incorporated `cargo check` to validate the package retrieval. Subsequent to this check, there's no necessity to fetch the package again using `cargo metadata`. This modification should rectify the point of failure in the Git action.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
