### PR TITLE
[macro_util] Add comment to core_reexport

### DIFF
--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -398,7 +398,8 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 }
 
 // NOTE: We can't change this to a `pub use core as core_reexport` until [1] is
-// fixed or we release a semver-breaking version (as of this writing, 0.8.0).
+// fixed or we update to a semver-breaking version (as of this writing, 0.8.0)
+// on the `main` branch.
 //
 // [1] https://github.com/obi1kenobi/cargo-semver-checks/issues/573
 pub mod core_reexport {

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -397,6 +397,10 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     unsafe { &mut *dst }
 }
 
+// NOTE: We can't change this to a `pub use core as core_reexport` until [1] is
+// fixed or we release a semver-breaking version (as of this writing, 0.8.0).
+//
+// [1] https://github.com/obi1kenobi/cargo-semver-checks/issues/573
 pub mod core_reexport {
     pub use core::*;
 


### PR DESCRIPTION
Add a comment explaining why we don't change core_reexport to `pub use core as core_reexport`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
