### PR TITLE
Traits other than `NoCell` permit `UnsafeCell`s

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -35,10 +35,10 @@
 //!
 //! ```rust,edition2021
 //! # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
-//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeros, Ref, Unaligned};
+//! use zerocopy::{AsBytes, ByteSlice, FromBytes, FromZeros, NoCell, Ref, Unaligned};
 //! use zerocopy::byteorder::network_endian::U16;
 //!
-//! #[derive(FromZeros, FromBytes, AsBytes, Unaligned)]
+//! #[derive(FromZeros, FromBytes, AsBytes, NoCell, Unaligned)]
 //! #[repr(C)]
 //! struct UdpHeader {
 //!     src_port: U16,
@@ -655,7 +655,7 @@ mod tests {
     use compatibility::*;
 
     // A native integer type (u16, i32, etc).
-    trait Native: Arbitrary + FromBytes + AsBytes + Copy + PartialEq + Debug {
+    trait Native: Arbitrary + FromBytes + AsBytes + NoCell + Copy + PartialEq + Debug {
         const ZERO: Self;
         const MAX_VALUE: Self;
 
@@ -692,7 +692,7 @@ mod tests {
     }
 
     trait ByteArray:
-        FromBytes + AsBytes + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq
+        FromBytes + AsBytes + NoCell + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq
     {
         /// Invert the order of the bytes in the array.
         fn invert(self) -> Self;

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -342,8 +342,8 @@ macro_rules! assert_size_eq {
 /// # Safety
 ///
 /// The caller must guarantee that:
-/// - `Src: AsBytes`
-/// - `Dst: FromBytes`
+/// - `Src: AsBytes + NoCell`
+/// - `Dst: FromBytes + NoCell`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
 #[inline(always)]
@@ -358,8 +358,8 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     //   caller has guaranteed that `Src: AsBytes`, `Dst: FromBytes`, and
     //   `size_of::<Src>() == size_of::<Dst>()`.
     // - We know that there are no `UnsafeCell`s, and thus we don't have to
-    //   worry about `UnsafeCell` overlap, because `Src: AsBytes` and `Dst:
-    //   FromBytes` both forbid `UnsafeCell`s.
+    //   worry about `UnsafeCell` overlap, because `Src: NoCell` and `Dst:
+    //   NoCell`.
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.
@@ -372,10 +372,11 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 /// # Safety
 ///
 /// The caller must guarantee that:
-/// - `Src: FromBytes + AsBytes`
-/// - `Dst: FromBytes + AsBytes`
+/// - `Src: FromBytes + AsBytes + NoCell`
+/// - `Dst: FromBytes + AsBytes + NoCell`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
+// TODO(#686): Consider removing the `NoCell` requirement.
 #[inline(always)]
 pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     src: &'src mut Src,
@@ -389,8 +390,8 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     //   AsBytes`, `Dst: FromBytes + AsBytes`, and `size_of::<Src>() ==
     //   size_of::<Dst>()`.
     // - We know that there are no `UnsafeCell`s, and thus we don't have to
-    //   worry about `UnsafeCell` overlap, because `Src: FromBytes + AsBytes`
-    //   and `Dst: FromBytes + AsBytes` forbid `UnsafeCell`s.
+    //   worry about `UnsafeCell` overlap, because `Src: NoCell`
+    //   and `Dst: NoCell`.
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.

--- a/tests/ui-msrv/include_value_not_from_bytes.stderr
+++ b/tests/ui-msrv/include_value_not_from_bytes.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
-  --> tests/ui-msrv/include_value_not_from_bytes.rs:12:5
+error[E0277]: the trait bound `NotZerocopy<u32>: FromBytes` is not satisfied
+  --> tests/ui-msrv/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
    |
 note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-msrv/include_value_not_from_bytes.rs:12:5
+  --> tests/ui-msrv/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
@@ -37,3 +37,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-msrv/transmute-mut-dst-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-nocell.rs

--- a/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Dst`
+   |
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-unsized.stderr
@@ -5,25 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
@@ -1,7 +1,7 @@
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `T` (this type does not have a fixed size)
@@ -9,9 +9,9 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)

--- a/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -19,11 +19,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -33,53 +33,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-mut-src-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-generic.stderr
@@ -1,7 +1,7 @@
 error[E0405]: cannot find trait `FromBytes` in this scope
   --> tests/ui-msrv/transmute-mut-src-generic.rs:15:31
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
    |                               ^^^^^^^^^ not found in this scope
    |
 help: consider importing this trait

--- a/tests/ui-msrv/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-msrv/transmute-mut-src-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-nocell.rs

--- a/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -19,39 +19,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:18:42
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
    |
-note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:18:42
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui-msrv/transmute-ref-dst-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-nocell.rs

--- a/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Dst`
+   |
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
@@ -40,3 +40,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -19,11 +19,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -33,11 +33,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-asbytes.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-msrv/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-not-nocell.rs
+++ b/tests/ui-msrv/transmute-ref-src-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-nocell.rs

--- a/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-unsized.stderr
@@ -5,11 +5,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -19,11 +19,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/include_value_not_from_bytes.rs
+++ b/tests/ui-nightly/include_value_not_from_bytes.rs
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+include!("../../zerocopy-derive/tests/util.rs");
+
 #[macro_use]
 extern crate zerocopy;
 
 fn main() {}
 
-// Should fail because `UnsafeCell<u32>: !FromBytes`.
-const NOT_FROM_BYTES: core::cell::UnsafeCell<u32> =
-    include_value!("../../testdata/include_value/data");
+// Should fail because `NotZerocopy<u32>: !FromBytes`.
+const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");

--- a/tests/ui-nightly/include_value_not_from_bytes.stderr
+++ b/tests/ui-nightly/include_value_not_from_bytes.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
-  --> tests/ui-nightly/include_value_not_from_bytes.rs:12:5
+error[E0277]: the trait bound `NotZerocopy<u32>: FromBytes` is not satisfied
+  --> tests/ui-nightly/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
-   |     required by a bound introduced by this call
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
+   |                                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -18,8 +18,8 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
              u8
            and $N others
 note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-nightly/include_value_not_from_bytes.rs:12:5
+  --> tests/ui-nightly/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, AsBytes, FromBytes};
+use zerocopy::{transmute_mut, AsBytes, FromBytes, NoCell};
 
 fn main() {}
 
-fn transmute_mut<T: AsBytes + FromBytes>(u: &mut u8) -> &mut T {
+fn transmute_mut<T: AsBytes + FromBytes + NoCell>(u: &mut u8) -> &mut T {
     // `transmute_mut!` requires the destination type to be concrete.
     transmute_mut!(u)
 }

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
@@ -37,3 +37,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-asbytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::AsBytes)]
+#[derive(zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the destination type implements `NoCell`
+const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   the trait `NoCell` is not implemented for `Dst`
+   |                                   required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-unsized.stderr
@@ -8,28 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                doesn't have a size known at compile-time
-   |                                required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-nightly/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/transmute-mut-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-dst-generic.rs
@@ -8,11 +8,13 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, AsBytes, FromBytes};
+use zerocopy::{transmute_mut, AsBytes, FromBytes, NoCell};
 
 fn main() {}
 
-fn transmute_mut<T: AsBytes + FromBytes, U: AsBytes + FromBytes>(t: &mut T) -> &mut U {
+fn transmute_mut<T: AsBytes + FromBytes + NoCell, U: AsBytes + FromBytes + NoCell>(
+    t: &mut T,
+) -> &mut U {
     // `transmute_mut!` requires the source and destination types to be
     // concrete.
     transmute_mut!(t)

--- a/tests/ui-nightly/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-generic.stderr
@@ -1,7 +1,7 @@
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `T` (this type does not have a fixed size)
@@ -9,9 +9,9 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-nightly/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)

--- a/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -39,59 +39,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    doesn't have a size known at compile-time
-   |                                    required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    doesn't have a size known at compile-time
-   |                                    required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-nightly/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/transmute-mut-src-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, AsBytes};
+use zerocopy::{transmute_mut, AsBytes, NoCell};
 
 fn main() {}
 
-fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
     // `transmute_mut!` requires the source type to be concrete.
     transmute_mut!(t)
 }

--- a/tests/ui-nightly/transmute-mut-src-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-src-generic.stderr
@@ -1,7 +1,7 @@
 error[E0405]: cannot find trait `FromBytes` in this scope
   --> tests/ui-nightly/transmute-mut-src-generic.rs:15:31
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
    |                               ^^^^^^^^^ not found in this scope
    |
 help: consider importing this trait

--- a/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-asbytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::AsBytes)]
+#[derive(zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+extern crate zerocopy;
+
+use zerocopy::transmute_mut;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes)]
+#[repr(C)]
+struct Src;
+
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::NoCell)]
+#[repr(C)]
+struct Dst;
+
+// `transmute_mut` requires that the source type implements `NoCell`
+const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
@@ -1,0 +1,48 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   the trait `NoCell` is not implemented for `Src`
+   |                                   required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-mut-src-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,42 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   doesn't have a size known at compile-time
-   |                                   required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-nightly/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/transmute-ref-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, FromBytes};
+use zerocopy::{transmute_ref, FromBytes, NoCell};
 
 fn main() {}
 
-fn transmute_ref<T: FromBytes>(u: &u8) -> &T {
+fn transmute_ref<T: FromBytes + NoCell>(u: &u8) -> &T {
     // `transmute_ref!` requires the destination type to be concrete.
     transmute_ref!(u)
 }

--- a/tests/ui-nightly/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
@@ -14,5 +14,9 @@ use zerocopy::transmute_ref;
 
 fn main() {}
 
+#[derive(zerocopy::NoCell)]
+#[repr(transparent)]
+struct Dst(AU16);
+
 // `transmute_ref` requires that the destination type implements `FromBytes`
-const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
+const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:18:42
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                          |
-   |                                          the trait `FromBytes` is not implemented for `NotZerocopy`
-   |                                          required by a bound introduced by this call
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `FromBytes` is not implemented for `Dst`
+   |                                  required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:18:42
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
+#[repr(transparent)]
+struct Dst(AU16);
+
+// `transmute_ref` requires that the destination type implements `NoCell`
+const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               the trait `NoCell` is not implemented for `Dst`
+   |                               required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-nightly/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/transmute-ref-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, AsBytes, FromBytes};
+use zerocopy::{transmute_ref, AsBytes, FromBytes, NoCell};
 
 fn main() {}
 
-fn transmute_ref<T: AsBytes, U: FromBytes>(t: &T) -> &U {
+fn transmute_ref<T: AsBytes + NoCell, U: FromBytes + NoCell>(t: &T) -> &U {
     // `transmute_ref!` requires the source and destination types to be
     // concrete.
     transmute_ref!(t)

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -43,3 +43,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -39,11 +39,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-nightly/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-nightly/transmute-ref-src-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, AsBytes};
+use zerocopy::{transmute_ref, AsBytes, NoCell};
 
 fn main() {}
 
-fn transmute_ref<T: AsBytes>(t: &T) -> &u8 {
+fn transmute_ref<T: AsBytes + NoCell>(t: &T) -> &u8 {
     // `transmute_ref!` requires the source type to be concrete.
     transmute_ref!(t)
 }

--- a/tests/ui-nightly/transmute-ref-src-not-asbytes.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-asbytes.rs
@@ -14,5 +14,9 @@ use zerocopy::transmute_ref;
 
 fn main() {}
 
+#[derive(zerocopy::NoCell)]
+#[repr(transparent)]
+struct Src(AU16);
+
 // `transmute_ref` requires that the source type implements `AsBytes`
-const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
+const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));

--- a/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-asbytes.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                 |
-   |                                 the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                 the trait `AsBytes` is not implemented for `Src`
    |                                 required by a bound introduced by this call
    |
    = help: the following other types implement trait `AsBytes`:
@@ -17,18 +17,18 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
    = help: the following other types implement trait `AsBytes`:
              bool
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-nightly/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-nocell.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+include!("../../zerocopy-derive/tests/util.rs");
+
+extern crate zerocopy;
+
+use zerocopy::transmute_ref;
+
+fn main() {}
+
+#[derive(zerocopy::AsBytes)]
+#[repr(transparent)]
+struct Src(AU16);
+
+// `transmute_ref` requires that the source type implements `NoCell`
+const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));

--- a/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
@@ -1,0 +1,48 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `NoCell` is not implemented for `Src`
+   |                                required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-unsized.stderr
+++ b/tests/ui-nightly/transmute-ref-src-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-nightly/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/include_value_not_from_bytes.stderr
+++ b/tests/ui-stable/include_value_not_from_bytes.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
-  --> tests/ui-stable/include_value_not_from_bytes.rs:12:5
+error[E0277]: the trait bound `NotZerocopy<u32>: FromBytes` is not satisfied
+  --> tests/ui-stable/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     the trait `FromBytes` is not implemented for `UnsafeCell<u32>`
-   |     required by a bound introduced by this call
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
+   |                                          required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -18,8 +18,8 @@ error[E0277]: the trait bound `UnsafeCell<u32>: FromBytes` is not satisfied
              u8
            and $N others
 note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-stable/include_value_not_from_bytes.rs:12:5
+  --> tests/ui-stable/include_value_not_from_bytes.rs:13:42
    |
-12 |     include_value!("../../testdata/include_value/data");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+13 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
@@ -37,3 +37,23 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |
+   = note:           expected type `usize`
+           found mutable reference `&mut _`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-stable/transmute-mut-dst-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-dst-not-nocell.rs

--- a/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   the trait `NoCell` is not implemented for `Dst`
+   |                                   required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-dst-unsized.stderr
@@ -8,28 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                doesn't have a size known at compile-time
-   |                                required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-stable/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-generic.stderr
@@ -1,7 +1,7 @@
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `T` (this type does not have a fixed size)
@@ -9,9 +9,9 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:18:5
+  --> tests/ui-stable/transmute-mut-src-dst-generic.rs:20:5
    |
-18 |     transmute_mut!(t)
+20 |     transmute_mut!(t)
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)

--- a/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -39,59 +39,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    doesn't have a size known at compile-time
-   |                                    required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsFromBytes`
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                    |
-   |                                    doesn't have a size known at compile-time
-   |                                    required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertDstIsAsBytes`
-  --> tests/ui-stable/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsAsBytes`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/transmute-mut-src-generic.stderr
+++ b/tests/ui-stable/transmute-mut-src-generic.stderr
@@ -1,7 +1,7 @@
 error[E0405]: cannot find trait `FromBytes` in this scope
   --> tests/ui-stable/transmute-mut-src-generic.rs:15:31
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes>(t: &mut T) -> &mut u8 {
+15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
    |                               ^^^^^^^^^ not found in this scope
    |
 help: consider importing this trait

--- a/tests/ui-stable/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-stable/transmute-mut-src-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-mut-src-not-nocell.rs

--- a/tests/ui-stable/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-nocell.stderr
@@ -1,0 +1,48 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   the trait `NoCell` is not implemented for `Src`
+   |                                   required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-unsized.stderr
+++ b/tests/ui-stable/transmute-mut-src-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,42 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsFromBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   doesn't have a size known at compile-time
-   |                                   required by a bound introduced by this call
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertSrcIsAsBytes`
-  --> tests/ui-stable/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-stable/transmute-ref-dst-mutable.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut u8`
+                      found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
@@ -27,3 +27,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:18:42
+error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                          |
-   |                                          the trait `FromBytes` is not implemented for `NotZerocopy`
-   |                                          required by a bound introduced by this call
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `FromBytes` is not implemented for `Dst`
+   |                                  required by a bound introduced by this call
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
              usize
              u8
            and $N others
-note: required by a bound in `AssertIsFromBytes`
-  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:18:42
+note: required by a bound in `AssertDstIsFromBytes`
+  --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:22:34
    |
-18 | const DST_NOT_FROM_BYTES: &NotZerocopy = transmute_ref!(&AU16(0));
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+22 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui-stable/transmute-ref-dst-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-dst-not-nocell.rs

--- a/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               the trait `NoCell` is not implemented for `Dst`
+   |                               required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertDstIsNoCell`
+  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:22:31
+   |
+22 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-stable/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
@@ -43,3 +43,23 @@ error[E0308]: mismatched types
    = note:   expected type `usize`
            found reference `&_`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |
+   = note:   expected type `usize`
+           found reference `&_`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -39,11 +39,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-stable/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-asbytes.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                 |
-   |                                 the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                 the trait `AsBytes` is not implemented for `Src`
    |                                 required by a bound introduced by this call
    |
    = help: the following other types implement trait `AsBytes`:
@@ -17,18 +17,18 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
-  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
    = help: the following other types implement trait `AsBytes`:
              bool
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertIsAsBytes`
-  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:18:33
+note: required by a bound in `AssertSrcIsAsBytes`
+  --> tests/ui-stable/transmute-ref-src-not-asbytes.rs:22:33
    |
-18 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+22 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsAsBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-not-nocell.rs
+++ b/tests/ui-stable/transmute-ref-src-not-nocell.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-ref-src-not-nocell.rs

--- a/tests/ui-stable/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-nocell.stderr
@@ -1,0 +1,48 @@
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `NoCell` is not implemented for `Src`
+   |                                required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Src: NoCell` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |
+   = help: the following other types implement trait `NoCell`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required by a bound in `AssertSrcIsNoCell`
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:22:32
+   |
+22 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-unsized.stderr
+++ b/tests/ui-stable/transmute-ref-src-unsized.stderr
@@ -8,11 +8,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `AssertIsAsBytes`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-stable/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsAsBytes`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time


### PR DESCRIPTION
Previously, `FromZeros`, `FromBytes`, and `AsBytes` could not be
implemented for types containing `UnsafeCell`s. This is a soundness
precondition for some types of reference transmutations (notably
transmuting either direction between `&[u8]` and `&T`). However, some of
our machinery operates only on values (e.g. `transmute!`), and that
machinery should in principle be able to support types which contain
`UnsafeCell`s.

In this commit, we remove the "no `UnsafeCell`" restriction from
`FromZeros`, `FromBytes`, and `AsBytes`. We use the recently-added
`NoCell` trait as a bound on individual functions and methods where
`UnsafeCell`s would be unsound. This permits some APIs to support
`UnsafeCell`s which could not previously support them.

Closes https://github.com/google/zerocopy/issues/251