### PR TITLE
Pin transitive dep `cargo-platform` for MSRV

### DIFF
--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 
 [dependencies]
 cargo_metadata = "0.18.0"
+# Pin to 0.1.5 because more recent versions require a Rust version more recent
+# than our MSRV.
+cargo-platform = "=0.1.5"
 rustc_version = "0.4.0"
 # Pin to 0.3.0 because more recent versions require a Rust version more recent
 # than our MSRV.


### PR DESCRIPTION
Version 0.1.6 requires a Rust version more recent than our MSRV. To work around this, we take an explicit dependency on it, and pin to 0.1.5.
