### PR TITLE
[ci] Use pinned nightly for cargo-semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,10 +251,7 @@ jobs:
         # an API that cargo-semver-checks can understand.
         package: zerocopy
         feature-group: all-features
-        # TODO: Set this to the specific nightly we have pinned in CI. Not a big
-        # deal since this isn't affected by the trybuild stderr files, which is
-        # the reason we need to pin to a specific nightly.
-        rust-toolchain: nightly
+        rust-toolchain: ${{ env.ZC_TOOLCHAIN }}
       if: matrix.crate == 'zerocopy' && matrix.features == '--all-features' && matrix.toolchain == 'nightly'
 
   kani:


### PR DESCRIPTION
As reported in obi1kenobi/cargo-semver-checks-action#61, a recent update to the nightly toolchain broke cargo-semver-checks. Previously, we were using the latest nightly toolchain rather than the pinned nightly toolchain in order to run cargo-semver-checks, which caused our CI to break when this new nightly was released.

In this commit, we use our pinned nightly version instead, hopefully avoiding issues like this in the future.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
