### PR TITLE
[derive] Exclude large test files when publishing

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -16,7 +16,12 @@ license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
 rust-version = "1.60.0"
 
-exclude = [".*"]
+# We prefer to include tests when publishing to crates.io so that Crater [1] can
+# detect regressions in our test suite. These two tests are excessively large,
+# so we exclude them to keep the published crate file small.
+#
+# [1] https://github.com/rust-lang/crater
+exclude = [".*", "tests/enum_from_bytes.rs", "tests/ui-nightly/enum_from_bytes_u16_too_few.rs.disabled"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Exclude the following files from the crate file uploaded to crates.io; they are excessively large, and cause the resulting crate file to be large as well.
- tests/enum_from_bytes.rs
- tests/ui-nightly/enum_from_bytes_u16_too_few.rs.disabled

This commit saves a significant amount of space from the published crate file as reported by `cargo package`:

           Uncompressed   Compressed
Before     3.6MiB         526.8KiB
After      249.9KiB       41.8KiB

This represents a 14x size reduction uncompressed and a 13x size reduction compressed.

Makes progress on #742

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
