### PR TITLE
[ci] Fix all-jobs-succeeded job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,9 +445,14 @@ jobs:
   # Used to signal to branch protections that all other jobs have succeeded.
   all-jobs-succeed:
       name: All checks succeeded
-      if: success()
+      # On failure, we run and unconditionally exit with a failing status code.
+      # On success, this job is skipped. Jobs skipped using `if:` are considered
+      # to have succeeded:
+      #
+      # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      if: failure()
       runs-on: ubuntu-latest
       needs: [build_test, kani, check_fmt, check_readme, check_msrv, check_versions, generate_cache]
       steps:
-        - name: Mark the job as successful
-          run: exit 0
+        - name: Mark the job as failed
+          run: exit 1


### PR DESCRIPTION
Previously, this job used `if: success()` to only run on success. Unfortunately, GitHub interprets jobs skipped via `if:` to be successful. In this commit, we invert the logic, only running (and unconditionally failing) on `if: failure()`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
