### PR TITLE
Add TryFromBytes trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ so you don't have to.
 
 ## Overview
 
-Zerocopy provides four core marker traits, each of which can be derived
+Zerocopy provides five core marker traits, each of which can be derived
 (e.g., `#[derive(FromZeroes)]`):
 - `FromZeroes` indicates that a sequence of zero bytes represents a valid
   instance of a type
 - `FromBytes` indicates that a type may safely be converted from an
   arbitrary byte sequence
+- `TryFromBytes` supports non-`FromBytes` types by providing the ability
+  to check the validity of a conversion at runtime
 - `AsBytes` indicates that a type may safely be converted *to* a byte
   sequence
 - `Unaligned` indicates that a type's alignment requirement is 1

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,14 +33,43 @@ macro_rules! safety_comment {
 }
 
 /// Unsafely implements trait(s) for a type.
+///
+/// # Safety
+///
+/// The trait impl must be sound.
+///
+/// When implementing `TryFromBytes`:
+/// - If no `is_bit_valid` impl is provided, then it must be valid for
+///   `is_bit_valid` to unconditionally return `true`. In other words, it must
+///   be the case that any initialized sequence of bytes constitutes a valid
+///   instance of `$ty`.
+/// - If an `is_bit_valid` impl is provided, then:
+///   - Regardless of whether the provided closure takes a `Ptr<$repr>` or
+///     `&$repr` argument, it must be the case that, given `t: *mut $ty`, `let r
+///     = t as *mut $repr` is valid, and `r` refers to an object of equal or
+///     lesser size than the object referred to by `t`.
+///   - If the provided closure takes a `Ptr<$repr>` argument, then given a
+///     `Ptr<$ty>` which satisfies the preconditions of
+///     `TryFromBytes::<$ty>::is_bit_valid`, it must be guaranteed that a
+///     `Ptr<$repr>` with the same address, provenance, and pointer metadata
+///     satisfies the preconditions of `TryFromBytes::<$repr>::is_bit_valid`.
+///   - If the provided closure takes a `&$repr` argument, then given a
+///     `Ptr<'a, $ty>` which satisfies the preconditions of
+///     `TryFromBytes::<$ty>::is_bit_valid`, it must be sound to convert it to a
+///     `$repr` pointer with the same address, provenance, and pointer metadata,
+///     and to subsequently dereference that pointer as a `&'a $repr`.
+///   - The impl of `is_bit_valid` must only return `true` for its argument
+///     `Ptr<$repr>` if the original `Ptr<$ty>` refers to a valid `$ty`.
 macro_rules! unsafe_impl {
     // Implement `$trait` for `$ty` with no bounds.
-    ($(#[$attr:meta])* $ty:ty: $trait:ty) => {
+    ($(#[$attr:meta])* $ty:ty: $trait:ident $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?) => {
         $(#[$attr])*
-        unsafe impl $trait for $ty { #[allow(clippy::missing_inline_in_public_items)] fn only_derive_is_allowed_to_implement_this_trait() {} }
+        unsafe impl $trait for $ty {
+            unsafe_impl!(@method $trait $(; |$candidate: &$repr| $is_bit_valid)?);
+        }
     };
     // Implement all `$traits` for `$ty` with no bounds.
-    ($ty:ty: $($traits:ty),*) => {
+    ($ty:ty: $($traits:ident),*) => {
         $( unsafe_impl!($ty: $traits); )*
     };
     // This arm is identical to the following one, except it contains a
@@ -72,26 +101,26 @@ macro_rules! unsafe_impl {
         $(#[$attr:meta])*
         const $constname:ident : $constty:ident $(,)?
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: Ptr<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             $(#[$attr])*
             @const $constname: $constty,
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate $(: &$ref_repr)? $(: Ptr<$ptr_repr>)?| $is_bit_valid)?
         );
     };
     (
         $(#[$attr:meta])*
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: Ptr<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             $(#[$attr])*
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate $(: &$ref_repr)? $(: Ptr<$ptr_repr>)?| $is_bit_valid)?
         );
     };
     (
@@ -99,13 +128,51 @@ macro_rules! unsafe_impl {
         $(#[$attr:meta])*
         $(@const $constname:ident : $constty:ident,)*
         $($tyvar:ident $(: $(? $optbound:ident +)* + $($bound:ident +)* )?,)*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: Ptr<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         $(#[$attr])*
         unsafe impl<$(const $constname: $constty,)* $($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> $trait for $ty {
-            #[allow(clippy::missing_inline_in_public_items)]
-            fn only_derive_is_allowed_to_implement_this_trait() {}
+            unsafe_impl!(@method $trait $(; |$candidate: $(&$ref_repr)? $(Ptr<$ptr_repr>)?| $is_bit_valid)?);
         }
+    };
+
+    (@method TryFromBytes ; |$candidate:ident: &$repr:ty| $is_bit_valid:expr) => {
+        #[inline]
+        unsafe fn is_bit_valid(candidate: Ptr<'_, Self>) -> bool {
+            // SAFETY:
+            // - The argument to `cast_unsized` is `|p| p as *mut _` as required
+            //   by that method's safety precondition.
+            // - The caller has promised that the cast results in an object of
+            //   equal or lesser size.
+            #[allow(clippy::as_conversions)]
+            let candidate = unsafe { candidate.cast_unsized::<$repr>(|p| p as *mut _) };
+            // SAFETY: The caller has promised that, so long as `candidate`
+            // satisfies the preconditions for `is_bit_valid`, it is valid to
+            // convert it to a reference with the same lifetime as `candidate`.
+            let $candidate: &$repr = unsafe { candidate._as_ref() };
+            $is_bit_valid
+        }
+    };
+    (@method TryFromBytes ; |$candidate:ident: Ptr<$repr:ty>| $is_bit_valid:expr) => {
+        #[inline]
+        unsafe fn is_bit_valid(candidate: Ptr<'_, Self>) -> bool {
+            // SAFETY:
+            // - The argument to `cast_unsized` is `|p| p as *mut _` as required
+            //   by that method's safety precondition.
+            // - The caller has promised that the cast results in an object of
+            //   equal or lesser size.
+            #[allow(clippy::as_conversions)]
+            let $candidate = unsafe { candidate.cast_unsized::<$repr>(|p| p as *mut _) };
+            $is_bit_valid
+        }
+    };
+    (@method TryFromBytes) => { #[inline(always)] unsafe fn is_bit_valid(_: Ptr<'_, Self>) -> bool { true } };
+    (@method $trait:ident) => {
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    };
+    (@method $trait:ident; |$_candidate:ident $(: &$_ref_repr:ty)? $(: NonNull<$_ptr_repr:ty>)?| $_is_bit_valid:expr) => {
+        compile_error!("Can't provide `is_bit_valid` impl for trait other than `TryFromBytes`");
     };
 }
 


### PR DESCRIPTION
`TryFromBytes` can be implemented for types which are not `FromZeroes` or `FromBytes`; it supports performing a runtime check to determine whether a given byte sequence contains a valid instance of `Self`.

This is the first step of #5. Future commits will add support for a custom derive and for implementing `TryFromBytes` on unsized types.

Makes progress on #5

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
