### PR TITLE
[ci] Skip MIPS tests on the stable toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
             features: "--features __internal_use_only_features_that_work_on_stable"
           - crate: "zerocopy-derive"
             features: "--all-features"
+          # Exclude any combination in which the target is unavailable on
+          # the given toolchain.
+          - toolchain: "stable"
+            target: "mips-unknown-linux-gnu"
+          - toolchain: "stable"
+            target: "mips64-unknown-linux-gnuabi64"
 
     name: Build & Test (crate:${{ matrix.crate }}, toolchain:${{ matrix.toolchain }}, target:${{ matrix.target }}, features:${{ matrix.features }})
 


### PR DESCRIPTION
MIPS targets are not available for the 1.72.1 toolchain. Prior to this commit, attempting to roll the stable toolchain to 1.72.1 was failing due to these missing targets: https://github.com/google/zerocopy/pull/447#pullrequestreview-1655828229

This commit skips building/testing/etc MIPS targets with the stable toolchain. This commit does not roll the stable toolchain. We want to make sure that our auto-roll procedure works, and by only disabling these target/toolchain pairs without rolling manually, we will give the auto-roller a chance to try again within 24 hours (as opposed to having to wait until the next stable toolchain release in up to six weeks).

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
