### PR TITLE
[ci][kani] Pass correct RUSTFLAGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           set -eo pipefail
           cargo install --locked kani-verifier
           cargo kani setup
-          RUSTFLAGS="$ZC_NIGHTLY_RUSTFLAGS" ./cargo.sh +nightly kani                   \
+          RUSTFLAGS="$RUSTFLAGS $ZC_NIGHTLY_RUSTFLAGS" ./cargo.sh +nightly kani        \
             --package zerocopy --all-features --output-format terse --randomize-layout \
             --memory-safety-checks --overflow-checks --undefined-function-checks       \
             --unwinding-checks

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -947,7 +947,7 @@ mod tests {
         call_for_all_types!(test_non_native, NonNativeEndian);
     }
 
-    #[cfg_attr(test, test)]
+    #[test]
     fn test_ops_impls() {
         // Test implementations of traits in `core::ops`. Some of these are
         // fairly banal, but some are optimized to perform the operation without


### PR DESCRIPTION
Previously, we spuriously didn't pass our global `RUSTFLAGS` that are passed in other CI jobs. As a result, `-Dwarnings` is now used, which causes `byteorder::tests::test_ops_impls` to be recognized as unused. This is also fixed.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
