### PR TITLE
Rename `FromZeroes` to `FromZeros`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ so you don't have to.
 ## Overview
 
 Zerocopy provides four core marker traits, each of which can be derived
-(e.g., `#[derive(FromZeroes)]`):
-- `FromZeroes` indicates that a sequence of zero bytes represents a valid
+(e.g., `#[derive(FromZeros)]`):
+- `FromZeros` indicates that a sequence of zero bytes represents a valid
   instance of a type
 - `FromBytes` indicates that a type may safely be converted from an
   arbitrary byte sequence
@@ -76,7 +76,7 @@ for network parsing.
   ```
 
 - **`simd`**
-  When the `simd` feature is enabled, `FromZeroes`, `FromBytes`, and
+  When the `simd` feature is enabled, `FromZeros`, `FromBytes`, and
   `AsBytes` impls are emitted for all stable SIMD types which exist on the
   target platform. Note that the layout of SIMD types is not yet stabilized,
   so these impls may be removed in the future if layout changes make them

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -35,10 +35,10 @@
 //!
 //! ```rust,edition2021
 //! # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
-//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeroes, Ref, Unaligned};
+//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeros, Ref, Unaligned};
 //! use zerocopy::byteorder::network_endian::U16;
 //!
-//! #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+//! #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
 //! #[repr(C)]
 //! struct UdpHeader {
 //!     src_port: U16,
@@ -276,7 +276,7 @@ example of how it can be used for parsing UDP packets.
 [`AsBytes`]: crate::AsBytes
 [`Unaligned`]: crate::Unaligned"),
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-            #[cfg_attr(any(feature = "derive", test), derive(KnownLayout, NoCell, FromZeroes, FromBytes, AsBytes, Unaligned))]
+            #[cfg_attr(any(feature = "derive", test), derive(KnownLayout, NoCell, FromZeros, FromBytes, AsBytes, Unaligned))]
             #[repr(transparent)]
             pub struct $name<O>([u8; $bytes], PhantomData<O>);
         }
@@ -288,10 +288,10 @@ example of how it can be used for parsing UDP packets.
             /// SAFETY:
             /// `$name<O>` is `repr(transparent)`, and so it has the same layout
             /// as its only non-zero field, which is a `u8` array. `u8` arrays
-            /// are `NoCell`, `FromZeroes`, `FromBytes`, `AsBytes`, and
+            /// are `NoCell`, `FromZeros`, `FromBytes`, `AsBytes`, and
             /// `Unaligned`.
             impl_or_verify!(O => NoCell for $name<O>);
-            impl_or_verify!(O => FromZeroes for $name<O>);
+            impl_or_verify!(O => FromZeros for $name<O>);
             impl_or_verify!(O => FromBytes for $name<O>);
             impl_or_verify!(O => AsBytes for $name<O>);
             impl_or_verify!(O => Unaligned for $name<O>);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -262,7 +262,7 @@ macro_rules! opt_fn {
 ///
 /// ```rust,ignore
 /// // Note that these derives are gated by `feature = "derive"`
-/// #[cfg_attr(any(feature = "derive", test), derive(FromZeroes, FromBytes, AsBytes, Unaligned))]
+/// #[cfg_attr(any(feature = "derive", test), derive(FromZeros, FromBytes, AsBytes, Unaligned))]
 /// #[repr(transparent)]
 /// struct Wrapper<T>(T);
 ///
@@ -270,7 +270,7 @@ macro_rules! opt_fn {
 ///     /// SAFETY:
 ///     /// `Wrapper<T>` is `repr(transparent)`, so it is sound to implement any
 ///     /// zerocopy trait if `T` implements that trait.
-///     impl_or_verify!(T: FromZeroes => FromZeroes for Wrapper<T>);
+///     impl_or_verify!(T: FromZeros => FromZeros for Wrapper<T>);
 ///     impl_or_verify!(T: FromBytes => FromBytes for Wrapper<T>);
 ///     impl_or_verify!(T: AsBytes => AsBytes for Wrapper<T>);
 ///     impl_or_verify!(T: Unaligned => Unaligned for Wrapper<T>);

--- a/src/util.rs
+++ b/src/util.rs
@@ -698,7 +698,7 @@ pub(crate) mod testutil {
     #[derive(
         KnownLayout,
         NoCell,
-        FromZeroes,
+        FromZeros,
         FromBytes,
         AsBytes,
         Eq,
@@ -727,7 +727,7 @@ pub(crate) mod testutil {
     }
 
     #[derive(
-        NoCell, FromZeroes, FromBytes, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Copy, Clone,
+        NoCell, FromZeros, FromBytes, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Copy, Clone,
     )]
     #[repr(C)]
     pub(crate) struct Nested<T, U: ?Sized> {

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -60,7 +60,7 @@ use super::*;
 #[derive(Default, Copy)]
 #[cfg_attr(
     any(feature = "derive", test),
-    derive(NoCell, KnownLayout, FromZeroes, FromBytes, AsBytes, Unaligned)
+    derive(NoCell, KnownLayout, FromZeros, FromBytes, AsBytes, Unaligned)
 )]
 #[repr(C, packed)]
 pub struct Unalign<T>(T);
@@ -73,12 +73,12 @@ safety_comment! {
     /// - `Unalign<T>` is `repr(packed)`, so it is unaligned regardless of the
     ///   alignment of `T`, and so we don't require that `T: Unaligned`
     /// - `Unalign<T>` has the same bit validity as `T`, and so it is
-    ///   `FromZeroes`, `FromBytes`, or `AsBytes` exactly when `T` is as well.
+    ///   `FromZeros`, `FromBytes`, or `AsBytes` exactly when `T` is as well.
     /// - `NoCell`: `Unalign<T>` has the same fields as `T`, so it contains
     ///   `UnsafeCell`s exactly when `T` does.
     impl_or_verify!(T => Unaligned for Unalign<T>);
     impl_or_verify!(T: NoCell => NoCell for Unalign<T>);
-    impl_or_verify!(T: FromZeroes => FromZeroes for Unalign<T>);
+    impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
     impl_or_verify!(T: AsBytes => AsBytes for Unalign<T>);
 }

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -1,19 +1,19 @@
-error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
+error[E0277]: the trait bound `T: FromZeroes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
-   |                                                                    ^^^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+   |                                                                    ^^^^^^^^ the trait `FromZeroes` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   | ------------------------------------------ in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::FromZeroes` for `Foo<T>`
+note: required because of the requirements on the impl of `FromZeroes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |          ^^^^^^^^^^
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |          ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -22,13 +22,13 @@ note: required by a bound in `_::Subtrait`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-26 | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
-   |                  ++++++++++++++++++++++
+26 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
@@ -42,10 +42,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    | ------------------------------------------ in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::FromBytes` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:22
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                      ^^^^^^^^^
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                     ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -74,10 +74,10 @@ error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
    | ---------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::AsBytes` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:33
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                 ^^^^^^^
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                ^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -106,10 +106,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    | ------------------------------------------ in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::Unaligned` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:42
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:41
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                          ^^^^^^^^^
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                         ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |

--- a/tests/ui-nightly/invalid-impls/invalid-impls.rs
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.rs
@@ -19,11 +19,11 @@ use zerocopy_derive::*;
 
 fn main() {}
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
 #[repr(transparent)]
 struct Foo<T>(T);
 
-impl_or_verify!(T => FromZeroes for Foo<T>);
+impl_or_verify!(T => FromZeros for Foo<T>);
 impl_or_verify!(T => FromBytes for Foo<T>);
 impl_or_verify!(T => AsBytes for Foo<T>);
 impl_or_verify!(T => Unaligned for Foo<T>);

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -1,14 +1,14 @@
-error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:26:37
+error[E0277]: the trait bound `T: FromZeroes` is not satisfied
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:26:36
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   |                                     ^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`
    |
-note: required for `Foo<T>` to implement `zerocopy::FromZeroes`
+note: required for `Foo<T>` to implement `FromZeroes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |          ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -17,13 +17,13 @@ note: required by a bound in `_::Subtrait`
    |
   ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:26:1
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-26 | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
-   |                  ++++++++++++++++++++++
+26 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:36
@@ -32,10 +32,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:22
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                      ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
    |                                  ^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::AsBytes`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:33
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                 ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:42
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:41
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |

--- a/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
@@ -12,7 +12,7 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
 #[repr(C)]
 struct Src;
 

--- a/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
@@ -16,7 +16,7 @@ fn main() {}
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-stable/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-stable/invalid-impls/invalid-impls.stderr
@@ -1,14 +1,14 @@
-error[E0277]: the trait bound `T: zerocopy::FromZeroes` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:26:37
+error[E0277]: the trait bound `T: FromZeroes` is not satisfied
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:26:36
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   |                                     ^^^^^^ the trait `zerocopy::FromZeroes` is not implemented for `T`
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`
    |
-note: required for `Foo<T>` to implement `zerocopy::FromZeroes`
+note: required for `Foo<T>` to implement `FromZeroes`
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |          ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -17,13 +17,13 @@ note: required by a bound in `_::Subtrait`
    |
   ::: tests/ui-stable/invalid-impls/invalid-impls.rs:26:1
    |
-26 | impl_or_verify!(T => FromZeroes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+26 | impl_or_verify!(T => FromZeros for Foo<T>);
+   | ------------------------------------------ in this macro invocation
+   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-26 | impl_or_verify!(T: zerocopy::FromZeroes => FromZeroes for Foo<T>);
-   |                  ++++++++++++++++++++++
+26 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:27:36
@@ -32,10 +32,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:22
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                      ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `T: zerocopy::AsBytes` is not satisfied
    |                                  ^^^^^^ the trait `zerocopy::AsBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::AsBytes`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:33
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                 ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:42
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:41
    |
-22 | #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
-   |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |

--- a/zerocopy-derive/tests/enum_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_from_bytes.rs
@@ -12,7 +12,7 @@ mod util;
 
 use {
     static_assertions::assert_impl_all,
-    zerocopy::{FromBytes, FromZeroes},
+    zerocopy::{FromBytes, FromZeros},
 };
 
 // An enum is `FromBytes` if:
@@ -32,7 +32,7 @@ use {
 // `Variant128` has a discriminant of -128) since Rust won't automatically wrap
 // a signed discriminant around without you explicitly telling it to.
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u8)]
 enum FooU8 {
     Variant0,
@@ -295,7 +295,7 @@ enum FooU8 {
 
 assert_impl_all!(FooU8: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(i8)]
 enum FooI8 {
     Variant0,
@@ -558,7 +558,7 @@ enum FooI8 {
 
 assert_impl_all!(FooI8: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u8, align(2))]
 enum FooU8Align {
     Variant0,
@@ -821,7 +821,7 @@ enum FooU8Align {
 
 assert_impl_all!(FooU8Align: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(i8, align(2))]
 enum FooI8Align {
     Variant0,
@@ -1084,7 +1084,7 @@ enum FooI8Align {
 
 assert_impl_all!(FooI8Align: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u16)]
 enum FooU16 {
     Variant0,
@@ -66627,7 +66627,7 @@ enum FooU16 {
 
 assert_impl_all!(FooU16: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(i16)]
 enum FooI16 {
     Variant0,

--- a/zerocopy-derive/tests/enum_from_zeros.rs
+++ b/zerocopy-derive/tests/enum_from_zeros.rs
@@ -10,26 +10,26 @@
 
 mod util;
 
-use {static_assertions::assert_impl_all, zerocopy::FromZeroes};
+use {static_assertions::assert_impl_all, zerocopy::FromZeros};
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 enum Foo {
     A,
 }
 
-assert_impl_all!(Foo: FromZeroes);
+assert_impl_all!(Foo: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 enum Bar {
     A = 0,
 }
 
-assert_impl_all!(Bar: FromZeroes);
+assert_impl_all!(Bar: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 enum Baz {
     A = 1,
     B = 0,
 }
 
-assert_impl_all!(Baz: FromZeroes);
+assert_impl_all!(Baz: FromZeros);

--- a/zerocopy-derive/tests/hygiene.rs
+++ b/zerocopy-derive/tests/hygiene.rs
@@ -22,7 +22,7 @@ use std::{marker::PhantomData, option::IntoIter};
 use static_assertions::assert_impl_all;
 
 #[derive(
-    _zerocopy::KnownLayout, _zerocopy::FromZeroes, _zerocopy::FromBytes, _zerocopy::Unaligned,
+    _zerocopy::KnownLayout, _zerocopy::FromZeros, _zerocopy::FromBytes, _zerocopy::Unaligned,
 )]
 #[repr(C)]
 struct TypeParams<'a, T, I: Iterator> {
@@ -37,7 +37,7 @@ struct TypeParams<'a, T, I: Iterator> {
 assert_impl_all!(
     TypeParams<'static, (), IntoIter<()>>:
         _zerocopy::KnownLayout,
-        _zerocopy::FromZeroes,
+        _zerocopy::FromZeros,
         _zerocopy::FromBytes,
         _zerocopy::Unaligned
 );

--- a/zerocopy-derive/tests/paths_and_modules.rs
+++ b/zerocopy-derive/tests/paths_and_modules.rs
@@ -8,20 +8,20 @@
 
 #![allow(warnings)]
 
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{AsBytes, FromBytes, FromZeros, Unaligned};
 
 // Ensure that types that are use'd and types that are referenced by path work.
 
 mod foo {
-    use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+    use zerocopy::{AsBytes, FromBytes, FromZeros, Unaligned};
 
-    #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+    #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
     #[repr(C)]
     pub struct Foo {
         foo: u8,
     }
 
-    #[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+    #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
     #[repr(C)]
     pub struct Bar {
         bar: u8,
@@ -30,7 +30,7 @@ mod foo {
 
 use foo::Foo;
 
-#[derive(FromZeroes, FromBytes, AsBytes, Unaligned)]
+#[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
 #[repr(C)]
 struct Baz {
     foo: Foo,

--- a/zerocopy-derive/tests/priv_in_pub.rs
+++ b/zerocopy-derive/tests/priv_in_pub.rs
@@ -6,7 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use zerocopy::{AsBytes, FromBytes, FromZeroes, KnownLayout, Unaligned};
+use zerocopy::{AsBytes, FromBytes, FromZeros, KnownLayout, Unaligned};
 
 // These derives do not result in E0446 as of Rust 1.59.0, because of
 // https://github.com/rust-lang/rust/pull/90586.
@@ -15,10 +15,10 @@ use zerocopy::{AsBytes, FromBytes, FromZeroes, KnownLayout, Unaligned};
 // bounds for field types (i.e., the emission of E0446 for private field
 // types).
 
-#[derive(KnownLayout, AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(KnownLayout, AsBytes, FromZeros, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct Public(Private);
 
-#[derive(KnownLayout, AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(KnownLayout, AsBytes, FromZeros, FromBytes, Unaligned)]
 #[repr(C)]
 struct Private(());

--- a/zerocopy-derive/tests/struct_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_from_bytes.rs
@@ -14,7 +14,7 @@ use std::{marker::PhantomData, option::IntoIter};
 
 use {
     static_assertions::assert_impl_all,
-    zerocopy::{FromBytes, FromZeroes},
+    zerocopy::{FromBytes, FromZeros},
 };
 
 use crate::util::AU16;
@@ -22,19 +22,19 @@ use crate::util::AU16;
 // A struct is `FromBytes` if:
 // - all fields are `FromBytes`
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 struct Zst;
 
 assert_impl_all!(Zst: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 struct One {
     a: u8,
 }
 
 assert_impl_all!(One: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 struct Two {
     a: u8,
     b: Zst,
@@ -42,14 +42,14 @@ struct Two {
 
 assert_impl_all!(Two: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 struct Unsized {
     a: [u8],
 }
 
 assert_impl_all!(Unsized: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 struct TypeParams<'a, T: ?Sized, I: Iterator> {
     a: I::Item,
     b: u8,
@@ -65,7 +65,7 @@ assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromBytes);
 
 // Deriving `FromBytes` should work if the struct has bounded parameters.
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(transparent)]
 struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromBytes>(
     [T; N],

--- a/zerocopy-derive/tests/struct_from_zeros.rs
+++ b/zerocopy-derive/tests/struct_from_zeros.rs
@@ -13,41 +13,41 @@ mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
 
-use {static_assertions::assert_impl_all, zerocopy::FromZeroes};
+use {static_assertions::assert_impl_all, zerocopy::FromZeros};
 
 use crate::util::AU16;
 
-// A struct is `FromZeroes` if:
-// - all fields are `FromZeroes`
+// A struct is `FromZeros` if:
+// - all fields are `FromZeros`
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 struct Zst;
 
-assert_impl_all!(Zst: FromZeroes);
+assert_impl_all!(Zst: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 struct One {
     a: bool,
 }
 
-assert_impl_all!(One: FromZeroes);
+assert_impl_all!(One: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 struct Two {
     a: bool,
     b: Zst,
 }
 
-assert_impl_all!(Two: FromZeroes);
+assert_impl_all!(Two: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 struct Unsized {
     a: [u8],
 }
 
-assert_impl_all!(Unsized: FromZeroes);
+assert_impl_all!(Unsized: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 struct TypeParams<'a, T: ?Sized, I: Iterator> {
     a: I::Item,
     b: u8,
@@ -57,21 +57,21 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
     f: T,
 }
 
-assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeroes);
-assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: FromZeroes);
-assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromZeroes);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeros);
+assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: FromZeros);
+assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromZeros);
 
-// Deriving `FromZeroes` should work if the struct has bounded parameters.
+// Deriving `FromZeros` should work if the struct has bounded parameters.
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 #[repr(transparent)]
-struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeroes>(
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeros>(
     [T; N],
     PhantomData<&'a &'b ()>,
 )
 where
     'a: 'b,
     'b: 'a,
-    T: 'a + 'b + FromZeroes;
+    T: 'a + 'b + FromZeros;
 
-assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeroes);
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeros);

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,19 +1,19 @@
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `FromZeroes` for `TransparentStruct<NotZerocopy>`
   --> tests/ui-msrv/derive_transparent.rs:27:19
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
@@ -23,10 +23,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:27:31
+  --> tests/ui-msrv/derive_transparent.rs:27:30
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                               ^^^^^^^^^
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                              ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:38:1
    |
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
 note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
   --> tests/ui-msrv/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
    |          ^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:39:1
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:27:42
+  --> tests/ui-msrv/derive_transparent.rs:27:41
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                                          ^^^^^^^^^
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                                         ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:40:1
    |

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -23,34 +23,34 @@ error: conflicting representation hints
    | ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-  --> tests/ui-msrv/enum.rs:42:22
+  --> tests/ui-msrv/enum.rs:42:21
    |
-42 | #[derive(FromZeroes, FromBytes)]
-   |                      ^^^^^^^^^
+42 | #[derive(FromZeros, FromBytes)]
+   |                     ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-msrv/enum.rs:70:1
    |
-70 | / enum FromZeroes1 {
+70 | / enum FromZeros1 {
 71 | |     A(u8),
 72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-msrv/enum.rs:75:1
    |
-75 | / enum FromZeroes2 {
+75 | / enum FromZeros2 {
 76 | |     A,
 77 | |     B(u8),
 78 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-msrv/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -9,11 +9,11 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:28:10
    |
-28 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+28 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
-   = note: this error originates in the derive macro `FromZeroes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:37:10
@@ -33,8 +33,8 @@ error[E0277]: the trait bound `FromBytes1: FromZeroes` is not satisfied
 note: required by a bound in `FromBytes`
   --> $WORKSPACE/src/lib.rs
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   |                             ^^^^^^^^^^ required by this bound in `FromBytes`
+   | pub unsafe trait FromBytes: FromZeros {
+   |                             ^^^^^^^^^ required by this bound in `FromBytes`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 
 use {
     static_assertions::assert_impl_all,
-    zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned},
+    zerocopy::{AsBytes, FromBytes, FromZeros, Unaligned},
 };
 
 use self::util::NotZerocopy;
@@ -24,7 +24,7 @@ fn main() {}
 
 // Test generic transparent structs
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
 #[repr(transparent)]
 struct TransparentStruct<T> {
     inner: T,
@@ -34,7 +34,7 @@ struct TransparentStruct<T> {
 // It should be legal to derive these traits on a transparent struct, but it
 // must also ensure the traits are only implemented when the inner type
 // implements them.
-assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
+assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
 assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
 assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
 assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:37:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
@@ -17,14 +17,14 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
   --> tests/ui-nightly/derive_transparent.rs:27:19
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-   = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:38:18
@@ -43,10 +43,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              u8
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-nightly/derive_transparent.rs:27:31
+  --> tests/ui-nightly/derive_transparent.rs:27:30
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                               ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:38:1
    |
@@ -73,7 +73,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-nightly/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:39:1
@@ -99,10 +99,10 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              U128<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-nightly/derive_transparent.rs:27:42
+  --> tests/ui-nightly/derive_transparent.rs:27:41
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-nightly/derive_transparent.rs:40:1
    |

--- a/zerocopy-derive/tests/ui-nightly/enum.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum.rs
@@ -15,31 +15,31 @@ fn main() {}
 // Generic errors
 //
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr("foo")]
 enum Generic1 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(foo)]
 enum Generic2 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(transparent)]
 enum Generic3 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u8, u16)]
 enum Generic4 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 enum Generic5 {
     A,
 }
@@ -63,22 +63,22 @@ enum NoCell2 {
 }
 
 //
-// FromZeroes errors
+// FromZeros errors
 //
 
-#[derive(FromZeroes)]
-enum FromZeroes1 {
+#[derive(FromZeros)]
+enum FromZeros1 {
     A(u8),
 }
 
-#[derive(FromZeroes)]
-enum FromZeroes2 {
+#[derive(FromZeros)]
+enum FromZeros2 {
     A,
     B(u8),
 }
 
-#[derive(FromZeroes)]
-enum FromZeroes3 {
+#[derive(FromZeros)]
+enum FromZeros3 {
     A = 1,
     B,
 }
@@ -87,43 +87,43 @@ enum FromZeroes3 {
 // FromBytes errors
 //
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(C)]
 enum FromBytes1 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(usize)]
 enum FromBytes2 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(isize)]
 enum FromBytes3 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u32)]
 enum FromBytes4 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(i32)]
 enum FromBytes5 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(u64)]
 enum FromBytes6 {
     A,
 }
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(i64)]
 enum FromBytes7 {
     A,

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -23,34 +23,34 @@ error: conflicting representation hints
    |        ^^^^^^^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-  --> tests/ui-nightly/enum.rs:42:22
+  --> tests/ui-nightly/enum.rs:42:21
    |
-42 | #[derive(FromZeroes, FromBytes)]
-   |                      ^^^^^^^^^
+42 | #[derive(FromZeros, FromBytes)]
+   |                     ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-nightly/enum.rs:70:1
    |
-70 | / enum FromZeroes1 {
+70 | / enum FromZeros1 {
 71 | |     A(u8),
 72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-nightly/enum.rs:75:1
    |
-75 | / enum FromZeroes2 {
+75 | / enum FromZeros2 {
 76 | |     A,
 77 | |     B(u8),
 78 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-nightly/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.rs
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.rs
@@ -22,11 +22,11 @@ fn main() {}
 // the compiler will never get to that pass, and so we won't get the errors.
 
 //
-// FromZeroes errors
+// FromZeros errors
 //
 
-#[derive(FromZeroes)]
-struct FromZeroes1 {
+#[derive(FromZeros)]
+struct FromZeros1 {
     value: NotZerocopy,
 }
 

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -9,8 +9,8 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:28:10
    |
-28 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+28 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
              bool
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-   = note: this error originates in the derive macro `FromZeroes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:37:10
@@ -65,8 +65,8 @@ error[E0277]: the trait bound `FromBytes1: FromZeroes` is not satisfied
 note: required by a bound in `FromBytes`
   --> $WORKSPACE/src/lib.rs
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   |                             ^^^^^^^^^^ required by this bound in `FromBytes`
+   | pub unsafe trait FromBytes: FromZeros {
+   |                             ^^^^^^^^^ required by this bound in `FromBytes`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:37:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
@@ -17,14 +17,14 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
   --> tests/ui-stable/derive_transparent.rs:27:19
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeroes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
-   = note: this error originates in the derive macro `FromZeroes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:38:18
@@ -43,10 +43,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              u8
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-stable/derive_transparent.rs:27:31
+  --> tests/ui-stable/derive_transparent.rs:27:30
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                               ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:38:1
    |
@@ -73,7 +73,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-stable/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:39:1
@@ -99,10 +99,10 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              U128<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-stable/derive_transparent.rs:27:42
+  --> tests/ui-stable/derive_transparent.rs:27:41
    |
-27 | #[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
-   |                                          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-stable/derive_transparent.rs:40:1
    |

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -23,34 +23,34 @@ error: conflicting representation hints
    | ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-  --> tests/ui-stable/enum.rs:42:22
+  --> tests/ui-stable/enum.rs:42:21
    |
-42 | #[derive(FromZeroes, FromBytes)]
-   |                      ^^^^^^^^^
+42 | #[derive(FromZeros, FromBytes)]
+   |                     ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-stable/enum.rs:70:1
    |
-70 | / enum FromZeroes1 {
+70 | / enum FromZeros1 {
 71 | |     A(u8),
 72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
+error: only C-like enums can implement FromZeros
   --> tests/ui-stable/enum.rs:75:1
    |
-75 | / enum FromZeroes2 {
+75 | / enum FromZeros2 {
 76 | |     A,
 77 | |     B(u8),
 78 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-stable/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -9,8 +9,8 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:28:10
    |
-28 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+28 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
              bool
@@ -23,7 +23,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              i128
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `FromZeroes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:37:10
@@ -63,8 +63,8 @@ error[E0277]: the trait bound `FromBytes1: FromZeroes` is not satisfied
 note: required by a bound in `FromBytes`
   --> $WORKSPACE/src/lib.rs
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   |                             ^^^^^^^^^^ required by this bound in `FromBytes`
+   | pub unsafe trait FromBytes: FromZeros {
+   |                             ^^^^^^^^^ required by this bound in `FromBytes`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied

--- a/zerocopy-derive/tests/union_from_bytes.rs
+++ b/zerocopy-derive/tests/union_from_bytes.rs
@@ -12,27 +12,27 @@ use std::{marker::PhantomData, option::IntoIter};
 
 use {
     static_assertions::assert_impl_all,
-    zerocopy::{FromBytes, FromZeroes},
+    zerocopy::{FromBytes, FromZeros},
 };
 
 // A union is `FromBytes` if:
 // - all fields are `FromBytes`
 
-#[derive(Clone, Copy, FromZeroes, FromBytes)]
+#[derive(Clone, Copy, FromZeros, FromBytes)]
 union Zst {
     a: (),
 }
 
 assert_impl_all!(Zst: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 union One {
     a: u8,
 }
 
 assert_impl_all!(One: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 union Two {
     a: u8,
     b: Zst,
@@ -40,7 +40,7 @@ union Two {
 
 assert_impl_all!(Two: FromBytes);
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 union TypeParams<'a, T: Copy, I: Iterator>
 where
     I::Item: Copy,
@@ -57,7 +57,7 @@ assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);
 
 // Deriving `FromBytes` should work if the union has bounded parameters.
 
-#[derive(FromZeroes, FromBytes)]
+#[derive(FromZeros, FromBytes)]
 #[repr(C)]
 union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromBytes>
 where

--- a/zerocopy-derive/tests/union_from_zeros.rs
+++ b/zerocopy-derive/tests/union_from_zeros.rs
@@ -13,34 +13,34 @@ mod util;
 
 use std::{marker::PhantomData, option::IntoIter};
 
-use {static_assertions::assert_impl_all, zerocopy::FromZeroes};
+use {static_assertions::assert_impl_all, zerocopy::FromZeros};
 
-// A union is `FromZeroes` if:
-// - all fields are `FromZeroes`
+// A union is `FromZeros` if:
+// - all fields are `FromZeros`
 
-#[derive(Clone, Copy, FromZeroes)]
+#[derive(Clone, Copy, FromZeros)]
 union Zst {
     a: (),
 }
 
-assert_impl_all!(Zst: FromZeroes);
+assert_impl_all!(Zst: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 union One {
     a: bool,
 }
 
-assert_impl_all!(One: FromZeroes);
+assert_impl_all!(One: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 union Two {
     a: bool,
     b: Zst,
 }
 
-assert_impl_all!(Two: FromZeroes);
+assert_impl_all!(Two: FromZeros);
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 union TypeParams<'a, T: Copy, I: Iterator>
 where
     I::Item: Copy,
@@ -53,20 +53,20 @@ where
     g: PhantomData<String>,
 }
 
-assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeroes);
+assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeros);
 
-// Deriving `FromZeroes` should work if the union has bounded parameters.
+// Deriving `FromZeros` should work if the union has bounded parameters.
 
-#[derive(FromZeroes)]
+#[derive(FromZeros)]
 #[repr(C)]
-union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeroes>
+union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeros>
 where
     'a: 'b,
     'b: 'a,
-    T: 'a + 'b + Copy + FromZeroes,
+    T: 'a + 'b + Copy + FromZeros,
 {
     a: [T; N],
     b: PhantomData<&'a &'b ()>,
 }
 
-assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeroes);
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeros);

--- a/zerocopy-derive/tests/util.rs
+++ b/zerocopy-derive/tests/util.rs
@@ -6,7 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use zerocopy::{AsBytes, FromBytes, FromZeroes, KnownLayout, NoCell};
+use zerocopy::{AsBytes, FromBytes, FromZeros, KnownLayout, NoCell};
 
 /// A type that doesn't implement any zerocopy traits.
 pub struct NotZerocopy<T = ()>(T);
@@ -15,6 +15,6 @@ pub struct NotZerocopy<T = ()>(T);
 ///
 /// Though `u16` has alignment 2 on some platforms, it's not guaranteed. By
 /// contrast, `AU16` is guaranteed to have alignment 2.
-#[derive(KnownLayout, NoCell, FromZeroes, FromBytes, AsBytes, Copy, Clone)]
+#[derive(KnownLayout, NoCell, FromZeros, FromBytes, AsBytes, Copy, Clone)]
 #[repr(C, align(2))]
 pub struct AU16(u16);


### PR DESCRIPTION
Pretend you didn't see this.

`FromZeroes` is retained as a deprecated, `doc(hidden)` re-export.

Additionally, for consistency, `LayoutVerified` is changed from a type alias to `pub use ... as ...` reexport.
