### PR TITLE
[CI] Treat "derive" as a stable feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,14 @@ path = "src/lib.rs"
 [features]
 default = ["byteorder"]
 
-derive = ["zerocopy-derive"]
 alloc = []
+derive = ["zerocopy-derive"]
 simd = []
 simd-nightly = ["simd"]
 # This feature depends on all other features that work on the stable compiler.
 # We make no stability guarantees about this feature; it may be modified or
 # removed at any time.
-__internal_use_only_features_that_work_on_stable = ["alloc", "simd"]
+__internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
 zerocopy-derive = { version = "=0.7.3", path = "zerocopy-derive", optional = true }

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -1,15 +1,15 @@
 error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
-   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
-   |                                                        ^^^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+   |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
+   |                                                                    ^^^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:22:1
    |
 22 | impl_or_verify!(T => FromZeroes for Foo<T>);
    | ------------------------------------------- in this macro invocation
    |
-note: required for `Foo<T>` to implement `zerocopy::FromZeroes`
+note: required because of the requirements on the impl of `zerocopy::FromZeroes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:10
    |
 18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -26,23 +26,22 @@ note: required by a bound in `_::Subtrait`
    | ------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
-   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
     |
-    | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
+22  | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
     |                  ++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
-   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
-   |                                                        ^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+   |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
+   |                                                                    ^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:23:1
    |
 23 | impl_or_verify!(T => FromBytes for Foo<T>);
    | ------------------------------------------ in this macro invocation
    |
-note: required for `Foo<T>` to implement `zerocopy::FromBytes`
+note: required because of the requirements on the impl of `zerocopy::FromBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:22
    |
 18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -59,23 +58,22 @@ note: required by a bound in `_::Subtrait`
    | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
-   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
     |
-    | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+23  | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
     |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
-   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
-   |                                                        ^^^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
+   |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
+   |                                                                    ^^^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:24:1
    |
 24 | impl_or_verify!(T => AsBytes for Foo<T>);
    | ---------------------------------------- in this macro invocation
    |
-note: required for `Foo<T>` to implement `zerocopy::AsBytes`
+note: required because of the requirements on the impl of `zerocopy::AsBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:33
    |
 18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -92,23 +90,22 @@ note: required by a bound in `_::Subtrait`
    | ---------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
-   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
     |
-    | impl_or_verify!(T: zerocopy::AsBytes => AsBytes for Foo<T>);
+24  | impl_or_verify!(T: zerocopy::AsBytes => AsBytes for Foo<T>);
     |                  +++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
-   |         impl_or_verify!(@verify $trait, { impl<$tyvar> Subtrait for $ty {} });
-   |                                                        ^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+   |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
+   |                                                                    ^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:25:1
    |
 25 | impl_or_verify!(T => Unaligned for Foo<T>);
    | ------------------------------------------ in this macro invocation
    |
-note: required for `Foo<T>` to implement `zerocopy::Unaligned`
+note: required because of the requirements on the impl of `zerocopy::Unaligned` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:18:42
    |
 18 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
@@ -125,7 +122,6 @@ note: required by a bound in `_::Subtrait`
    | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
-   --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
     |
-    | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+25  | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
     |                  +++++++++++++++++++++


### PR DESCRIPTION
Previously, we mistakenly omitted "derive" as one of the features to test on the MSRV and stable toolchains. As a result, our UI test .stderr files for the MSRV toolchain were stale.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
