### PR TITLE
[WIP] TryFromBuild derive support for enums

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -176,16 +176,20 @@ example of how it can be used for parsing UDP packets.
 [`AsBytes`]: crate::AsBytes
 [`Unaligned`]: crate::Unaligned"),
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-            #[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+            #[cfg_attr(any(feature = "derive", test), derive(TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned))]
             #[repr(transparent)]
             pub struct $name<O>([u8; $bytes], PhantomData<O>);
         }
+
+        impl_known_layout!(O => $name<O>);
 
         safety_comment! {
             /// SAFETY:
             /// `$name<O>` is `repr(transparent)`, and so it has the same layout
             /// as its only non-zero field, which is a `u8` array. `u8` arrays
-            /// are `FromZeroes`, `FromBytes`, `AsBytes`, and `Unaligned`.
+            /// are `TryFromBytes`, `FromZeroes`, `FromBytes`, `AsBytes`, and
+            /// `Unaligned`.
+            impl_or_verify!(O => TryFromBytes for $name<O>);
             impl_or_verify!(O => FromZeroes for $name<O>);
             impl_or_verify!(O => FromBytes for $name<O>);
             impl_or_verify!(O => AsBytes for $name<O>);

--- a/src/derive_util.rs
+++ b/src/derive_util.rs
@@ -66,6 +66,7 @@ macro_rules! union_has_padding {
 #[cfg(test)]
 mod tests {
     use crate::util::testutil::*;
+    use crate::*;
 
     #[test]
     fn test_struct_has_padding() {
@@ -123,5 +124,16 @@ mod tests {
         // targets, and this isn't a particularly complex macro we're testing
         // anyway.
         test!(#[repr(C)] #[repr(packed)] {a: u8, b: u64} => true);
+    }
+
+    #[test]
+    fn foo() {
+        #[derive(TryFromBytes)]
+        struct Foo {
+            f: u8,
+            b: bool,
+        }
+
+        impl_known_layout!(Foo);
     }
 }

--- a/src/derive_util.rs
+++ b/src/derive_util.rs
@@ -128,12 +128,16 @@ mod tests {
 
     #[test]
     fn foo() {
-        #[derive(TryFromBytes)]
-        struct Foo {
-            f: u8,
-            b: bool,
-        }
+        #[derive(TryFromBytes, Eq, PartialEq, Debug)]
+        #[zerocopy(validator = |f| f.0 < 128)]
+        #[repr(C)]
+        struct Foo(u8, bool);
 
         impl_known_layout!(Foo);
+
+        assert_eq!(try_transmute!([0u8, 0]), Some(Foo(0, false)));
+        assert_eq!(try_transmute!([1u8, 1]), Some(Foo(1, true)));
+        assert_eq!(try_transmute!([2u8, 2]), None::<Foo>);
+        assert_eq!(try_transmute!([128u8, 1]), None::<Foo>);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,6 +1002,11 @@ pub unsafe trait FromBytes: FromZeroes {
 /// [github-repo]: https://github.com/google/zerocopy
 /// [`try_from_ref`]: TryFromBytes::try_from_ref
 pub unsafe trait TryFromBytes: KnownLayout {
+    #[doc(hidden)]
+    fn only_derive_is_allowed_to_implement_this_trait()
+    where
+        Self: Sized;
+
     /// Does a given memory range contain a valid instance of `Self`?
     ///
     /// # Safety
@@ -3669,9 +3674,15 @@ mod tests {
     //
     // This is used to test the custom derives of our traits. The `[u8]` type
     // gets a hand-rolled impl, so it doesn't exercise our custom derives.
-    #[derive(Debug, Eq, PartialEq, FromZeroes, FromBytes, AsBytes, Unaligned)]
+    #[derive(Debug, Eq, PartialEq, TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned)]
     #[repr(transparent)]
     struct Unsized([u8]);
+
+    // SAFETY: `Unsized` is a `#[repr(transparent)]` wrapper around `[u8]`.
+    unsafe_impl_known_layout!(
+        #[repr([u8])]
+        Unsized
+    );
 
     impl Unsized {
         fn from_mut_slice(slc: &mut [u8]) -> &mut Unsized {
@@ -4612,13 +4623,15 @@ mod tests {
             assert_eq!(too_many_bytes[0], 123);
         }
 
-        #[derive(Debug, Eq, PartialEq, FromZeroes, FromBytes, AsBytes)]
+        #[derive(Debug, Eq, PartialEq, TryFromBytes, FromZeroes, FromBytes, AsBytes)]
         #[repr(C)]
         struct Foo {
             a: u32,
             b: Wrapping<u32>,
             c: Option<NonZeroU32>,
         }
+
+        impl_known_layout!(Foo);
 
         let expected_bytes: Vec<u8> = if cfg!(target_endian = "little") {
             vec![1, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]
@@ -4641,11 +4654,13 @@ mod tests {
 
     #[test]
     fn test_array() {
-        #[derive(FromZeroes, FromBytes, AsBytes)]
+        #[derive(TryFromBytes, FromZeroes, FromBytes, AsBytes)]
         #[repr(C)]
         struct Foo {
             a: [u16; 33],
         }
+
+        impl_known_layout!(Foo);
 
         let foo = Foo { a: [0xFFFF; 33] };
         let expected = [0xFFu8; 66];
@@ -4705,23 +4720,25 @@ mod tests {
 
     #[test]
     fn test_transparent_packed_generic_struct() {
-        #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+        #[derive(AsBytes, TryFromBytes, FromZeroes, FromBytes, Unaligned)]
         #[repr(transparent)]
         struct Foo<T> {
             _t: T,
             _phantom: PhantomData<()>,
         }
 
+        impl_known_layout!(T => Foo<T>);
         assert_impl_all!(Foo<u32>: FromZeroes, FromBytes, AsBytes);
         assert_impl_all!(Foo<u8>: Unaligned);
 
-        #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+        #[derive(AsBytes, TryFromBytes, FromZeroes, FromBytes, Unaligned)]
         #[repr(packed)]
         struct Bar<T, U> {
             _t: T,
             _u: U,
         }
 
+        impl_known_layout!(T, U => Bar<T, U>);
         assert_impl_all!(Bar<u8, AU64>: FromZeroes, FromBytes, AsBytes, Unaligned);
     }
 
@@ -4985,7 +5002,7 @@ mod tests {
         assert_impls!(Wrapping<bool>: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
         assert_impls!(Wrapping<NotZerocopy>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
 
-        assert_impls!(Unalign<u8>: FromZeroes, FromBytes, AsBytes, Unaligned, !TryFromBytes);
+        assert_impls!(Unalign<u8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned, TryFromBytes);
         assert_impls!(Unalign<NotZerocopy>: Unaligned, !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes);
 
         assert_impls!([u8]: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,14 @@
 //! parsing and serialization by allowing zero-copy conversion to/from byte
 //! slices.
 //!
-//! This is enabled by four core marker traits, each of which can be derived
-//! (e.g., `#[derive(FromZeroes)]`):
+//! This is enabled by five core traits, each of which can be derived (e.g.,
+//! `#[derive(FromZeroes)]`):
 //! - [`FromZeroes`] indicates that a sequence of zero bytes represents a valid
 //!   instance of a type
 //! - [`FromBytes`] indicates that a type may safely be converted from an
 //!   arbitrary byte sequence
+//! - [`TryFromBytes`] supports non-`FromBytes` types by providing the ability
+//!   to check the validity of a conversion at runtime
 //! - [`AsBytes`] indicates that a type may safely be converted *to* a byte
 //!   sequence
 //! - [`Unaligned`] indicates that a type's alignment requirement is 1
@@ -185,16 +187,25 @@ use core::{
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
     },
     ops::{Deref, DerefMut},
-    ptr, slice,
+    ptr::{self, NonNull},
+    slice,
 };
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "alloc")]
-use {
-    alloc::{boxed::Box, vec::Vec},
-    core::ptr::NonNull,
-};
+use alloc::{boxed::Box, vec::Vec};
+
+use crate::util::AsAddress as _;
+
+// For each polyfill, as soon as the corresponding feature is stable, the
+// polyfill import will be unused because method/function resolution will prefer
+// the inherent method/function over a trait method/function. Thus, we suppress
+// the `unused_imports` warning.
+//
+// See the documentation on `util::polyfills` for more information.
+#[allow(unused_imports)]
+use crate::util::polyfills::{NonNullExt as _, NonNullSliceExt as _};
 
 // This is a hack to allow zerocopy-derive derives to work in this crate. They
 // assume that zerocopy is linked as an extern crate, so they access items from
@@ -229,8 +240,8 @@ pub struct DstLayout {
 }
 
 #[cfg_attr(test, derive(Copy, Clone, Debug))]
-enum _CastType {
-    _Prefix,
+enum CastType {
+    Prefix,
     _Suffix,
 }
 
@@ -323,11 +334,11 @@ impl DstLayout {
     /// `validate_cast_and_convert_metadata` will panic. The caller should not
     /// rely on `validate_cast_and_convert_metadata` panicking in any particular
     /// condition, even if `debug_assertions` are enabled.
-    const fn _validate_cast_and_convert_metadata(
+    const fn validate_cast_and_convert_metadata(
         &self,
         addr: usize,
         bytes_len: usize,
-        cast_type: _CastType,
+        cast_type: CastType,
     ) -> Option<(usize, usize)> {
         // `debug_assert!`, but with `#[allow(clippy::arithmetic_side_effects)]`.
         macro_rules! __debug_assert {
@@ -372,8 +383,8 @@ impl DstLayout {
         // bytes_len`) is not aligned, then no valid start address will be
         // aligned either.
         let offset = match cast_type {
-            _CastType::_Prefix => 0,
-            _CastType::_Suffix => bytes_len,
+            CastType::Prefix => 0,
+            CastType::_Suffix => bytes_len,
         };
 
         // Addition is guaranteed not to overflow because `offset <= bytes_len`,
@@ -464,14 +475,31 @@ impl DstLayout {
         __debug_assert!(self_bytes <= bytes_len);
 
         let split_at = match cast_type {
-            _CastType::_Prefix => self_bytes,
+            CastType::Prefix => self_bytes,
             // Guaranteed not to underflow because `self_bytes <= bytes_len`
             // (lemma 4).
             #[allow(clippy::arithmetic_side_effects)]
-            _CastType::_Suffix => bytes_len - self_bytes,
+            CastType::_Suffix => bytes_len - self_bytes,
         };
 
         Some((elems, split_at))
+    }
+
+    /// Calls `validate_cast_and_convert_metadata` and ensures that all of
+    /// `bytes_len` are used, leaving no prefix or suffix bytes.
+    ///
+    /// Passes all arguments to `validate_cast_and_convert_metadata`, and passes
+    /// `CastType::Prefix`. If the cast would leave any suffix bytes left over,
+    /// `validate_cast_and_convert_metadata_no_prefix_suffix` returns `None`.
+    const fn validate_cast_and_convert_metadata_no_prefix_suffix(
+        &self,
+        addr: usize,
+        bytes_len: usize,
+    ) -> Option<usize> {
+        match self.validate_cast_and_convert_metadata(addr, bytes_len, CastType::Prefix) {
+            Some((elems, split_at)) if split_at == bytes_len => Some(elems),
+            Some(_) | None => None,
+        }
     }
 }
 
@@ -491,12 +519,27 @@ impl DstLayout {
 pub unsafe trait KnownLayout: sealed::KnownLayoutSealed {
     #[doc(hidden)]
     const LAYOUT: DstLayout;
+
+    /// SAFETY: The returned pointer has the same address and provenance as
+    /// `bytes`. If `Self` is a DST, the returned pointer's referent has `elems`
+    /// elements in its trailing slice. If `Self` is sized, `elems` is ignored.
+    #[doc(hidden)]
+    fn raw_from_ptr_len(bytes: NonNull<u8>, elems: usize) -> NonNull<Self>;
 }
 
 impl<T: KnownLayout> sealed::KnownLayoutSealed for [T] {}
 // SAFETY: Delegates safety to `DstLayout::for_slice`.
 unsafe impl<T: KnownLayout> KnownLayout for [T] {
     const LAYOUT: DstLayout = DstLayout::for_slice::<T>();
+
+    // SAFETY: `.cast` preserves address and provenance. The returned pointer
+    // refers to an object with `elems` elements by construction.
+    #[inline(always)]
+    fn raw_from_ptr_len(data: NonNull<u8>, elems: usize) -> NonNull<Self> {
+        // TODO(#67): Remove this allow. See NonNullExt for more details.
+        #[allow(unstable_name_collisions)]
+        NonNull::slice_from_raw_parts(data.cast::<T>(), elems)
+    }
 }
 
 #[rustfmt::skip]
@@ -901,6 +944,268 @@ pub unsafe trait FromBytes: FromZeroes {
     }
 }
 
+/// Types whose validity can be checked at runtime, allowing them to be
+/// conditionally converted from byte slices.
+///
+/// WARNING: Do not implement this trait yourself! Instead, use
+/// `#[derive(TryFromBytes)]`.
+///
+/// `TryFromBytes` types can safely be deserialized from an untrusted sequence
+/// of bytes by performing a runtime check that the byte sequence contains a
+/// valid instance of `Self`.
+///
+/// `TryFromBytes` is ignorant of byte order. For byte order-aware types, see
+/// the [`byteorder`] module.
+///
+/// # What is a "valid instance"?
+///
+/// In Rust, each type has *bit validity*, which refers to the set of bit
+/// patterns which may appear in an instance of that type. It is impossible for
+/// safe Rust code to produce values which violate bit validity (ie, values
+/// outside of the "valid" set of bit patterns). If `unsafe` code produces an
+/// invalid value, this is considered [undefined behavior].
+///
+/// Rust's bit validity rules are currently being decided, which means that some
+/// types have three classes of bit patterns: those which are definitely valid,
+/// and whose validity is documented in the language; those which may or may not
+/// be considered valid at some point in the future; and those which are
+/// definitely invalid.
+///
+/// Zerocopy takes a conservative approach, and only considers a bit pattern to
+/// be valid if its validity is a documenteed guarantee provided by the
+/// language.
+///
+/// For most use cases, Rust's current guarantees align with programmers'
+/// intuitions about what ought to be valid. As a result, zerocopy's
+/// conservatism should not affect most users. One notable exception is unions,
+/// whose bit validity is very up in the air; zerocopy does not permit
+/// implementing `TryFromBytes` for any union type.
+///
+/// If you are negatively affected by lack of support for a particular type,
+/// we encourage you to let us know by [filing an issue][github-repo].
+///
+/// # Safety
+///
+/// On its own, `T: TryFromBytes` does not make any guarantees about the layout
+/// or representation of `T`. It merely provides the ability to perform a
+/// validity check at runtime via methods like [`try_from_ref`].
+///
+/// Currently, it is not possible to stably implement `TryFromBytes` other than
+/// by using `#[derive(TryFromBytes)]`. While there are `#[doc(hidden)]` items
+/// on this trait that provide well-defined safety invariants, no stability
+/// guarantees are made with respect to these items. In particular, future
+/// releases of zerocopy may make backwards-breaking changes to these items,
+/// including changes that only affect soundness, which may cause code which
+/// uses those items to silently become unsound.
+///
+/// [undefined behavior]: https://raphlinus.github.io/programming/rust/2018/08/17/undefined-behavior.html
+/// [github-repo]: https://github.com/google/zerocopy
+/// [`try_from_ref`]: TryFromBytes::try_from_ref
+pub unsafe trait TryFromBytes: KnownLayout {
+    /// Does a given memory range contain a valid instance of `Self`?
+    ///
+    /// # Safety
+    ///
+    /// ## Preconditions
+    ///
+    /// `candidate` must be properly aligned for `Self`, and it must be [valid]
+    /// for reads. The total length encoded by the pointer must not overflow an
+    /// `isize`. The memory addressed by `candidate` must fall within a single
+    /// allocation.
+    ///
+    /// `candidate` is not required to refer to a valid `Self`. However, it must
+    /// satisfy the requirement that uninitialized bytes may only be present
+    /// where it is possible for them to be present in `Self`. This is a dynamic
+    /// property: if, at a particular byte offset, a valid enum discriminant is
+    /// set, the subsequent bytes may only have uninitialized bytes as
+    /// specificed by the corresponding enum.
+    ///
+    /// Formally, given `len = size_of_val_raw(candidate)`, at every byte
+    /// offset, `b`, in the range `[0, len)`:
+    /// - If, in all instances `s: Self` of length `len`, the byte at offset `b`
+    ///   in `s` is initialized, then the byte at offset `b` within `*candidate`
+    ///   must be initialized.
+    /// - Let `c` be the contents of the byte range `[0, b)` in `*candidate`.
+    ///   Let `S` be the subset of valid instances of `Self` of length `len`
+    ///   which contain `c` in the offset range `[0, b)`. If, for all instances
+    ///   of `s: Self` in `S`, the byte at offset `b` in `s` is initialized,
+    ///   then the byte at offset `b` in `*candidate` must be initialized.
+    ///
+    ///   Pragmatically, this means that if `*candidate` is guaranteed to
+    ///   contain an enum type at a particular offset, and the enum discriminant
+    ///   stored in `*candidate` corresponds to a valid variant of that enum
+    ///   type, then it is guaranteed that the appropriate bytes of `*candidate`
+    ///   are initialized as defined by that variant's bit validity (although
+    ///   note that the variant may contain another enum type, in which case the
+    ///   same rules apply depending on the state of its discriminant, and so on
+    ///   recursively).
+    ///
+    /// ## Postconditions
+    ///
+    /// Unsafe code may assume that, if `is_bit_valid(candidate)` returns true,
+    /// `*candidate` contains a valid `Self`.
+    ///
+    /// # Panics
+    ///
+    /// `is_bit_valid` may panic. Callers are responsible for ensuring that any
+    /// `unsafe` code remains sound even in the face of `is_bit_valid`
+    /// panicking. (We support user-defined validation routines; so long as
+    /// these routines are not required to be `unsafe`, there is no way to
+    /// ensure that these do not generate panics.)
+    ///
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    #[doc(hidden)]
+    unsafe fn is_bit_valid(candidate: NonNull<Self>) -> bool;
+
+    /// Attempts to interpret a byte slice as a `Self`.
+    ///
+    /// `try_from_ref` validates that `bytes` contains a valid `Self`, and that
+    /// it satisfies `Self`'s alignment requirement. If it does, then `bytes` is
+    /// reinterpreted as a `Self`.
+    ///
+    /// Note that Rust's bit validity rules are still being decided. As such,
+    /// there exist types whose bit validity is ambiguous. See the
+    /// `TryFromBytes` docs for a discussion of how these cases are handled.
+    // TODO(#251): In a future in which we distinguish between `FromBytes` and
+    // `RefFromBytes`, this requires `where Self: RefFromBytes` to disallow
+    // interior mutability.
+    #[inline]
+    fn try_from_ref(bytes: &[u8]) -> Option<&Self> {
+        // PANICS: `bytes` is a `&[u8]`, and so the sum of its address and
+        // length cannot overflow `usize`.
+        let trailing_elems = Self::LAYOUT
+            .validate_cast_and_convert_metadata_no_prefix_suffix(bytes.addr(), bytes.len())?;
+        let maybe_self = Self::raw_from_ptr_len(NonNull::from(bytes).cast::<u8>(), trailing_elems);
+
+        // SAFETY:
+        // - `bytes` is a `&[u8]`, which guarantees that its length doesn't
+        //   overflow `isize` and that it comes from a single allocation
+        // - `validate_exact_cast` checked alignment
+        // - all bytes of `bytes` are initialized
+        //
+        // This call may panic. If that happens, it doesn't cause any soundness
+        // issues, as we have not generated any invalid state which we need to
+        // fix before returning.
+        if unsafe { !Self::is_bit_valid(maybe_self) } {
+            return None;
+        }
+
+        // SAFETY:
+        // - `is_bit_valid` guaranteed that `*maybe_self` contains a valid
+        //   `Self`
+        // - Since `Self` is not allowed to contain any `UnsafeCell`s:
+        //   - The caller cannot use the `&Self` to perform interior mutation on
+        //     a byte range that `bytes` views as not containing `UnsafeCell`s
+        //   - The caller cannot use the `&Self` to write invalid values to
+        //     `bytes` (namely, uninitialized bytes, as `[u8]` has no other bit
+        //     validity constraints)
+        // - Since `[u8]` does not contain any `UnsafeCell`s, we are guaranteed
+        //   that, having verified that `maybe_self` currently contains a valid
+        //   `Self`, code with access to `bytes` cannot cause it to no longer
+        //   contain a valid `Self` in the future
+        Some(unsafe { &*maybe_self.as_ptr() })
+    }
+
+    /// Attempts to interpret a mutable byte slice as a `Self`.
+    ///
+    /// `try_from_mut` validates that `bytes` contains a valid `Self`, and that
+    /// it satisfies `Self`'s alignment requirement. If it does, then `bytes` is
+    /// reinterpreted as a `Self`.
+    ///
+    /// Note that Rust's bit validity rules are still being decided. As such,
+    /// there exist types whose bit validity is ambiguous. See the
+    /// `TryFromBytes` docs for a discussion of how these cases are handled.
+    // TODO(#251): In a future in which we distinguish between `FromBytes` and
+    // `RefFromBytes`, this requires `where Self: RefFromBytes` to disallow
+    // interior mutability.
+    #[inline]
+    fn try_from_mut(bytes: &mut [u8]) -> Option<&mut Self>
+    where
+        Self: AsBytes,
+    {
+        // PANICS: `bytes` is a `&[u8]`, and so the sum of its address and
+        // length cannot overflow `usize`.
+        let trailing_elems = Self::LAYOUT
+            .validate_cast_and_convert_metadata_no_prefix_suffix(bytes.addr(), bytes.len())?;
+        let maybe_self = Self::raw_from_ptr_len(NonNull::from(bytes).cast::<u8>(), trailing_elems);
+
+        // SAFETY:
+        // - `bytes` is a `&[u8]`, which guarantees that its length doesn't
+        //   overflow `isize` and that it comes from a single allocation
+        // - `validate_exact_cast` checked alignment
+        // - all bytes of `bytes` are initialized
+        //
+        // This call may panic. If that happens, it doesn't cause any soundness
+        // issues, as we have not generated any invalid state which we need to
+        // fix before returning.
+        if unsafe { !Self::is_bit_valid(maybe_self) } {
+            return None;
+        }
+
+        // SAFETY:
+        // - `is_bit_valid` guaranteed that `*maybe_self` contains a valid
+        //   `Self`
+        // - Since `Self: AsBytes`, any values written to the returned `&mut
+        //   Self` will be valid for `[u8]` once it is accessible again
+        // - Since the returned `&mut Self` has the same lifetime as the input
+        //   `&mut [u8]`, that input cannot be directly mutated so long as the
+        //   returned reference exists. Thus, having verified that `maybe_self`
+        //   currently contains a valid `Self`, code with access to `bytes`
+        //   cannot cause it to no longer contain a valid `Self` in the future.
+        Some(unsafe { &mut *maybe_self.as_ptr() })
+    }
+
+    /// Attempts to read a `Self` from a byte slice.
+    ///
+    /// `try_from_mut` validates that `bytes` contains a valid `Self`. If it
+    /// does, then the contents of `bytes` are copied and reinterpreted as a
+    /// `Self`.
+    ///
+    /// Note that Rust's bit validity rules are still being decided. As such,
+    /// there exist types whose bit validity is ambiguous. See the
+    /// `TryFromBytes` docs for a discussion of how these cases are handled.
+    #[inline]
+    fn try_read_from(bytes: &[u8]) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        // A note on performance: We unconditionally read `size_of::<Self>()`
+        // bytes into the local stack frame before validation. This has
+        // advantages and disadvantages:
+        // - It allows `MaybeUninit` to be aligned to `T`, and thus allows
+        //   `is_bit_valid` to operate on an aligned value.
+        // - It requires us to perform the copy even if validation fails.
+        //
+        // The authors believe that this is a worthwhile tradeoff. Allowing
+        // `is_bit_valid` to operate on an aligned value can make the generated
+        // machine code significantly smaller and faster. On the other hand, we
+        // expect the vast majority of calls to `try_read_from` to succeed, and
+        // in these cases, the copy will not be wasted.
+        let maybe_uninit = MaybeUninit::<Self>::read_from(bytes)?;
+        let candidate = NonNull::from(&maybe_uninit).cast::<Self>();
+
+        // SAFETY:
+        // - `MaybeUninit<Self>` has the same alignment as `Self`, so this is
+        //   aligned
+        // - `maybe_uninit` was initialized from `bytes`, so all of its bytes
+        //   are initialized
+        //
+        // This call may panic. If that happens, it doesn't cause any soundness
+        // issues, as we have not generated any invalid state which we need to
+        // fix before returning. The `MaybeUninit` will be dropped, but it does
+        // not have any validity requirements, so it may soundly be dropped in
+        // any state.
+        if unsafe { !Self::is_bit_valid(candidate) } {
+            return None;
+        }
+
+        // SAFETY: `is_bit_valid` promises that it only returns true if its
+        // argument contains a valid `Self`. This is exactly the safety
+        // precondition of `assume_init`.
+        Some(unsafe { maybe_uninit.assume_init() })
+    }
+}
+
 /// Types which are safe to treat as an immutable byte slice.
 ///
 /// WARNING: Do not implement this trait yourself! Instead, use
@@ -1017,7 +1322,8 @@ pub unsafe trait AsBytes {
         //   reference, the only other references to this memory region that
         //   could exist are other immutable references, and those don't allow
         //   mutation. `AsBytes` prohibits types which contain `UnsafeCell`s,
-        //   which are the only types for which this rule wouldn't be sufficient.
+        //   which are the only types for which this rule wouldn't be
+        //   sufficient.
         // - The total size of the resulting slice is no larger than
         //   `isize::MAX` because no allocation produced by safe code can be
         //   larger than `isize::MAX`.
@@ -1131,19 +1437,20 @@ safety_comment! {
     /// SAFETY:
     /// Per the reference [1], "the unit tuple (`()`) ... is guaranteed as a
     /// zero-sized type to have a size of 0 and an alignment of 1."
-    /// - `FromZeroes`, `FromBytes`: There is only one possible sequence of 0
-    ///   bytes, and `()` is inhabited.
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`: There
+    ///   is only one possible sequence of 0 bytes, and `()` is inhabited.
     /// - `AsBytes`: Since `()` has size 0, it contains no padding bytes.
     /// - `Unaligned`: `()` has alignment 1.
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#tuple-layout
-    unsafe_impl!((): FromZeroes, FromBytes, AsBytes, Unaligned);
+    unsafe_impl!((): TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
     assert_unaligned!(());
 }
 
 safety_comment! {
     /// SAFETY:
-    /// - `FromZeroes`, `FromBytes`: all bit patterns are valid for integers [1]
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`: all bit
+    ///   patterns are valid for integers [1]
     /// - `AsBytes`: integers have no padding bytes [1]
     /// - `Unaligned` (`u8` and `i8` only): The reference [2] specifies the size
     ///   of `u8` and `i8` as 1 byte. We also know that:
@@ -1155,30 +1462,31 @@ safety_comment! {
     /// [1] TODO(https://github.com/rust-lang/reference/issues/1291): Once the
     ///     reference explicitly guarantees these properties, cite it.
     /// [2] https://doc.rust-lang.org/reference/type-layout.html#primitive-data-layout
-    unsafe_impl!(u8: FromZeroes, FromBytes, AsBytes, Unaligned);
-    unsafe_impl!(i8: FromZeroes, FromBytes, AsBytes, Unaligned);
+    unsafe_impl!(u8: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+    unsafe_impl!(i8: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
     assert_unaligned!(u8, i8);
-    unsafe_impl!(u16: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(i16: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(u32: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(i32: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(u64: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(i64: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(u128: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(i128: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(usize: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(isize: FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(u16: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(i16: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(u32: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(i32: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(u64: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(i64: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(u128: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(i128: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(usize: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(isize: TryFromBytes, FromZeroes, FromBytes, AsBytes);
 }
 
 safety_comment! {
     /// SAFETY:
-    /// - `FromZeroes`, `FromBytes`: the `{f32,f64}::from_bits` constructors'
-    ///   documentation [1,2] states that they are currently equivalent to
-    ///   `transmute`. [3]
-    /// - `AsBytes`: the `{f32,f64}::to_bits` methods' documentation [4,5]
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`: the
+    ///   `{f32,f64}::from_bits` constructors' documentation [1] [2] states that
+    ///   they are currently equivalent to `transmute`. [3]
+    /// - `AsBytes`: the `{f32,f64}::to_bits` methods' documentation [4] [5]
     ///   states that they are currently equivalent to `transmute`. [3]
     ///
-    /// TODO: Make these arguments more precisely in terms of the documentation.
+    /// TODO(#61): Make these arguments more precisely in terms of the
+    /// documentation.
     ///
     /// [1] https://doc.rust-lang.org/nightly/std/primitive.f32.html#method.from_bits
     /// [2] https://doc.rust-lang.org/nightly/std/primitive.f64.html#method.from_bits
@@ -1186,8 +1494,8 @@ safety_comment! {
     ///     reference explicitly guarantees these properties, cite it.
     /// [4] https://doc.rust-lang.org/nightly/std/primitive.f32.html#method.to_bits
     /// [5] https://doc.rust-lang.org/nightly/std/primitive.f64.html#method.to_bits
-    unsafe_impl!(f32: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(f64: FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(f32: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(f64: TryFromBytes, FromZeroes, FromBytes, AsBytes);
 }
 
 safety_comment! {
@@ -1203,6 +1511,18 @@ safety_comment! {
     /// [1] https://doc.rust-lang.org/reference/types/boolean.html
     unsafe_impl!(bool: FromZeroes, AsBytes, Unaligned);
     assert_unaligned!(bool);
+    /// SAFETY:
+    /// - Since `bool`'s single byte is always initialized, the `is_bit_valid`
+    ///   caller is required to ensure that the referent of the `NonNull<bool>`
+    ///   argument is initialized. Since `u8` has no alignment requirement, this
+    ///   means that, after converting from `NonNull<bool>` to `&u8`, the
+    ///   resulting reference is properly aligned and points to a
+    ///   properly-initialized `u8`.
+    /// - All values less than 2 are valid instances of `bool` [1], and so this
+    ///   is a sound implementation of `TryFromBytes::is_bit_valid`.
+    ///
+    /// [1] https://doc.rust-lang.org/reference/types/boolean.html
+    unsafe_impl!(bool: TryFromBytes; |byte: &u8| *byte < 2);
 }
 safety_comment! {
     /// SAFETY:
@@ -1214,6 +1534,37 @@ safety_comment! {
     ///
     /// [1] https://doc.rust-lang.org/reference/types/textual.html
     unsafe_impl!(char: FromZeroes, AsBytes);
+    /// SAFETY:
+    /// - `MaybeUninit<char>` has no bit validity requirements, and has the same
+    ///   alignment as `char`. Since the `is_bit_valid` caller must promise that
+    ///   the provided `NonNull<char>` is properly-aligned and points a region
+    ///   which is valid for reads, that's all we need to ensure that converting
+    ///   it to a `&MaybeUninit<char>` is sound.
+    /// - Since we transmute `c` from the bytes passed to `is_bit_valid` without
+    ///   modifying them, and since `char::from_u32` guarantees that it returns
+    ///   `None` if its input is not a valid `char` [1], this function only
+    ///   returns `true` if its argument is a valid `char`, and so this is a
+    ///   sound implementation of `TryFromBytes::is_bit_valid`.
+    ///
+    /// Note that it might be slightly simpler to treat `candidate` as a `[u8;
+    /// 4]` - it would make the code and the safety argument a bit simpler.
+    /// However, using `&MaybeUninit<char>` ensures that the compiler preserves
+    /// alignment information, which it may be able to use to produce smaller or
+    /// better-performing assembly.
+    ///
+    /// [1] https://doc.rust-lang.org/std/primitive.char.html#method.from_u32
+    ///
+    /// TODO(https://github.com/rust-lang/reference/pull/1401): Use `&u32`
+    /// instead once it's guaranteed that `align_of::<u32>() ==
+    /// align_of::<char>()`.
+    unsafe_impl!(char: TryFromBytes; |candidate: &MaybeUninit<char>| {
+        // SAFETY: `MaybeUninit<u32>` has no bit validity constraints.
+        let c: MaybeUninit<u32> = unsafe { mem::transmute(*candidate) };
+        // SAFETY: Since all bytes of a `char` must be initialized, the bytes
+        // passed to this function must all have been initialized.
+        let c = unsafe { c.assume_init() };
+        char::from_u32(c).is_some()
+    });
 }
 safety_comment! {
     /// SAFETY:
@@ -1226,6 +1577,28 @@ safety_comment! {
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#str-layout
     unsafe_impl!(str: FromZeroes, AsBytes, Unaligned);
+    /// SAFETY:
+    /// - Since `str`'s bytes are all always initialized, `is_bit_valid`'s
+    ///   caller must ensure that the bytes they pass are all initialized. Since
+    ///   `&[u8]` has no alignment requirement and no bit validity requirement
+    ///   beyond that its bytes be initialized, it is sound to convert the
+    ///   caller's `NonNull<str>` (which they promise is valid for reads) to a
+    ///   `&[u8]`.
+    /// - `str`'s bit validity requirement is that it is valid UTF-8. [1] Thus,
+    ///   if `from_utf8` can successfully convert `bytes` to a `str`, then the
+    ///   `str` is valid [2], and so this is a sound implementation of
+    ///   `TryFromBytes::is_bit_valid`.
+    ///
+    /// [1] https://doc.rust-lang.org/reference/types/textual.html
+    /// [2] https://doc.rust-lang.org/core/str/fn.from_utf8.html
+    unsafe_impl!(str: TryFromBytes; |bytes: &[u8]| {
+        // Note that, while this function has no documented panic conditions, it
+        // would still be sound even if it panicked. `is_bit_valid` does not
+        // promise that it will not panic (in fact, it explicitly warns that
+        // it's a possibility), and we have not violated any safety invariants
+        // that we must fix before returning.
+        core::str::from_utf8(bytes).is_ok()
+    });
 }
 
 safety_comment! {
@@ -1263,12 +1636,40 @@ safety_comment! {
     unsafe_impl!(NonZeroI128: AsBytes);
     unsafe_impl!(NonZeroUsize: AsBytes);
     unsafe_impl!(NonZeroIsize: AsBytes);
+
+    /// SAFETY:
+    /// - The caller is required to provide a `NonNull<NonZeroXxx>` which is
+    ///   properly aligned and is valid for reads. Since very byte of a
+    ///   `NonZeroXxx` must be initialized, the pointer's referent must have all
+    ///   its bytes initialized.
+    ///
+    ///   Since `Xxx` has the same size and alignment as `NonZeroXxx`, the
+    ///   provided `NonNull<NonZeroXxx>` is also aligned to `Xxx` and is valid
+    ///   for reads of size `Xxx`. Since `Xxx` has no bit validity requirements
+    ///   other than that its bytes are initialized, this means that the
+    ///   provided `NonNull<NonZeroXxx>` may soundly be converted to a `&Xxx`.
+    /// - `NonZeroXxx`'s only validity constraint is that it is non-zero, which
+    ///   all of these closures ensure. Thus, these closures are sound
+    ///   implementations of `TryFromBytes::is_bit_valid`.
+    unsafe_impl!(NonZeroU8: TryFromBytes; |n: &u8| *n != 0);
+    unsafe_impl!(NonZeroI8: TryFromBytes; |n: &i8| *n != 0);
+    unsafe_impl!(NonZeroU16: TryFromBytes; |n: &u16| *n != 0);
+    unsafe_impl!(NonZeroI16: TryFromBytes; |n: &i16| *n != 0);
+    unsafe_impl!(NonZeroU32: TryFromBytes; |n: &u32| *n != 0);
+    unsafe_impl!(NonZeroI32: TryFromBytes; |n: &i32| *n != 0);
+    unsafe_impl!(NonZeroU64: TryFromBytes; |n: &u64| *n != 0);
+    unsafe_impl!(NonZeroI64: TryFromBytes; |n: &i64| *n != 0);
+    unsafe_impl!(NonZeroU128: TryFromBytes; |n: &u128| *n != 0);
+    unsafe_impl!(NonZeroI128: TryFromBytes; |n: &i128| *n != 0);
+    unsafe_impl!(NonZeroUsize: TryFromBytes; |n: &usize| *n != 0);
+    unsafe_impl!(NonZeroIsize: TryFromBytes; |n: &isize| *n != 0);
 }
 safety_comment! {
     /// SAFETY:
-    /// - `FromZeroes`, `FromBytes`, `AsBytes`: The Rust compiler reuses `0`
-    ///   value to represent `None`, so `size_of::<Option<NonZeroXxx>>() ==
-    ///   size_of::<xxx>()`; see `NonZeroXxx` documentation.
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`,
+    ///   `AsBytes`: The Rust compiler reuses `0` value to represent `None`, so
+    ///   `size_of::<Option<NonZeroXxx>>() == size_of::<xxx>()`; see
+    ///   `NonZeroXxx` documentation.
     /// - `Unaligned`: `NonZeroU8` and `NonZeroI8` document that
     ///   `Option<NonZeroU8>` and `Option<NonZeroI8>` both have size 1. [1] [2]
     ///   This is worded in a way that makes it unclear whether it's meant as a
@@ -1281,32 +1682,34 @@ safety_comment! {
     ///
     /// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
     /// for layout guarantees.
-    unsafe_impl!(Option<NonZeroU8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-    unsafe_impl!(Option<NonZeroI8>: FromZeroes, FromBytes, AsBytes, Unaligned);
+    unsafe_impl!(Option<NonZeroU8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+    unsafe_impl!(Option<NonZeroI8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
     assert_unaligned!(Option<NonZeroU8>, Option<NonZeroI8>);
-    unsafe_impl!(Option<NonZeroU16>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroI16>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroU32>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroI32>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroU64>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroI64>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroU128>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroI128>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroUsize>: FromZeroes, FromBytes, AsBytes);
-    unsafe_impl!(Option<NonZeroIsize>: FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroU16>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroI16>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroU32>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroI32>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroU64>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroI64>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroU128>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroI128>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroUsize>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
+    unsafe_impl!(Option<NonZeroIsize>: TryFromBytes, FromZeroes, FromBytes, AsBytes);
 }
 
 safety_comment! {
     /// SAFETY:
     /// For all `T`, `PhantomData<T>` has size 0 and alignment 1. [1]
-    /// - `FromZeroes`, `FromBytes`: There is only one possible sequence of 0
-    ///   bytes, and `PhantomData` is inhabited.
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`: There
+    ///   is only one possible sequence of 0 bytes, and `PhantomData` is
+    ///   inhabited.
     /// - `AsBytes`: Since `PhantomData` has size 0, it contains no padding
     ///   bytes.
     /// - `Unaligned`: Per the preceding reference, `PhantomData` has alignment
     ///   1.
     ///
     /// [1] https://doc.rust-lang.org/std/marker/struct.PhantomData.html#layout-1
+    unsafe_impl!(T: ?Sized => TryFromBytes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => FromZeroes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => FromBytes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => AsBytes for PhantomData<T>);
@@ -1317,11 +1720,35 @@ safety_comment! {
     /// SAFETY:
     /// `Wrapping<T>` is guaranteed by its docs [1] to have the same layout as
     /// `T`. Also, `Wrapping<T>` is `#[repr(transparent)]`, and has a single
-    /// field, which is `pub`. Per the reference [2], this means that the
+    /// field, which is `pub`. Per the nomicon [2], this means that the
     /// `#[repr(transparent)]` attribute is "considered part of the public ABI".
+    /// - `TryFromBytes`: `Wrapping<T>` has the same layout and bit validity as
+    ///   `T`, so if the provided `NonNull<Wrapping<T>>` satisfies the
+    ///   preconditions for `TryFromBytes::<Wrapping<T>>::is_bit_valid`, then it
+    ///   is sound to convert it to a `NonNull<T>`, and that pointer satisfies
+    ///   the preconditions for `TryFromBytes::<T>::is_bit_valid`. For DSTs,
+    ///   `Wrapping<T>` and `T` have the same pointer metadata, so pointer
+    ///   casting preserves length.
+    ///
+    ///   Since their bit validity requirements are the same,
+    ///   `TryFromBytes::<T>::is_bit_valid` is a sound implementation of
+    ///   `TryFromBytes::<Wrapping<T>>::is_bit_valid`.
+    /// - `FromZeroes`, `FromBytes`: Since it has the same layout as `T`, any
+    ///   valid `T` is a valid `Wrapping<T>`. If `T: FromZeroes`, a sequence of
+    ///   zero bytes is a valid `T`, and thus a valid `Wrapping<T>`. If `T:
+    ///   FromBytes`, any sequence of bytes is a valid `T`, and thus a valid
+    ///   `Wrapping<T>`.
     ///
     /// [1] https://doc.rust-lang.org/nightly/core/num/struct.Wrapping.html#layout-1
     /// [2] https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
+    // TODO(#5): Implement `TryFromBytes` for `Wrapping<T>`.
+    unsafe_impl!(T: TryFromBytes => TryFromBytes for Wrapping<T>; |c: NonNull<T>| {
+        // Note that this call may panic, but it would still be sound even if it
+        // did. `is_bit_valid` does not promise that it will not panic (in fact,
+        // it explicitly warns that it's a possibility), and we have not
+        // violated any safety invariants that we must fix before returning.
+        unsafe { T::is_bit_valid(c) }
+    });
     unsafe_impl!(T: FromZeroes => FromZeroes for Wrapping<T>);
     unsafe_impl!(T: FromBytes => FromBytes for Wrapping<T>);
     unsafe_impl!(T: AsBytes => AsBytes for Wrapping<T>);
@@ -1333,12 +1760,13 @@ safety_comment! {
     // since it may contain uninitialized bytes.
     //
     /// SAFETY:
-    /// - `FromZeroes`, `FromBytes`: `MaybeUninit<T>` has no restrictions on its
-    ///   contents. Unfortunately, in addition to bit validity, `FromZeroes` and
-    ///   `FromBytes` also require that implementers contain no `UnsafeCell`s.
-    ///   Thus, we require `T: FromZeroes` and `T: FromBytes` in order to ensure
-    ///   that `T` - and thus `MaybeUninit<T>` - contains to `UnsafeCell`s.
-    ///   Thus, requiring that `T` implement each of these traits is sufficient
+    /// - `TryFromBytes` (with no validator), `FromZeroes`, `FromBytes`:
+    ///   `MaybeUninit<T>` has no restrictions on its contents. Unfortunately,
+    ///   in addition to bit validity, these traits also require that
+    ///   implementers contain no `UnsafeCell`s. Thus, we require a trait bound
+    ///   for `T` in order to ensure that `T` - and thus `MaybeUninit<T>` -
+    ///   contains to `UnsafeCell`s. Thus, requiring that `T` implement each of
+    ///   these traits is sufficient.
     /// - `Unaligned`: `MaybeUninit<T>` is guaranteed by its documentation [1]
     ///   to have the same alignment as `T`.
     ///
@@ -1349,8 +1777,11 @@ safety_comment! {
     /// `FromBytes` and `RefFromBytes`, or if we introduce a separate
     /// `NoCell`/`Freeze` trait, we can relax the trait bounds for `FromZeroes`
     /// and `FromBytes`.
-    unsafe_impl!(T: FromZeroes => FromZeroes for MaybeUninit<T>);
-    unsafe_impl!(T: FromBytes => FromBytes for MaybeUninit<T>);
+    ///
+    /// TODO(#251): Replace these bounds with `NoCell` once we support it.
+    unsafe_impl!(T: TryFromBytes => TryFromBytes for MaybeUninit<T>);
+    unsafe_impl!(T: TryFromBytes => FromZeroes for MaybeUninit<T>);
+    unsafe_impl!(T: TryFromBytes => FromBytes for MaybeUninit<T>);
     unsafe_impl!(T: Unaligned => Unaligned for MaybeUninit<T>);
     assert_unaligned!(MaybeUninit<()>, MaybeUninit<u8>);
 }
@@ -1358,7 +1789,20 @@ safety_comment! {
     /// SAFETY:
     /// `ManuallyDrop` has the same layout as `T`, and accessing the inner value
     /// is safe (meaning that it's unsound to leave the inner value
-    /// uninitialized while exposing the `ManuallyDrop` to safe code).
+    /// uninitialized while exposing the `ManuallyDrop` to safe code). It's
+    /// nearly certain that `ManuallyDrop` has the same bit validity as `T`, but
+    /// this is technically not yet documented. [1]
+    /// - `TryFromBytes`: `ManuallyDrop<T>` has the same layout and bit validity
+    ///   as `T`, so if the provided `NonNull<ManuallyDrop<T>>` satisfies the
+    ///   preconditions for `TryFromBytes::<ManuallyDrop<T>>::is_bit_valid`,
+    ///   then it is sound to convert it to a `NonNull<T>`, and that pointer
+    ///   satisfies the preconditions for `TryFromBytes::<T>::is_bit_valid`.
+    ///   For DSTs, `ManuallyDrop<T>` and `T` have the same pointer metadata,
+    ///   so pointer casting preserves length.
+    ///
+    ///   Since their bit validity requirements are the same,
+    ///   `TryFromBytes::<T>::is_bit_valid` is a sound implementation of
+    ///   `TryFromBytes::<ManuallyDrop<T>>::is_bit_valid`.
     /// - `FromZeroes`, `FromBytes`: Since it has the same layout as `T`, any
     ///   valid `T` is a valid `ManuallyDrop<T>`. If `T: FromZeroes`, a sequence
     ///   of zero bytes is a valid `T`, and thus a valid `ManuallyDrop<T>`. If
@@ -1371,6 +1815,19 @@ safety_comment! {
     ///   code can only ever access a `ManuallyDrop` with all initialized bytes.
     /// - `Unaligned`: `ManuallyDrop` has the same layout (and thus alignment)
     ///   as `T`, and `T: Unaligned` guarantees that that alignment is 1.
+    ///
+    /// [1] https://github.com/rust-lang/rust/pull/115522
+    ///
+    /// TODO(https://github.com/rust-lang/rust/pull/115522): Update these docs
+    /// once ManuallyDrop bit validity is guaranteed.
+    unsafe_impl!(
+        T: ?Sized TryFromBytes => TryFromBytes for ManuallyDrop<T>;
+        // Note that this call may panic, but it would still be sound even if it
+        // did. `is_bit_valid` does not promise that it will not panic (in fact,
+        // it explicitly warns that it's a possibility), and we have not
+        // violated any safety invariants that we must fix before returning.
+        |c: NonNull<T>| unsafe { T::is_bit_valid(c) }
+    );
     unsafe_impl!(T: ?Sized + FromZeroes => FromZeroes for ManuallyDrop<T>);
     unsafe_impl!(T: ?Sized + FromBytes => FromBytes for ManuallyDrop<T>);
     unsafe_impl!(T: ?Sized + AsBytes => AsBytes for ManuallyDrop<T>);
@@ -1396,15 +1853,78 @@ safety_comment! {
     /// (respectively). Furthermore, since an array/slice has "the same
     /// alignment of `T`", `[T]` and `[T; N]` are `Unaligned` if `T` is.
     ///
+    /// Finally, because of this layout equivalence, an instance of `[T]` or
+    /// `[T; N]` is valid if each `T` is valid. Thus, it is sound to implement
+    /// `TryFromBytes::is_bit_valid` by calling `is_bit_valid` on each element.
+    ///
     /// Note that we don't `assert_unaligned!` for slice types because
     /// `assert_unaligned!` uses `align_of`, which only works for `Sized` types.
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#array-layout
+    unsafe_impl!(const N: usize, T: TryFromBytes => TryFromBytes for [T; N]; |c: NonNull<[T; N]>| {
+        #[allow(unstable_name_collisions)]
+        let slice = NonNull::slice_from_raw_parts(c.cast::<T>(), N);
+        // SAFETY: The preconditions of `is_bit_valid` are identical for `[T;
+        // N]` and for `[T]` if the passed pointer encodes a slice of `N`
+        // elements. Thus, if the caller has upheld their preconditions, then we
+        // uphold the preconditions for this call.
+        //
+        // Note that this call may panic, but it would still be sound even if it
+        // did. `is_bit_valid` does not promise that it will not panic (in fact,
+        // it explicitly warns that it's a possibility), and we have not
+        // violated any safety invariants that we must fix before returning.
+        unsafe { <[T] as TryFromBytes>::is_bit_valid(slice) }
+    });
     unsafe_impl!(const N: usize, T: FromZeroes => FromZeroes for [T; N]);
     unsafe_impl!(const N: usize, T: FromBytes => FromBytes for [T; N]);
     unsafe_impl!(const N: usize, T: AsBytes => AsBytes for [T; N]);
     unsafe_impl!(const N: usize, T: Unaligned => Unaligned for [T; N]);
     assert_unaligned!([(); 0], [(); 1], [u8; 0], [u8; 1]);
+    unsafe_impl!(T: TryFromBytes => TryFromBytes for [T]; |c: NonNull<[T]>| {
+        let base = c.cast::<T>().as_ptr();
+        // TODO(#67): Remove this allow. See NonNulSlicelExt for more details.
+        #[allow(unstable_name_collisions)]
+        (0..c.len()).all(|i| {
+            // TODO(https://github.com/rust-lang/rust/issues/74265): Use
+            // `NonNull::get_unchecked_mut`.
+
+            // SAFETY:
+            // - `i` is in bounds of `c.len()` by construction, and so the
+            //   result of this addition cannot overflow past the end of the
+            //   allocation referred to by `c`.
+            // - It is a precondition of `is_bit_valid` that the total length
+            //   encoded by `c` doesn't overflow `isize`.
+            // - Since `c` must point to a valid allocation, and valid
+            //   allocations cannot wrap around the address space, we know that
+            //   this addition will not wrap around either.
+            let elem = unsafe { base.add(i) };
+            // SAFETY: `base` is constructed from a `NonNull` pointer, and the
+            // addition that produces `elem` is guaranteed not to wrap
+            // around/overflow, so `elem >= base > 0`.
+            let elem = unsafe { NonNull::new_unchecked(elem) };
+
+            // SAFETY: The caller promises that `c` is aligned and is valid for
+            // reads. They also promise that any byte which is always
+            // initialized in a valid `[T]` is initialized in `c`'s referent.
+            // While the exact, formal property is slightly more complicated
+            // (see the safety docs on `is_bit_valid`), what's important is
+            // that, for types which are merely the concatenation of other types
+            // (structs, tuples, arrays, slices), the property is also
+            // compositional - if it holds for the larger type, then by
+            // definition it holds for each element of the type. Thus, since the
+            // caller has promised that it holds of the entire `[T]`, it must
+            // also hold for each individual `T`.
+            //
+            // Thus, the preconditions for this call are satisfied.
+            //
+            // Note that this call may panic, but it would still be sound even
+            // if it did. `is_bit_valid` does not promise that it will not panic
+            // (in fact, it explicitly warns that it's a possibility), and we
+            // have not violated any safety invariants that we must fix before
+            // returning.
+            unsafe { <T as TryFromBytes>::is_bit_valid(elem) }
+        })
+    });
     unsafe_impl!(T: FromZeroes => FromZeroes for [T]);
     unsafe_impl!(T: FromBytes => FromBytes for [T]);
     unsafe_impl!(T: AsBytes => AsBytes for [T]);
@@ -1456,8 +1976,8 @@ safety_comment! {
 // Given this background, we can observe that:
 // - The size and bit pattern requirements of a SIMD type are equivalent to the
 //   equivalent array type. Thus, for any SIMD type whose primitive `T` is
-//   `FromZeroes`, `FromBytes`, or `AsBytes`, that SIMD type is also
-//   `FromZeroes`, `FromBytes`, or `AsBytes` respectively.
+//   `FromZeroes`, `FromBytes`, `TryFromBytes`, or `AsBytes`, that SIMD type is
+//   also `FromZeroes`, `FromBytes`, `TryFromBytes`, or `AsBytes` respectively.
 // - Since no upper bound is placed on the alignment, no SIMD type can be
 //   guaranteed to be `Unaligned`.
 //
@@ -1468,21 +1988,23 @@ safety_comment! {
 //
 // See issue #38 [2]. While this behavior is not technically guaranteed, the
 // likelihood that the behavior will change such that SIMD types are no longer
-// `FromZeroes`, `FromBytes`, or `AsBytes` is next to zero, as that would defeat
-// the entire purpose of SIMD types. Nonetheless, we put this behavior behind
-// the `simd` Cargo feature, which requires consumers to opt into this stability
-// hazard.
+// `FromZeroes`, `FromBytes`, `TryFromBytes`, or `AsBytes` is next to zero, as
+// that would defeat the entire purpose of SIMD types. Nonetheless, we put this
+// behavior behind the `simd` Cargo feature, which requires consumers to opt
+// into this stability hazard.
 //
 // [1] https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
 // [2] https://github.com/rust-lang/unsafe-code-guidelines/issues/38
 #[cfg(feature = "simd")]
 mod simd {
-    /// Defines a module which implements `FromZeroes`, `FromBytes`, and
-    /// `AsBytes` for a set of types from a module in `core::arch`.
+    /// Defines a module which implements `FromZeroes`, `FromBytes`,
+    /// `TryFromBytes`, and `AsBytes` for a set of types from a module in
+    /// `core::arch`.
     ///
     /// `$arch` is both the name of the defined module and the name of the
     /// module in `core::arch`, and `$typ` is the list of items from that module
-    /// to implement `FromZeroes`, `FromBytes`, and `AsBytes` for.
+    /// for which to implement `FromZeroes`, `FromBytes`, `TryFromBytes`, and
+    /// `AsBytes`.
     #[allow(unused_macros)] // `allow(unused_macros)` is needed because some
                             // target/feature combinations don't emit any impls
                             // and thus don't use this macro.
@@ -1496,7 +2018,7 @@ mod simd {
                 safety_comment! {
                     /// SAFETY:
                     /// See comment on module definition for justification.
-                    $( unsafe_impl!($typ: FromZeroes, FromBytes, AsBytes); )*
+                    $( unsafe_impl!($typ: TryFromBytes, FromZeroes, FromBytes, AsBytes); )*
                 }
             }
         };
@@ -3037,7 +3559,7 @@ mod tests {
                     test!(@generate_cast_type $cast_type)
                 ).for_each(|(base_size, align, trailing_size, addr, bytes_len, cast_type)| {
                     let actual = std::panic::catch_unwind(|| {
-                        layout(base_size, align, trailing_size)._validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
+                        layout(base_size, align, trailing_size).validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
                     }).map_err(|d| {
                         *d.downcast::<&'static str>().expect("expected string panic message").as_ref()
                     });
@@ -3050,8 +3572,8 @@ mod tests {
             (@generate_usize _) => { 0..8 };
             (@generate_align _) => { [1, 2, 4, 8, 16] };
             (@generate_opt_usize _) => { [None].into_iter().chain((0..8).map(Some).into_iter()) };
-            (@generate_cast_type _) => { [_CastType::_Prefix, _CastType::_Suffix] };
-            (@generate_cast_type $variant:ident) => { [_CastType::$variant] };
+            (@generate_cast_type _) => { [CastType::Prefix, CastType::_Suffix] };
+            (@generate_cast_type $variant:ident) => { [CastType::$variant] };
             // Some expressions need to be wrapped in parentheses in order to be
             // valid `tt`s (required by the top match pattern). See the comment
             // below for more details. This arm removes these parentheses to
@@ -3069,8 +3591,8 @@ mod tests {
         test!(layout((2..8), _, ((1..8).map(Some))).validate(_, [1], _), Ok(None));
 
         // addr is unaligned for prefix cast
-        test!(layout(_, [2], [None]).validate(ODDS, _, _Prefix), Ok(None));
-        test!(layout(_, [2], (NZ_EVENS.map(Some))).validate(ODDS, _, _Prefix), Ok(None));
+        test!(layout(_, [2], [None]).validate(ODDS, _, Prefix), Ok(None));
+        test!(layout(_, [2], (NZ_EVENS.map(Some))).validate(ODDS, _, Prefix), Ok(None));
 
         // addr is aligned, but end of buffer is unaligned for suffix cast
         test!(layout(_, [2], [None]).validate(EVENS, ODDS, _Suffix), Ok(None));
@@ -3113,10 +3635,10 @@ mod tests {
         // documented safety postconditions, and also a few other properties
         // that aren't documented but we want to guarantee anyway.
         fn validate_behavior(
-            (layout, addr, bytes_len, cast_type): (DstLayout, usize, usize, _CastType),
+            (layout, addr, bytes_len, cast_type): (DstLayout, usize, usize, CastType),
         ) {
             if let Some((elems, split_at)) =
-                layout._validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
+                layout.validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
             {
                 let (base_size, align, trailing_elem_size) = (
                     layout._base_layout.size(),
@@ -3148,11 +3670,11 @@ mod tests {
                 // Test safety postconditions guaranteed by `validate_cast_and_convert_metadata`.
                 assert!(resulting_size <= bytes_len);
                 match cast_type {
-                    _CastType::_Prefix => {
+                    CastType::Prefix => {
                         assert_eq!(addr % align, 0, "{}", debug_str);
                         assert_eq!(resulting_size, split_at, "{}", debug_str);
                     }
-                    _CastType::_Suffix => {
+                    CastType::_Suffix => {
                         assert_eq!(split_at, bytes_len - resulting_size, "{}", debug_str);
                         assert_eq!((addr + split_at) % align, 0, "{}", debug_str);
                     }
@@ -3165,7 +3687,7 @@ mod tests {
                 size % align == 0 && trailing_elem_size.unwrap_or(*align) % align == 0
             })
             .map(|(s, a, t)| layout(s, a, t));
-        itertools::iproduct!(layouts, 0..8, 0..8, [_CastType::_Prefix, _CastType::_Suffix])
+        itertools::iproduct!(layouts, 0..8, 0..8, [CastType::Prefix, CastType::_Suffix])
             .for_each(validate_behavior);
     }
 
@@ -3980,9 +4502,175 @@ mod tests {
 
     #[test]
     fn test_impls() {
+        use core::borrow::Borrow;
+
+        // A type that can supply test cases for testing
+        // `TryFromBytes::is_bit_valid`. All types passed to `assert_impls!`
+        // must implement this trait; that macro uses it to generate runtime
+        // tests for `TryFromBytes` impls.
+        //
+        // All `T: FromBytes` types are provided with a blanket impl. Other
+        // types must implement `TryFromBytesTestable` directly (ie using
+        // `impl_try_from_bytes_testable!`).
+        trait TryFromBytesTestable {
+            fn with_passing_test_cases<F: Fn(&Self)>(f: F);
+            fn with_failing_test_cases<F: Fn(&[u8])>(f: F);
+        }
+
+        impl<T: FromBytes> TryFromBytesTestable for T {
+            fn with_passing_test_cases<F: Fn(&Self)>(f: F) {
+                // Test with a zeroed value.
+                f(&Self::new_zeroed());
+
+                let ffs = {
+                    let mut t = Self::new_zeroed();
+                    let ptr: *mut T = &mut t;
+                    // SAFETY: `T: FromBytes`
+                    unsafe { ptr::write_bytes(ptr.cast::<u8>(), 0xFF, mem::size_of::<T>()) };
+                    t
+                };
+
+                // Test with a value initialized with 0xFF.
+                f(&ffs);
+            }
+
+            fn with_failing_test_cases<F: Fn(&[u8])>(_f: F) {}
+        }
+
+        // Implements `TryFromBytesTestable`.
+        macro_rules! impl_try_from_bytes_testable {
+            // Base case for recursion (when the list of types has run out).
+            (=> @success $($success_case:expr),* $(, @failure $($failure_case:expr),*)?) => {};
+            // Implements for type(s) with no type parameters.
+            ($ty:ty $(,$tys:ty)* => @success $($success_case:expr),* $(, @failure $($failure_case:expr),*)?) => {
+                impl TryFromBytesTestable for $ty {
+                    impl_try_from_bytes_testable!(
+                        @methods     @success $($success_case),*
+                                 $(, @failure $($failure_case),*)?
+                    );
+                }
+                impl_try_from_bytes_testable!($($tys),* => @success $($success_case),* $(, @failure $($failure_case),*)?);
+            };
+            // Implements for multiple types with no type parameters.
+            ($($($ty:ty),* => @success $($success_case:expr), * $(, @failure $($failure_case:expr),*)?;)*) => {
+                $(
+                    impl_try_from_bytes_testable!($($ty),* => @success $($success_case),* $(, @failure $($failure_case),*)*);
+                )*
+            };
+            // Implements only the methods; caller must invoke this from inside
+            // an impl block.
+            (@methods @success $($success_case:expr),* $(, @failure $($failure_case:expr),*)?) => {
+                fn with_passing_test_cases<F: Fn(&Self)>(_f: F) {
+                    $(
+                        _f($success_case.borrow());
+                    )*
+                }
+
+                fn with_failing_test_cases<F: Fn(&[u8])>(_f: F) {
+                    $($(
+                        // `unused_qualifications` is spuriously triggered on
+                        // `Option::<Self>::None`.
+                        #[allow(unused_qualifications)]
+                        let case = $failure_case.as_bytes();
+                        _f(case.as_bytes());
+                    )*)?
+                }
+            };
+        }
+
+        // Note that these impls are only for types which are not `FromBytes`.
+        // `FromBytes` types are covered by a preceding blanket impl.
+        impl_try_from_bytes_testable!(
+            bool => @success true, false,
+                    @failure 2u8, 3u8, 0xFFu8;
+            char => @success '\u{0}', '\u{D7FF}', '\u{E000}', '\u{10FFFF}',
+                    @failure 0xD800u32, 0xDFFFu32, 0x110000u32;
+            str  => @success "", "hello", "❤️🧡💛💚💙💜",
+                    @failure [0, 159, 146, 150];
+            [u8] => @success [], [0, 1, 2];
+            NonZeroU8, NonZeroI8, NonZeroU16, NonZeroI16, NonZeroU32,
+            NonZeroI32, NonZeroU64, NonZeroI64, NonZeroU128, NonZeroI128,
+            NonZeroUsize, NonZeroIsize
+                 => @success Self::new(1).unwrap(),
+                    // Doing this instead of `0` ensures that we always satisfy
+                    // the size and alignment requirements of `Self` (whereas
+                    // `0` may be any integer type with a different size or
+                    // alignment than some `NonZeroXxx` types).
+                    @failure Option::<Self>::None;
+            ManuallyDrop<bool>
+                 => @success ManuallyDrop::new(true), ManuallyDrop::new(false),
+                    @failure 3u8, 4u8, 0xFFu8;
+            Wrapping<bool>
+                => @success Wrapping(true), Wrapping(false),
+                    @failure 3u8, 4u8, 0xFFu8;
+            // TODO(#321): Add success test cases for `ManuallyDrop<[u8]>` and
+            // `ManuallyDrop<[bool]>` once we have an easy way of converting
+            // `[ManuallyDrop<T>] -> ManuallyDrop<[T]>`. Here are some suggested
+            // test cases:
+            //
+            //      @success [ManuallyDrop::new(true), ManuallyDrop::new(false)][..],
+            //               [ManuallyDrop::new(false), ManuallyDrop::new(true)][..],
+            ManuallyDrop<[u8]> => @success;
+            ManuallyDrop<[bool]>
+                 => @success,
+                    @failure [2u8], [3u8], [0xFFu8], [0u8, 1u8, 2u8];
+            [bool; 0] => @success [];
+            [bool; 1]
+                 => @success [true], [false],
+                    @failure [2u8], [3u8], [0xFFu8];
+            [bool]
+                 => @success [true, false], [false, true],
+                    @failure [2u8], [3u8], [0xFFu8], [0u8, 1u8, 2u8];
+
+
+        );
+
         // Asserts that `$ty` implements any `$trait` and doesn't implement any
         // `!$trait`. Note that all `$trait`s must come before any `!$trait`s.
+        //
+        // For `T: TryFromBytes`, uses `TryFromBytesTestable` to test success
+        // and failure cases for `TryFromBytes::is_bit_valid`.
         macro_rules! assert_impls {
+            ($ty:ty: TryFromBytes) => {
+                <$ty as TryFromBytesTestable>::with_passing_test_cases(|val| {
+                    let c = NonNull::from(val);
+                    // SAFETY:
+                    // - Since `val` is a normal reference, `c` is guranteed to
+                    //   be aligned, to point to a single allocation, and to
+                    //   have a size which doesn't overflow `isize`.
+                    // - Since `val` is a valid `$ty`, `c`'s referent satisfies
+                    //   the bit validity constraints of `is_bit_valid`, which
+                    //   are a superset of the bit validity constraints of
+                    //   `$ty`.
+                    let res = unsafe { <$ty as TryFromBytes>::is_bit_valid(c) };
+                    assert!(res, "{}::is_bit_valid({:?}): got false, expected true", stringify!($ty), val);
+
+                    // TODO(#5): In addition to testing `is_bit_valid`, test the
+                    // methods built on top of it. This would both allow us to
+                    // test their implementations and actually convert the bytes
+                    // to `$ty`, giving Miri a chance to catch if this is
+                    // unsound (ie, if our `is_bit_valid` impl is buggy).
+                    //
+                    // The following code was tried, but it doesn't work because
+                    // a) some types are not `AsBytes` and, b) some types are
+                    // not `Sized`.
+                    //
+                    //   let r = <$ty as TryFromBytes>::try_from_ref(val.as_bytes()).unwrap();
+                    //   assert_eq!(r, &val);
+                    //   let r = <$ty as TryFromBytes>::try_from_mut(val.as_bytes_mut()).unwrap();
+                    //   assert_eq!(r, &mut val);
+                    //   let v = <$ty as TryFromBytes>::try_read_from(val.as_bytes()).unwrap();
+                    //   assert_eq!(v, val);
+                });
+                #[allow(clippy::as_conversions)]
+                <$ty as TryFromBytesTestable>::with_failing_test_cases(|c| {
+                    let res = <$ty as TryFromBytes>::try_from_ref(c);
+                    assert!(res.is_none(), "{}::is_bit_valid({:?}): got true, expected false", stringify!($ty), c);
+                });
+
+                #[allow(dead_code)]
+                const _: () = { static_assertions::assert_impl_all!($ty: TryFromBytes); };
+            };
             ($ty:ty: $trait:ident) => {
                 #[allow(dead_code)]
                 const _: () = { static_assertions::assert_impl_all!($ty: $trait); };
@@ -4002,77 +4690,87 @@ mod tests {
             };
         }
 
-        assert_impls!((): FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(u8: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(i8: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(u16: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(i16: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(u32: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(i32: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(u64: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(i64: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(u128: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(i128: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(usize: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(isize: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(f32: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(f64: FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!((): TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(u8: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(i8: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(u16: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(i16: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(u32: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(i32: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(u64: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(i64: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(u128: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(i128: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(usize: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(isize: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(f32: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(f64: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
 
-        assert_impls!(bool: FromZeroes, AsBytes, Unaligned, !FromBytes);
-        assert_impls!(char: FromZeroes, AsBytes, !FromBytes, !Unaligned);
-        assert_impls!(str: FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!(bool: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!(char: TryFromBytes, FromZeroes, AsBytes, !FromBytes, !Unaligned);
+        assert_impls!(str: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
 
-        assert_impls!(NonZeroU8: AsBytes, Unaligned, !FromZeroes, !FromBytes);
-        assert_impls!(NonZeroI8: AsBytes, Unaligned, !FromZeroes, !FromBytes);
-        assert_impls!(NonZeroU16: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroI16: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroU32: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroI32: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroU64: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroI64: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroU128: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroI128: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroUsize: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
-        assert_impls!(NonZeroIsize: AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroU8: TryFromBytes, AsBytes, Unaligned, !FromZeroes, !FromBytes);
+        assert_impls!(NonZeroI8: TryFromBytes, AsBytes, Unaligned, !FromZeroes, !FromBytes);
+        assert_impls!(NonZeroU16: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroI16: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroU32: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroI32: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroU64: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroI64: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroU128: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroI128: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroUsize: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
+        assert_impls!(NonZeroIsize: TryFromBytes, AsBytes, !FromZeroes, !FromBytes, !Unaligned);
 
-        assert_impls!(Option<NonZeroU8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(Option<NonZeroI8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(Option<NonZeroU16>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI16>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU32>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI32>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU64>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI64>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU128>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI128>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroUsize>: FromZeroes, FromBytes, AsBytes, !Unaligned);
-        assert_impls!(Option<NonZeroIsize>: FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(Option<NonZeroI8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(Option<NonZeroU16>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI16>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU32>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI32>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU64>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI64>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU128>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI128>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroUsize>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
+        assert_impls!(Option<NonZeroIsize>: TryFromBytes, FromZeroes, FromBytes, AsBytes, !Unaligned);
 
         // Implements none of the ZC traits.
         struct NotZerocopy;
 
-        assert_impls!(PhantomData<NotZerocopy>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(PhantomData<[u8]>: FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(PhantomData<NotZerocopy>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(PhantomData<[u8]>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
 
-        assert_impls!(ManuallyDrop<u8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(ManuallyDrop<[u8]>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(ManuallyDrop<NotZerocopy>: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
-        assert_impls!(ManuallyDrop<[NotZerocopy]>: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!(ManuallyDrop<u8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(ManuallyDrop<[u8]>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(ManuallyDrop<bool>: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!(ManuallyDrop<[bool]>: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!(ManuallyDrop<NotZerocopy>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!(ManuallyDrop<[NotZerocopy]>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
 
-        assert_impls!(MaybeUninit<u8>: FromZeroes, FromBytes, Unaligned, !AsBytes);
-        assert_impls!(MaybeUninit<NotZerocopy>: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!(MaybeUninit<u8>: TryFromBytes, FromZeroes, FromBytes, Unaligned, !AsBytes);
+        assert_impls!(MaybeUninit<bool>: TryFromBytes, FromZeroes, FromBytes, Unaligned, !AsBytes);
+        assert_impls!(MaybeUninit<MaybeUninit<u8>>: TryFromBytes, FromZeroes, FromBytes, Unaligned, !AsBytes);
+        assert_impls!(MaybeUninit<MaybeUninit<bool>>: TryFromBytes, FromZeroes, FromBytes, Unaligned, !AsBytes);
+        assert_impls!(MaybeUninit<NotZerocopy>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!(MaybeUninit<MaybeUninit<NotZerocopy>>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
 
-        assert_impls!(Wrapping<u8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(Wrapping<NotZerocopy>: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!(Wrapping<u8>: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!(Wrapping<bool>: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!(Wrapping<NotZerocopy>: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
 
-        assert_impls!(Unalign<u8>: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!(Unalign<NotZerocopy>: Unaligned, !FromZeroes, !FromBytes, !AsBytes);
+        assert_impls!(Unalign<u8>: FromZeroes, FromBytes, AsBytes, Unaligned, !TryFromBytes);
+        assert_impls!(Unalign<NotZerocopy>: Unaligned, !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes);
 
-        assert_impls!([u8]: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!([NotZerocopy]: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
-        assert_impls!([u8; 0]: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!([NotZerocopy; 0]: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
-        assert_impls!([u8; 1]: FromZeroes, FromBytes, AsBytes, Unaligned);
-        assert_impls!([NotZerocopy; 1]: !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!([u8]: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!([bool]: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!([NotZerocopy]: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!([u8; 0]: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!([bool; 0]: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!([NotZerocopy; 0]: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
+        assert_impls!([u8; 1]: TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned);
+        assert_impls!([bool; 1]: TryFromBytes, FromZeroes, AsBytes, Unaligned, !FromBytes);
+        assert_impls!([NotZerocopy; 1]: !TryFromBytes, !FromZeroes, !FromBytes, !AsBytes, !Unaligned);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2062,21 +2062,43 @@ mod simd {
     simd_arch_mod!(arm, int8x4_t, uint8x4_t);
 }
 
-// Used in `transmute!` below.
+// Used in macros below.
 #[doc(hidden)]
 pub use core::mem::transmute as __real_transmute;
+#[doc(hidden)]
+pub use core::mem::ManuallyDrop as __RealManuallyDrop;
 
 /// Safely transmutes a value of one type to a value of another type of the same
 /// size.
 ///
-/// The expression `$e` must have a concrete type, `T`, which implements
-/// `AsBytes`. The `transmute!` expression must also have a concrete type, `U`
+/// The expression, `$e`, must have a concrete type, `T`, which implements
+/// [`AsBytes`]. The `transmute!` expression must also have a concrete type, `U`
 /// (`U` is inferred from the calling context), and `U` must implement
-/// `FromBytes`.
+/// [`FromBytes`]. `T` and `U` must have the same size.
 ///
 /// Note that the `T` produced by the expression `$e` will *not* be dropped.
 /// Semantically, its bits will be copied into a new value of type `U`, the
 /// original `T` will be forgotten, and the value of type `U` will be returned.
+///
+/// # Examples
+///
+/// ```rust
+/// # use zerocopy::transmute;
+/// use core::num::NonZeroU64;
+///
+/// // Why would you want to do this? Who knows ¯\_(ツ)_/¯
+/// let opt: Option<NonZeroU64> = transmute!(0.0f64);
+/// assert_eq!(opt, None);
+/// ```
+///
+/// ```rust,compile_fail
+/// # use zerocopy::try_transmute;
+/// // Fails to compile: `bool` does not implement `FromBytes`
+/// assert_eq!(transmute!(1u8), true);
+///
+/// // Fails to compile: can't transmute between sizes of different types
+/// let _: u8 = try_transmute!(0u16);
+/// ```
 #[macro_export]
 macro_rules! transmute {
     ($e:expr) => {{
@@ -2110,6 +2132,178 @@ macro_rules! transmute {
             unsafe { $crate::__real_transmute(e) }
         }
     }}
+}
+
+/// Safely attempts to transmute a value of one type to a value of another type
+/// of the same size, failing if the transmute would be unsound.
+///
+/// The expression, `$e`, must have a concrete type, `T`, which implements
+/// [`AsBytes`]. The `try_transmute!` expression must also have a concrete type,
+/// `Option<U>` (`U` is inferred from the calling context), and `U` must
+/// implement [`TryFromBytes`]. `T` and `U` must have the same size.
+///
+/// [`TryFromBytes::try_read_from`] is used to attempt to convert `$e` to the
+/// output type `U`. This will fail if the bytes of `$e` do not correspond to a
+/// valid instance of `U`.
+///
+/// Note that the `T` produced by the expression `$e` will *not* be dropped.
+/// Semantically, its bits will be copied into a new value of type `U`, the
+/// original `T` will be forgotten, and the value of type `U` will be returned.
+///
+/// # Examples
+///
+/// ```rust
+/// # use zerocopy::try_transmute;
+/// assert_eq!(try_transmute!(1u8), Some(true));
+/// assert_eq!(try_transmute!(2u8), None::<bool>);
+///
+/// assert_eq!(try_transmute!(108u32), Some('l'));
+/// assert_eq!(try_transmute!(0xD800u32), None::<char>);
+/// ```
+///
+/// ```rust,compile_fail
+/// # use zerocopy::try_transmute;
+/// // Attempting to transmute from 2 to 1 bytes will fail to compile
+/// let _: Option<u8> = try_transmute!(0u16);
+/// ```
+#[macro_export]
+macro_rules! try_transmute {
+    ($e:expr) => {{
+        // NOTE: This must be a macro (rather than a function with trait bounds)
+        // because there's no way, in a generic context, to enforce that two
+        // types have the same size. `core::mem::transmute` uses compiler magic
+        // to enforce this so long as the types are concrete.
+
+        let e = $e;
+        if false {
+            // This branch, though never taken, ensures that the type of `e` is
+            // `AsBytes` and that the type of this macro invocation expression
+            // is `TryFromBytes`.
+            const fn transmute<T: $crate::AsBytes, U: $crate::TryFromBytes>(_t: T) -> U {
+                unreachable!()
+            }
+            Some(transmute(e))
+        } else if false {
+            // Though never executed, this ensures that the source and
+            // destination types have the same size. This isn't strictly
+            // necessary for soundness, but it turns what would otherwise be
+            // runtime errors into compile-time errors.
+            //
+            // SAFETY: This branch never executes.
+            Some(unsafe { $crate::__real_transmute(e) })
+        } else {
+            // TODO: What's the correct drop behavior on `None`? Does this just
+            // behave like `mem::forget` in that case?
+            let m = $crate::__RealManuallyDrop::new(e);
+            $crate::TryFromBytes::try_read_from($crate::AsBytes::as_bytes(&m))
+        }
+    }}
+}
+
+/// Safely attempts to transmute a reference of one type to a reference of
+/// another type, failing if the transmute would be unsound.
+///
+/// The expression, `$e`, must have a concrete type, `&T`, where [`T: AsBytes`].
+/// The `try_transmute_ref!` expression must also have a concrete type,
+/// `Option<&U>` (`U` is inferred from the calling context), and `U` must
+/// implement [`TryFromBytes`].
+///
+/// [`TryFromBytes::try_from_ref`] is used to attempt to convert `$e` to the
+/// output reference type `&U`. This will fail if `$e` is not the right size, is
+/// not properly aligned, or if the bytes of `$e` do not correspond to a valid
+/// instance of `U`.
+///
+/// Note that, if `U` is an unsized type, there will be multiple sizes for `$e`
+/// which correspond to valid values of `U`.
+///
+/// [`T: AsBytes`]: AsBytes
+///
+/// # Examples
+///
+/// ```rust
+/// # use zerocopy::try_transmute_ref;
+/// # use zerocopy::AsBytes as _;
+/// let s: Option<&str> = try_transmute_ref!(&[104u8, 101, 108, 108, 111]);
+/// assert_eq!(s, Some("hello"));
+///
+/// // Invalid UTF-8
+/// assert_eq!(try_transmute_ref!(&0xFFFFFFFFu32), None::<&str>);
+///
+/// // Not enough bytes for a `u8`
+/// assert_eq!(try_transmute_ref!(&()), None::<&u8>);
+///
+/// // Valid `&[[u8; 2]]` slices could be 2 or 4 bytes long,
+/// // but not 3.
+/// assert_eq!(try_transmute_ref!(&[0u8, 1, 2]), None::<&[[u8; 2]]>);
+///
+/// // Guaranteed to be invalidly-aligned so long as
+/// // `align_of::<u16>() == 2` and `align_of::<u32>() >= 2`
+/// // (this is true on most targets, but it isn't guaranteed).
+/// assert_eq!(try_transmute_ref!(&0u32.as_bytes()[1..]), None::<&u16>);
+/// ```
+#[macro_export]
+macro_rules! try_transmute_ref {
+    ($e:expr) => {
+        $crate::TryFromBytes::try_from_ref($crate::AsBytes::as_bytes($e))
+    };
+}
+
+/// Safely attempts to transmute a mutable reference of one type to a mutable
+/// reference of another type, failing if the transmute would be unsound.
+///
+/// The expression, `$e`, must have a concrete type, `&mut T`, where `T:
+/// FromBytes + AsBytes`. The `try_transmute_ref!` expression must also have a
+/// concrete type, `Option<&mut U>` (`U` is inferred from the calling context),
+/// and `U` must implement [`TryFromBytes`].
+///
+/// [`TryFromBytes::try_from_mut`] is used to attempt to convert `$e` to the
+/// output reference type, `&mut U`. This will fail if `$e` is not the right
+/// size, is not properly aligned, or if the bytes of `$e` do not correspond to
+/// a valid instance of `U`.
+///
+/// Note that, if `U` is an unsized type, there will be multiple sizes for `$e`
+/// which correspond to valid values of `U`.
+///
+/// [`TryFromBytes`]: TryFromBytes
+///
+/// # Examples
+///
+/// ```rust
+/// # use zerocopy::try_transmute_mut;
+/// # use zerocopy::AsBytes as _;
+/// let bytes = &mut [104u8, 101, 108, 108, 111];
+/// let mut s = try_transmute_mut!(bytes);
+/// assert_eq!(s, Some(String::from("hello").as_mut_str()));
+///
+/// // Mutations to the transmuted reference are reflected
+/// // in the original reference.
+/// s.as_mut().unwrap().make_ascii_uppercase();
+/// assert_eq!(bytes, &[72, 69, 76, 76, 79]);
+///
+/// // Invalid UTF-8
+/// let mut u = 0xFFFFFFFFu32;
+/// assert_eq!(try_transmute_mut!(&mut u), None::<&mut str>);
+///
+/// // Not enough bytes for a `u8`
+/// let mut tuple = ();
+/// assert_eq!(try_transmute_mut!(&mut tuple), None::<&mut u8>);
+///
+/// // Valid `&mut [[u8; 2]]` slices could be 2 or 4 bytes
+/// // long, but not 3.
+/// let bytes = &mut [0u8, 1, 2];
+/// assert_eq!(try_transmute_mut!(bytes), None::<&mut [[u8; 2]]>);
+///
+/// // Guaranteed to be invalidly-aligned so long as
+/// // `align_of::<u16>() == 2` and `align_of::<u32>() >= 2`
+/// // (this is true on most targets, but it isn't guaranteed).
+/// let mut u = 0u32;
+/// assert_eq!(try_transmute_mut!(&mut u.as_bytes_mut()[1..]), None::<&mut u16>);
+/// ```
+#[macro_export]
+macro_rules! try_transmute_mut {
+    ($e:expr) => {
+        $crate::TryFromBytes::try_from_mut($crate::AsBytes::as_bytes_mut($e))
+    };
 }
 
 /// A typed reference derived from a byte slice.
@@ -3799,10 +3993,16 @@ mod tests {
         // Test that memory is transmuted as expected.
         let array_of_u8s = [0u8, 1, 2, 3, 4, 5, 6, 7];
         let array_of_arrays = [[0, 1], [2, 3], [4, 5], [6, 7]];
+
         let x: [[u8; 2]; 4] = transmute!(array_of_u8s);
         assert_eq!(x, array_of_arrays);
+        let x: Option<[[u8; 2]; 4]> = try_transmute!(array_of_u8s);
+        assert_eq!(x, Some(array_of_arrays));
+
         let x: [u8; 8] = transmute!(array_of_arrays);
         assert_eq!(x, array_of_u8s);
+        let x: Option<[u8; 8]> = try_transmute!(array_of_arrays);
+        assert_eq!(x, Some(array_of_u8s));
 
         // Test that the source expression's value is forgotten rather than
         // dropped.
@@ -3815,12 +4015,37 @@ mod tests {
             }
         }
         let _: () = transmute!(PanicOnDrop(()));
+        let _: Option<()> = try_transmute!(PanicOnDrop(()));
 
         // Test that `transmute!` is legal in a const context.
         const ARRAY_OF_U8S: [u8; 8] = [0u8, 1, 2, 3, 4, 5, 6, 7];
         const ARRAY_OF_ARRAYS: [[u8; 2]; 4] = [[0, 1], [2, 3], [4, 5], [6, 7]];
         const X: [[u8; 2]; 4] = transmute!(ARRAY_OF_U8S);
         assert_eq!(X, ARRAY_OF_ARRAYS);
+
+        // Test fallible transmutations with `try_transmute!`.
+        let mut b: Option<bool> = try_transmute!(0u8);
+        assert_eq!(b, Some(false));
+        b = try_transmute!(1u8);
+        assert_eq!(b, Some(true));
+        b = try_transmute!(2u8);
+        assert_eq!(b, None);
+    }
+
+    #[test]
+    fn test_try_transmute_ref_mut() {
+        // These macros are dead-simple thin wrappers which delegate to other
+        // traits. We only have this test to ensure that the macros are uesd
+        // somewhere so our tests will break if the paths to various items
+        // break.
+        let x: Option<&[u8; 2]> = try_transmute_ref!(&0xFFFFu16);
+        assert_eq!(x, Some(&[255, 255]));
+
+        let mut u = 0xFFFFu16;
+        let x: Option<&mut [u8; 2]> = try_transmute_mut!(&mut u);
+        assert_eq!(x, Some(&mut [255, 255]));
+        *x.unwrap() = [0, 0];
+        assert_eq!(u, 0);
     }
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -130,6 +130,9 @@ macro_rules! unsafe_impl {
             let $candidate = unsafe { &*(candidate.as_ptr() as *const $repr) };
             $is_bit_valid
         }
+
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn only_derive_is_allowed_to_implement_this_trait() {}
     };
     (@method TryFromBytes ; |$candidate:ident: NonNull<$repr:ty>| $is_bit_valid:expr) => {
         #[inline]
@@ -141,8 +144,15 @@ macro_rules! unsafe_impl {
             let $candidate = unsafe { NonNull::new_unchecked(candidate.as_ptr() as *mut $repr) };
             $is_bit_valid
         }
+
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn only_derive_is_allowed_to_implement_this_trait() {}
     };
-    (@method TryFromBytes) => { #[inline(always)] unsafe fn is_bit_valid(_: NonNull<Self>) -> bool { true } };
+    (@method TryFromBytes) => {
+        #[inline(always)] unsafe fn is_bit_valid(_: NonNull<Self>) -> bool { true }
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items)]
         fn only_derive_is_allowed_to_implement_this_trait() {}
@@ -253,17 +263,17 @@ macro_rules! impl_known_layout {
     ($(const $constvar:ident : $constty:ty, $tyvar:ident $(: ?$optbound:ident)? => $ty:ty),* $(,)?) => {
         $(impl_known_layout!(@inner const $constvar: $constty, $tyvar $(: ?$optbound)? => $ty);)*
     };
-    ($($tyvar:ident $(: ?$optbound:ident)? => $ty:ty),* $(,)?) => {
-        $(impl_known_layout!(@inner , $tyvar $(: ?$optbound)? => $ty);)*
+    ($($($tyvar:ident $(: ?$optbound:ident)?),* => $ty:ty),* $(,)?) => {
+        $(impl_known_layout!(@inner , $($tyvar $(: ?$optbound)?),* => $ty);)*
     };
     ($($ty:ty),*) => { $(impl_known_layout!(@inner , => $ty);)* };
-    (@inner $(const $constvar:ident : $constty:ty)? , $($tyvar:ident $(: ?$optbound:ident)?)? => $ty:ty) => {
+    (@inner $(const $constvar:ident : $constty:ty)? , $($tyvar:ident $(: ?$optbound:ident)?),* => $ty:ty) => {
         const _: () = {
             use core::ptr::NonNull;
 
-            impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> sealed::KnownLayoutSealed for $ty {}
+            impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?),*> sealed::KnownLayoutSealed for $ty {}
             // SAFETY: Delegates safety to `DstLayout::for_type`.
-            unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> KnownLayout for $ty {
+            unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?),*> KnownLayout for $ty {
                 const LAYOUT: DstLayout = DstLayout::for_type::<$ty>();
 
                 // SAFETY: `.cast` preserves address and provenance.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,13 +29,38 @@ macro_rules! safety_comment {
 }
 
 /// Unsafely implements trait(s) for a type.
+///
+/// # Safety
+///
+/// The trait impl must be sound.
+///
+/// When implementing `TryFromBytes`:
+/// - If no `is_bit_valid` impl is provided, then it must be valid for
+///   `is_bit_valid` to unconditionally return `true`. In other words, it must
+///   be the case that any initialized sequence of bytes constitutes a valid
+///   instance of `$ty`.
+/// - If an `is_bit_valid` impl is provided, then:
+///   - If the provided closure takes a `NonNull<$repr>` argument, then given a
+///     `NonNull<$ty>` which satisfies the preconditions of
+///     `TryFromBytes::<$ty>::is_bit_valid`, it must be guaranteed that a
+///     `NonNull<$repr>` with the same address, provenance, and pointer metadata
+///     satisfies the preconditions of `TryFromBytes::<$repr>::is_bit_valid`.
+///   - If the provided closure takes a `&$repr` argument, then given a
+///     `NonNull<$ty>` which satisfies the preconditions of
+///     `TryFromBytes::<$ty>::is_bit_valid`, it must be sound to convert it to a
+///     `$repr` pointer with the same address, provenance, and pointer metadata,
+///     and to subsequently dereference that pointer as a `&$repr`.
+///   - The impl of `is_bit_valid` must only return `true` for its argument
+///     `NonNull<$repr>` if the original `NonNull<$ty>` refers to a valid `$ty`.
 macro_rules! unsafe_impl {
     // Implement `$trait` for `$ty` with no bounds.
-    ($ty:ty: $trait:ty) => {
-        unsafe impl $trait for $ty { #[allow(clippy::missing_inline_in_public_items)] fn only_derive_is_allowed_to_implement_this_trait() {} }
+    ($ty:ty: $trait:ident $(; |$candidate:ident: &$repr:ty| $is_bit_valid:expr)?) => {
+        unsafe impl $trait for $ty {
+            unsafe_impl!(@method $trait $(; |$candidate: &$repr| $is_bit_valid)?);
+        }
     };
     // Implement all `$traits` for `$ty` with no bounds.
-    ($ty:ty: $($traits:ty),*) => {
+    ($ty:ty: $($traits:ident),*) => {
         $( unsafe_impl!($ty: $traits); )*
     };
     // This arm is identical to the following one, except it contains a
@@ -66,35 +91,64 @@ macro_rules! unsafe_impl {
     (
         const $constname:ident : $constty:ident $(,)?
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: NonNull<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             @const $constname: $constty,
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate $(: &$ref_repr)? $(: NonNull<$ptr_repr>)?| $is_bit_valid)?
         );
     };
     (
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: NonNull<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         unsafe_impl!(
             @inner
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
+            => $trait for $ty $(; |$candidate $(: &$ref_repr)? $(: NonNull<$ptr_repr>)?| $is_bit_valid)?
         );
     };
     (
         @inner
         $(@const $constname:ident : $constty:ident,)*
         $($tyvar:ident $(: $(? $optbound:ident +)* + $($bound:ident +)* )?,)*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: &$ref_repr:ty)? $(: NonNull<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         unsafe impl<$(const $constname: $constty,)* $($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> $trait for $ty {
-            #[allow(clippy::missing_inline_in_public_items)]
-            fn only_derive_is_allowed_to_implement_this_trait() {}
+            unsafe_impl!(@method $trait $(; |$candidate: $(&$ref_repr)? $(NonNull<$ptr_repr>)?| $is_bit_valid)?);
         }
+    };
+
+    (@method TryFromBytes ; |$candidate:ident: &$repr:ty| $is_bit_valid:expr) => {
+        #[inline]
+        unsafe fn is_bit_valid(candidate: NonNull<Self>) -> bool {
+            // SAFETY: The caller has promised that it is sound to perform this
+            // pointer cast and dereference.
+            #[allow(clippy::as_conversions)]
+            let $candidate = unsafe { &*(candidate.as_ptr() as *const $repr) };
+            $is_bit_valid
+        }
+    };
+    (@method TryFromBytes ; |$candidate:ident: NonNull<$repr:ty>| $is_bit_valid:expr) => {
+        #[inline]
+        unsafe fn is_bit_valid(candidate: NonNull<Self>) -> bool {
+            // SAFETY: `candidate` is a non-null pointer. The caller has
+            // promised that it is sound to invoke their `$is_bit_valid` with
+            // this pointer.
+            #[allow(clippy::as_conversions)]
+            let $candidate = unsafe { NonNull::new_unchecked(candidate.as_ptr() as *mut $repr) };
+            $is_bit_valid
+        }
+    };
+    (@method TryFromBytes) => { #[inline(always)] unsafe fn is_bit_valid(_: NonNull<Self>) -> bool { true } };
+    (@method $trait:ident) => {
+        #[allow(clippy::missing_inline_in_public_items)]
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    };
+    (@method $trait:ident; |$_candidate:ident $(: &$_ref_repr:ty)? $(: NonNull<$_ptr_repr:ty>)?| $_is_bit_valid:expr) => {
+        compile_error!("Can't provide `is_bit_valid` impl for trait other than `TryFromBytes`");
     };
 }
 
@@ -204,11 +258,21 @@ macro_rules! impl_known_layout {
     };
     ($($ty:ty),*) => { $(impl_known_layout!(@inner , => $ty);)* };
     (@inner $(const $constvar:ident : $constty:ty)? , $($tyvar:ident $(: ?$optbound:ident)?)? => $ty:ty) => {
-        impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> sealed::KnownLayoutSealed for $ty {}
-        // SAFETY: Delegates safety to `DstLayout::for_type`.
-        unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> KnownLayout for $ty {
-            const LAYOUT: DstLayout = DstLayout::for_type::<$ty>();
-        }
+        const _: () = {
+            use core::ptr::NonNull;
+
+            impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> sealed::KnownLayoutSealed for $ty {}
+            // SAFETY: Delegates safety to `DstLayout::for_type`.
+            unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> KnownLayout for $ty {
+                const LAYOUT: DstLayout = DstLayout::for_type::<$ty>();
+
+                // SAFETY: `.cast` preserves address and provenance.
+                #[inline(always)]
+                fn raw_from_ptr_len(bytes: NonNull<u8>, _elems: usize) -> NonNull<Self> {
+                    bytes.cast::<Self>()
+                }
+            }
+        };
     };
 }
 
@@ -225,10 +289,25 @@ macro_rules! impl_known_layout {
 ///   and this operation must preserve referent size (ie, `size_of_val_raw`).
 macro_rules! unsafe_impl_known_layout {
     ($($tyvar:ident: ?Sized + KnownLayout =>)? #[repr($repr:ty)] $ty:ty) => {
-        impl<$($tyvar: ?Sized + KnownLayout)?> sealed::KnownLayoutSealed for $ty {}
-        unsafe impl<$($tyvar: ?Sized + KnownLayout)?> KnownLayout for $ty {
-            const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
-        }
+        const _: () = {
+            use core::ptr::NonNull;
+
+            impl<$($tyvar: ?Sized + KnownLayout)?> sealed::KnownLayoutSealed for $ty {}
+            unsafe impl<$($tyvar: ?Sized + KnownLayout)?> KnownLayout for $ty {
+                const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
+
+                // SAFETY: All operations preserve address and provenance. Caller
+                // has promised that the `as` cast preserves size.
+                #[inline(always)]
+                #[allow(unused_qualifications)] // for `core::ptr::NonNull`
+                fn raw_from_ptr_len(bytes: NonNull<u8>, elems: usize) -> NonNull<Self> {
+                    #[allow(clippy::as_conversions)]
+                    let ptr = <$repr>::raw_from_ptr_len(bytes, elems).as_ptr() as *mut Self;
+                    // SAFETY: `ptr` was converted from `bytes`, which is non-null.
+                    unsafe { NonNull::new_unchecked(ptr) }
+                }
+            }
+        };
     };
 }
 

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -54,9 +54,14 @@ use super::*;
 // [3] https://github.com/google/zerocopy/issues/209
 #[allow(missing_debug_implementations)]
 #[derive(Default, Copy)]
-#[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+#[cfg_attr(
+    any(feature = "derive", test),
+    derive(TryFromBytes, FromZeroes, FromBytes, AsBytes, Unaligned)
+)]
 #[repr(C, packed)]
 pub struct Unalign<T>(T);
+
+impl_known_layout!(T => Unalign<T>);
 
 safety_comment! {
     /// SAFETY:

--- a/tests/ui-nightly/transmute-illegal.rs
+++ b/tests/ui-nightly/transmute-illegal.rs
@@ -8,3 +8,9 @@ fn main() {}
 
 // It is unsound to inspect the usize value of a pointer during const eval.
 const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
+
+// `transmute!` and `try_transmute!` enforce size equality.
+const TOO_LARGE: u64 = zerocopy::transmute!(0u8);
+const TRY_TOO_LARGE: Option<u64> = zerocopy::try_transmute!(0u8);
+const TOO_SMALL: u8 = zerocopy::transmute!(0u64);
+const TRY_TOO_SMALL: Option<u8> = zerocopy::try_transmute!(0u64);

--- a/tests/ui-nightly/transmute-illegal.stderr
+++ b/tests/ui-nightly/transmute-illegal.stderr
@@ -14,3 +14,43 @@ note: required by a bound in `POINTER_VALUE::transmute`
 10 | const POINTER_VALUE: usize = zerocopy::transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
    = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-illegal.rs:13:24
+   |
+13 | const TOO_LARGE: u64 = zerocopy::transmute!(0u8);
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `u64` (64 bits)
+   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-illegal.rs:14:36
+   |
+14 | const TRY_TOO_LARGE: Option<u64> = zerocopy::try_transmute!(0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `u64` (64 bits)
+   = note: this error originates in the macro `zerocopy::try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-illegal.rs:15:23
+   |
+15 | const TOO_SMALL: u8 = zerocopy::transmute!(0u64);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u64` (64 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `zerocopy::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-illegal.rs:16:35
+   |
+16 | const TRY_TOO_SMALL: Option<u8> = zerocopy::try_transmute!(0u64);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u64` (64 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `zerocopy::try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.1"
 quote = "1.0.10"
-syn = "2.0.31"
+syn = { version = "2.0.31", features = ["full", "parsing"] }
 
 [dev-dependencies]
 rustversion = "1.0"

--- a/zerocopy-derive/src/ext.rs
+++ b/zerocopy-derive/src/ext.rs
@@ -4,7 +4,7 @@
 
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{Data, DataEnum, DataStruct, DataUnion, Field, Index, Type};
+use syn::{Data, DataEnum, DataStruct, DataUnion, Field, Fields, Index, Type};
 
 pub trait DataExt {
     /// Extract the names and types of all fields. For enums, extract the names
@@ -43,6 +43,12 @@ impl DataExt for DataEnum {
 impl DataExt for DataUnion {
     fn fields(&self) -> Vec<(TokenStream, &Type)> {
         map_fields(&self.fields.named)
+    }
+}
+
+impl DataExt for Fields {
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(self)
     }
 }
 

--- a/zerocopy-derive/src/ext.rs
+++ b/zerocopy-derive/src/ext.rs
@@ -2,40 +2,66 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use syn::{Data, DataEnum, DataStruct, DataUnion, Type};
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Data, DataEnum, DataStruct, DataUnion, Field, Index, Type};
 
 pub trait DataExt {
-    /// Extract the types of all fields. For enums, extract the types of fields
-    /// from each variant.
-    fn field_types(&self) -> Vec<&Type>;
+    /// Extract the names and types of all fields. For enums, extract the names
+    /// and types of fields from each variant. For tuple structs, the names are
+    /// the indices used to index into the struct (ie, `0`, `1`, etc).
+    ///
+    /// TODO: Extracting field names for enums doesn't really make sense. Types
+    /// makes sense because we don't care about where they live - we just care
+    /// about transitive ownership. But for field names, we'd only use them when
+    /// generating is_bit_valid, which cares about where they live.
+    fn fields(&self) -> Vec<(TokenStream, &Type)>;
 }
 
 impl DataExt for Data {
-    fn field_types(&self) -> Vec<&Type> {
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
         match self {
-            Data::Struct(strc) => strc.field_types(),
-            Data::Enum(enm) => enm.field_types(),
-            Data::Union(un) => un.field_types(),
+            Data::Struct(strc) => strc.fields(),
+            Data::Enum(enm) => enm.fields(),
+            Data::Union(un) => un.fields(),
         }
     }
 }
 
 impl DataExt for DataStruct {
-    fn field_types(&self) -> Vec<&Type> {
-        self.fields.iter().map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(&self.fields)
     }
 }
 
 impl DataExt for DataEnum {
-    fn field_types(&self) -> Vec<&Type> {
-        self.variants.iter().flat_map(|var| &var.fields).map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(self.variants.iter().flat_map(|var| &var.fields))
     }
 }
 
 impl DataExt for DataUnion {
-    fn field_types(&self) -> Vec<&Type> {
-        self.fields.named.iter().map(|f| &f.ty).collect()
+    fn fields(&self) -> Vec<(TokenStream, &Type)> {
+        map_fields(&self.fields.named)
     }
+}
+
+fn map_fields<'a>(
+    fields: impl 'a + IntoIterator<Item = &'a Field>,
+) -> Vec<(TokenStream, &'a Type)> {
+    fields
+        .into_iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            (
+                f.ident
+                    .as_ref()
+                    .map(ToTokens::to_token_stream)
+                    .unwrap_or_else(|| Index::from(idx).to_token_stream()),
+                &f.ty,
+            )
+        })
+        .collect()
 }
 
 pub trait EnumExt {
@@ -44,6 +70,6 @@ pub trait EnumExt {
 
 impl EnumExt for DataEnum {
     fn is_c_like(&self) -> bool {
-        self.field_types().is_empty()
+        self.fields().is_empty()
     }
 }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -49,11 +49,27 @@ use {crate::ext::*, crate::repr::*};
 // help: required by the derive of FromBytes
 //
 // Instead, we have more verbose error messages like "unsupported representation
-// for deriving FromZeroes, FromBytes, AsBytes, or Unaligned on an enum"
+// for deriving TryFromBytes, FromZeroes, FromBytes, AsBytes, or Unaligned on an
+// enum"
 //
 // This will probably require Span::error
 // (https://doc.rust-lang.org/nightly/proc_macro/struct.Span.html#method.error),
 // which is currently unstable. Revisit this once it's stable.
+
+#[proc_macro_derive(TryFromBytes)]
+pub fn derive_try_from_bytes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input!(ts as DeriveInput);
+    match &ast.data {
+        Data::Struct(strct) => derive_try_from_bytes_struct(&ast, strct),
+        Data::Enum(_) => {
+            Error::new_spanned(&ast, "TryFromBytes not supported on enum types").to_compile_error()
+        }
+        Data::Union(_) => {
+            Error::new_spanned(&ast, "TryFromBytes not supported on union types").to_compile_error()
+        }
+    }
+    .into()
+}
 
 #[proc_macro_derive(FromZeroes)]
 pub fn derive_from_zeroes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -110,6 +126,10 @@ macro_rules! try_or_print {
     };
 }
 
+fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
+    impl_block(ast, strct, "TryFromBytes", true, None, true)
+}
+
 const STRUCT_UNION_ALLOWED_REPR_COMBINATIONS: &[&[StructRepr]] = &[
     &[StructRepr::C],
     &[StructRepr::Transparent],
@@ -121,7 +141,7 @@ const STRUCT_UNION_ALLOWED_REPR_COMBINATIONS: &[&[StructRepr]] = &[
 // - all fields are `FromZeroes`
 
 fn derive_from_zeroes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
-    impl_block(ast, strct, "FromZeroes", true, None)
+    impl_block(ast, strct, "FromZeroes", true, None, false)
 }
 
 // An enum is `FromZeroes` if:
@@ -155,21 +175,21 @@ fn derive_from_zeroes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::To
         .to_compile_error();
     }
 
-    impl_block(ast, enm, "FromZeroes", true, None)
+    impl_block(ast, enm, "FromZeroes", true, None, false)
 }
 
 // Like structs, unions are `FromZeroes` if
 // - all fields are `FromZeroes`
 
 fn derive_from_zeroes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
-    impl_block(ast, unn, "FromZeroes", true, None)
+    impl_block(ast, unn, "FromZeroes", true, None, false)
 }
 
 // A struct is `FromBytes` if:
 // - all fields are `FromBytes`
 
 fn derive_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
-    impl_block(ast, strct, "FromBytes", true, None)
+    impl_block(ast, strct, "FromBytes", true, None, false)
 }
 
 // An enum is `FromBytes` if:
@@ -212,7 +232,7 @@ fn derive_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Tok
         .to_compile_error();
     }
 
-    impl_block(ast, enm, "FromBytes", true, None)
+    impl_block(ast, enm, "FromBytes", true, None, false)
 }
 
 #[rustfmt::skip]
@@ -243,7 +263,7 @@ const ENUM_FROM_BYTES_CFG: Config<EnumRepr> = {
 // - all fields are `FromBytes`
 
 fn derive_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
-    impl_block(ast, unn, "FromBytes", true, None)
+    impl_block(ast, unn, "FromBytes", true, None, false)
 }
 
 // A struct is `AsBytes` if:
@@ -277,7 +297,7 @@ fn derive_as_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2:
     //   any padding bytes would need to come from the fields, all of which
     //   we require to be `AsBytes` (meaning they don't have any padding).
     let padding_check = if is_transparent || is_packed { None } else { Some(PaddingCheck::Struct) };
-    impl_block(ast, strct, "AsBytes", true, padding_check)
+    impl_block(ast, strct, "AsBytes", true, padding_check, false)
 }
 
 const STRUCT_UNION_AS_BYTES_CFG: Config<StructRepr> = Config {
@@ -300,7 +320,7 @@ fn derive_as_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Token
     // We don't care what the repr is; we only care that it is one of the
     // allowed ones.
     let _: Vec<repr::EnumRepr> = try_or_print!(ENUM_AS_BYTES_CFG.validate_reprs(ast));
-    impl_block(ast, enm, "AsBytes", false, None)
+    impl_block(ast, enm, "AsBytes", false, None, false)
 }
 
 #[rustfmt::skip]
@@ -342,7 +362,7 @@ fn derive_as_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::Tok
 
     try_or_print!(STRUCT_UNION_AS_BYTES_CFG.validate_reprs(ast));
 
-    impl_block(ast, unn, "AsBytes", true, Some(PaddingCheck::Union))
+    impl_block(ast, unn, "AsBytes", true, Some(PaddingCheck::Union), false)
 }
 
 // A struct is `Unaligned` if:
@@ -355,7 +375,7 @@ fn derive_unaligned_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2
     let reprs = try_or_print!(STRUCT_UNION_UNALIGNED_CFG.validate_reprs(ast));
     let require_trait_bound = !reprs.contains(&StructRepr::Packed);
 
-    impl_block(ast, strct, "Unaligned", require_trait_bound, None)
+    impl_block(ast, strct, "Unaligned", require_trait_bound, None, false)
 }
 
 const STRUCT_UNION_UNALIGNED_CFG: Config<StructRepr> = Config {
@@ -386,7 +406,7 @@ fn derive_unaligned_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Toke
     // for `require_trait_bounds` doesn't really do anything. But it's
     // marginally more future-proof in case that restriction is lifted in the
     // future.
-    impl_block(ast, enm, "Unaligned", true, None)
+    impl_block(ast, enm, "Unaligned", true, None, false)
 }
 
 #[rustfmt::skip]
@@ -424,7 +444,7 @@ fn derive_unaligned_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::To
     let reprs = try_or_print!(STRUCT_UNION_UNALIGNED_CFG.validate_reprs(ast));
     let require_trait_bound = !reprs.contains(&StructRepr::Packed);
 
-    impl_block(ast, unn, "Unaligned", require_trait_bound, None)
+    impl_block(ast, unn, "Unaligned", require_trait_bound, None, false)
 }
 
 // This enum describes what kind of padding check needs to be generated for the
@@ -455,6 +475,7 @@ fn impl_block<D: DataExt>(
     trait_name: &str,
     require_trait_bound: bool,
     padding_check: Option<PaddingCheck>,
+    emit_is_bit_valid: bool,
 ) -> proc_macro2::TokenStream {
     // In this documentation, we will refer to this hypothetical struct:
     //
@@ -516,18 +537,18 @@ fn impl_block<D: DataExt>(
 
     let type_ident = &input.ident;
     let trait_ident = Ident::new(trait_name, Span::call_site());
-    let field_types = data.field_types();
+    let fields = data.fields();
 
     let field_type_bounds = require_trait_bound
-        .then(|| field_types.iter().map(|ty| parse_quote!(#ty: zerocopy::#trait_ident)))
+        .then(|| fields.iter().map(|(_name, ty)| parse_quote!(#ty: zerocopy::#trait_ident)))
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
 
     // Don't bother emitting a padding check if there are no fields.
     #[allow(unstable_name_collisions)] // See `BoolExt` below
-    let padding_check_bound = padding_check.and_then(|check| (!field_types.is_empty()).then_some(check)).map(|check| {
-        let fields = field_types.iter();
+    let padding_check_bound = padding_check.and_then(|check| (!fields.is_empty()).then_some(check)).map(|check| {
+        let fields = fields.iter().map(|(_name, ty)| ty);
         let validator_macro = check.validator_macro_ident();
         parse_quote!(
             zerocopy::derive_util::HasPadding<#type_ident, {zerocopy::#validator_macro!(#type_ident, #(#fields),*)}>:
@@ -564,12 +585,69 @@ fn impl_block<D: DataExt>(
         GenericParam::Const(cnst) => quote!(#cnst),
     });
 
+    let is_bit_valid = emit_is_bit_valid.then(|| {
+        let field_names = fields.iter().map(|(name, _ty)| name);
+        let field_tys = fields.iter().map(|(_name, ty)| ty);
+        quote!(
+            // SAFETY: We use `is_bit_valid` to validate that each field is
+            // bit-valid, and only return `true` if all of them are. The bit
+            // validity of a struct is just the composition of the bit
+            // validities of its fields, so this is a sound implementation of
+            // `is_bit_valid`.
+            unsafe fn is_bit_valid(candidate: ::core::ptr::NonNull<Self>) -> bool {
+                let _c = candidate.as_ptr();
+                true #(&& {
+                    let field_candidate = ::core::ptr::addr_of_mut!((*_c).#field_names);
+                    // SAFETY: Caller has promised that `candidate` points to a
+                    // single allocation, and allocations cannot wrap around the
+                    // address space. `field_candidate` is at some offset within
+                    // this allocation, so it also cannot wrap around. Since
+                    // `candidate` is a non-null pointer, `field_candidate`'s
+                    // smallest possible value is non-null, and its largest
+                    // possible value doesn't wrap around, and is thus also
+                    // non-null.
+                    let f = unsafe { ::core::ptr::NonNull::new_unchecked(field_candidate) };
+                    // SAFETY:
+                    // - `f` is properly aligned for `#field_tys` because
+                    //   `candidate` is properly aligned for `Self`.
+                    // - `f` is valid for reads because `candidate` is.
+                    // - Total length encoded by `f` doesn't overflow `isize`
+                    //   because it's no greater than the size encoded by
+                    //   `candidate`, whose size doesn't overflow `isize`.
+                    // - `f` addresses a range which falls inside a single
+                    //   allocation because that range is a subset of the range
+                    //   addressed by `candidate`, and that latter range falls
+                    //   inside a single allocation.
+                    // - The bit validity property of `is_bit_valid` is
+                    //   trivially compositional for structs. In particular, in
+                    //   a struct, there is no data dependency between bit
+                    //   validity in any two byte offsets (this is notably not
+                    //   true of enums). Since we know that the bit validity
+                    //   property holds for all of `candidate`, we also know
+                    //   that it holds for `f` regardless of the contents of any
+                    //   other region of `candidate`.
+                    //
+                    // Note that it's possible that this call will panic -
+                    // `is_bit_valid` does not promise that it doesn't panic,
+                    // and in practice, we support user-defined validators,
+                    // which could panic. This is sound because we haven't
+                    // violated any safety invariants which we would need to fix
+                    // before returning.
+                    <#field_tys as zerocopy::TryFromBytes>::is_bit_valid(f)
+                })*
+            }
+        )
+    });
+
     quote! {
+        #[deny(unsafe_op_in_unsafe_fn)]
         unsafe impl < #(#params),* > zerocopy::#trait_ident for #type_ident < #(#param_idents),* >
         where
             #(#bounds,)*
         {
             fn only_derive_is_allowed_to_implement_this_trait() {}
+
+            #is_bit_valid
         }
     }
 }


### PR DESCRIPTION
TODO:
- Clean up repr computation
- Support enums with fields
- If we don't support enums with fields, enforce that
- Should enum variants be considered "used" in the sense of dead code? It's possible to never construct an enum variant from Rust's perspective even though it is constructed via TryFromBytes.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
