### PR TITLE
Prove correctness of layout len utilities with kani

### DIFF
--- a/src/third_party/rust/layout.rs
+++ b/src/third_party/rust/layout.rs
@@ -14,6 +14,8 @@ use core::num::NonZeroUsize;
 /// # Panics
 ///
 /// May panic if `align` is not a power of two.
+//
+// TODO(#419): Replace `len` with a witness type for region size.
 #[inline(always)]
 pub(crate) const fn _padding_needed_for(len: usize, align: NonZeroUsize) -> usize {
     // Rounded up value is:


### PR DESCRIPTION
Uses kani to prove that `round_down_to_next_multiple_of_alignment` and `padding_needed_for` are equivalent to straightforward model implementations.
