### PR TITLE
Add `Ptr::try_cast_into` method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly
   # toolchain.
   ZC_NIGHTLY_RUSTFLAGS: -Zrandomize-layout
-  ZC_NIGHTLY_MIRIFLAGS: "-Zmiri-symbolic-alignment-check -Zmiri-strict-provenance -Zmiri-backtrace=full"
+  ZC_NIGHTLY_MIRIFLAGS: "-Zmiri-strict-provenance -Zmiri-backtrace=full"
 
 jobs:
   build_test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,15 @@ use {
     core::{alloc::Layout, ptr::NonNull},
 };
 
+// For each polyfill, as soon as the corresponding feature is stable, the
+// polyfill import will be unused because method/function resolution will prefer
+// the inherent method/function over a trait method/function. Thus, we suppress
+// the `unused_imports` warning.
+//
+// See the documentation on `util::polyfills` for more information.
+#[allow(unused_imports)]
+use crate::util::polyfills::NonNullExt as _;
+
 // This is a hack to allow zerocopy-derive derives to work in this crate. They
 // assume that zerocopy is linked as an extern crate, so they access items from
 // it as `zerocopy::Xxx`. This makes that still work.
@@ -352,8 +361,11 @@ impl SizeInfo {
     }
 }
 
-#[cfg_attr(test, derive(Copy, Clone, Debug))]
-enum _CastType {
+#[doc(hidden)]
+#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(Debug))]
+#[allow(missing_debug_implementations)]
+pub enum _CastType {
     _Prefix,
     _Suffix,
 }
@@ -457,6 +469,9 @@ impl DstLayout {
     /// mere fact that this method returned successfully.
     ///
     /// # Panics
+    ///
+    /// `validate_cast_and_convert_metadata` will panic if `self` describes a
+    /// DST whose trailing slice element is zero-sized.
     ///
     /// If `addr + bytes_len` overflows `usize`,
     /// `validate_cast_and_convert_metadata` may panic, or it may return

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,8 @@ use core::{
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
     },
     ops::{Deref, DerefMut},
-    ptr, slice,
+    ptr::{self, NonNull},
+    slice,
 };
 
 #[cfg(feature = "alloc")]
@@ -255,7 +256,7 @@ extern crate alloc;
 #[cfg(feature = "alloc")]
 use {
     alloc::{boxed::Box, vec::Vec},
-    core::{alloc::Layout, ptr::NonNull},
+    core::alloc::Layout,
 };
 
 // For each polyfill, as soon as the corresponding feature is stable, the
@@ -265,7 +266,7 @@ use {
 //
 // See the documentation on `util::polyfills` for more information.
 #[allow(unused_imports)]
-use crate::util::polyfills::NonNullExt as _;
+use crate::util::polyfills::{NonNullExt as _, NonNullSliceExt as _};
 
 // This is a hack to allow zerocopy-derive derives to work in this crate. They
 // assume that zerocopy is linked as an extern crate, so they access items from
@@ -640,12 +641,27 @@ impl DstLayout {
 pub unsafe trait KnownLayout: sealed::KnownLayoutSealed {
     #[doc(hidden)]
     const LAYOUT: DstLayout;
+
+    /// SAFETY: The returned pointer has the same address and provenance as
+    /// `bytes`. If `Self` is a DST, the returned pointer's referent has `elems`
+    /// elements in its trailing slice. If `Self` is sized, `elems` is ignored.
+    #[doc(hidden)]
+    fn raw_from_ptr_len(bytes: NonNull<u8>, elems: usize) -> NonNull<Self>;
 }
 
 impl<T: KnownLayout> sealed::KnownLayoutSealed for [T] {}
 // SAFETY: Delegates safety to `DstLayout::for_slice`.
 unsafe impl<T: KnownLayout> KnownLayout for [T] {
     const LAYOUT: DstLayout = DstLayout::for_slice::<T>();
+
+    // SAFETY: `.cast` preserves address and provenance. The returned pointer
+    // refers to an object with `elems` elements by construction.
+    #[inline(always)]
+    fn raw_from_ptr_len(data: NonNull<u8>, elems: usize) -> NonNull<Self> {
+        // TODO(#67): Remove this allow. See NonNullExt for more details.
+        #[allow(unstable_name_collisions)]
+        NonNull::slice_from_raw_parts(data.cast::<T>(), elems)
+    }
 }
 
 #[rustfmt::skip]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -204,11 +204,24 @@ macro_rules! impl_known_layout {
     };
     ($($ty:ty),*) => { $(impl_known_layout!(@inner , => $ty);)* };
     (@inner $(const $constvar:ident : $constty:ty)? , $($tyvar:ident $(: ?$optbound:ident)?)? => $ty:ty) => {
-        impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> sealed::KnownLayoutSealed for $ty {}
-        // SAFETY: Delegates safety to `DstLayout::for_type`.
-        unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> KnownLayout for $ty {
-            const LAYOUT: DstLayout = DstLayout::for_type::<$ty>();
-        }
+        const _: () = {
+            use core::ptr::NonNull;
+
+            impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> sealed::KnownLayoutSealed for $ty {}
+            // SAFETY: Delegates safety to `DstLayout::for_type`.
+            unsafe impl<$(const $constvar : $constty,)? $($tyvar $(: ?$optbound)?)?> KnownLayout for $ty {
+                const LAYOUT: DstLayout = DstLayout::for_type::<$ty>();
+
+                // SAFETY: `.cast` preserves address and provenance.
+                //
+                // TODO(#429): Add documentation to `.cast` that promises that
+                // it preserves provenance.
+                #[inline(always)]
+                fn raw_from_ptr_len(bytes: NonNull<u8>, _elems: usize) -> NonNull<Self> {
+                    bytes.cast::<Self>()
+                }
+            }
+        };
     };
 }
 
@@ -225,10 +238,28 @@ macro_rules! impl_known_layout {
 ///   and this operation must preserve referent size (ie, `size_of_val_raw`).
 macro_rules! unsafe_impl_known_layout {
     ($($tyvar:ident: ?Sized + KnownLayout =>)? #[repr($repr:ty)] $ty:ty) => {
-        impl<$($tyvar: ?Sized + KnownLayout)?> sealed::KnownLayoutSealed for $ty {}
-        unsafe impl<$($tyvar: ?Sized + KnownLayout)?> KnownLayout for $ty {
-            const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
-        }
+        const _: () = {
+            use core::ptr::NonNull;
+
+            impl<$($tyvar: ?Sized + KnownLayout)?> sealed::KnownLayoutSealed for $ty {}
+            unsafe impl<$($tyvar: ?Sized + KnownLayout)?> KnownLayout for $ty {
+                const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
+
+                // SAFETY: All operations preserve address and provenance.
+                // Caller has promised that the `as` cast preserves size.
+                //
+                // TODO(#429): Add documentation to `NonNull::new_unchecked`
+                // that it preserves provenance.
+                #[inline(always)]
+                #[allow(unused_qualifications)] // for `core::ptr::NonNull`
+                fn raw_from_ptr_len(bytes: NonNull<u8>, elems: usize) -> NonNull<Self> {
+                    #[allow(clippy::as_conversions)]
+                    let ptr = <$repr>::raw_from_ptr_len(bytes, elems).as_ptr() as *mut Self;
+                    // SAFETY: `ptr` was converted from `bytes`, which is non-null.
+                    unsafe { NonNull::new_unchecked(ptr) }
+                }
+            }
+        };
     };
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,150 @@
 #[path = "third_party/rust/layout.rs"]
 pub(crate) mod core_layout;
 
-use core::{mem, num::NonZeroUsize};
+use core::{
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+    mem,
+    num::NonZeroUsize,
+    ptr::NonNull,
+};
+
+/// A raw pointer with more restrictions.
+///
+/// `Ptr<T>` is similar to `NonNull<T>`, but it is more restrictive in the
+/// following ways:
+/// - It must derive from a valid allocation
+/// - It must reference a byte range which is contained inside the allocation
+///   from which it derives
+///   - As a consequence, the byte range it references must have a size which
+///     does not overflow `isize`
+/// - It must satisfy `T`'s alignment requirement
+///
+/// Thanks to these restrictions, it is easier to prove the soundness of some
+/// operations using `Ptr`s.
+///
+/// `Ptr<'a, T>` is [covariant] in `'a` and `T`.
+///
+/// [covariant]: https://doc.rust-lang.org/reference/subtyping.html
+pub(crate) struct Ptr<'a, T: 'a + ?Sized> {
+    // INVARIANTS:
+    // - `ptr` is derived from some valid Rust allocation, `A`
+    // - `ptr` has the same provenance as `A`
+    // - `ptr` addresses a byte range which is entirely contained in `A`
+    // - `ptr` addresses a byte range which is not longer than `isize::MAX`
+    // - `ptr` addresses a byte range which does not wrap around the address
+    //   space
+    // - `ptr` is validly-aligned for `T`
+    // - `A` is guaranteed to live for at least `'a`
+    // - `T: 'a`
+    ptr: NonNull<T>,
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a, T: ?Sized> Copy for Ptr<'a, T> {}
+impl<'a, T: ?Sized> Clone for Ptr<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: ?Sized> Ptr<'a, T> {
+    /// Returns a shared reference to the value.
+    ///
+    /// # Safety
+    ///
+    /// TODO(#29), TODO(#429): What is the right way to articulate the safety
+    /// invariant here? I can see two possible approaches:
+    /// - Mimic the invariants on [`NonNull::as_ref`] so that it's easy to write
+    ///   the safety comment on the inner call to `self.ptr.as_ref()`.
+    /// - Simply say that it's the caller's responsibility to ensure that the
+    ///   resulting reference is valid.
+    ///
+    /// These two approaches should in principle be equivalent, but since our
+    /// memory model is undefined, there are some subtleties here. See, e.g.:
+    /// <https://github.com/rust-lang/unsafe-code-guidelines/issues/463#issuecomment-1736771593>
+    ///
+    /// # Old draft of Safety section
+    ///
+    /// - The referenced memory must contain a validly-initialized `T` for the
+    ///   duration of `'a`. Note that this requires that any interior mutation
+    ///   (i.e. via [`UnsafeCell`]) performed after this method call leave the
+    ///   memory region always containing a valid `T`.
+    /// - The referenced memory must not also by referenced by any mutable
+    ///   references during the lifetime `'a`.
+    /// - There must not exist any references to the same memory region which
+    ///   contain `UnsafeCell`s at byte ranges which are not identical to the
+    ///   byte ranges at which `T` contains `UnsafeCell`s.
+    ///
+    /// TODO: What about reads/mutation via raw pointers? Presumably these can
+    /// happen under the following conditions:
+    /// - Mutation only occurs inside `UnsafeCell`s
+    /// - Reads only happen using `UnsafeCell`s in places where there are
+    ///   `UnsafeCell`s in `T` (otherwise, those reads could be unsound due to
+    ///   assuming no concurrent mutation)
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub(crate) unsafe fn _as_ref(&self) -> &'a T {
+        // TODO(#429): Add a safety comment. This will depend on how we resolve
+        // the question about how to define the safety invariants on this
+        // method.
+        //
+        // Old draft of safety comment:
+        // - By invariant, `self.ptr` is properly-aligned for `T`.
+        // - By invariant, `self.ptr` is "dereferenceable" in that it points to
+        //   a single allocation
+        // - By invariant, the allocation is live for `'a`
+        // - The caller promises that no mutable references exist to this region
+        //   during `'a`
+        // - The caller promises that `UnsafeCell`s match exactly
+        // - The caller promises that the memory region contains a
+        //   validly-intialized `T`
+        #[allow(clippy::undocumented_unsafe_blocks)]
+        unsafe {
+            self.ptr.as_ref()
+        }
+    }
+}
+
+impl<'a, T: 'a + ?Sized> From<&'a T> for Ptr<'a, T> {
+    #[inline(always)]
+    fn from(t: &'a T) -> Ptr<'a, T> {
+        // SAFETY: `t` points to a valid Rust allocation, `A`, by construction.
+        // Thus:
+        // - `ptr` is derived from `A`
+        // - Since we use `NonNull::from`, which preserves provenance, `ptr` has
+        //   the same provenance as `A`
+        // - Since `NonNull::from` creates a pointer which addresses the same
+        //   bytes as `t`, `ptr` addresses a byte range entirely contained in
+        //   (in this case, identical to) `A`
+        // - Since `t: &T`, it addresses no more than `isize::MAX` bytes. [1]
+        // - Since `t: &T`, it addresses a byte range which does not wrap around
+        //   the address space. [2]
+        // - Since it is constructed from a valid `&T`, `ptr` is validly-aligned
+        //   for `T`
+        // - Since `t: &'a T`, the allocation `A` is guaranteed to live for at
+        //   least `'a`
+        // - `T: 'a` by trait bound
+        //
+        // TODO(#429), TODO(https://github.com/rust-lang/rust/issues/116181):
+        // Once it's documented, reference the guarantee that `NonNull::from`
+        // preserves provenance.
+        //
+        // TODO(#429),
+        // TODO(https://github.com/rust-lang/unsafe-code-guidelines/issues/465):
+        // - [1] Where does the reference document that allocations fit in
+        //   `isize`?
+        // - [2] Where does the reference document that allocations don't wrap
+        //   around the address space?
+        Ptr { ptr: NonNull::from(t), _lifetime: PhantomData }
+    }
+}
+
+impl<'a, T: 'a + ?Sized> Debug for Ptr<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        self.ptr.fmt(f)
+    }
+}
 
 pub(crate) trait AsAddress {
     fn addr(self) -> usize;
@@ -75,6 +218,37 @@ pub(crate) const fn _round_down_to_next_multiple_of_alignment(
     #[allow(clippy::arithmetic_side_effects)]
     let mask = !(align - 1);
     n & mask
+}
+
+/// Since we support multiple versions of Rust, there are often features which
+/// have been stabilized in the most recent stable release which do not yet
+/// exist (stably) on our MSRV. This module provides polyfills for those
+/// features so that we can write more "modern" code, and just remove the
+/// polyfill once our MSRV supports the corresponding feature. Without this,
+/// we'd have to write worse/more verbose code and leave TODO comments sprinkled
+/// throughout the codebase to update to the new pattern once it's stabilized.
+///
+/// Each trait is imported as `_` at the crate root; each polyfill should "just
+/// work" at usage sites.
+pub(crate) mod polyfills {
+    use core::ptr::{self, NonNull};
+
+    // A polyfill for `NonNull::slice_from_raw_parts` that we can use before our
+    // MSRV is 1.70, when that function was stabilized.
+    //
+    // TODO(#67): Once our MSRV is 1.70, remove this.
+    pub(crate) trait NonNullExt<T> {
+        fn slice_from_raw_parts(data: Self, len: usize) -> NonNull<[T]>;
+    }
+
+    impl<T> NonNullExt<T> for NonNull<T> {
+        #[inline(always)]
+        fn slice_from_raw_parts(data: Self, len: usize) -> NonNull<[T]> {
+            let ptr = ptr::slice_from_raw_parts_mut(data.as_ptr(), len);
+            // SAFETY: `ptr` is converted from `data`, which is non-null.
+            unsafe { NonNull::new_unchecked(ptr) }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`try_cast_into` attempts to cast a `Ptr<[u8]>` into a `Ptr<U>` where `U: ?Sized + KnownLayout`, and will be built upon in future commits as a building block of `TryFromBytes`.

Because `try_cast_into` performs a runtime check to validate alignment, this requires disabling Miri's "symbolic alignment check" feature. While it would be possible to run both with and without that feature in order to still test other code using symbolic alignment checking, I don't think that the benefit is worth a) the complexity of passing the information necessary for certain tests to not run under symbolic alignment checking and, b) the extra CI time to run Miri tests twice.

Makes progress on #29

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
