### PR TITLE
[ci] configure CI to support merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - v0.6.x
+  merge_group:
 
 permissions: read-all
 


### PR DESCRIPTION
Fixes #344. Maybe. Only way to find out is to merge it, and then see if we can enable the merge queue. 