### PR TITLE
[derive] FromZeros requires repr on unit-only enums

### DIFF
--- a/zerocopy-derive/tests/enum_from_zeros.rs
+++ b/zerocopy-derive/tests/enum_from_zeros.rs
@@ -13,6 +13,7 @@ mod util;
 use {static_assertions::assert_impl_all, zerocopy::FromZeros};
 
 #[derive(FromZeros)]
+#[repr(C)]
 enum Foo {
     A,
 }
@@ -20,6 +21,7 @@ enum Foo {
 assert_impl_all!(Foo: FromZeros);
 
 #[derive(FromZeros)]
+#[repr(C)]
 enum Bar {
     A = 0,
 }
@@ -27,6 +29,7 @@ enum Bar {
 assert_impl_all!(Bar: FromZeros);
 
 #[derive(FromZeros)]
+#[repr(C)]
 enum Baz {
     A = 1,
     B = 0,

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -67,6 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-msrv/enum.rs:42:24
+   |
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:42:35
    |
 42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
@@ -117,14 +125,13 @@ error: TryFromBytes not supported on enum types
 84 | | }
    | |_^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-  --> tests/ui-msrv/enum.rs:81:1
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-msrv/enum.rs:80:24
    |
-81 | / enum FromZeros3 {
-82 | |     A = 1,
-83 | |     B,
-84 | | }
-   | |_^
+80 | #[derive(TryFromBytes, FromZeros)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
   --> tests/ui-msrv/enum.rs:91:1

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -67,6 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-nightly/enum.rs:42:24
+   |
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:42:35
    |
 42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
@@ -117,14 +125,13 @@ error: TryFromBytes not supported on enum types
 84 | | }
    | |_^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-  --> tests/ui-nightly/enum.rs:81:1
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-nightly/enum.rs:80:24
    |
-81 | / enum FromZeros3 {
-82 | |     A = 1,
-83 | |     B,
-84 | | }
-   | |_^
+80 | #[derive(TryFromBytes, FromZeros)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
   --> tests/ui-nightly/enum.rs:91:1

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -67,6 +67,14 @@ error: TryFromBytes not supported on enum types
    | |_^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-stable/enum.rs:42:24
+   |
+42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:42:35
    |
 42 | #[derive(TryFromBytes, FromZeros, FromBytes)]
@@ -117,14 +125,13 @@ error: TryFromBytes not supported on enum types
 84 | | }
    | |_^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-  --> tests/ui-stable/enum.rs:81:1
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-stable/enum.rs:80:24
    |
-81 | / enum FromZeros3 {
-82 | |     A = 1,
-83 | |     B,
-84 | | }
-   | |_^
+80 | #[derive(TryFromBytes, FromZeros)]
+   |                        ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: TryFromBytes not supported on enum types
   --> tests/ui-stable/enum.rs:91:1


### PR DESCRIPTION
Previously, these were supported, but probably technically shouldn't have been. While in practice unit-only enums have a layout which matches their discriminants, this isn't technically guaranteed without an explicit repr attribute.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
