### PR TITLE
Fix Ref::new_slice_from_suffix() (#506)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1639,10 +1639,8 @@ where
             Some(len) => len,
             None => return None,
         };
-        if bytes.len() < expected_len {
-            return None;
-        }
-        let (bytes, suffix) = bytes.split_at(expected_len);
+        let split_at = bytes.len().checked_sub(expected_len)?;
+        let (bytes, suffix) = bytes.split_at(split_at);
         Self::new_slice(suffix).map(move |l| (bytes, l))
     }
 }
@@ -3376,9 +3374,10 @@ mod tests {
 
         {
             buf.set_default();
+            buf.t[8..].fill(0xFF);
             let (lv, suffix) =
                 LayoutVerified::<_, [AU64]>::new_slice_from_prefix(&mut buf.t[..], 1).unwrap();
-            assert_eq!(suffix, [0; 8]);
+            assert_eq!(suffix, [0xFF; 8]);
             test_new_helper_slice(lv, 1);
         }
         {
@@ -3391,9 +3390,10 @@ mod tests {
         }
         {
             buf.set_default();
+            buf.t[..8].fill(0xFF);
             let (prefix, lv) =
                 LayoutVerified::<_, [AU64]>::new_slice_from_suffix(&mut buf.t[..], 1).unwrap();
-            assert_eq!(prefix, [0; 8]);
+            assert_eq!(prefix, [0xFF; 8]);
             test_new_helper_slice(lv, 1);
         }
         {


### PR DESCRIPTION
* Fix Ref::new_slice_from_suffix()

`new_slice_from_suffix()` has a bug and implemented exactly as `new_slice_from_prefix()`. Now part of buffer is chosen right.

Tests couldn't have caught because buffer was just zeros. Now buffer is not just zeros so that tests can prove correctness of `new_slice_from_suffix()`.

* position -> split_at



---------

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
