### PR TITLE
Deny strict provenance lints during testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@
     unused_qualifications,
     variant_size_differences
 )]
+#![cfg_attr(
+    __INTERNAL_USE_ONLY_NIGHLTY_FEATURES_IN_TESTS,
+    deny(fuzzy_provenance_casts, lossy_provenance_casts)
+)]
 #![deny(
     clippy::all,
     clippy::alloc_instead_of_core,

--- a/src/util.rs
+++ b/src/util.rs
@@ -464,10 +464,11 @@ impl<'a, T: ?Sized> AsAddress for &'a mut T {
 impl<T: ?Sized> AsAddress for *const T {
     #[inline(always)]
     fn addr(self) -> usize {
-        // TODO(https://github.com/rust-lang/rust/issues/95228): Use `.addr()`
-        // instead of `as usize` once it's stable, and get rid of this `allow`.
-        // Currently, `as usize` is the only way to accomplish this.
+        // TODO(#181), TODO(https://github.com/rust-lang/rust/issues/95228): Use
+        // `.addr()` instead of `as usize` once it's stable, and get rid of this
+        // `allow`. Currently, `as usize` is the only way to accomplish this.
         #[allow(clippy::as_conversions)]
+        #[cfg_attr(__INTERNAL_USE_ONLY_NIGHLTY_FEATURES_IN_TESTS, allow(lossy_provenance_casts))]
         return self.cast::<()>() as usize;
     }
 }


### PR DESCRIPTION
When testing in CI on the nightly toolchain, deny the `fuzzy_provenance_casts` and `lossy_provenance_casts` lints.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
