### PR TITLE
improve `FromZeroes` documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause"
@@ -41,7 +41,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.11", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.7.12", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -52,7 +52,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.11", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.12", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -67,4 +67,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.11", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.12", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.7.11"
+version = "0.7.12"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause"


### PR DESCRIPTION
This PR does essentially three things:
1. Provides examples of `#[derive(FromZeroes)]` being used
2. Provides examples of using many of `FromZeroes`'s methods.
3. Separates the documentation of the safety conditions of `FromZeroes`, from the documentation of how `derive(FromZeroes)` performs its analysis.

If the model of this PR looks good, I'll also apply it to `FromBytes` and `AsBytes`.