### PR TITLE
[derive] Support TryFromBytes for structs

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -270,16 +270,20 @@ example of how it can be used for parsing UDP packets.
 [`AsBytes`]: crate::AsBytes
 [`Unaligned`]: crate::Unaligned"),
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-            #[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+            #[cfg_attr(any(feature = "derive", test), derive(TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned))]
             #[repr(transparent)]
             pub struct $name<O>([u8; $bytes], PhantomData<O>);
         }
+
+        impl_known_layout!(O => $name<O>);
 
         safety_comment! {
             /// SAFETY:
             /// `$name<O>` is `repr(transparent)`, and so it has the same layout
             /// as its only non-zero field, which is a `u8` array. `u8` arrays
-            /// are `FromZeroes`, `FromBytes`, `AsBytes`, and `Unaligned`.
+            /// are `TryFromBytes`, `FromZeroes`, `FromBytes`, `AsBytes`, and
+            /// `Unaligned`.
+            impl_or_verify!(O => TryFromBytes for $name<O>);
             impl_or_verify!(O => FromZeroes for $name<O>);
             impl_or_verify!(O => FromBytes for $name<O>);
             impl_or_verify!(O => AsBytes for $name<O>);

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -109,6 +109,7 @@ mod tests {
 
     use super::*;
     use crate::util::testutil::*;
+    use crate::*;
 
     #[test]
     fn test_align_of() {
@@ -216,5 +217,16 @@ mod tests {
         // targets, and this isn't a particularly complex macro we're testing
         // anyway.
         test!(#[repr(C)] #[repr(packed)] {a: u8, b: u64} => true);
+    }
+
+    #[test]
+    fn foo() {
+        #[derive(TryFromBytes)]
+        struct Foo {
+            f: u8,
+            b: bool,
+        }
+
+        impl_known_layout!(Foo);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,6 +41,7 @@ use crate::util::polyfills::NonNullSliceExt as _;
 /// `Ptr<'a, T>` is [covariant] in `'a` and `T`.
 ///
 /// [covariant]: https://doc.rust-lang.org/reference/subtyping.html
+#[doc(hidden)]
 pub struct Ptr<'a, T: 'a + ?Sized> {
     // INVARIANTS:
     // - `ptr` is derived from some valid Rust allocation, `A`
@@ -141,9 +142,7 @@ impl<'a, T: ?Sized> Ptr<'a, T> {
         //   validly-intialized `T`
         unsafe { self.ptr.as_mut() }
     }
-}
 
-impl<'a, T: 'a + ?Sized> Ptr<'a, T> {
     /// TODO
     ///
     /// # Safety
@@ -176,6 +175,23 @@ impl<'a, T: 'a + ?Sized> Ptr<'a, T> {
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         // SAFETY: TODO
         Ptr { ptr, _lifetime: PhantomData }
+    }
+
+    /// TODO
+    ///
+    /// # Safety
+    ///
+    /// TODO
+    #[doc(hidden)]
+    pub unsafe fn project<U: 'a + ?Sized>(
+        self,
+        project: impl FnOnce(*mut T) -> *mut U,
+    ) -> Ptr<'a, U> {
+        let field = project(self.ptr.as_ptr());
+        // SAFETY: TODO
+        let field = unsafe { NonNull::new_unchecked(field) };
+        // SAFETY: TODO
+        Ptr { ptr: field, _lifetime: PhantomData }
     }
 }
 

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -54,9 +54,14 @@ use super::*;
 // [3] https://github.com/google/zerocopy/issues/209
 #[allow(missing_debug_implementations)]
 #[derive(Default, Copy)]
-#[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+#[cfg_attr(
+    any(feature = "derive", test),
+    derive(TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned)
+)]
 #[repr(C, packed)]
 pub struct Unalign<T>(T);
+
+impl_known_layout!(T => Unalign<T>);
 
 safety_comment! {
     /// SAFETY:

--- a/zerocopy-derive/src/ext.rs
+++ b/zerocopy-derive/src/ext.rs
@@ -2,40 +2,66 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use syn::{Data, DataEnum, DataStruct, DataUnion, Type};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Data, DataEnum, DataStruct, DataUnion, Field, Index, Type};
 
 pub trait DataExt {
-    /// Extract the types of all fields. For enums, extract the types of fields
-    /// from each variant.
-    fn field_types(&self) -> Vec<&Type>;
+    /// Extract the names and types of all fields. For enums, extract the names
+    /// and types of fields from each variant. For tuple structs, the names are
+    /// the indices used to index into the struct (ie, `0`, `1`, etc).
+    ///
+    /// TODO: Extracting field names for enums doesn't really make sense. Types
+    /// makes sense because we don't care about where they live - we just care
+    /// about transitive ownership. But for field names, we'd only use them when
+    /// generating is_bit_valid, which cares about where they live.
+    fn fields(&self) -> Vec<(TokenStream, &Type)>;
 }
 
 impl DataExt for Data {
-    fn field_types(&self) -> Vec<&Type> {
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
         match self {
-            Data::Struct(strc) => strc.field_types(),
-            Data::Enum(enm) => enm.field_types(),
-            Data::Union(un) => un.field_types(),
+            Data::Struct(strc) => strc.fields(),
+            Data::Enum(enm) => enm.fields(),
+            Data::Union(un) => un.fields(),
         }
     }
 }
 
 impl DataExt for DataStruct {
-    fn field_types(&self) -> Vec<&Type> {
-        self.fields.iter().map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(&self.fields)
     }
 }
 
 impl DataExt for DataEnum {
-    fn field_types(&self) -> Vec<&Type> {
-        self.variants.iter().flat_map(|var| &var.fields).map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(self.variants.iter().flat_map(|var| &var.fields))
     }
 }
 
 impl DataExt for DataUnion {
-    fn field_types(&self) -> Vec<&Type> {
-        self.fields.named.iter().map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(&self.fields.named)
     }
+}
+
+fn map_fields<'a>(
+    fields: impl 'a + IntoIterator<Item = &'a Field>,
+) -> Vec<(TokenStream, &'a Type)> {
+    fields
+        .into_iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            (
+                f.ident
+                    .as_ref()
+                    .map(ToTokens::to_token_stream)
+                    .unwrap_or_else(|| Index::from(idx).to_token_stream()),
+                &f.ty,
+            )
+        })
+        .collect()
 }
 
 pub trait EnumExt {
@@ -44,6 +70,6 @@ pub trait EnumExt {
 
 impl EnumExt for DataEnum {
     fn is_c_like(&self) -> bool {
-        self.field_types().is_empty()
+        self.fields().is_empty()
     }
 }


### PR DESCRIPTION
TODO:
- Should DataExt::fields have a different shape? Extracting field names for enums doesn't really make sense
- Add SAFETY comments in emitted `is_bit_valid` impl
- Do we need to update the TryFromBytes doc comment at all?
- Lots and lots of tests

Makes progress on #5

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
