### PR TITLE
[ci] check all-jobs-succeed depends on all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
                   <(yq -r '.jobs.all-jobs-succeed.needs[]' "$i" | sort | uniq)
               fi
 
-            # The sed call here excludes all-jobs-succeed from the list of jobs that
+            # The grep call here excludes all-jobs-succeed from the list of jobs that
             # all-jobs-succeed does not depend on.  If all-jobs-succeed does
             # not depend on itself, we do not care about it.
             done | sort | uniq | grep -v '^all-jobs-succeed$' || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,10 +490,8 @@ jobs:
 
           if [ -n "$jobs" ]
           then
-            echo 'There are jobs triggered by pull requests that'
-            echo 'are not listed in all-jobs-succeed.needs:'
-
-            echo $jobs
+            missing_jobs="$(echo "$jobs" | tr ' ' '\n')"
+            echo "all-jobs-succeed missing dependencies on some jobs: $missing_jobs" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,6 +461,38 @@ jobs:
           cargo install --locked kani-verifier       &> /dev/null || true
           cargo kani setup                           &> /dev/null || true
 
+  check-job-dependencies:
+    runs-on: ubuntu-latest
+    name: Check all-jobs-succeeded depends on all jobs
+    steps:
+      - name: Install yq (for YAML parsing)
+        run: go install github.com/mikefarah/yq/v4@latest
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Run dependency check
+        run: |
+          set -eo pipefail
+          jobs=$(for i in $(find .github -iname '*.yaml' -or -iname '*.yml')
+            do
+              # Select jobs that are triggered by pull request.
+              if yq -e '.on | has("pull_request")' "$i" 2>/dev/null >/dev/null
+              then
+                # This gets the list of jobs that are not in
+                # all-jobs-succeed.needs .
+                comm -23 \
+                  <(yq -r '.jobs | keys | .[]' "$i" | sort | uniq) \
+                  <(yq -r '.jobs.all-jobs-succeed.needs[]' "$i" | sort | uniq)
+              fi
+            done | sort | uniq
+          )
+          # Effectively, this checks that all-jobs-succeed does not depend on
+          # itself. Checking for the existence of a job that we don't want
+          # all-jobs-succeed to depend on acts as a crude test that the
+          # building of the dependency list is working as expected.
+          if [ "$jobs" != "all-jobs-succeed" ]
+          then
+            exit 1
+          fi
+
   # Used to signal to branch protections that all other jobs have succeeded.
   all-jobs-succeed:
       name: All checks succeeded
@@ -471,7 +503,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_fmt, check_readme, check_msrv, check_versions, generate_cache]
+      needs: [build_test, kani, check_fmt, check_readme, check_msrv, check_versions, generate_cache, check-job-dependencies]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,20 +476,24 @@ jobs:
               # Select jobs that are triggered by pull request.
               if yq -e '.on | has("pull_request")' "$i" 2>/dev/null >/dev/null
               then
-                # This gets the list of jobs that are not in
-                # all-jobs-succeed.needs .
+                # This gets the list of jobs that all-jobs-succeed does not depend on.
                 comm -23 \
                   <(yq -r '.jobs | keys | .[]' "$i" | sort | uniq) \
                   <(yq -r '.jobs.all-jobs-succeed.needs[]' "$i" | sort | uniq)
               fi
-            done | sort | uniq
+
+            # The sed call here excludes all-jobs-succeed from the list of jobs that
+            # all-jobs-succeed does not depend on.  If all-jobs-succeed does
+            # not depend on itself, we do not care about it.
+            done | sort | uniq | sed '/^all-jobs-succeed$/d'
           )
-          # Effectively, this checks that all-jobs-succeed does not depend on
-          # itself. Checking for the existence of a job that we don't want
-          # all-jobs-succeed to depend on acts as a crude test that the
-          # building of the dependency list is working as expected.
-          if [ "$jobs" != "all-jobs-succeed" ]
+
+          if [ -n "$jobs" ]
           then
+            echo 'There are jobs triggered by pull requests that'
+            echo 'are not listed in all-jobs-succeed.needs:'
+
+            echo $jobs
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
             # The grep call here excludes all-jobs-succeed from the list of jobs that
             # all-jobs-succeed does not depend on.  If all-jobs-succeed does
             # not depend on itself, we do not care about it.
-            done | sort | uniq | grep -v '^all-jobs-succeed$' || true
+            done | sort | uniq | (grep -v '^all-jobs-succeed$' || true)
           )
 
           if [ -n "$jobs" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
             # The sed call here excludes all-jobs-succeed from the list of jobs that
             # all-jobs-succeed does not depend on.  If all-jobs-succeed does
             # not depend on itself, we do not care about it.
-            done | sort | uniq | sed '/^all-jobs-succeed$/d'
+            done | sort | uniq | grep -v '^all-jobs-succeed$' || true
           )
 
           if [ -n "$jobs" ]


### PR DESCRIPTION
Potentially a new per-PR job could be added to CI without it being included in `all-jobs-succeed`'s dependencies.  This prevents that.

I have successfully constructed a [failure](https://github.com/tommy-gilligan/zerocopy/actions/runs/7195624547/job/19598647853) (by deleting a job from `all-jobs-succeed`'s dependencies)

Closes #444