### PR TITLE
[miri] Skip running UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,14 +168,11 @@ jobs:
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
-          # Skip the `ui` test since it invokes the compiler, which we can't do
-          # from Miri (and wouldn't want to do anyway).
           MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +${{ matrix.toolchain }} \
             miri test \
             --package ${{ matrix.crate }} \
             --target ${{ matrix.target }} \
-            ${{ matrix.features }} \
-            -- --skip ui
+            ${{ matrix.features }}
         done
       # Only nightly has a working Miri, so we skip installing on all other
       # toolchains.

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -23,6 +23,7 @@ const SOURCE_FILES_DIR: &str = "tests/ui-stable";
 const SOURCE_FILES_DIR: &str = "tests/ui-msrv";
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail(format!("{SOURCE_FILES_DIR}/*.rs"));
@@ -37,6 +38,7 @@ fn ui() {
 // tests the correct behavior when the "derive" feature is enabled.
 #[cfg(feature = "derive")]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn ui_invalid_impls() {
     let t = trybuild::TestCases::new();
     t.compile_fail(format!("{SOURCE_FILES_DIR}/invalid-impls/*.rs"));

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -23,6 +23,7 @@ const SOURCE_FILES_GLOB: &str = "tests/ui-stable/*.rs";
 const SOURCE_FILES_GLOB: &str = "tests/ui-msrv/*.rs";
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail(SOURCE_FILES_GLOB);


### PR DESCRIPTION
Mark UI tests as `#[cfg_attr(miri, ignore)]`. In CI, remove `-- --skip ui` from our Miri invocation.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
