### PR TITLE
Lower MSRV to 1.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@
 [workspace]
 
 [package]
-edition = "2021"
+edition = "2018"
 name = "zerocopy"
-version = "0.7.18"
+version = "0.7.19"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
-rust-version = "1.61.0"
+rust-version = "1.60.0"
 
 exclude = [".*"]
 
@@ -45,7 +45,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.18", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.7.19", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -56,7 +56,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.18", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.19", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -71,4 +71,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.18", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.19", path = "zerocopy-derive" }

--- a/tests/ui-msrv/include_value_not_from_bytes.stderr
+++ b/tests/ui-msrv/include_value_not_from_bytes.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
 12 |     include_value!("../../testdata/include_value/data");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
    |
-note: required by a bound in `NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/include_value_not_from_bytes.rs:12:5
    |
 12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NOT_FROM_BYTES::transmute`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-dst-not-frombytes.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
    |                                         ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/transmute-dst-not-frombytes.rs:18:41
    |
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-alignment-increase.stderr
@@ -16,7 +16,7 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: cannot call non-const fn `INCREASE_ALIGNMENT::transmute::<[u8; 2], AU16>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<[u8; 2], AU16>` in constants
   --> tests/ui-msrv/transmute-mut-alignment-increase.rs:19:39
    |
 19 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);

--- a/tests/ui-msrv/transmute-mut-const.stderr
+++ b/tests/ui-msrv/transmute-mut-const.stderr
@@ -21,7 +21,7 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<[u8; 2], [u8; 2]>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<[u8; 2], [u8; 2]>` in constants
   --> tests/ui-msrv/transmute-mut-const.rs:20:37
    |
 20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
@@ -17,3 +17,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-asbytes.stderr
@@ -4,12 +4,9 @@ error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
    |
-note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertDstIsAsBytes`
   --> tests/ui-msrv/transmute-mut-dst-not-asbytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this
-   |                                    required by this bound in `DST_NOT_AS_BYTES::transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
@@ -4,12 +4,9 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
    |
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-msrv/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this
-   |                                      required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-unsized.stderr
@@ -5,11 +5,25 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_UNSIZED::transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,11 +58,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                         ^ required by this bound in `std::intrinsics::transmute`
+   |                         ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -78,3 +92,17 @@ note: required by a bound in `MaxAlignsOf`
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                          ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-mut-size-decrease.stderr
@@ -16,7 +16,7 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: cannot call non-const fn `DECREASE_SIZE::transmute::<[u8; 2], u8>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<[u8; 2], u8>` in constants
   --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:32
    |
 17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);

--- a/tests/ui-msrv/transmute-mut-size-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-size-increase.stderr
@@ -16,7 +16,7 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: cannot call non-const fn `INCREASE_SIZE::transmute::<u8, [u8; 2]>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<u8, [u8; 2]>` in constants
   --> tests/ui-msrv/transmute-mut-size-increase.rs:17:37
    |
 17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);

--- a/tests/ui-msrv/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-not-references.stderr
@@ -1,22 +1,12 @@
 error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-src-dst-not-references.rs:17:44
+  --> tests/ui-msrv/transmute-mut-src-dst-not-references.rs:17:59
    |
 17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^ expected `&mut _`, found `usize`
+   |                                            ---------------^^^^^^-
+   |                                            |              |
+   |                                            |              expected `&mut _`, found `usize`
+   |                                            |              help: consider mutably borrowing here: `&mut 0usize`
+   |                                            expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-src-dst-not-references.rs:17:44
-   |
-17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^------^
-   |                                            |              |
-   |                                            |              expected due to this value
-   |                                            expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
@@ -5,11 +5,81 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_DST_UNSIZED::transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,11 +100,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                      ^ required by this bound in `std::intrinsics::transmute`
+   |                      ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -140,6 +210,20 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-mut-src-immutable.stderr
+++ b/tests/ui-msrv/transmute-mut-src-immutable.stderr
@@ -1,9 +1,11 @@
 error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-src-immutable.rs:17:22
+  --> tests/ui-msrv/transmute-mut-src-immutable.rs:17:37
    |
 17 |     let _: &mut u8 = transmute_mut!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |                      ---------------^^^^-
+   |                      |              |
+   |                      |              types differ in mutability
+   |                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                       found reference `&u8`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-a-reference.stderr
@@ -1,22 +1,12 @@
 error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-src-not-a-reference.rs:17:38
+  --> tests/ui-msrv/transmute-mut-src-not-a-reference.rs:17:53
    |
 17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^ expected `&mut _`, found `usize`
+   |                                      ---------------^^^^^^-
+   |                                      |              |
+   |                                      |              expected `&mut _`, found `usize`
+   |                                      |              help: consider mutably borrowing here: `&mut 0usize`
+   |                                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-src-not-a-reference.rs:17:38
-   |
-17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^------^
-   |                                      |              |
-   |                                      |              expected due to this value
-   |                                      expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-asbytes.stderr
@@ -4,12 +4,22 @@ error[E0277]: the trait bound `Src: AsBytes` is not satisfied
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertSrcIsAsBytes`
   --> tests/ui-msrv/transmute-mut-src-not-asbytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this
-   |                                    required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
@@ -4,12 +4,22 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
    |
-note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
    |
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this
-   |                                      required by this bound in `SRC_NOT_FROM_BYTES::transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-unsized.stderr
@@ -5,11 +5,53 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_UNSIZED::transmute`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,11 +72,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                      ^ required by this bound in `std::intrinsics::transmute`
+   |                      ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -130,6 +172,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35

--- a/tests/ui-msrv/transmute-ptr-to-usize.stderr
+++ b/tests/ui-msrv/transmute-ptr-to-usize.stderr
@@ -10,9 +10,28 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
              <f64 as AsBytes>
              <i128 as AsBytes>
            and $N others
-note: required by a bound in `POINTER_VALUE::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `POINTER_VALUE::transmute`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |
+   = help: the following implementations were found:
+             <usize as AsBytes>
+             <f32 as AsBytes>
+             <f64 as AsBytes>
+             <i128 as AsBytes>
+           and $N others
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
@@ -4,9 +4,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:18:42
    |
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DST_UNSIZED::transmute`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,11 +44,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                         ^ required by this bound in `std::intrinsics::transmute`
+   |                         ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -78,3 +78,17 @@ note: required by a bound in `MaxAlignsOf`
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                                ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
@@ -1,9 +1,24 @@
-error[E0614]: type `usize` cannot be dereferenced
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:54
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ---------------^^^^^^-
+   |                                       |              |
+   |                                       |              expected reference, found `usize`
+   |                                       |              help: consider borrowing here: `&0usize`
+   |                                       expected due to this
+   |
+   = note: expected reference `&_`
+                   found type `usize`
+
+error[E0308]: mismatched types
   --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
    |
+   = note:   expected type `usize`
+           found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
@@ -5,11 +5,39 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_DST_UNSIZED::transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsFromBytes`
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,11 +58,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                      ^ required by this bound in `std::intrinsics::transmute`
+   |                      ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -140,6 +168,20 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-a-reference.stderr
@@ -1,7 +1,12 @@
-error[E0614]: type `usize` cannot be dereferenced
-  --> tests/ui-msrv/transmute-ref-src-not-a-reference.rs:17:34
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-not-a-reference.rs:17:49
    |
 17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ---------------^^^^^^-
+   |                                  |              |
+   |                                  |              expected reference, found `usize`
+   |                                  |              help: consider borrowing here: `&0usize`
+   |                                  expected due to this
    |
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: expected reference `&_`
+                   found type `usize`

--- a/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
@@ -4,9 +4,22 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
 18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
    |
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
    |
 18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-unsized.stderr
@@ -5,11 +5,25 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_UNSIZED::transmute`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,11 +44,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<T, U>(e: T) -> U;
-   |                      ^ required by this bound in `std::intrinsics::transmute`
+   |                      ^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -130,6 +144,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31

--- a/tests/ui-msrv/transmute-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-src-not-asbytes.stderr
@@ -4,9 +4,22 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
 18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
    |
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-msrv/transmute-src-not-asbytes.rs:18:32
    |
 18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `SRC_NOT_AS_BYTES::transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-msrv/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/include_value_not_from_bytes.stderr
+++ b/tests/ui-nightly/include_value_not_from_bytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
   --> tests/ui-nightly/include_value_not_from_bytes.rs:12:5
    |
 12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
+   |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/include_value_not_from_bytes.rs:12:5
    |
 12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:18:41
    |
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                         required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:18:41
    |
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-const.stderr
+++ b/tests/ui-nightly/transmute-mut-const.stderr
@@ -22,7 +22,7 @@ error[E0658]: mutable references are not allowed in constants
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<'_, [u8; 2], [u8; 2]>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, [u8; 2], [u8; 2]>` in constants
   --> tests/ui-nightly/transmute-mut-const.rs:20:37
    |
 20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
@@ -17,3 +17,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-asbytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
   --> tests/ui-nightly/transmute-mut-dst-not-asbytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `AsBytes` is not implemented for `Dst`
+   |                                    required by a bound introduced by this call
    |
    = help: the following other types implement trait `AsBytes`:
              bool
@@ -14,12 +17,9 @@ error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertDstIsAsBytes`
   --> tests/ui-nightly/transmute-mut-dst-not-asbytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this function
-   |                                    required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
   --> tests/ui-nightly/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Dst`
+   |                                      required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,12 +17,9 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-nightly/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this function
-   |                                      required by this bound in `transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-unsized.stderr
@@ -2,14 +2,34 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,9 +64,23 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                          ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
@@ -1,30 +1,15 @@
 error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:59
    |
 17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^
-   |                                            |
-   |                                            expected `&mut _`, found `usize`
-   |                                            arguments to this function are incorrect
+   |                                            ---------------^^^^^^-
+   |                                            |              |
+   |                                            |              expected `&mut _`, found `usize`
+   |                                            expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-note: function defined here
-  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+help: consider mutably borrowing here
    |
-17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
-   |
-17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^------^
-   |                                            |              |
-   |                                            |              expected due to this value
-   |                                            expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(&mut 0usize);
+   |                                                           ++++

--- a/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,76 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -127,9 +192,40 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                          ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-immutable.stderr
+++ b/tests/ui-nightly/transmute-mut-src-immutable.stderr
@@ -1,17 +1,11 @@
 error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
+  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:37
    |
 17 |     let _: &mut u8 = transmute_mut!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   |                      |
-   |                      types differ in mutability
-   |                      arguments to this function are incorrect
+   |                      ---------------^^^^-
+   |                      |              |
+   |                      |              types differ in mutability
+   |                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                       found reference `&u8`
-note: function defined here
-  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
-   |
-17 |     let _: &mut u8 = transmute_mut!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
@@ -1,30 +1,15 @@
 error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:53
    |
 17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      expected `&mut _`, found `usize`
-   |                                      arguments to this function are incorrect
+   |                                      ---------------^^^^^^-
+   |                                      |              |
+   |                                      |              expected `&mut _`, found `usize`
+   |                                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-note: function defined here
-  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+help: consider mutably borrowing here
    |
-17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
-   |
-17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^------^
-   |                                      |              |
-   |                                      |              expected due to this value
-   |                                      expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(&mut 0usize);
+   |                                                     ++++

--- a/tests/ui-nightly/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-asbytes.stderr
@@ -17,12 +17,32 @@ error[E0277]: the trait bound `Src: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertSrcIsAsBytes`
   --> tests/ui-nightly/transmute-mut-src-not-asbytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this function
-   |                                    required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
@@ -17,12 +17,32 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
    |
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this function
-   |                                      required by this bound in `transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-unsized.stderr
@@ -8,11 +8,56 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -94,3 +139,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ptr-to-usize.stderr
+++ b/tests/ui-nightly/transmute-ptr-to-usize.stderr
@@ -8,9 +8,23 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
    |                              required by a bound introduced by this call
    |
    = help: the trait `AsBytes` is implemented for `usize`
-note: required by a bound in `POINTER_VALUE::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |
+   = help: the trait `AsBytes` is implemented for `usize`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:18:42
    |
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:18:42
    |
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,9 +47,23 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                                ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -1,9 +1,27 @@
-error[E0614]: type `usize` cannot be dereferenced
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:54
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ---------------^^^^^^-
+   |                                       |              |
+   |                                       |              expected `&_`, found `usize`
+   |                                       expected due to this
+   |
+   = note: expected reference `&_`
+                   found type `usize`
+help: consider borrowing here
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(&0usize);
+   |                                                      +
+
+error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
    |
+   = note:   expected type `usize`
+           found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,28 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsFromBytes`
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -127,9 +144,40 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
    |                           ^^^ required by this bound in `transmute`
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                                ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
@@ -1,7 +1,15 @@
-error[E0614]: type `usize` cannot be dereferenced
-  --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:17:34
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:17:49
    |
 17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ---------------^^^^^^-
+   |                                  |              |
+   |                                  |              expected `&_`, found `usize`
+   |                                  expected due to this
    |
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: expected reference `&_`
+                   found type `usize`
+help: consider borrowing here
+   |
+17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(&0usize);
+   |                                                 +

--- a/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
@@ -17,9 +17,32 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
    |
 18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-unsized.stderr
@@ -8,11 +8,25 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -94,3 +108,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-src-not-asbytes.stderr
@@ -17,9 +17,32 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-nightly/transmute-src-not-asbytes.rs:18:32
    |
 18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-nightly/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/include_value_not_from_bytes.stderr
+++ b/tests/ui-stable/include_value_not_from_bytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
   --> tests/ui-stable/include_value_not_from_bytes.rs:12:5
    |
 12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
+   |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/include_value_not_from_bytes.rs:12:5
    |
 12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:18:41
    |
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                         required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:18:41
    |
 18 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-const.stderr
+++ b/tests/ui-stable/transmute-mut-const.stderr
@@ -21,7 +21,7 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: cannot call non-const fn `CONST_CONTEXT::transmute::<'_, [u8; 2], [u8; 2]>` in constants
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, [u8; 2], [u8; 2]>` in constants
   --> tests/ui-stable/transmute-mut-const.rs:20:37
    |
 20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
@@ -17,3 +17,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-asbytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
   --> tests/ui-stable/transmute-mut-dst-not-asbytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `AsBytes` is not implemented for `Dst`
+   |                                    required by a bound introduced by this call
    |
    = help: the following other types implement trait `AsBytes`:
              bool
@@ -14,12 +17,9 @@ error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `DST_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertDstIsAsBytes`
   --> tests/ui-stable/transmute-mut-dst-not-asbytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this function
-   |                                    required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
   --> tests/ui-stable/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Dst`
+   |                                      required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,12 +17,9 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-stable/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this function
-   |                                      required by this bound in `transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-dst-unsized.stderr
@@ -2,14 +2,34 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,7 +64,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -70,3 +90,17 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
+   |
+17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                          ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-not-references.stderr
@@ -1,30 +1,15 @@
 error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
+  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:59
    |
 17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^
-   |                                            |
-   |                                            expected `&mut _`, found `usize`
-   |                                            arguments to this function are incorrect
+   |                                            ---------------^^^^^^-
+   |                                            |              |
+   |                                            |              expected `&mut _`, found `usize`
+   |                                            expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-note: function defined here
-  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
+help: consider mutably borrowing here
    |
-17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-src-dst-not-references.rs:17:44
-   |
-17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
-   |                                            ^^^^^^^^^^^^^^^------^
-   |                                            |              |
-   |                                            |              expected due to this value
-   |                                            expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(&mut 0usize);
+   |                                                           ++++

--- a/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,76 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertDstIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -50,7 +115,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -164,7 +229,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -190,3 +255,34 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                          ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-immutable.stderr
+++ b/tests/ui-stable/transmute-mut-src-immutable.stderr
@@ -1,17 +1,11 @@
 error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-src-immutable.rs:17:22
+  --> tests/ui-stable/transmute-mut-src-immutable.rs:17:37
    |
 17 |     let _: &mut u8 = transmute_mut!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   |                      |
-   |                      types differ in mutability
-   |                      arguments to this function are incorrect
+   |                      ---------------^^^^-
+   |                      |              |
+   |                      |              types differ in mutability
+   |                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                       found reference `&u8`
-note: function defined here
-  --> tests/ui-stable/transmute-mut-src-immutable.rs:17:22
-   |
-17 |     let _: &mut u8 = transmute_mut!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-a-reference.stderr
@@ -1,30 +1,15 @@
 error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
+  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:53
    |
 17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      expected `&mut _`, found `usize`
-   |                                      arguments to this function are incorrect
+   |                                      ---------------^^^^^^-
+   |                                      |              |
+   |                                      |              expected `&mut _`, found `usize`
+   |                                      expected due to this
    |
    = note: expected mutable reference `&mut _`
                            found type `usize`
-note: function defined here
-  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
+help: consider mutably borrowing here
    |
-17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-src-not-a-reference.rs:17:38
-   |
-17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
-   |                                      ^^^^^^^^^^^^^^^------^
-   |                                      |              |
-   |                                      |              expected due to this value
-   |                                      expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(&mut 0usize);
+   |                                                     ++++

--- a/tests/ui-stable/transmute-mut-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-asbytes.stderr
@@ -17,12 +17,32 @@ error[E0277]: the trait bound `Src: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertSrcIsAsBytes`
   --> tests/ui-stable/transmute-mut-src-not-asbytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    required by a bound in this function
-   |                                    required by this bound in `transmute`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-not-asbytes.rs:24:36
+   |
+24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
@@ -17,12 +17,32 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `SRC_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
    |
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                      |
-   |                                      required by a bound in this function
-   |                                      required by this bound in `transmute`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: FromBytes` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `FromBytes`:
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+             u8
+           and $N others
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
+   |
+24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-unsized.stderr
@@ -8,11 +8,56 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsFromBytes`
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -36,7 +81,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -131,3 +176,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
+   |
+16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_mut`
+  --> src/macro_util.rs
+   |
+   | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                               ^^^ required by this bound in `transmute_mut`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ptr-to-usize.stderr
+++ b/tests/ui-stable/transmute-ptr-to-usize.stderr
@@ -8,9 +8,23 @@ error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
    |                              required by a bound introduced by this call
    |
    = help: the trait `AsBytes` is implemented for `usize`
-note: required by a bound in `POINTER_VALUE::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |
+   = help: the trait `AsBytes` is implemented for `usize`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
+   |
+20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-stable/transmute-ref-dst-mutable.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
@@ -17,3 +17,13 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
@@ -2,7 +2,10 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:18:42
    |
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -14,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:18:42
    |
 18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -44,7 +47,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -70,3 +73,17 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
+   |
+17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                                ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
@@ -1,9 +1,27 @@
-error[E0614]: type `usize` cannot be dereferenced
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:54
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ---------------^^^^^^-
+   |                                       |              |
+   |                                       |              expected `&_`, found `usize`
+   |                                       expected due to this
+   |
+   = note: expected reference `&_`
+                   found type `usize`
+help: consider borrowing here
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(&0usize);
+   |                                                      +
+
+error[E0308]: mismatched types
   --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
    |
+   = note:   expected type `usize`
+           found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,28 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_DST_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsFromBytes`
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -50,7 +67,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -164,7 +181,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -190,3 +207,34 @@ note: required by a bound in `MaxAlignsOf::<T, U>::new`
    |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
    |            --- required by a bound in this associated function
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                                ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-a-reference.stderr
@@ -1,7 +1,15 @@
-error[E0614]: type `usize` cannot be dereferenced
-  --> tests/ui-stable/transmute-ref-src-not-a-reference.rs:17:34
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-not-a-reference.rs:17:49
    |
 17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ---------------^^^^^^-
+   |                                  |              |
+   |                                  |              expected `&_`, found `usize`
+   |                                  expected due to this
    |
-   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: expected reference `&_`
+                   found type `usize`
+help: consider borrowing here
+   |
+17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(&0usize);
+   |                                                 +

--- a/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
@@ -17,9 +17,32 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
    |
 18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+   |
+18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-unsized.stderr
@@ -8,11 +8,25 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `SRC_UNSIZED::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -36,7 +50,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `std::intrinsics::transmute`
+note: required by a bound in `transmute`
   --> $RUST/core/src/intrinsics.rs
    |
    |     pub fn transmute<Src, Dst>(src: Src) -> Dst;
@@ -131,3 +145,20 @@ note: required by a bound in `AlignOf`
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
    = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
+   |
+16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `transmute_ref`
+  --> src/macro_util.rs
+   |
+   | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
+   |                                                     ^^^ required by this bound in `transmute_ref`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-src-not-asbytes.stderr
@@ -17,9 +17,32 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
+note: required by a bound in `AssertIsAsBytes`
   --> tests/ui-stable/transmute-src-not-asbytes.rs:18:32
    |
 18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `transmute`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |
+   = help: the following other types implement trait `AsBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertIsAsBytes`
+  --> tests/ui-stable/transmute-src-not-asbytes.rs:18:32
+   |
+18 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -7,14 +7,14 @@
 # those terms.
 
 [package]
-edition = "2021"
+edition = "2018"
 name = "zerocopy-derive"
-version = "0.7.18"
+version = "0.7.19"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
-rust-version = "1.61.0"
+rust-version = "1.60.0"
 
 exclude = [".*"]
 


### PR DESCRIPTION
Modify the way that certain memory safety properties are validated in our `transmute!`, `transmute_ref!`, and `transmute_mut!` macros to allow that code to compile on 1.60.

Makes progress on https://github.com/google/zerocopy/issues/554

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
