### PR TITLE
[ci] Don't run ignored tests under Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,24 +168,14 @@ jobs:
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
-          # On `--skip ui`: Skip the `ui` test since it invokes the compiler,
-          # which we can't do from Miri (and wouldn't want to do anyway).
-          #
-          # On `matrix.features == '--all-features': We mark tests which are
-          # particularly expensive to run under Miri as
-          # `#[cfg_attr(miri, ignore)]`. We want to run them once per
-          # toolchain/target combination, but not once per feature set so we
-          # keep the expensive computation to a minimum.
-          #
-          # TODO(#391): Optimize these tests.
+          # Skip the `ui` test since it invokes the compiler, which we can't do
+          # from Miri (and wouldn't want to do anyway).
           MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +${{ matrix.toolchain }} \
             miri test \
             --package ${{ matrix.crate }} \
             --target ${{ matrix.target }} \
             ${{ matrix.features }} \
-            -- --skip ui \
-            ${{ matrix.features == '--all-features' && '--ignored' || '' }}
-
+            -- --skip ui
         done
       # Only nightly has a working Miri, so we skip installing on all other
       # toolchains.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3325,10 +3325,7 @@ mod tests {
             .for_each(validate_behavior);
     }
 
-    // TODO(#391): Optimize this test so we it consumes less time under Miri in
-    // CI.
     #[test]
-    #[cfg_attr(miri, ignore)]
     #[cfg(__INTERNAL_USE_ONLY_NIGHLTY_FEATURES_IN_TESTS)]
     fn test_validate_rust_layout() {
         use core::ptr::NonNull;


### PR DESCRIPTION
In #376, we introduced `test_validate_rust_layout`, which took a long time to run under Miri. In order to prevent it from consuming too much time in CI, we marked it as `#[cfg_attr(miri, ignore)]`, and configured CI to pass `-- --ignored` to Miri only a small percentage of the time.

This had the unintended side effect of running
`test_validate_cast_and_convert_metadata` under Miri. That test is marked as `#[cfg_attr(miri, ignore)]` for good reason - it takes far too long to run under Miri, and doesn't exercise any `unsafe` code, so doesn't benefit from Miri. Enabling this test has caused CI to timeout.

In the interim, in #395, we optimized `test_validate_rust_layout` so that it no longer takes an unreasonably long time to run under Miri. Thus, in this commit, we remove the `#[cfg_attr(miri, ignore)]` annotation from that test, and no longer pass `-- --ignored` to Miri in CI.

Closes #397

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
