### PR TITLE
[byteorder] Remove byteorder feature and crate dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,6 @@ pinned-nightly = "nightly-2024-01-11"
 features = ["__internal_use_only_features_that_work_on_stable"]
 
 [features]
-default = ["byteorder"]
-
 alloc = []
 derive = ["zerocopy-derive"]
 simd = []
@@ -50,11 +48,6 @@ __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
 zerocopy-derive = { version = "=0.8.0-alpha.2", path = "zerocopy-derive", optional = true }
-
-[dependencies.byteorder]
-version = "1.3"
-default-features = false
-optional = true
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.

--- a/README.md
+++ b/README.md
@@ -49,15 +49,6 @@ for network parsing.
   the `alloc` crate is added as a dependency, and some allocation-related
   functionality is added.
 
-- **`byteorder`** (enabled by default)
-  Adds the `byteorder` module and a dependency on the `byteorder` crate.
-  The `byteorder` module provides byte order-aware equivalents of the
-  multi-byte primitive numerical types. Unlike their primitive equivalents,
-  the types in this module have no alignment requirement and support byte
-  order conversions. This can be useful in handling file formats, network
-  packet layouts, etc which don't provide alignment guarantees and which may
-  use a byte order different from that of the execution platform.
-
 - **`derive`**
   Provides derives for the core marker traits via the `zerocopy-derive`
   crate. These derives are re-exported from `zerocopy`, so it is not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,15 +49,6 @@
 //!   the `alloc` crate is added as a dependency, and some allocation-related
 //!   functionality is added.
 //!
-//! - **`byteorder`** (enabled by default)   
-//!   Adds the [`byteorder`] module and a dependency on the `byteorder` crate.
-//!   The `byteorder` module provides byte order-aware equivalents of the
-//!   multi-byte primitive numerical types. Unlike their primitive equivalents,
-//!   the types in this module have no alignment requirement and support byte
-//!   order conversions. This can be useful in handling file formats, network
-//!   packet layouts, etc which don't provide alignment guarantees and which may
-//!   use a byte order different from that of the execution platform.
-//!
 //! - **`derive`**   
 //!   Provides derives for the core marker traits via the `zerocopy-derive`
 //!   crate. These derives are re-exported from `zerocopy`, so it is not
@@ -245,8 +236,6 @@ extern crate self as zerocopy;
 #[macro_use]
 mod macros;
 
-#[cfg(feature = "byteorder")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "byteorder")))]
 pub mod byteorder;
 #[doc(hidden)]
 pub mod macro_util;
@@ -257,8 +246,6 @@ mod util;
 // TODO(#252): If we make this pub, come up with a better name.
 mod wrappers;
 
-#[cfg(feature = "byteorder")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "byteorder")))]
 pub use crate::byteorder::*;
 pub use crate::wrappers::*;
 

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -39,4 +39,4 @@ testutil = { path = "../testutil" }
 # sometimes change the output format slightly, so a version mismatch can cause
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
-zerocopy = { path = "../", features = ["default", "derive"] }
+zerocopy = { path = "../", features = ["derive"] }


### PR DESCRIPTION
Remove the `byteorder` feature and the dependency on the `byteorder` crate. Replace the `ByteOrder` trait and types which implement it from the `byteorder` crate with our own native implementations. This allows us to make some of our functions and methods `const`.

Add `Usize` and `Isize` byte order-aware types.

Closes #438

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
