### PR TITLE
[macro_util] Add trailing_field_offset! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,5 @@ testutil = { path = "testutil" }
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
 zerocopy-derive = { version = "=0.7.20", path = "zerocopy-derive" }
+# TODO(#381) Remove this dependency once we have our own layout gadgets.
+elain = "0.3.0"

--- a/src/util.rs
+++ b/src/util.rs
@@ -601,6 +601,15 @@ pub(crate) mod testutil {
             Display::fmt(&self.0, f)
         }
     }
+
+    #[derive(
+        FromZeroes, FromBytes, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Copy, Clone,
+    )]
+    #[repr(C)]
+    pub(crate) struct Nested<T, U: ?Sized> {
+        _t: T,
+        _u: U,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This macro will be used by the derive of KnownLayout for slice DSTs.

Makes progress on #29

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
