### PR TITLE
[roll-pinned-toolchain-versions] Allow manual trigger

### DIFF
--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -12,6 +12,7 @@ name: Roll pinned toolchain versions
 on:
   schedule:
     - cron: '29 12 * * *'
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Allow triggering manually from the GitHub web UI.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
