### PR TITLE
[clippy] Be more permissive with safety comments

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+# Copyright 2023 The Fuchsia Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+accept-comment-above-statement = true
+accept-comment-above-attributes = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3626,11 +3626,6 @@ mod tests {
                     let slc_field_ptr = addr_of_slice_field(ptr).as_ptr();
                     // SAFETY: Both `slc_field_ptr` and `ptr` are pointers to
                     // the same valid Rust object.
-                    //
-                    // TODO(https://github.com/rust-lang/rust-clippy/issues/11534):
-                    // Remove this `allow` once Clippy recognizes this block as
-                    // having a safety comment.
-                    #[allow(clippy::undocumented_unsafe_blocks)]
                     let offset: usize =
                         unsafe { slc_field_ptr.byte_offset_from(ptr.as_ptr()).try_into().unwrap() };
                     assert_eq!(offset, args.offset);

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -268,17 +268,13 @@ impl<T> Unalign<T> {
 
         impl<T> Drop for WriteBackOnDrop<T> {
             fn drop(&mut self) {
-                // SAFETY: See inline comments.
-                unsafe {
-                    // SAFETY: We never use `copy` again as required by
-                    // `ManuallyDrop::take`.
-                    let copy = ManuallyDrop::take(&mut self.copy);
-                    // SAFETY: `slf` is the raw pointer value of `self`. We know
-                    // it is valid for writes and properly aligned because
-                    // `self` is a mutable reference, which guarantees both of
-                    // these properties.
-                    ptr::write(self.slf, Unalign::new(copy));
-                }
+                // SAFETY: We never use `copy` again as required by
+                // `ManuallyDrop::take`.
+                let copy = unsafe { ManuallyDrop::take(&mut self.copy) };
+                // SAFETY: `slf` is the raw pointer value of `self`. We know it
+                // is valid for writes and properly aligned because `self` is a
+                // mutable reference, which guarantees both of these properties.
+                unsafe { ptr::write(self.slf, Unalign::new(copy)) };
             }
         }
 


### PR DESCRIPTION
Set the following Clippy configuration variables to `true`:
- `accept-comment-above-statement`
- `accept-comment-above-attributes`

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
