### PR TITLE
[derive] Exclude large test files when publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2018"
 name = "zerocopy"
-version = "0.7.31"
+version = "0.7.32"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
@@ -49,7 +49,7 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.7.31", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.7.32", path = "zerocopy-derive", optional = true }
 
 [dependencies.byteorder]
 version = "1.3"
@@ -60,7 +60,7 @@ optional = true
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.7.31", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.32", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -75,6 +75,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.85", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.7.31", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.7.32", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,14 +9,19 @@
 [package]
 edition = "2018"
 name = "zerocopy-derive"
-version = "0.7.31"
+version = "0.7.32"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
 rust-version = "1.60.0"
 
-exclude = [".*"]
+# We prefer to include tests when publishing to crates.io so that Crater [1] can
+# detect regressions in our test suite. These two tests are excessively large,
+# so we exclude them to keep the published crate file small.
+#
+# [1] https://github.com/rust-lang/crater
+exclude = [".*", "tests/enum_from_bytes.rs", "tests/ui-nightly/enum_from_bytes_u16_too_few.rs.disabled"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Exclude the following files from the crate file uploaded to crates.io; they are excessively large, and cause the resulting crate file to be large as well.
- tests/enum_from_bytes.rs
- tests/ui-nightly/enum_from_bytes_u16_too_few.rs.disabled

This commit saves a significant amount of space from the published crate file as reported by `cargo package`:

           Uncompressed   Compressed
Before     3.6MiB         526.8KiB
After      249.9KiB       41.8KiB

This represents a 14x size reduction uncompressed and a 13x size reduction compressed.

Release 0.7.32.

Closes #742

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
