### PR TITLE
Minimal implementation of `TryFromBytes`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,9 @@
 ///     /// Safety comment starts on its own line.
 ///     macro_1!(args);
 ///     macro_2! { args };
+///     /// SAFETY:
+///     /// Subsequent safety comments are allowed but not required.
+///     macro_3! { args };
 /// }
 /// ```
 ///
@@ -26,13 +29,27 @@ macro_rules! safety_comment {
 }
 
 /// Unsafely implements trait(s) for a type.
+///
+/// # Safety
+///
+/// The trait impl must be sound.
+///
+/// When implementing `TryFromBytes`:
+/// - If no `is_bit_valid` impl is provided, then it must be valid for
+///   `is_bit_valid` to unconditionally return `true`.
+/// - If an `is_bit_valid` impl is provided, then:
+///   - It must be sound to transmute `&MaybeValid<$ty>` into `&$repr`.
+///   - The impl of `is_bit_valid` must satisfy `TryFromByte`'s safety
+///     requirements.
 macro_rules! unsafe_impl {
     // Implement `$trait` for `$ty` with no bounds.
-    ($ty:ty: $trait:ty) => {
-        unsafe impl $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+    ($ty:ty: $trait:ident $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?) => {
+        unsafe impl $trait for $ty {
+            unsafe_impl!(@method $trait $(; |$candidate: &$repr| $is_bit_valid)?);
+        }
     };
     // Implement all `$traits` for `$ty` with no bounds.
-    ($ty:ty: $($traits:ty),*) => {
+    ($ty:ty: $($traits:ident),*) => {
         $( unsafe_impl!($ty: $traits); )*
     };
     // This arm is identical to the following one, except it contains a
@@ -63,34 +80,54 @@ macro_rules! unsafe_impl {
     (
         const $constname:ident : $constty:ident $(,)?
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             @const $constname: $constty,
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate: &$repr| $is_bit_valid)?
         );
     };
     (
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate: &$repr| $is_bit_valid)?
         );
     };
     (
         @inner
         $(@const $constname:ident : $constty:ident,)*
         $($tyvar:ident $(: $(? $optbound:ident +)* + $($bound:ident +)* )?,)*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?
     ) => {
         unsafe impl<$(const $constname: $constty,)* $($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> $trait for $ty {
-            fn only_derive_is_allowed_to_implement_this_trait() {}
+        unsafe_impl!(@method $trait $(; |$candidate: &$repr| $is_bit_valid)?);
         }
+    };
+
+    (@method TryFromBytes ; |$candidate:ident: &$repr:ty| $is_bit_valid:expr) => {
+        fn is_bit_valid(candidate: &MaybeValid<Self>) -> bool {
+            // SAFETY: The macro caller has promised that it is sound to
+            // transmute `&MaybeValid<Self>` to `&$repr`.
+            //
+            // Note: this Clippy warning is only emitted on our MSRV (1.61), but
+            // not on later versions of Clippy. Thus, we consider it spurious.
+            #[allow(clippy::as_conversions)]
+            let $candidate = unsafe { &*(candidate as *const MaybeValid<Self> as *const $repr) };
+            $is_bit_valid
+        }
+    };
+    (@method TryFromBytes) => { fn is_bit_valid(_: &MaybeValid<Self>) -> bool { true } };
+    (@method $trait:ident) => {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    };
+    (@method $trait:ident; |$_candidate:ident: &$_repr:ty| $_is_bit_valid:expr) => {
+        compile_error!("Can't provide `is_bit_valid` impl for trait other than `TryFromBytes`");
     };
 }
 


### PR DESCRIPTION
This PR is a more minimal version of #279. Most notably, it doesn't rely on field projection, which was a significant source of complexity. A future PR which adds support for deriving `TryFromBytes` will need to tackle field projection.

Makes progress on #5.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
