### PR TITLE
Initial commit of DstLayout::for_dst

### DIFF
--- a/zerocopy-derive/src/repr.rs
+++ b/zerocopy-derive/src/repr.rs
@@ -248,7 +248,7 @@ impl Display for Repr {
     }
 }
 
-fn reprs<R: KindRepr>(attrs: &[Attribute]) -> Result<Vec<(Meta, R)>, Vec<Error>> {
+pub(crate) fn reprs<R: KindRepr>(attrs: &[Attribute]) -> Result<Vec<(Meta, R)>, Vec<Error>> {
     let mut reprs = Vec::new();
     let mut errors = Vec::new();
     for attr in attrs {


### PR DESCRIPTION
This will be used by the custom derive of `KnownLayout` to compute the `DstLayout` for unsized types.

Makes progress on #29

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
