### PR TITLE
Add `MaybeValid` type

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,8 @@
 
 use core::mem;
 
-pub(crate) trait AsAddress {
+#[doc(hidden)]
+pub trait AsAddress {
     fn addr(self) -> usize;
 }
 


### PR DESCRIPTION
`MaybeValid<T>` is a `T` which might not be valid. It is similar to `MaybeUninit<T>`, but it is slightly more strict: any byte in `T` which is guaranteed to be initialized is also guaranteed to be initialized in `MaybeValid<T>` (see the doc comment for a more precise definition).

`MaybeValid` is a building block of the `TryFromBytes` design outlined in #5.

Makes progress on #5

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
