### PR TITLE
[derive] Fix AsBytes for `#[repr(C, packed(N))]`

### DIFF
--- a/zerocopy-derive/tests/struct_as_bytes.rs
+++ b/zerocopy-derive/tests/struct_as_bytes.rs
@@ -80,6 +80,18 @@ struct CPacked {
 assert_impl_all!(CPacked: AsBytes);
 
 #[derive(AsBytes)]
+#[repr(C, packed(2))]
+// The same caveats as for CPacked apply - we're assuming u64 is at least
+// 4-byte aligned by default. Without packed(2), this should fail, as there
+// would be padding between a/b assuming u64 is 4+ byte aligned.
+struct CPacked2 {
+    a: u16,
+    b: u64,
+}
+
+assert_impl_all!(CPacked2: AsBytes);
+
+#[derive(AsBytes)]
 #[repr(C, packed)]
 struct CPackedGeneric<T, U: ?Sized> {
     t: T,

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -7,39 +7,39 @@ error: unsupported on generic structs that are not repr(transparent) or repr(pac
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:71:11
+  --> tests/ui-msrv/struct.rs:80:11
    |
-71 | #[repr(C, align(2))]
+80 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:75:21
+  --> tests/ui-msrv/struct.rs:84:21
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |                     ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:81:16
+  --> tests/ui-msrv/struct.rs:90:16
    |
-81 | #[repr(packed, align(2))]
+90 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:85:18
+  --> tests/ui-msrv/struct.rs:94:18
    |
-85 | #[repr(align(1), align(2))]
+94 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/struct.rs:89:8
+  --> tests/ui-msrv/struct.rs:98:8
    |
-89 | #[repr(align(2), align(4))]
+98 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> tests/ui-msrv/struct.rs:75:8
+  --> tests/ui-msrv/struct.rs:84:8
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -95,6 +95,17 @@ error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is n
    |
 59 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
+   |
+   = help: the following implementations were found:
+             <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+   = help: see issue #48214
+   = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `HasPadding<AsBytes3, true>: ShouldBe<false>` is not satisfied
+  --> tests/ui-msrv/struct.rs:66:10
+   |
+66 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes3, true>`
    |
    = help: the following implementations were found:
              <HasPadding<T, VALUE> as ShouldBe<VALUE>>

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -63,6 +63,15 @@ struct AsBytes2 {
     bar: AU16,
 }
 
+#[derive(AsBytes)]
+#[repr(C, packed(2))]
+struct AsBytes3 {
+    foo: u8,
+    // We'd prefer to use AU64 here, but you can't use aligned types in
+    // packed structs.
+    bar: u64,
+}
+
 //
 // Unaligned errors
 //

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -7,39 +7,39 @@ error: unsupported on generic structs that are not repr(transparent) or repr(pac
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:71:11
+  --> tests/ui-nightly/struct.rs:80:11
    |
-71 | #[repr(C, align(2))]
+80 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:75:21
+  --> tests/ui-nightly/struct.rs:84:21
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |                     ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:81:16
+  --> tests/ui-nightly/struct.rs:90:16
    |
-81 | #[repr(packed, align(2))]
+90 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:85:18
+  --> tests/ui-nightly/struct.rs:94:18
    |
-85 | #[repr(align(1), align(2))]
+94 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/struct.rs:89:8
+  --> tests/ui-nightly/struct.rs:98:8
    |
-89 | #[repr(align(2), align(4))]
+98 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> tests/ui-nightly/struct.rs:75:8
+  --> tests/ui-nightly/struct.rs:84:8
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -125,8 +125,19 @@ error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is n
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0587]: type has conflicting packed and align representation hints
-  --> tests/ui-nightly/struct.rs:82:1
+error[E0277]: the trait bound `HasPadding<AsBytes3, true>: ShouldBe<false>` is not satisfied
+  --> tests/ui-nightly/struct.rs:66:10
    |
-82 | struct Unaligned3;
+66 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes3, true>`
+   |
+   = help: the trait `ShouldBe<true>` is implemented for `HasPadding<AsBytes3, true>`
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0587]: type has conflicting packed and align representation hints
+  --> tests/ui-nightly/struct.rs:91:1
+   |
+91 | struct Unaligned3;
    | ^^^^^^^^^^^^^^^^^

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -7,39 +7,39 @@ error: unsupported on generic structs that are not repr(transparent) or repr(pac
    = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/struct.rs:71:11
+  --> tests/ui-stable/struct.rs:80:11
    |
-71 | #[repr(C, align(2))]
+80 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/struct.rs:75:21
+  --> tests/ui-stable/struct.rs:84:21
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |                     ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/struct.rs:81:16
+  --> tests/ui-stable/struct.rs:90:16
    |
-81 | #[repr(packed, align(2))]
+90 | #[repr(packed, align(2))]
    |                ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/struct.rs:85:18
+  --> tests/ui-stable/struct.rs:94:18
    |
-85 | #[repr(align(1), align(2))]
+94 | #[repr(align(1), align(2))]
    |                  ^^^^^^^^
 
 error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/struct.rs:89:8
+  --> tests/ui-stable/struct.rs:98:8
    |
-89 | #[repr(align(2), align(4))]
+98 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> tests/ui-stable/struct.rs:75:8
+  --> tests/ui-stable/struct.rs:84:8
    |
-75 | #[repr(transparent, align(2))]
+84 | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -115,6 +115,16 @@ error[E0277]: the trait bound `HasPadding<AsBytes2, true>: ShouldBe<false>` is n
    |
 59 | #[derive(AsBytes)]
    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes2, true>`
+   |
+   = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
+   = help: see issue #48214
+   = note: this error originates in the derive macro `AsBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `HasPadding<AsBytes3, true>: ShouldBe<false>` is not satisfied
+  --> tests/ui-stable/struct.rs:66:10
+   |
+66 | #[derive(AsBytes)]
+   |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<AsBytes3, true>`
    |
    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
    = help: see issue #48214


### PR DESCRIPTION
`packed(N)` does not gaurantee no padding, but it doesn't prevent it either. This was previously supported.

This regressed in #643 (left out of the commit message because of the requirement not to link to review sites).