### PR TITLE
Add `transmute_mut!` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.7.16"
+version = "0.7.17"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -45,7 +45,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.16", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.7.17", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -56,7 +56,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.16", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.17", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -71,4 +71,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.16", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.17", path = "zerocopy-derive" }

--- a/tests/ui-msrv/transmute-mut-alignment-increase.rs
+++ b/tests/ui-msrv/transmute-mut-alignment-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-alignment-increase.rs

--- a/tests/ui-msrv/transmute-mut-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-alignment-increase.stderr
@@ -1,0 +1,36 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:19:39
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:19:54
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                                      ^^^^^^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `INCREASE_ALIGNMENT::transmute::<[u8; 2], AU16>` in constants
+  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:19:39
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:19:59
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                       --------------------^^^^^^^^-
+   |                                       |                   |
+   |                                       |                   creates a temporary which is freed while still in use
+   |                                       temporary value is freed at the end of this statement
+   |                                       using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-msrv/transmute-mut-const.rs
+++ b/tests/ui-msrv/transmute-mut-const.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-const.rs

--- a/tests/ui-msrv/transmute-mut-const.stderr
+++ b/tests/ui-msrv/transmute-mut-const.stderr
@@ -1,0 +1,41 @@
+error: taking a mutable reference to a `const` item
+  --> tests/ui-msrv/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D const-item-mutation` implied by `-D warnings`
+   = note: each usage of a `const` item creates a new temporary
+   = note: the mutable reference will refer to this temporary, not the original `const` item
+note: `const` item defined here
+  --> tests/ui-msrv/transmute-mut-const.rs:17:1
+   |
+17 | const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<[u8; 2], [u8; 2]>` in constants
+  --> tests/ui-msrv/transmute-mut-const.rs:20:37
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-const.rs:20:57
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     --------------------^^^^^^^^^^^^-
+   |                                     |                   |
+   |                                     |                   creates a temporary which is freed while still in use
+   |                                     temporary value is freed at the end of this statement
+   |                                     using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-msrv/transmute-mut-dst-generic.rs
+++ b/tests/ui-msrv/transmute-mut-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-generic.rs

--- a/tests/ui-msrv/transmute-mut-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.rs
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-a-reference.rs

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-asbytes.rs
+++ b/tests/ui-msrv/transmute-mut-dst-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-asbytes.rs

--- a/tests/ui-msrv/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-asbytes.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
+   |
+note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+  --> tests/ui-msrv/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this
+   |                                    required by this bound in `DST_NOT_AS_BYTES::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-msrv/transmute-mut-dst-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-frombytes.rs

--- a/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-msrv/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this
+   |                                      required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-unsized.rs
+++ b/tests/ui-msrv/transmute-mut-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-unsized.rs

--- a/tests/ui-msrv/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-unsized.stderr
@@ -1,0 +1,80 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                         ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-illegal-lifetime.rs
+++ b/tests/ui-msrv/transmute-mut-illegal-lifetime.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-illegal-lifetime.rs

--- a/tests/ui-msrv/transmute-mut-illegal-lifetime.stderr
+++ b/tests/ui-msrv/transmute-mut-illegal-lifetime.stderr
@@ -1,0 +1,9 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-msrv/transmute-mut-illegal-lifetime.rs:14:56
+   |
+14 |     let _: &'static mut u64 = zerocopy::transmute_mut!(&mut x);
+   |            ----------------                            ^^^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+15 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-msrv/transmute-mut-size-decrease.rs
+++ b/tests/ui-msrv/transmute-mut-size-decrease.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-size-decrease.rs

--- a/tests/ui-msrv/transmute-mut-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-mut-size-decrease.stderr
@@ -1,0 +1,36 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:32
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:47
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                               ^^^^^^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `DECREASE_SIZE::transmute::<[u8; 2], u8>` in constants
+  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:32
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:52
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                --------------------^^^^^^^^-
+   |                                |                   |
+   |                                |                   creates a temporary which is freed while still in use
+   |                                temporary value is freed at the end of this statement
+   |                                using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-msrv/transmute-mut-size-increase.rs
+++ b/tests/ui-msrv/transmute-mut-size-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-size-increase.rs

--- a/tests/ui-msrv/transmute-mut-size-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-size-increase.stderr
@@ -1,0 +1,36 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:37
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:52
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                                    ^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `INCREASE_SIZE::transmute::<u8, [u8; 2]>` in constants
+  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:37
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:57
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                     --------------------^^^-
+   |                                     |                   |
+   |                                     |                   creates a temporary which is freed while still in use
+   |                                     temporary value is freed at the end of this statement
+   |                                     using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-msrv/transmute-mut-src-dst-generic.rs
+++ b/tests/ui-msrv/transmute-mut-src-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-generic.rs

--- a/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-dst-not-references.rs
+++ b/tests/ui-msrv/transmute-mut-src-dst-not-references.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-not-references.rs

--- a/tests/ui-msrv/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-not-references.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^ expected `&mut _`, found `usize`
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^------^
+   |                                            |              |
+   |                                            |              expected due to this value
+   |                                            expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-dst-unsized.rs
+++ b/tests/ui-msrv/transmute-mut-src-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-unsized.rs

--- a/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
@@ -1,0 +1,153 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_DST_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                      ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-generic.rs
+++ b/tests/ui-msrv/transmute-mut-src-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-generic.rs

--- a/tests/ui-msrv/transmute-mut-src-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-generic.stderr
@@ -1,0 +1,10 @@
+error[E0405]: cannot find trait `FromBytes` in this scope
+  --> tests/ui-msrv/transmute-mut-src-generic.rs:15:31
+   |
+15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+   |                               ^^^^^^^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+11 | use zerocopy::FromBytes;
+   |

--- a/tests/ui-msrv/transmute-mut-src-immutable.rs
+++ b/tests/ui-msrv/transmute-mut-src-immutable.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-immutable.rs

--- a/tests/ui-msrv/transmute-mut-src-immutable.stderr
+++ b/tests/ui-msrv/transmute-mut-src-immutable.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut _`
+                      found reference `&u8`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-a-reference.rs
+++ b/tests/ui-msrv/transmute-mut-src-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-a-reference.rs

--- a/tests/ui-msrv/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-a-reference.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^ expected `&mut _`, found `usize`
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^------^
+   |                                      |              |
+   |                                      |              expected due to this value
+   |                                      expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-asbytes.rs
+++ b/tests/ui-msrv/transmute-mut-src-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-asbytes.rs

--- a/tests/ui-msrv/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-asbytes.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-msrv/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this
+   |                                    required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-msrv/transmute-mut-src-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-frombytes.rs

--- a/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
+   |
+note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+  --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this
+   |                                      required by this bound in `SRC_NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-unsized.rs
+++ b/tests/ui-msrv/transmute-mut-src-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-unsized.rs

--- a/tests/ui-msrv/transmute-mut-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-unsized.stderr
@@ -1,0 +1,142 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_UNSIZED::transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                      ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all function arguments must have a statically known size
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-alignment-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `T` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-dst-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<u8>` (8 bits)
    = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:18:22
-   |
-18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
-   |
-   = note: expected mutable reference `&mut u8`
-                      found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.stderr
@@ -30,37 +30,26 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
-  --> $RUST/core/src/intrinsics.rs
-   |
-   |     pub fn transmute<T, U>(e: T) -> U;
-   |                         ^ required by this bound in `std::intrinsics::transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `MaxAlignsOf`
   --> src/macro_util.rs
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<T, U>(e: T) -> U;
+   |                         ^ required by this bound in `std::intrinsics::transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
@@ -74,7 +63,7 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |
    | impl<T, U> MaxAlignsOf<T, U> {
    |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
@@ -88,4 +77,4 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-ref-size-decrease.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 2]` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-size-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-size-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `U` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-src-dst-generic.rs:18:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
@@ -25,13 +25,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:39
-   |
-17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
@@ -35,29 +35,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `std::intrinsics::transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -71,7 +49,7 @@ note: required by a bound in `AlignOf::<T>::into_t`
    |
    | impl<T> AlignOf<T> {
    |      ^ required by this bound in `AlignOf::<T>::into_t`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -81,7 +59,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -95,7 +73,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -109,7 +87,7 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |
    | impl<T, U> MaxAlignsOf<T, U> {
    |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -123,7 +101,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -137,7 +115,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -151,7 +129,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -172,4 +150,4 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all function arguments must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-src-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-unsized.stderr
@@ -35,18 +35,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `std::intrinsics::transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -60,7 +49,7 @@ note: required by a bound in `AlignOf::<T>::into_t`
    |
    | impl<T> AlignOf<T> {
    |      ^ required by this bound in `AlignOf::<T>::into_t`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -70,7 +59,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -84,7 +73,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -98,7 +87,7 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |
    | impl<T, U> MaxAlignsOf<T, U> {
    |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -112,7 +101,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -126,7 +115,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -140,7 +129,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -150,4 +139,4 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all function arguments must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-alignment-increase.rs
+++ b/tests/ui-nightly/transmute-mut-alignment-increase.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting from a type of smaller
+// alignment to one of larger alignment.
+const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);

--- a/tests/ui-nightly/transmute-mut-alignment-increase.stderr
+++ b/tests/ui-nightly/transmute-mut-alignment-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-alignment-increase.rs:19:39
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-const.rs
+++ b/tests/ui-nightly/transmute-mut-const.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
+
+// `transmute_mut!` cannot, generally speaking, be used in const contexts.
+const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);

--- a/tests/ui-nightly/transmute-mut-const.stderr
+++ b/tests/ui-nightly/transmute-mut-const.stderr
@@ -1,0 +1,43 @@
+error: taking a mutable reference to a `const` item
+  --> tests/ui-nightly/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: the mutable reference will refer to this temporary, not the original `const` item
+note: `const` item defined here
+  --> tests/ui-nightly/transmute-mut-const.rs:17:1
+   |
+17 | const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D const-item-mutation` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(const_item_mutation)]`
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-nightly/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<'_, [u8; 2], [u8; 2]>` in constants
+  --> tests/ui-nightly/transmute-mut-const.rs:20:37
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-nightly/transmute-mut-const.rs:20:57
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     --------------------^^^^^^^^^^^^-
+   |                                     |                   |
+   |                                     |                   creates a temporary value which is freed while still in use
+   |                                     temporary value is freed at the end of this statement
+   |                                     using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-nightly/transmute-mut-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-dst-generic.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_mut, AsBytes, FromBytes};
+
+fn main() {}
+
+fn transmute_mut<T: AsBytes + FromBytes>(u: &mut u8) -> &mut T {
+    // `transmute_mut!` requires the destination type to be concrete.
+    transmute_mut!(u)
+}

--- a/tests/ui-nightly/transmute-mut-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting into a non-reference
+// destination type.
+const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the destination type implements `AsBytes`
+const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-asbytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+  --> tests/ui-nightly/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this function
+   |                                    required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::AsBytes)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the destination type implements `FromBytes`
+const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-nightly/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this function
+   |                                      required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-unsized.rs
+++ b/tests/ui-nightly/transmute-mut-dst-unsized.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting into an unsized destination
+// type.
+const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);

--- a/tests/ui-nightly/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-unsized.stderr
@@ -1,0 +1,72 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-illegal-lifetime.rs
+++ b/tests/ui-nightly/transmute-mut-illegal-lifetime.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+fn main() {}
+
+fn increase_lifetime() {
+    let mut x = 0u64;
+    // It is illegal to increase the lifetime scope.
+    let _: &'static mut u64 = zerocopy::transmute_mut!(&mut x);
+}

--- a/tests/ui-nightly/transmute-mut-illegal-lifetime.stderr
+++ b/tests/ui-nightly/transmute-mut-illegal-lifetime.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-nightly/transmute-mut-illegal-lifetime.rs:14:56
+   |
+12 |     let mut x = 0u64;
+   |         ----- binding `x` declared here
+13 |     // It is illegal to increase the lifetime scope.
+14 |     let _: &'static mut u64 = zerocopy::transmute_mut!(&mut x);
+   |            ----------------                            ^^^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+15 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-nightly/transmute-mut-size-decrease.rs
+++ b/tests/ui-nightly/transmute-mut-size-decrease.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// We require that the size of the destination type is not smaller than the size
+// of the source type.
+const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);

--- a/tests/ui-nightly/transmute-mut-size-decrease.stderr
+++ b/tests/ui-nightly/transmute-mut-size-decrease.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-size-decrease.rs:17:32
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-size-increase.rs
+++ b/tests/ui-nightly/transmute-mut-size-increase.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting from a smaller type to a larger
+// one.
+const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);

--- a/tests/ui-nightly/transmute-mut-size-increase.stderr
+++ b/tests/ui-nightly/transmute-mut-size-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-size-increase.rs:17:37
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-dst-generic.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_mut, AsBytes, FromBytes};
+
+fn main() {}
+
+fn transmute_mut<T: AsBytes + FromBytes, U: AsBytes + FromBytes>(t: &mut T) -> &mut U {
+    // `transmute_mut!` requires the source and destination types to be
+    // concrete.
+    transmute_mut!(t)
+}

--- a/tests/ui-nightly/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-dst-not-references.rs
+++ b/tests/ui-nightly/transmute-mut-src-dst-not-references.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting between non-reference source
+// and destination types.
+const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);

--- a/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^
+   |                                            |
+   |                                            expected `&mut _`, found `usize`
+   |                                            arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+note: function defined here
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^------^
+   |                                            |              |
+   |                                            |              expected due to this value
+   |                                            expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-dst-unsized.rs
+++ b/tests/ui-nightly/transmute-mut-src-dst-unsized.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting between unsized source and
+// destination types.
+const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);

--- a/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
@@ -1,0 +1,192 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-generic.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::{transmute_mut, AsBytes};
+
+fn main() {}
+
+fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+    // `transmute_mut!` requires the source type to be concrete.
+    transmute_mut!(t)
+}

--- a/tests/ui-nightly/transmute-mut-src-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-src-generic.stderr
@@ -1,0 +1,10 @@
+error[E0405]: cannot find trait `FromBytes` in this scope
+  --> tests/ui-nightly/transmute-mut-src-generic.rs:15:31
+   |
+15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+   |                               ^^^^^^^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+11 + use zerocopy::FromBytes;
+   |

--- a/tests/ui-nightly/transmute-mut-src-immutable.rs
+++ b/tests/ui-nightly/transmute-mut-src-immutable.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+fn ref_src_immutable() {
+    // `transmute_mut!` requires that its source type be a mutable reference.
+    let _: &mut u8 = transmute_mut!(&0u8);
+}

--- a/tests/ui-nightly/transmute-mut-src-immutable.stderr
+++ b/tests/ui-nightly/transmute-mut-src-immutable.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      types differ in mutability
+   |                      arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                      found reference `&u8`
+note: function defined here
+  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-a-reference.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-a-reference.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting from a non-reference source
+// type.
+const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);

--- a/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      expected `&mut _`, found `usize`
+   |                                      arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+note: function defined here
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^------^
+   |                                      |              |
+   |                                      |              expected due to this value
+   |                                      expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the source type implements `AsBytes`
+const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-asbytes.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `AsBytes` is not implemented for `Src`
+   |                                    required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-nightly/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this function
+   |                                    required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::AsBytes)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the source type implements `FromBytes`
+const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Src`
+   |                                      required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+  --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this function
+   |                                      required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-unsized.rs
+++ b/tests/ui-nightly/transmute-mut-src-unsized.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+// `transmute_mut!` does not support transmuting from an unsized source type.
+const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);

--- a/tests/ui-nightly/transmute-mut-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-unsized.stderr
@@ -1,0 +1,133 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-nightly/transmute-ref-alignment-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `T` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-nightly/transmute-ref-dst-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<u8>` (8 bits)
    = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
-   |
-18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
-   |
-   = note: expected mutable reference `&mut u8`
-                      found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-unsized.stderr
@@ -30,37 +30,26 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
-  --> $RUST/core/src/intrinsics.rs
-   |
-   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
-   |                           ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `MaxAlignsOf`
   --> src/macro_util.rs
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
@@ -80,4 +69,4 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-size-decrease.stderr
+++ b/tests/ui-nightly/transmute-ref-size-decrease.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 2]` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-size-increase.stderr
+++ b/tests/ui-nightly/transmute-ref-size-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `U` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-nightly/transmute-ref-src-dst-generic.rs:18:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -25,13 +25,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
-   |
-17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
@@ -55,7 +55,96 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                      ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
@@ -80,118 +169,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf::<T>::into_t`
-  --> src/macro_util.rs
-   |
-   | impl<T> AlignOf<T> {
-   |      ^ required by this bound in `AlignOf::<T>::into_t`
-   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-   |     pub fn into_t(self) -> T {
-   |            ------ required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf`
-  --> src/macro_util.rs
-   |
-   | pub struct AlignOf<T> {
-   |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                doesn't have a size known at compile-time
-   |                                required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf::<T, U>::new`
-  --> src/macro_util.rs
-   |
-   | impl<T, U> MaxAlignsOf<T, U> {
-   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
-   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf`
-  --> src/macro_util.rs
-   |
-   | pub struct AlignOf<T> {
-   |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
@@ -211,4 +189,4 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-generic.stderr
+++ b/tests/ui-nightly/transmute-ref-src-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-nightly/transmute-ref-src-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-unsized.stderr
@@ -41,18 +41,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                      ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -69,7 +58,7 @@ note: required by a bound in `AlignOf::<T>::into_t`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn into_t(self) -> T {
    |            ------ required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -79,7 +68,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -93,7 +82,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -113,7 +102,7 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -127,7 +116,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
@@ -141,4 +130,4 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-alignment-increase.rs
+++ b/tests/ui-stable/transmute-mut-alignment-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-alignment-increase.rs

--- a/tests/ui-stable/transmute-mut-alignment-increase.stderr
+++ b/tests/ui-stable/transmute-mut-alignment-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-alignment-increase.rs:19:39
+   |
+19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<[u8; 2]>` (8 bits)
+   = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-const.rs
+++ b/tests/ui-stable/transmute-mut-const.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-const.rs

--- a/tests/ui-stable/transmute-mut-const.stderr
+++ b/tests/ui-stable/transmute-mut-const.stderr
@@ -1,0 +1,41 @@
+error: taking a mutable reference to a `const` item
+  --> tests/ui-stable/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: the mutable reference will refer to this temporary, not the original `const` item
+note: `const` item defined here
+  --> tests/ui-stable/transmute-mut-const.rs:17:1
+   |
+17 | const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `-D const-item-mutation` implied by `-D warnings`
+
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-stable/transmute-mut-const.rs:20:52
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<'_, [u8; 2], [u8; 2]>` in constants
+  --> tests/ui-stable/transmute-mut-const.rs:20:37
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-stable/transmute-mut-const.rs:20:57
+   |
+20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+   |                                     --------------------^^^^^^^^^^^^-
+   |                                     |                   |
+   |                                     |                   creates a temporary value which is freed while still in use
+   |                                     temporary value is freed at the end of this statement
+   |                                     using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-stable/transmute-mut-dst-generic.rs
+++ b/tests/ui-stable/transmute-mut-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-generic.rs

--- a/tests/ui-stable/transmute-mut-dst-generic.stderr
+++ b/tests/ui-stable/transmute-mut-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `T` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-dst-generic.rs:17:5
+   |
+17 |     transmute_mut!(u)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<u8>` (8 bits)
+   = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.rs
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-a-reference.rs

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-asbytes.rs
+++ b/tests/ui-stable/transmute-mut-dst-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-asbytes.rs

--- a/tests/ui-stable/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-asbytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+  --> tests/ui-stable/transmute-mut-dst-not-asbytes.rs:24:36
+   |
+24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this function
+   |                                    required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-stable/transmute-mut-dst-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-frombytes.rs

--- a/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+  --> tests/ui-stable/transmute-mut-dst-not-frombytes.rs:24:38
+   |
+24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this function
+   |                                      required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-unsized.rs
+++ b/tests/ui-stable/transmute-mut-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-unsized.rs

--- a/tests/ui-stable/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-dst-unsized.stderr
@@ -1,0 +1,72 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                          ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-illegal-lifetime.rs
+++ b/tests/ui-stable/transmute-mut-illegal-lifetime.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-illegal-lifetime.rs

--- a/tests/ui-stable/transmute-mut-illegal-lifetime.stderr
+++ b/tests/ui-stable/transmute-mut-illegal-lifetime.stderr
@@ -1,0 +1,12 @@
+error[E0597]: `x` does not live long enough
+  --> tests/ui-stable/transmute-mut-illegal-lifetime.rs:14:56
+   |
+12 |     let mut x = 0u64;
+   |         ----- binding `x` declared here
+13 |     // It is illegal to increase the lifetime scope.
+14 |     let _: &'static mut u64 = zerocopy::transmute_mut!(&mut x);
+   |            ----------------                            ^^^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `x` is borrowed for `'static`
+15 | }
+   | - `x` dropped here while still borrowed

--- a/tests/ui-stable/transmute-mut-size-decrease.rs
+++ b/tests/ui-stable/transmute-mut-size-decrease.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-size-decrease.rs

--- a/tests/ui-stable/transmute-mut-size-decrease.stderr
+++ b/tests/ui-stable/transmute-mut-size-decrease.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-size-decrease.rs:17:32
+   |
+17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `[u8; 2]` (16 bits)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-size-increase.rs
+++ b/tests/ui-stable/transmute-mut-size-increase.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-size-increase.rs

--- a/tests/ui-stable/transmute-mut-size-increase.stderr
+++ b/tests/ui-stable/transmute-mut-size-increase.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-size-increase.rs:17:37
+   |
+17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `[u8; 2]` (16 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-dst-generic.rs
+++ b/tests/ui-stable/transmute-mut-src-dst-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-generic.rs

--- a/tests/ui-stable/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-generic.stderr
@@ -1,0 +1,19 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `U` (this type does not have a fixed size)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:18:5
+   |
+18 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-dst-not-references.rs
+++ b/tests/ui-stable/transmute-mut-src-dst-not-references.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-not-references.rs

--- a/tests/ui-stable/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-not-references.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^
+   |                                            |
+   |                                            expected `&mut _`, found `usize`
+   |                                            arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+note: function defined here
+  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^------^
+   |                                            |              |
+   |                                            |              expected due to this value
+   |                                            expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-dst-unsized.rs
+++ b/tests/ui-stable/transmute-mut-src-dst-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-dst-unsized.rs

--- a/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
@@ -1,0 +1,192 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_DST_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-generic.rs
+++ b/tests/ui-stable/transmute-mut-src-generic.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-generic.rs

--- a/tests/ui-stable/transmute-mut-src-generic.stderr
+++ b/tests/ui-stable/transmute-mut-src-generic.stderr
@@ -1,0 +1,10 @@
+error[E0405]: cannot find trait `FromBytes` in this scope
+  --> tests/ui-stable/transmute-mut-src-generic.rs:15:31
+   |
+15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+   |                               ^^^^^^^^^ not found in this scope
+   |
+help: consider importing this trait
+   |
+11 + use zerocopy::FromBytes;
+   |

--- a/tests/ui-stable/transmute-mut-src-immutable.rs
+++ b/tests/ui-stable/transmute-mut-src-immutable.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-immutable.rs

--- a/tests/ui-stable/transmute-mut-src-immutable.stderr
+++ b/tests/ui-stable/transmute-mut-src-immutable.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      types differ in mutability
+   |                      arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                      found reference `&u8`
+note: function defined here
+  --> tests/ui-stable/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-a-reference.rs
+++ b/tests/ui-stable/transmute-mut-src-not-a-reference.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-a-reference.rs

--- a/tests/ui-stable/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-a-reference.stderr
@@ -1,0 +1,30 @@
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      expected `&mut _`, found `usize`
+   |                                      arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                           found type `usize`
+note: function defined here
+  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^------^
+   |                                      |              |
+   |                                      |              expected due to this value
+   |                                      expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-asbytes.rs
+++ b/tests/ui-stable/transmute-mut-src-not-asbytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-asbytes.rs

--- a/tests/ui-stable/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-asbytes.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `AsBytes` is not implemented for `Src`
+   |                                    required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+  --> tests/ui-stable/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    required by a bound in this function
+   |                                    required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-stable/transmute-mut-src-not-frombytes.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-frombytes.rs

--- a/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Src`
+   |                                      required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+  --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      required by a bound in this function
+   |                                      required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-unsized.rs
+++ b/tests/ui-stable/transmute-mut-src-unsized.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-unsized.rs

--- a/tests/ui-stable/transmute-mut-src-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-unsized.stderr
@@ -1,0 +1,133 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `SRC_UNSIZED::transmute`
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                      ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-stable/transmute-ref-alignment-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-generic.stderr
+++ b/tests/ui-stable/transmute-ref-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `T` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-stable/transmute-ref-dst-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<u8>` (8 bits)
    = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-stable/transmute-ref-dst-mutable.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
-   |
-18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
-   |
-   = note: expected mutable reference `&mut u8`
-                      found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
@@ -17,13 +17,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-dst-unsized.stderr
@@ -30,37 +30,26 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
-  --> $RUST/core/src/intrinsics.rs
-   |
-   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
-   |                           ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `MaxAlignsOf`
   --> src/macro_util.rs
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `std::intrinsics::transmute`
+  --> $RUST/core/src/intrinsics.rs
+   |
+   |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
+   |                           ^^^ required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
@@ -80,4 +69,4 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-size-decrease.stderr
+++ b/tests/ui-stable/transmute-ref-size-decrease.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 2]` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-size-increase.stderr
+++ b/tests/ui-stable/transmute-ref-size-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `U` (this type does not have a fixed size)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-stable/transmute-ref-src-dst-generic.rs:18:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
@@ -25,13 +25,3 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
-   |
-17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
-   |
-   = note:   expected type `usize`
-           found reference `&_`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
@@ -55,7 +55,96 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                      ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn into_t(self) -> T {
+   |            ------ required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: the left-hand-side of an assignment must have a statically known size
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
+   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
+   |            --- required by a bound in this associated function
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf`
+  --> src/macro_util.rs
+   |
+   | pub union MaxAlignsOf<T, U> {
+   |                       ^ required by this bound in `MaxAlignsOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AlignOf`
+  --> src/macro_util.rs
+   |
+   | pub struct AlignOf<T> {
+   |                    ^ required by this bound in `AlignOf`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
@@ -80,118 +169,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf::<T>::into_t`
-  --> src/macro_util.rs
-   |
-   | impl<T> AlignOf<T> {
-   |      ^ required by this bound in `AlignOf::<T>::into_t`
-   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-   |     pub fn into_t(self) -> T {
-   |            ------ required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf`
-  --> src/macro_util.rs
-   |
-   | pub struct AlignOf<T> {
-   |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                doesn't have a size known at compile-time
-   |                                required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf::<T, U>::new`
-  --> src/macro_util.rs
-   |
-   | impl<T, U> MaxAlignsOf<T, U> {
-   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
-   |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AlignOf`
-  --> src/macro_util.rs
-   |
-   | pub struct AlignOf<T> {
-   |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
@@ -211,4 +189,4 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-generic.stderr
+++ b/tests/ui-stable/transmute-ref-src-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-stable/transmute-ref-src-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-unsized.stderr
@@ -41,18 +41,7 @@ note: required by a bound in `std::intrinsics::transmute`
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                      ^^^ required by this bound in `transmute`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all local variables must have a statically known size
-   = help: unsized locals are gated as an unstable feature
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -69,7 +58,7 @@ note: required by a bound in `AlignOf::<T>::into_t`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn into_t(self) -> T {
    |            ------ required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -79,7 +68,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -93,7 +82,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -113,7 +102,7 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     #[inline(never)] // Make `missing_inline_in_public_items` happy.
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -127,7 +116,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
@@ -141,4 +130,4 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.7.16"
+version = "0.7.17"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
This macro is like the existing `transmute!`, but it transmutes mutable references rather than values.

Issue #159