### PR TITLE
Make sure generate cache without needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: Build & Tests
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - v0.6.x
-  merge_group:
+  workflow_run:
+    workflows: [Generate Cache Workflow]
+    types:
+      - completed
 
 permissions: read-all
 
@@ -27,7 +25,6 @@ jobs:
     # first, most jobs would duplicate the work of downloading crates from
     # the internet. Populating the cache first ensures that this work only
     # happens once.
-    needs: generate_cache
 
     strategy:
       # By default, this is set to `true`, which means that a single CI job
@@ -230,7 +227,6 @@ jobs:
   kani:
     runs-on: ubuntu-latest
     name: Run tests under Kani
-    needs: generate_cache
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Configure ZC_TOOLCHAIN environment variable
@@ -265,7 +261,6 @@ jobs:
           rustfmt --check zerocopy-derive/tests/**/*.rs
 
   check_readme:
-    needs: generate_cache
     runs-on: ubuntu-latest
     name: Check README.md
     steps:
@@ -290,7 +285,6 @@ jobs:
           exit $?
 
   check_msrv:
-    needs: generate_cache
     runs-on: ubuntu-latest
     name: Check MSRVs match
     steps:
@@ -333,7 +327,6 @@ jobs:
           fi
 
   check_versions:
-    needs: generate_cache
     runs-on: ubuntu-latest
     name: Check crate versions match
     steps:
@@ -408,36 +401,3 @@ jobs:
             exit 1
           fi
 
-  generate_cache:
-    runs-on: ubuntu-latest
-    name: Generate cache
-    steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Populate cache
-        run: |
-          # Ensure all dependencies are downloaded - both for our crates and for
-          # tools we use in CI. We don't care about these tools succeeding for
-          # two reasons: First, this entire job is best-effort since it's just a
-          # performance optimization. Second, there may be failures due to
-          # issues other than failing to download dependencies (e.g., `cargo
-          # metadata` called with a malformed `Cargo.toml`, build failure in our
-          # own crate or in dependencies, etc). For those reasons, we discard
-          # stderr and ignore status codes.
-          #
-          # For downloading our crates' dependencies in particular, note that
-          # there is no support for doing this directly [1], so we just check
-          # all crates using --tests.
-          #
-          # [1]  https://stackoverflow.com/a/42139535/836390
-          cargo check --workspace --tests            &> /dev/null || true
-          cargo metadata                             &> /dev/null || true
-          cargo install cargo-readme --version 3.2.0 &> /dev/null || true
-          cargo install --locked kani-verifier       &> /dev/null || true
-          cargo kani setup                           &> /dev/null || true

--- a/.github/workflows/generate_cache_workflow.yml
+++ b/.github/workflows/generate_cache_workflow.yml
@@ -1,0 +1,44 @@
+name: Generate Cache Workflow
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - v0.6.x
+  merge_group:
+
+jobs:
+  generate_cache:
+    runs-on: ubuntu-latest
+    name: Generate cache
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Populate cache
+        run: |
+          # Ensure all dependencies are downloaded - both for our crates and for
+          # tools we use in CI. We don't care about these tools succeeding for
+          # two reasons: First, this entire job is best-effort since it's just a
+          # performance optimization. Second, there may be failures due to
+          # issues other than failing to download dependencies (e.g., `cargo
+          # metadata` called with a malformed `Cargo.toml`, build failure in our
+          # own crate or in dependencies, etc). For those reasons, we discard
+          # stderr and ignore status codes.
+          #
+          # For downloading our crates' dependencies in particular, note that
+          # there is no support for doing this directly [1], so we just check
+          # all crates using --tests.
+          #
+          # [1]  https://stackoverflow.com/a/42139535/836390
+          cargo check --workspace --tests            &> /dev/null || true
+          cargo metadata                             &> /dev/null || true
+          cargo install cargo-readme --version 3.2.0 &> /dev/null || true
+          cargo install --locked kani-verifier       &> /dev/null || true
+          cargo kani setup                           &> /dev/null || true


### PR DESCRIPTION
Fixes #340 

Use the `workflow_run` event to ensure that jobs are triggered only when the cache already exists. The new `Generate Cache Workflow` is triggered by:

1. A pull request (PR).
2. A branch push.
3. A merge operation within a group.

Once the `Generate Cache Workflow` is completed, trigger the `Build & Tests` workflow.