### PR TITLE
Handle const generics and bounded lifetimes in derives

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -606,14 +606,21 @@ fn impl_block<D: DataExt>(
         }
         quote!(#param)
     });
+
     // The identifiers of the parameters without trait bounds or type defaults.
     let param_idents = input.generics.params.iter().map(|param| match param {
         GenericParam::Type(ty) => {
             let ident = &ty.ident;
             quote!(#ident)
         }
-        GenericParam::Lifetime(l) => quote!(#l),
-        GenericParam::Const(cnst) => quote!(#cnst),
+        GenericParam::Lifetime(l) => {
+            let ident = &l.lifetime;
+            quote!(#ident)
+        }
+        GenericParam::Const(cnst) => {
+            let ident = &cnst.ident;
+            quote!({#ident})
+        }
     });
 
     quote! {

--- a/zerocopy-derive/tests/enum_known_layout.rs
+++ b/zerocopy-derive/tests/enum_known_layout.rs
@@ -6,7 +6,7 @@
 
 mod util;
 
-use {static_assertions::assert_impl_all, zerocopy::KnownLayout};
+use {core::marker::PhantomData, static_assertions::assert_impl_all, zerocopy::KnownLayout};
 
 #[derive(KnownLayout)]
 enum Foo {
@@ -29,3 +29,18 @@ enum Baz {
 }
 
 assert_impl_all!(Baz: KnownLayout);
+
+// Deriving `KnownLayout` should work if the enum has bounded parameters.
+
+#[derive(KnownLayout)]
+#[repr(C)]
+enum WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + KnownLayout>
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + KnownLayout,
+{
+    Variant([T; N], PhantomData<&'a &'b ()>),
+}
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: KnownLayout);

--- a/zerocopy-derive/tests/struct_as_bytes.rs
+++ b/zerocopy-derive/tests/struct_as_bytes.rs
@@ -132,3 +132,18 @@ struct Unsized {
 }
 
 assert_impl_all!(Unsized: AsBytes);
+
+// Deriving `AsBytes` should work if the struct has bounded parameters.
+
+#[derive(AsBytes)]
+#[repr(transparent)]
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + AsBytes>(
+    [T; N],
+    PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + AsBytes;
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: AsBytes);

--- a/zerocopy-derive/tests/struct_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_from_bytes.rs
@@ -62,3 +62,18 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);
 assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: FromBytes);
 assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromBytes);
+
+// Deriving `FromBytes` should work if the struct has bounded parameters.
+
+#[derive(FromZeroes, FromBytes)]
+#[repr(transparent)]
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromBytes>(
+    [T; N],
+    PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + FromBytes;
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromBytes);

--- a/zerocopy-derive/tests/struct_from_zeroes.rs
+++ b/zerocopy-derive/tests/struct_from_zeroes.rs
@@ -60,3 +60,18 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeroes);
 assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: FromZeroes);
 assert_impl_all!(TypeParams<'static, [AU16], IntoIter<()>>: FromZeroes);
+
+// Deriving `FromZeroes` should work if the struct has bounded parameters.
+
+#[derive(FromZeroes)]
+#[repr(transparent)]
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeroes>(
+    [T; N],
+    PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + FromZeroes;
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeroes);

--- a/zerocopy-derive/tests/struct_known_layout.rs
+++ b/zerocopy-derive/tests/struct_known_layout.rs
@@ -45,3 +45,18 @@ struct TypeParams<'a, T, I: Iterator> {
 
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: KnownLayout);
 assert_impl_all!(TypeParams<'static, AU16, IntoIter<()>>: KnownLayout);
+
+// Deriving `KnownLayout` should work if the struct has bounded parameters.
+
+#[derive(KnownLayout)]
+#[repr(C)]
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + KnownLayout>(
+    [T; N],
+    PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + KnownLayout;
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: KnownLayout);

--- a/zerocopy-derive/tests/struct_unaligned.rs
+++ b/zerocopy-derive/tests/struct_unaligned.rs
@@ -83,3 +83,18 @@ struct TypeParams<'a, T: ?Sized, I: Iterator> {
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: Unaligned);
 assert_impl_all!(TypeParams<'static, u8, IntoIter<()>>: Unaligned);
 assert_impl_all!(TypeParams<'static, [u8], IntoIter<()>>: Unaligned);
+
+// Deriving `Unaligned` should work if the struct has bounded parameters.
+
+#[derive(Unaligned)]
+#[repr(transparent)]
+struct WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + Unaligned>(
+    [T; N],
+    PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + Unaligned;
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: Unaligned);

--- a/zerocopy-derive/tests/union_from_bytes.rs
+++ b/zerocopy-derive/tests/union_from_bytes.rs
@@ -54,3 +54,19 @@ where
 }
 
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromBytes);
+
+// Deriving `FromBytes` should work if the union has bounded parameters.
+
+#[derive(FromZeroes, FromBytes)]
+#[repr(C)]
+union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromBytes>
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + Copy + FromBytes,
+{
+    a: [T; N],
+    b: PhantomData<&'a &'b ()>,
+}
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromBytes);

--- a/zerocopy-derive/tests/union_from_zeroes.rs
+++ b/zerocopy-derive/tests/union_from_zeroes.rs
@@ -54,3 +54,19 @@ where
 }
 
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: FromZeroes);
+
+// Deriving `FromZeroes` should work if the union has bounded parameters.
+
+#[derive(FromZeroes)]
+#[repr(C)]
+union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + FromZeroes>
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + Copy + FromZeroes,
+{
+    a: [T; N],
+    b: PhantomData<&'a &'b ()>,
+}
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: FromZeroes);

--- a/zerocopy-derive/tests/union_known_layout.rs
+++ b/zerocopy-derive/tests/union_known_layout.rs
@@ -47,3 +47,19 @@ where
 }
 
 assert_impl_all!(TypeParams<'static, (), IntoIter<()>>: KnownLayout);
+
+// Deriving `KnownLayout` should work if the union has bounded parameters.
+
+#[derive(KnownLayout)]
+#[repr(C)]
+union WithParams<'a: 'b, 'b: 'a, const N: usize, T: 'a + 'b + KnownLayout>
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + Copy + KnownLayout,
+{
+    a: [T; N],
+    b: PhantomData<&'a &'b ()>,
+}
+
+assert_impl_all!(WithParams<'static, 'static, 42, u8>: KnownLayout);


### PR DESCRIPTION
Previously, the derive was not stripping out inline bounds.

Fixes #653
