### PR TITLE
Deny clippy::missing_inline_in_public_items

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -78,6 +78,7 @@ use super::*;
 macro_rules! impl_fmt_trait {
     ($name:ident, $native:ident, $trait:ident) => {
         impl<O: ByteOrder> $trait for $name<O> {
+            #[inline(always)]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 $trait::fmt(&self.get(), f)
             }
@@ -190,6 +191,7 @@ example of how it can be used for parsing UDP packets.
         }
 
         impl<O> Default for $name<O> {
+            #[inline(always)]
             fn default() -> $name<O> {
                 $name::ZERO
             }
@@ -207,6 +209,7 @@ example of how it can be used for parsing UDP packets.
 
             /// Constructs a new value from bytes which are already in the
             /// endianness `O`.
+            #[inline(always)]
             pub const fn from_bytes(bytes: [u8; $bytes]) -> $name<O> {
                 $name(bytes, PhantomData)
             }
@@ -218,6 +221,7 @@ example of how it can be used for parsing UDP packets.
 
             /// Constructs a new value, possibly performing an endianness swap
             /// to guarantee that the returned value has endianness `O`.
+            #[inline(always)]
             pub fn new(n: $native) -> $name<O> {
                 let mut out = $name::default();
                 O::$write_method(&mut out.0[..], n);
@@ -227,6 +231,7 @@ example of how it can be used for parsing UDP packets.
             /// Returns the value as a primitive type, possibly performing an
             /// endianness swap to guarantee that the return value has the
             /// endianness of the native platform.
+            #[inline(always)]
             pub fn get(self) -> $native {
                 O::$read_method(&self.0[..])
             }
@@ -234,6 +239,7 @@ example of how it can be used for parsing UDP packets.
             /// Updates the value in place as a primitive type, possibly
             /// performing an endianness swap to guarantee that the stored value
             /// has the endianness `O`.
+            #[inline(always)]
             pub fn set(&mut self, n: $native) {
                 O::$write_method(&mut self.0[..], n);
             }
@@ -245,24 +251,28 @@ example of how it can be used for parsing UDP packets.
         // inference issues.
 
         impl<O: ByteOrder> From<$name<O>> for [u8; $bytes] {
+            #[inline(always)]
             fn from(x: $name<O>) -> [u8; $bytes] {
                 x.0
             }
         }
 
         impl<O: ByteOrder> From<[u8; $bytes]> for $name<O> {
+            #[inline(always)]
             fn from(bytes: [u8; $bytes]) -> $name<O> {
                 $name(bytes, PhantomData)
             }
         }
 
         impl<O: ByteOrder> From<$name<O>> for $native {
+            #[inline(always)]
             fn from(x: $name<O>) -> $native {
                 x.get()
             }
         }
 
         impl<O: ByteOrder> From<$native> for $name<O> {
+            #[inline(always)]
             fn from(x: $native) -> $name<O> {
                 $name::new(x)
             }
@@ -270,6 +280,7 @@ example of how it can be used for parsing UDP packets.
 
         $(
             impl<O: ByteOrder> From<$name<O>> for $larger_native {
+                #[inline(always)]
                 fn from(x: $name<O>) -> $larger_native {
                     x.get().into()
                 }
@@ -279,6 +290,7 @@ example of how it can be used for parsing UDP packets.
         $(
             impl<O: ByteOrder> TryFrom<$larger_native_try> for $name<O> {
                 type Error = TryFromIntError;
+                #[inline(always)]
                 fn try_from(x: $larger_native_try) -> Result<$name<O>, TryFromIntError> {
                     $native::try_from(x).map($name::new)
                 }
@@ -287,6 +299,7 @@ example of how it can be used for parsing UDP packets.
 
         $(
             impl<O: ByteOrder, P: ByteOrder> From<$name<O>> for $larger_byteorder<P> {
+                #[inline(always)]
                 fn from(x: $name<O>) -> $larger_byteorder<P> {
                     $larger_byteorder::new(x.get().into())
                 }
@@ -296,6 +309,7 @@ example of how it can be used for parsing UDP packets.
         $(
             impl<O: ByteOrder, P: ByteOrder> TryFrom<$larger_byteorder_try<P>> for $name<O> {
                 type Error = TryFromIntError;
+                #[inline(always)]
                 fn try_from(x: $larger_byteorder_try<P>) -> Result<$name<O>, TryFromIntError> {
                     x.get().try_into().map($name::new)
                 }
@@ -303,24 +317,28 @@ example of how it can be used for parsing UDP packets.
         )*
 
         impl<O: ByteOrder> AsRef<[u8; $bytes]> for $name<O> {
+            #[inline(always)]
             fn as_ref(&self) -> &[u8; $bytes] {
                 &self.0
             }
         }
 
         impl<O: ByteOrder> AsMut<[u8; $bytes]> for $name<O> {
+            #[inline(always)]
             fn as_mut(&mut self) -> &mut [u8; $bytes] {
                 &mut self.0
             }
         }
 
         impl<O: ByteOrder> PartialEq<$name<O>> for [u8; $bytes] {
+            #[inline(always)]
             fn eq(&self, other: &$name<O>) -> bool {
                 self.eq(&other.0)
             }
         }
 
         impl<O: ByteOrder> PartialEq<[u8; $bytes]> for $name<O> {
+            #[inline(always)]
             fn eq(&self, other: &[u8; $bytes]) -> bool {
                 self.0.eq(other)
             }
@@ -329,6 +347,7 @@ example of how it can be used for parsing UDP packets.
         impl_fmt_traits!($name, $native, $number_kind);
 
         impl<O: ByteOrder> Debug for $name<O> {
+            #[inline]
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 // This results in a format like "U16(42)".
                 f.debug_tuple(stringify!($name)).field(&self.get()).finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@
     clippy::decimal_literal_representation,
     clippy::get_unwrap,
     clippy::indexing_slicing,
+    clippy::missing_inline_in_public_items,
     clippy::missing_safety_doc,
     clippy::obfuscated_if_else,
     clippy::perf,
@@ -295,6 +296,7 @@ pub unsafe trait FromZeroes {
     /// Self::new_zeroed()`, it differs in that `zero` does not semantically
     /// drop the current value and replace it with a new one - it simply
     /// modifies the bytes of the existing value.
+    #[inline(always)]
     fn zero(&mut self) {
         let slf: *mut Self = self;
         let len = mem::size_of_val(self);
@@ -309,6 +311,7 @@ pub unsafe trait FromZeroes {
     }
 
     /// Creates an instance of `Self` from zeroed bytes.
+    #[inline(always)]
     fn new_zeroed() -> Self
     where
         Self: Sized,
@@ -336,6 +339,7 @@ pub unsafe trait FromZeroes {
     ///
     /// Panics if allocation of `size_of::<Self>()` bytes fails.
     #[cfg(feature = "alloc")]
+    #[inline]
     fn new_box_zeroed() -> Box<Self>
     where
         Self: Sized,
@@ -380,6 +384,7 @@ pub unsafe trait FromZeroes {
     /// * Panics if `size_of::<Self>() * len` overflows.
     /// * Panics if allocation of `size_of::<Self>() * len` bytes fails.
     #[cfg(feature = "alloc")]
+    #[inline]
     fn new_box_slice_zeroed(len: usize) -> Box<[Self]>
     where
         Self: Sized,
@@ -441,6 +446,7 @@ pub unsafe trait FromZeroes {
     /// * Panics if `size_of::<Self>() * len` overflows.
     /// * Panics if allocation of `size_of::<Self>() * len` bytes fails.
     #[cfg(feature = "alloc")]
+    #[inline(always)]
     fn new_vec_zeroed(len: usize) -> Vec<Self>
     where
         Self: Sized,
@@ -536,6 +542,7 @@ pub unsafe trait FromBytes: FromZeroes {
     /// Reads a copy of `Self` from `bytes`.
     ///
     /// If `bytes.len() != size_of::<Self>()`, `read_from` returns `None`.
+    #[inline]
     fn read_from(bytes: &[u8]) -> Option<Self>
     where
         Self: Sized,
@@ -549,6 +556,7 @@ pub unsafe trait FromBytes: FromZeroes {
     /// `read_from_prefix` reads a `Self` from the first `size_of::<Self>()`
     /// bytes of `bytes`. If `bytes.len() < size_of::<Self>()`, it returns
     /// `None`.
+    #[inline]
     fn read_from_prefix(bytes: &[u8]) -> Option<Self>
     where
         Self: Sized,
@@ -562,6 +570,7 @@ pub unsafe trait FromBytes: FromZeroes {
     /// `read_from_suffix` reads a `Self` from the last `size_of::<Self>()`
     /// bytes of `bytes`. If `bytes.len() < size_of::<Self>()`, it returns
     /// `None`.
+    #[inline]
     fn read_from_suffix(bytes: &[u8]) -> Option<Self>
     where
         Self: Sized,
@@ -665,6 +674,7 @@ pub unsafe trait AsBytes {
     ///
     /// `as_bytes` provides access to the bytes of this value as an immutable
     /// byte slice.
+    #[inline(always)]
     fn as_bytes(&self) -> &[u8] {
         // Note that this method does not have a `Self: Sized` bound;
         // `size_of_val` works for unsized values too.
@@ -697,6 +707,7 @@ pub unsafe trait AsBytes {
     ///
     /// `as_bytes_mut` provides access to the bytes of this value as a mutable
     /// byte slice.
+    #[inline(always)]
     fn as_bytes_mut(&mut self) -> &mut [u8]
     where
         Self: FromBytes,
@@ -730,6 +741,7 @@ pub unsafe trait AsBytes {
     /// Writes a copy of `self` to `bytes`.
     ///
     /// If `bytes.len() != size_of_val(self)`, `write_to` returns `None`.
+    #[inline]
     fn write_to(&self, bytes: &mut [u8]) -> Option<()> {
         if bytes.len() != mem::size_of_val(self) {
             return None;
@@ -743,6 +755,7 @@ pub unsafe trait AsBytes {
     ///
     /// `write_to_prefix` writes `self` to the first `size_of_val(self)` bytes
     /// of `bytes`. If `bytes.len() < size_of_val(self)`, it returns `None`.
+    #[inline]
     fn write_to_prefix(&self, bytes: &mut [u8]) -> Option<()> {
         let size = mem::size_of_val(self);
         bytes.get_mut(..size)?.copy_from_slice(self.as_bytes());
@@ -753,6 +766,7 @@ pub unsafe trait AsBytes {
     ///
     /// `write_to_suffix` writes `self` to the last `size_of_val(self)` bytes of
     /// `bytes`. If `bytes.len() < size_of_val(self)`, it returns `None`.
+    #[inline]
     fn write_to_suffix(&self, bytes: &mut [u8]) -> Option<()> {
         let start = bytes.len().checked_sub(mem::size_of_val(self))?;
         bytes
@@ -1817,6 +1831,7 @@ where
     /// Converts this `Ref` into a reference.
     ///
     /// `into_ref` consumes the `Ref`, and returns a reference to `T`.
+    #[inline(always)]
     pub fn into_ref(self) -> &'a T {
         // SAFETY: This is sound because `B` is guaranteed to live for the
         // lifetime `'a`, meaning that a) the returned reference cannot outlive
@@ -1836,6 +1851,7 @@ where
     /// Converts this `Ref` into a mutable reference.
     ///
     /// `into_mut` consumes the `Ref`, and returns a mutable reference to `T`.
+    #[inline(always)]
     pub fn into_mut(mut self) -> &'a mut T {
         // SAFETY: This is sound because `B` is guaranteed to live for the
         // lifetime `'a`, meaning that a) the returned reference cannot outlive
@@ -1855,6 +1871,7 @@ where
     /// Converts this `Ref` into a slice reference.
     ///
     /// `into_slice` consumes the `Ref`, and returns a reference to `[T]`.
+    #[inline(always)]
     pub fn into_slice(self) -> &'a [T] {
         // SAFETY: This is sound because `B` is guaranteed to live for the
         // lifetime `'a`, meaning that a) the returned reference cannot outlive
@@ -1875,6 +1892,7 @@ where
     ///
     /// `into_mut_slice` consumes the `Ref`, and returns a mutable reference to
     /// `[T]`.
+    #[inline(always)]
     pub fn into_mut_slice(mut self) -> &'a mut [T] {
         // SAFETY: This is sound because `B` is guaranteed to live for the
         // lifetime `'a`, meaning that a) the returned reference cannot outlive
@@ -2378,6 +2396,7 @@ mod alloc_support {
     /// # Panics
     ///
     /// Panics if `Vec::reserve(additional)` fails to reserve enough memory.
+    #[inline(always)]
     pub fn extend_vec_zeroed<T: FromZeroes>(v: &mut Vec<T>, additional: usize) {
         insert_vec_zeroed(v, v.len(), additional);
     }
@@ -2389,6 +2408,7 @@ mod alloc_support {
     ///
     /// * Panics if `position > v.len()`.
     /// * Panics if `Vec::reserve(additional)` fails to reserve enough memory.
+    #[inline]
     pub fn insert_vec_zeroed<T: FromZeroes>(v: &mut Vec<T>, position: usize, additional: usize) {
         assert!(position <= v.len());
         v.reserve(additional);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@ macro_rules! safety_comment {
 macro_rules! unsafe_impl {
     // Implement `$trait` for `$ty` with no bounds.
     ($ty:ty: $trait:ty) => {
-        unsafe impl $trait for $ty { fn only_derive_is_allowed_to_implement_this_trait() {} }
+        unsafe impl $trait for $ty { #[inline] fn only_derive_is_allowed_to_implement_this_trait() {} }
     };
     // Implement all `$traits` for `$ty` with no bounds.
     ($ty:ty: $($traits:ty),*) => {
@@ -89,7 +89,7 @@ macro_rules! unsafe_impl {
         => $trait:ident for $ty:ty
     ) => {
         unsafe impl<$(const $constname: $constty,)* $($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> $trait for $ty {
-            fn only_derive_is_allowed_to_implement_this_trait() {}
+            #[inline] fn only_derive_is_allowed_to_implement_this_trait() {}
         }
     };
 }


### PR DESCRIPTION
This lint should catch every place that an `#[inline]` attribute could matter. This commit only addresses zerocopy, and does not change anything in zerocopy-derive.

Makes progress on #7

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
