### PR TITLE
[macros] safety_comment! permits multiple comments

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,13 +13,16 @@
 ///     /// Safety comment starts on its own line.
 ///     macro_1!(args);
 ///     macro_2! { args };
+///     /// SAFETY:
+///     /// Subsequent safety comments are allowed but not required.
+///     macro_3! { args };
 /// }
 /// ```
 ///
 /// The macro invocations are emitted, each decorated with the following
 /// attribute: `#[allow(clippy::undocumented_unsafe_blocks)]`.
 macro_rules! safety_comment {
-    (#[doc = r" SAFETY:"] $(#[doc = $_doc:literal])* $($macro:ident!$args:tt;)*) => {
+    (#[doc = r" SAFETY:"] $($(#[doc = $_doc:literal])* $macro:ident!$args:tt;)*) => {
         #[allow(clippy::undocumented_unsafe_blocks)]
         const _: () = { $($macro!$args;)* };
     }


### PR DESCRIPTION
The following is now supported:

```
    safety_comment! {
        /// SAFETY:
        /// Safety comment here.
        macro_invocation!();
        macro_invocation!();

        /// Previously, this comment (which appears after macro
        /// invocations) was not supported.
        macro_invocation!();
        macro_invocation!();
    }
```

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
