### PR TITLE
[tests] Fix UI tests with missing imports

### DIFF
--- a/tests/ui-msrv/transmute-mut-src-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-generic.stderr
@@ -1,10 +1,19 @@
-error[E0405]: cannot find trait `FromBytes` in this scope
-  --> tests/ui-msrv/transmute-mut-src-generic.rs:15:31
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-src-generic.rs:17:5
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
-   |                               ^^^^^^^^^ not found in this scope
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
-help: consider importing this trait
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-mut-src-generic.rs:17:5
    |
-11 | use zerocopy::FromBytes;
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-generic.rs
@@ -8,7 +8,7 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, AsBytes, NoCell};
+use zerocopy::{transmute_mut, AsBytes, FromBytes, NoCell};
 
 fn main() {}
 

--- a/tests/ui-nightly/transmute-mut-src-generic.stderr
+++ b/tests/ui-nightly/transmute-mut-src-generic.stderr
@@ -1,10 +1,19 @@
-error[E0405]: cannot find trait `FromBytes` in this scope
-  --> tests/ui-nightly/transmute-mut-src-generic.rs:15:31
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-src-generic.rs:17:5
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
-   |                               ^^^^^^^^^ not found in this scope
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
-help: consider importing this trait
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-mut-src-generic.rs:17:5
    |
-11 + use zerocopy::FromBytes;
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-generic.stderr
+++ b/tests/ui-stable/transmute-mut-src-generic.stderr
@@ -1,10 +1,19 @@
-error[E0405]: cannot find trait `FromBytes` in this scope
-  --> tests/ui-stable/transmute-mut-src-generic.rs:15:31
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-src-generic.rs:17:5
    |
-15 | fn transmute_mut<T: AsBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
-   |                               ^^^^^^^^^ not found in this scope
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
-help: consider importing this trait
+   = note: source type: `T` (this type does not have a fixed size)
+   = note: target type: `u8` (8 bits)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-mut-src-generic.rs:17:5
    |
-11 + use zerocopy::FromBytes;
+17 |     transmute_mut!(t)
+   |     ^^^^^^^^^^^^^^^^^
    |
+   = note: source type: `AlignOf<T>` (size can vary because of T)
+   = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,88 +1,89 @@
-<<<<<<< HEAD
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `FromZeroes` for `TransparentStruct<NotZerocopy>`
+note: required because of the requirements on the impl of `TryFromBytes` for `TransparentStruct<NotZerocopy>`
   --> tests/ui-msrv/derive_transparent.rs:27:19
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+  --> tests/ui-msrv/derive_transparent.rs:38:1
+   |
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |
+note: required because of the requirements on the impl of `FromZeroes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:27:33
+   |
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                 ^^^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-msrv/derive_transparent.rs:38:1
+   |
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:38:1
-=======
-error: cannot find derive macro `TryFromBytes` in this scope
-  --> tests/ui-msrv/derive_transparent.rs:27:19
+  --> tests/ui-msrv/derive_transparent.rs:39:1
    |
-27 | #[derive(AsBytes, TryFromBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FromBytes`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-  ::: src/lib.rs
-   |
-<<<<<<< HEAD
 note: required because of the requirements on the impl of `FromBytes` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:27:30
+  --> tests/ui-msrv/derive_transparent.rs:27:44
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                              ^^^^^^^^^
-note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-msrv/derive_transparent.rs:38:1
-   |
-38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
-=======
-   | pub fn derive_from_bytes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
-   | -------------------------------------------------------------------------------- similarly named derive macro `FromBytes` defined here
-   |
-   = note: consider importing one of these items:
-           zerocopy::TryFromBytes
-           zerocopy_derive::TryFromBytes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-
-error[E0405]: cannot find trait `TryFromBytes` in this scope
-  --> tests/ui-msrv/derive_transparent.rs:37:50
-   |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   |                                                  ^^^^^^^^^^^^
-   |
-<<<<<<< HEAD
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |          ^^^^^^^
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                            ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:39:1
-=======
-  ::: $WORKSPACE/src/lib.rs
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   | -------------------------------------- similarly named trait `FromBytes` defined here
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-msrv/derive_transparent.rs:40:1
    |
-help: a trait with a similar name exists
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-<<<<<<< HEAD
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
-  --> tests/ui-msrv/derive_transparent.rs:27:41
+note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                                         ^^^^^^^^^
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |          ^^^^^^^
 note: required by a bound in `_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:40:1
-=======
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   |                                                  ~~~~~~~~~
-help: consider importing this trait
    |
-14 | use zerocopy::TryFromBytes;
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+  --> tests/ui-msrv/derive_transparent.rs:41:1
    |
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |
+note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+  --> tests/ui-msrv/derive_transparent.rs:27:55
+   |
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                                       ^^^^^^^^^
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-msrv/derive_transparent.rs:41:1
+   |
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::assert_impl_all`
+   = note: this error originates in the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -67,33 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-<<<<<<< HEAD
-  --> tests/ui-msrv/enum.rs:42:21
+  --> tests/ui-msrv/enum.rs:42:35
    |
-42 | #[derive(FromZeros, FromBytes)]
-   |                     ^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: only C-like enums can implement FromZeros
-=======
-  --> tests/ui-msrv/enum.rs:42:36
-   |
-42 | #[derive(TryFromBytes, FromZeroes, FromBytes)]
-   |                                    ^^^^^^^^^
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                                   ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
-  --> tests/ui-msrv/enum.rs:70:1
-   |
-70 | / enum FromZeroes1 {
-71 | |     A(u8),
-72 | | }
-   | |_^
-
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
   --> tests/ui-msrv/enum.rs:70:1
    |
 70 | / enum FromZeros1 {
@@ -101,20 +82,15 @@ error: only C-like enums can implement FromZeroes
 72 | | }
    | |_^
 
-<<<<<<< HEAD
 error: only C-like enums can implement FromZeros
-=======
-error: TryFromBytes not supported on enum types
-  --> tests/ui-msrv/enum.rs:75:1
+  --> tests/ui-msrv/enum.rs:70:1
    |
-75 | / enum FromZeroes2 {
-76 | |     A,
-77 | |     B(u8),
-78 | | }
+70 | / enum FromZeros1 {
+71 | |     A(u8),
+72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: TryFromBytes not supported on enum types
   --> tests/ui-msrv/enum.rs:75:1
    |
 75 | / enum FromZeros2 {
@@ -123,20 +99,25 @@ error: only C-like enums can implement FromZeroes
 78 | | }
    | |_^
 
-<<<<<<< HEAD
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-=======
+error: only C-like enums can implement FromZeros
+  --> tests/ui-msrv/enum.rs:75:1
+   |
+75 | / enum FromZeros2 {
+76 | |     A,
+77 | |     B(u8),
+78 | | }
+   | |_^
+
 error: TryFromBytes not supported on enum types
   --> tests/ui-msrv/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-msrv/enum.rs:81:1
    |
 81 | / enum FromZeros3 {

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -9,10 +9,6 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:28:10
    |
-<<<<<<< HEAD
-28 | #[derive(FromZeros)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
-=======
 28 | #[derive(TryFromBytes)]
    |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
    |
@@ -22,9 +18,8 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:37:10
    |
-37 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+37 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.rs
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 
 use {
     static_assertions::assert_impl_all,
-    zerocopy::{AsBytes, FromBytes, FromZeros, Unaligned},
+    zerocopy::{AsBytes, FromBytes, FromZeros, TryFromBytes, Unaligned},
 };
 
 use self::util::NotZerocopy;

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -1,8 +1,35 @@
-<<<<<<< HEAD
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:37:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
+   |
+   = help: the following other types implement trait `TryFromBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `TryFromBytes`
+  --> tests/ui-nightly/derive_transparent.rs:27:19
+   |
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-nightly/derive_transparent.rs:37:1
+   |
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `TryFromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+  --> tests/ui-nightly/derive_transparent.rs:38:18
+   |
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
@@ -16,33 +43,23 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              i128
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
-  --> tests/ui-nightly/derive_transparent.rs:27:19
+  --> tests/ui-nightly/derive_transparent.rs:27:33
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                 ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:37:1
+  --> tests/ui-nightly/derive_transparent.rs:38:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:38:18
-=======
-error: cannot find derive macro `TryFromBytes` in this scope
-  --> tests/ui-nightly/derive_transparent.rs:27:19
+  --> tests/ui-nightly/derive_transparent.rs:39:18
    |
-27 | #[derive(AsBytes, TryFromBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^^^
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-  ::: src/lib.rs
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-   | pub fn derive_from_bytes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
-   | -------------------------------------------------------------------------------- similarly named derive macro `FromBytes` defined here
-   |
-<<<<<<< HEAD
    = help: the following other types implement trait `FromBytes`:
              isize
              i8
@@ -54,32 +71,23 @@ error: cannot find derive macro `TryFromBytes` in this scope
              u8
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-nightly/derive_transparent.rs:27:30
+  --> tests/ui-nightly/derive_transparent.rs:27:44
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                            ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:38:1
-=======
-help: a derive macro with a similar name exists
+  --> tests/ui-nightly/derive_transparent.rs:39:1
    |
-27 | #[derive(AsBytes, FromBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ~~~~~~~~~
-help: consider importing one of these items
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-14  + use zerocopy::TryFromBytes;
-    |
-14  + use zerocopy_derive::TryFromBytes;
-    |
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0405]: cannot find trait `TryFromBytes` in this scope
-  --> tests/ui-nightly/derive_transparent.rs:37:50
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-nightly/derive_transparent.rs:40:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   |                                                  ^^^^^^^^^^^^
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-<<<<<<< HEAD
    = help: the following other types implement trait `AsBytes`:
              bool
              char
@@ -93,25 +101,21 @@ error[E0405]: cannot find trait `TryFromBytes` in this scope
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-nightly/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:39:1
+  --> tests/ui-nightly/derive_transparent.rs:40:1
    |
-39 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-nightly/derive_transparent.rs:40:18
-=======
-  ::: $WORKSPACE/src/lib.rs
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+  --> tests/ui-nightly/derive_transparent.rs:41:18
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   | -------------------------------------- similarly named trait `FromBytes` defined here
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
-<<<<<<< HEAD
    = help: the following other types implement trait `Unaligned`:
              bool
              i8
@@ -123,19 +127,13 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              U128<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-nightly/derive_transparent.rs:27:41
+  --> tests/ui-nightly/derive_transparent.rs:27:55
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                                       ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-nightly/derive_transparent.rs:40:1
-=======
-help: a trait with a similar name exists
+  --> tests/ui-nightly/derive_transparent.rs:41:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   |                                                  ~~~~~~~~~
-help: consider importing this trait
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-14   + use zerocopy::TryFromBytes;
-     |
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -67,33 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-<<<<<<< HEAD
-  --> tests/ui-nightly/enum.rs:42:21
+  --> tests/ui-nightly/enum.rs:42:35
    |
-42 | #[derive(FromZeros, FromBytes)]
-   |                     ^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: only C-like enums can implement FromZeros
-=======
-  --> tests/ui-nightly/enum.rs:42:36
-   |
-42 | #[derive(TryFromBytes, FromZeroes, FromBytes)]
-   |                                    ^^^^^^^^^
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                                   ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
-  --> tests/ui-nightly/enum.rs:70:1
-   |
-70 | / enum FromZeroes1 {
-71 | |     A(u8),
-72 | | }
-   | |_^
-
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
   --> tests/ui-nightly/enum.rs:70:1
    |
 70 | / enum FromZeros1 {
@@ -101,20 +82,15 @@ error: only C-like enums can implement FromZeroes
 72 | | }
    | |_^
 
-<<<<<<< HEAD
 error: only C-like enums can implement FromZeros
-=======
-error: TryFromBytes not supported on enum types
-  --> tests/ui-nightly/enum.rs:75:1
+  --> tests/ui-nightly/enum.rs:70:1
    |
-75 | / enum FromZeroes2 {
-76 | |     A,
-77 | |     B(u8),
-78 | | }
+70 | / enum FromZeros1 {
+71 | |     A(u8),
+72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: TryFromBytes not supported on enum types
   --> tests/ui-nightly/enum.rs:75:1
    |
 75 | / enum FromZeros2 {
@@ -123,20 +99,25 @@ error: only C-like enums can implement FromZeroes
 78 | | }
    | |_^
 
-<<<<<<< HEAD
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-=======
+error: only C-like enums can implement FromZeros
+  --> tests/ui-nightly/enum.rs:75:1
+   |
+75 | / enum FromZeros2 {
+76 | |     A,
+77 | |     B(u8),
+78 | | }
+   | |_^
+
 error: TryFromBytes not supported on enum types
   --> tests/ui-nightly/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-nightly/enum.rs:81:1
    |
 81 | / enum FromZeros3 {

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -9,10 +9,6 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:28:10
    |
-<<<<<<< HEAD
-28 | #[derive(FromZeros)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
-=======
 28 | #[derive(TryFromBytes)]
    |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
    |
@@ -33,9 +29,8 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:37:10
    |
-37 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+37 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
              bool

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -1,8 +1,35 @@
-<<<<<<< HEAD
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:37:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
+   |
+   = help: the following other types implement trait `TryFromBytes`:
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `TryFromBytes`
+  --> tests/ui-stable/derive_transparent.rs:27:19
+   |
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                   ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `_::{closure#0}::assert_impl_all`
+  --> tests/ui-stable/derive_transparent.rs:37:1
+   |
+37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `TryFromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+  --> tests/ui-stable/derive_transparent.rs:38:18
+   |
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
@@ -16,33 +43,23 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              i128
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
-  --> tests/ui-stable/derive_transparent.rs:27:19
+  --> tests/ui-stable/derive_transparent.rs:27:33
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                 ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-stable/derive_transparent.rs:37:1
+  --> tests/ui-stable/derive_transparent.rs:38:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
-  --> tests/ui-stable/derive_transparent.rs:38:18
-=======
-error: cannot find derive macro `TryFromBytes` in this scope
-  --> tests/ui-stable/derive_transparent.rs:27:19
+  --> tests/ui-stable/derive_transparent.rs:39:18
    |
-27 | #[derive(AsBytes, TryFromBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ^^^^^^^^^^^^
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
-  ::: src/lib.rs
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-   | pub fn derive_from_bytes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
-   | -------------------------------------------------------------------------------- similarly named derive macro `FromBytes` defined here
-   |
-<<<<<<< HEAD
    = help: the following other types implement trait `FromBytes`:
              isize
              i8
@@ -54,32 +71,23 @@ error: cannot find derive macro `TryFromBytes` in this scope
              u8
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromBytes`
-  --> tests/ui-stable/derive_transparent.rs:27:30
+  --> tests/ui-stable/derive_transparent.rs:27:44
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                            ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-stable/derive_transparent.rs:38:1
-=======
-help: a derive macro with a similar name exists
+  --> tests/ui-stable/derive_transparent.rs:39:1
    |
-27 | #[derive(AsBytes, FromBytes, FromZeroes, FromBytes, Unaligned)]
-   |                   ~~~~~~~~~
-help: consider importing one of these items
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-14  + use zerocopy::TryFromBytes;
-    |
-14  + use zerocopy_derive::TryFromBytes;
-    |
+39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0405]: cannot find trait `TryFromBytes` in this scope
-  --> tests/ui-stable/derive_transparent.rs:37:50
+error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+  --> tests/ui-stable/derive_transparent.rs:40:18
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   |                                                  ^^^^^^^^^^^^
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
    |
-<<<<<<< HEAD
    = help: the following other types implement trait `AsBytes`:
              bool
              char
@@ -93,25 +101,21 @@ error[E0405]: cannot find trait `TryFromBytes` in this scope
 note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
   --> tests/ui-stable/derive_transparent.rs:27:10
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-stable/derive_transparent.rs:39:1
+  --> tests/ui-stable/derive_transparent.rs:40:1
    |
-39 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
+40 | assert_impl_all!(TransparentStruct<NotZerocopy>: AsBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `AsBytes` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-stable/derive_transparent.rs:40:18
-=======
-  ::: $WORKSPACE/src/lib.rs
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+  --> tests/ui-stable/derive_transparent.rs:41:18
    |
-   | pub unsafe trait FromBytes: FromZeroes {
-   | -------------------------------------- similarly named trait `FromBytes` defined here
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
-<<<<<<< HEAD
    = help: the following other types implement trait `Unaligned`:
              bool
              i8
@@ -123,19 +127,13 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              U128<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
-  --> tests/ui-stable/derive_transparent.rs:27:41
+  --> tests/ui-stable/derive_transparent.rs:27:55
    |
-27 | #[derive(AsBytes, FromZeros, FromBytes, Unaligned)]
-   |                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+27 | #[derive(AsBytes, TryFromBytes, FromZeros, FromBytes, Unaligned)]
+   |                                                       ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::assert_impl_all`
-  --> tests/ui-stable/derive_transparent.rs:40:1
-=======
-help: a trait with a similar name exists
+  --> tests/ui-stable/derive_transparent.rs:41:1
    |
-37 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   |                                                  ~~~~~~~~~
-help: consider importing this trait
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
-   |
-14   + use zerocopy::TryFromBytes;
-     |
+41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -67,33 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-<<<<<<< HEAD
-  --> tests/ui-stable/enum.rs:42:21
+  --> tests/ui-stable/enum.rs:42:35
    |
-42 | #[derive(FromZeros, FromBytes)]
-   |                     ^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: only C-like enums can implement FromZeros
-=======
-  --> tests/ui-stable/enum.rs:42:36
-   |
-42 | #[derive(TryFromBytes, FromZeroes, FromBytes)]
-   |                                    ^^^^^^^^^
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                                   ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
-  --> tests/ui-stable/enum.rs:70:1
-   |
-70 | / enum FromZeroes1 {
-71 | |     A(u8),
-72 | | }
-   | |_^
-
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
   --> tests/ui-stable/enum.rs:70:1
    |
 70 | / enum FromZeros1 {
@@ -101,20 +82,15 @@ error: only C-like enums can implement FromZeroes
 72 | | }
    | |_^
 
-<<<<<<< HEAD
 error: only C-like enums can implement FromZeros
-=======
-error: TryFromBytes not supported on enum types
-  --> tests/ui-stable/enum.rs:75:1
+  --> tests/ui-stable/enum.rs:70:1
    |
-75 | / enum FromZeroes2 {
-76 | |     A,
-77 | |     B(u8),
-78 | | }
+70 | / enum FromZeros1 {
+71 | |     A(u8),
+72 | | }
    | |_^
 
-error: only C-like enums can implement FromZeroes
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: TryFromBytes not supported on enum types
   --> tests/ui-stable/enum.rs:75:1
    |
 75 | / enum FromZeros2 {
@@ -123,20 +99,25 @@ error: only C-like enums can implement FromZeroes
 78 | | }
    | |_^
 
-<<<<<<< HEAD
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-=======
+error: only C-like enums can implement FromZeros
+  --> tests/ui-stable/enum.rs:75:1
+   |
+75 | / enum FromZeros2 {
+76 | |     A,
+77 | |     B(u8),
+78 | | }
+   | |_^
+
 error: TryFromBytes not supported on enum types
   --> tests/ui-stable/enum.rs:81:1
    |
-81 | / enum FromZeroes3 {
+81 | / enum FromZeros3 {
 82 | |     A = 1,
 83 | |     B,
 84 | | }
    | |_^
 
-error: FromZeroes only supported on enums with a variant that has a discriminant of `0`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
   --> tests/ui-stable/enum.rs:81:1
    |
 81 | / enum FromZeros3 {

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -9,10 +9,6 @@ warning: unused import: `zerocopy::KnownLayout`
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:28:10
    |
-<<<<<<< HEAD
-28 | #[derive(FromZeros)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
-=======
 28 | #[derive(TryFromBytes)]
    |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
    |
@@ -32,9 +28,8 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
 error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:37:10
    |
-37 | #[derive(FromZeroes)]
-   |          ^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
->>>>>>> [derive] Support `derive(TryFromBytes)` for structs
+37 | #[derive(FromZeros)]
+   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `FromZeroes`:
              bool


### PR DESCRIPTION
Previously, some UI tests had missing imports which caused the corresponding `.stderr` files to be populated with unhelpful "cannot find ..." messages. This is another point in favor of #187 (switching to the `ui-test` crate), which presumably would have made it much less likely for this to slip under the radar.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
