### PR TITLE
Fail compilation on targets w/o soundness proof

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,21 @@ mod zerocopy {
     pub(crate) use crate::*;
 }
 
+#[cfg(not(any(
+    target_arch = "i686",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+)))]
+compile_error!(
+r#"Zerocopy has not been proven sound on this architecture.
+
+This doesn't mean that it is unsound - just that we haven't gotten around to
+proving it sound. If you need support for this architecture, let us know and
+we'll prioritize it: https://github.com/google/zerocopy/issues/383"#
+);
+
 #[rustversion::nightly]
 #[cfg(all(test, not(__INTERNAL_USE_ONLY_NIGHLTY_FEATURES_IN_TESTS)))]
 const _: () = {


### PR DESCRIPTION
TODO: Figure out how to make sure we block the next minor version release on adding back all of the targets that people actually rely on.

Makes progress on #383

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
