### PR TITLE
Add `DstLayout::extend`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -512,6 +512,22 @@ pub(crate) const fn _round_down_to_next_multiple_of_alignment(
     n & mask
 }
 
+pub(crate) const fn max(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
+    if a.get() < b.get() {
+        b
+    } else {
+        a
+    }
+}
+
+pub(crate) const fn min(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
+    if a.get() > b.get() {
+        b
+    } else {
+        a
+    }
+}
+
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those

--- a/tests/ui-msrv/max-align.rs
+++ b/tests/ui-msrv/max-align.rs
@@ -1,0 +1,1 @@
+../ui-nightly/max-align.rs

--- a/tests/ui-msrv/max-align.stderr
+++ b/tests/ui-msrv/max-align.stderr
@@ -1,0 +1,5 @@
+error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+  --> tests/ui-msrv/max-align.rs:96:11
+   |
+96 | #[repr(C, align(1073741824))]
+   |           ^^^^^^^^^^^^^^^^^

--- a/tests/ui-nightly/max-align.rs
+++ b/tests/ui-nightly/max-align.rs
@@ -1,0 +1,99 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#[repr(C, align(1))]
+struct Align1;
+
+#[repr(C, align(2))]
+struct Align2;
+
+#[repr(C, align(4))]
+struct Align4;
+
+#[repr(C, align(8))]
+struct Align8;
+
+#[repr(C, align(16))]
+struct Align16;
+
+#[repr(C, align(32))]
+struct Align32;
+
+#[repr(C, align(64))]
+struct Align64;
+
+#[repr(C, align(128))]
+struct Align128;
+
+#[repr(C, align(256))]
+struct Align256;
+
+#[repr(C, align(512))]
+struct Align512;
+
+#[repr(C, align(1024))]
+struct Align1024;
+
+#[repr(C, align(2048))]
+struct Align2048;
+
+#[repr(C, align(4096))]
+struct Align4096;
+
+#[repr(C, align(8192))]
+struct Align8192;
+
+#[repr(C, align(16384))]
+struct Align16384;
+
+#[repr(C, align(32768))]
+struct Align32768;
+
+#[repr(C, align(65536))]
+struct Align65536;
+
+#[repr(C, align(131072))]
+struct Align131072;
+
+#[repr(C, align(262144))]
+struct Align262144;
+
+#[repr(C, align(524288))]
+struct Align524288;
+
+#[repr(C, align(1048576))]
+struct Align1048576;
+
+#[repr(C, align(2097152))]
+struct Align2097152;
+
+#[repr(C, align(4194304))]
+struct Align4194304;
+
+#[repr(C, align(8388608))]
+struct Align8388608;
+
+#[repr(C, align(16777216))]
+struct Align16777216;
+
+#[repr(C, align(33554432))]
+struct Align33554432;
+
+#[repr(C, align(67108864))]
+struct Align67108864;
+
+#[repr(C, align(134217728))]
+struct Align13421772;
+
+#[repr(C, align(268435456))]
+struct Align26843545;
+
+#[repr(C, align(1073741824))]
+struct Align1073741824;
+
+fn main() {}

--- a/tests/ui-nightly/max-align.stderr
+++ b/tests/ui-nightly/max-align.stderr
@@ -1,0 +1,5 @@
+error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+  --> tests/ui-nightly/max-align.rs:96:11
+   |
+96 | #[repr(C, align(1073741824))]
+   |           ^^^^^^^^^^^^^^^^^

--- a/tests/ui-stable/max-align.rs
+++ b/tests/ui-stable/max-align.rs
@@ -1,0 +1,1 @@
+../ui-nightly/max-align.rs

--- a/tests/ui-stable/max-align.stderr
+++ b/tests/ui-stable/max-align.stderr
@@ -1,0 +1,5 @@
+error[E0589]: invalid `repr(align)` attribute: larger than 2^29
+  --> tests/ui-stable/max-align.rs:96:11
+   |
+96 | #[repr(C, align(1073741824))]
+   |           ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`DstLayout::extend` is comparable to `alloc::Layout`, except that it additionally handles DSTs. This is the first of two steps needed for `DstLayout` to support an API in the form of:

```rust
// For illustrative purposes; `align` and `packed`
// can't actually be combined like this.
#[repr(C, align(2), packed(4))]
struct ReprCStruct<T, U, V> {
    foo: Foo<T>,
    bar: Bar<U>,
    baz: Baz<V>,
}

impl<T, U, V> KnownLayout for ReprCStruct<T, U, V> {
    const LAYOUT: DstLayout = {
        use ::zerocopy::macro_utils::core_reexport::num::NonZeroUsize;
        use ::zerocopy::DstLayout;

        let min_align = NonZeroUsize::new(2); // or `None`, w/o `align`
        let max_align = NonZeroUsize::new(4); // or `None`, w/o `packed`

        DstLayout::for_type::<()>()
            .extend(<Foo<T> as KnownLayout>::LAYOUT, max_align)
            .extend(<Bar<T> as KnownLayout>::LAYOUT, max_align)
            .extend(<Baz<T> as KnownLayout>::LAYOUT, max_align)
            .pad_to_align(min_align, max_align)
    };
}
```
(The next step is implementing `DstLayout::pad_to_align`). 

Despite the similarities between `DstLayout::extend` and `Layout::extend`, the former cannot be implemented in terms of the latter because `Layout::extend` is not `const`. This introduces a risk that our computations here diverge from those in `Layout::extend`, but this PR also includes Kani proofs that `DstLayout::extend` behaves comparably to `Layout::extend`.

Makes progress towards #29.