### PR TITLE
Restrict MaybeUninit trait impls to fix soundness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause"
@@ -38,7 +38,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.6.3", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.6.4", path = "zerocopy-derive" }
 
 [dependencies.byteorder]
 version = "1.3"

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause"


### PR DESCRIPTION
Previously, we implemented `FromZeroes` and `FromBytes` for `MaybeUninit<T>` with no bound on `T`. This resulted in a soundness hole in which `T` - and thus `MaybeUninit<T>` - could contain an `UnsafeCell`, which is a violation of the contracts of `FromZeroes` and `FromBytes`.

This is a breaking change, but it's very unlikely to be one that code is currently relying on. In this commit, we publish 0.6.4, and we will yank all preceding 0.6.x versions as soon as 0.6.4 is published.

This is a backport of #308

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
