### PR TITLE
[doc] fix doc_cfg feature name of new_vec_zeroed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1616,7 +1616,7 @@ pub unsafe trait FromZeros {
     /// * Panics if `size_of::<Self>() * len` overflows.
     /// * Panics if allocation of `size_of::<Self>() * len` bytes fails.
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "new_vec_zeroed")))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     #[inline(always)]
     fn new_vec_zeroed(len: usize) -> Vec<Self>
     where


### PR DESCRIPTION
Fixes: 4433ad371114 ("[doc] Use `doc(cfg(...))` in docs.rs (#579)")

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
