### PR TITLE
[byteorder] Optimize tests; large impact on Miri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ optional = true
 zerocopy-derive = { version = "=0.7.3", path = "zerocopy-derive" }
 
 [dev-dependencies]
-rand = "0.6"
+rand = { version = "0.8.5", features = ["small_rng"] }
 rustversion = "1.0"
 static_assertions = "1.1"
 # Pinned to a specific version so that the version used for local development


### PR DESCRIPTION
While they take a trivial amount of time running natively, the `test_native_endian` and `test_non_native_endian` unit tests previously took a long time to execute on Miri, slowing down local development and CI. As of the writing of this commit message, I was experiencing execution times for each test of ~60s.

This commit optimizes those tests in two ways:
- Use a faster RNG
- When running under Miri (detected using `cfg!(miri)`), perform a single loop iteration rather than 1024

Using `time cargo miri test -- --skip ui`, I have benchmarked the execution time before this commit at ~2m36s and the time after this commit at ~8s.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
