### PR TITLE
Lower MSRV to 1.56

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@
 [package]
 edition = "2018"
 name = "zerocopy"
-version = "0.7.21"
+version = "0.8.0-alpha"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
-rust-version = "1.60.0"
+rust-version = "1.56.0"
 
 exclude = [".*"]
 
@@ -36,8 +36,6 @@ pinned-nightly = "nightly-2023-10-31"
 features = ["__internal_use_only_features_that_work_on_stable"]
 
 [features]
-default = ["byteorder"]
-
 alloc = []
 derive = ["zerocopy-derive"]
 simd = []
@@ -48,7 +46,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.21", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.0-alpha", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -59,7 +57,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.21", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.0-alpha", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -74,6 +72,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.21", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.0-alpha", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+#[path = "src/third_party/libc/build.rs"]
+pub(crate) mod libc;
+
+fn main() {
+    // Avoid unnecessary re-building.
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let (minor, _nightly) = libc::rustc_minor_nightly();
+    if minor >= 57 {
+        println!("cargo:rustc-cfg=zerocopy_panic_in_const_fn");
+    }
+}

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -363,7 +363,9 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.
-    unsafe { &*dst }
+    //
+    // TODO(#67): Once our MSRV is 1.58, replace this `transmute` with `&*dst`.
+    unsafe { core::mem::transmute(dst) }
 }
 
 /// Transmutes a mutable reference of one type to a mutable reference of another

--- a/src/third_party/libc/LICENSE-APACHE
+++ b/src/third_party/libc/LICENSE-APACHE
@@ -1,0 +1,177 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+

--- a/src/third_party/libc/LICENSE-MIT
+++ b/src/third_party/libc/LICENSE-MIT
@@ -1,0 +1,26 @@
+Copyright (c) 2014-2020 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+

--- a/src/third_party/libc/README.fuchsia
+++ b/src/third_party/libc/README.fuchsia
@@ -1,0 +1,7 @@
+Name: libc
+License File: LICENSE-APACHE
+License File: LICENSE-MIT
+Description:
+
+See https://github.com/google/zerocopy/pull/492 for an explanation of why this
+file exists.

--- a/src/third_party/libc/build.rs
+++ b/src/third_party/libc/build.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::process::Command;
+use std::str;
+use std::string::String;
+
+pub(crate) fn rustc_minor_nightly() -> (u32, bool) {
+    macro_rules! otry {
+        ($e:expr) => {
+            match $e {
+                Some(e) => e,
+                None => panic!("Failed to get rustc version"),
+            }
+        };
+    }
+
+    let rustc = otry!(env::var_os("RUSTC"));
+    let output =
+        Command::new(rustc).arg("--version").output().ok().expect("Failed to get rustc version");
+    if !output.status.success() {
+        panic!("failed to run rustc: {}", String::from_utf8_lossy(output.stderr.as_slice()));
+    }
+
+    let version = otry!(str::from_utf8(&output.stdout).ok());
+    let mut pieces = version.split('.');
+
+    if pieces.next() != Some("rustc 1") {
+        panic!("Failed to get rustc version");
+    }
+
+    let minor = pieces.next();
+
+    // If `rustc` was built from a tarball, its version string
+    // will have neither a git hash nor a commit date
+    // (e.g. "rustc 1.39.0"). Treat this case as non-nightly,
+    // since a nightly build should either come from CI
+    // or a git checkout
+    let nightly_raw = otry!(pieces.next()).split('-').nth(1);
+    let nightly = nightly_raw
+        .map(|raw| raw.starts_with("dev") || raw.starts_with("nightly"))
+        .unwrap_or(false);
+    let minor = otry!(otry!(minor).parse().ok());
+
+    (minor, nightly)
+}

--- a/src/third_party/rust/layout.rs
+++ b/src/third_party/rust/layout.rs
@@ -38,6 +38,7 @@ pub(crate) const fn _padding_needed_for(len: usize, align: NonZeroUsize) -> usiz
     // the allocator to yield an error anyway.)
 
     let align = align.get();
+    #[cfg(zerocopy_panic_in_const_fn)]
     debug_assert!(align.is_power_of_two());
     let len_rounded_up = len.wrapping_add(align).wrapping_sub(1) & !align.wrapping_sub(1);
     len_rounded_up.wrapping_sub(len)

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -471,8 +471,9 @@ mod tests {
             // Make sure that `deref_unchecked` is `const`.
             //
             // SAFETY: The `Align<_, AU64>` guarantees proper alignment.
-            let au64 = unsafe { x.t.deref_unchecked() };
-            match au64 {
+            let _au64 = unsafe { x.t.deref_unchecked() };
+            #[cfg(zerocopy_panic_in_const_fn)]
+            match _au64 {
                 AU64(123) => {}
                 _ => unreachable!(),
             }

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -17,7 +17,7 @@ fn ui() {
     let source_files_dirname = version.get_ui_source_files_dirname_and_maybe_print_warning();
 
     let t = trybuild::TestCases::new();
-    t.compile_fail(format!("tests/{source_files_dirname}/*.rs"));
+    t.compile_fail(format!("tests/{}/*.rs", source_files_dirname));
 }
 
 // The file `invalid-impls.rs` directly includes `src/macros.rs` in order to
@@ -37,5 +37,5 @@ fn ui_invalid_impls() {
     let source_files_dirname = version.get_ui_source_files_dirname_and_maybe_print_warning();
 
     let t = trybuild::TestCases::new();
-    t.compile_fail(format!("tests/{source_files_dirname}/invalid-impls/*.rs"));
+    t.compile_fail(format!("tests/{}/invalid-impls/*.rs", source_files_dirname));
 }

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 name = "testutil"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.18.0"

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -40,10 +40,10 @@ impl PinnedVersions {
             .ok_or("failed to find msrv: no `rust-version` key present")?
             .to_string();
         let extract = |version_name, key| -> Result<String, String> {
-            let value = pkg.metadata.pointer(&format!("/ci/{key}")).ok_or_else(|| {
-                format!("failed to find {version_name}: no `metadata.ci.{key}` key present")
+            let value = pkg.metadata.pointer(&format!("/ci/{}", key)).ok_or_else(|| {
+                format!("failed to find {}: no `metadata.ci.{}` key present", version_name, key)
             })?;
-            value.as_str().map(str::to_string).ok_or_else(|| format!("failed to find {version_name}: key `metadata.ci.{key}` (contents: {value:?}) failed to parse as JSON string"))
+            value.as_str().map(str::to_string).ok_or_else(|| format!("failed to find {}: key `metadata.ci.{}` (contents: {:?}) failed to parse as JSON string", version_name, key, value))
         };
         let stable = extract("stable", "pinned-stable")?;
         let nightly = extract("nightly", "pinned-nightly")?;
@@ -85,7 +85,7 @@ impl ToolchainVersion {
             }
             Channel::Stable => {
                 let Version { major, minor, patch, .. } = current.semver;
-                format!("{major}.{minor}.{patch}")
+                format!("{}.{}.{}", major, minor, patch)
             }
         };
 
@@ -116,7 +116,8 @@ impl ToolchainVersion {
             _ if current.channel == Channel::Nightly => ToolchainVersion::OtherNightly,
             _ => {
                 return Err(format!(
-                    "current toolchain ({current:?}) doesn't match any known version"
+                    "current toolchain ({:?}) doesn't match any known version",
+                    current
                 )
                 .into())
             }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,12 +9,12 @@
 [package]
 edition = "2018"
 name = "zerocopy-derive"
-version = "0.7.21"
+version = "0.8.0-alpha"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
-rust-version = "1.60.0"
+rust-version = "1.56.0"
 
 exclude = [".*"]
 
@@ -34,4 +34,4 @@ testutil = { path = "../testutil" }
 # sometimes change the output format slightly, so a version mismatch can cause
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
-zerocopy = { path = "../", features = ["default", "derive"] }
+zerocopy = { path = "../", features = ["derive"] }


### PR DESCRIPTION
In order to do this, we make a few changes:
- In 1.56, panicking is not supported in `const fn`s. In order to
  support 1.56 while still panicking in `const fn`s in later versions,
  we make a few changes:
  - We introduce a `build.rs` script which detects the Rust toolchain
    version and emits the cfg `zerocopy_panic_in_const_fn` if the Rust
    version is at least 1.57.
  - In some `const fn`s, we put debug assertions behind
    `#[cfg(zerocopy_panic_in_const_fn)]`.
  - In some `const fn`s, we replace `unreachable!()` with non-panicking
    code when `#[cfg(not(zerocopy_panic_in_const_fn))]`.
  - In one case, we compile a method as either a `const fn` or a
    non-`const fn` depending on `zerocopy_panic_in_const_fn`.
- We replace `&*dst` with `transmute(dst)`.
- We make sure that, in `impl` blocks, `const` parameters always come
  last.
- We make the `byteorder` feature/crate dependency off by default. This
  is a breaking change, and so we bump the version number to
  0.8.0-alpha.

Release 0.8.0-alpha.

Makes progress on https://github.com/google/zerocopy/issues/554