### PR TITLE
Roll nightly toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.75.0"
-pinned-nightly = "nightly-2024-01-11"
+pinned-nightly = "nightly-2024-02-01"
 
 [package.metadata.playground]
 features = ["__internal_use_only_features_that_work_on_stable"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,6 @@
 #![deny(
     anonymous_parameters,
     deprecated_in_future,
-    illegal_floating_point_literal_pattern,
     late_bound_lifetime_arguments,
     missing_copy_implementations,
     missing_debug_implementations,
@@ -5121,6 +5120,7 @@ where
     T: FromBytes + PartialEq + NoCell,
 {
     #[inline]
+    #[allow(clippy::unconditional_recursion)] // Work around false positive: https://github.com/rust-lang/rust-clippy/issues/12154
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other.deref())
     }
@@ -5132,6 +5132,7 @@ where
     T: FromBytes + PartialEq + NoCell,
 {
     #[inline]
+    #[allow(clippy::unconditional_recursion)] // Work around false positive: https://github.com/rust-lang/rust-clippy/issues/12154
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other.deref())
     }

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:26:39
    |
 26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   |                                       ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
+   |                                       ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`, which is required by `Foo<T>: zerocopy::TryFromBytes`
    |
 note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
@@ -29,7 +29,7 @@ error[E0277]: the trait bound `T: FromZeroes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:36
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`
+   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`, which is required by `Foo<T>: FromZeroes`
    |
 note: required for `Foo<T>` to implement `FromZeroes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:24
@@ -56,7 +56,7 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:28:36
    |
 28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+   |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`, which is required by `Foo<T>: zerocopy::FromBytes`
    |
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:35
@@ -83,7 +83,7 @@ error[E0277]: the trait bound `T: AsBytes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:29:36
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`
+   |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`, which is required by `Foo<T>: AsBytes`
    |
 note: required for `Foo<T>` to implement `AsBytes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:46
@@ -110,7 +110,7 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:30:36
    |
 30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+   |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`, which is required by `Foo<T>: zerocopy::Unaligned`
    |
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:57

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:37:18
    |
 37 | assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: TryFromBytes`
    |
    = help: the following other types implement trait `TryFromBytes`:
              bool
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:38:18
    |
 38 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: FromZeroes`
    |
    = help: the following other types implement trait `FromZeroes`:
              bool
@@ -58,7 +58,7 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:39:18
    |
 39 | assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: FromBytes`
    |
    = help: the following other types implement trait `FromBytes`:
              isize
@@ -86,7 +86,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:40:18
    |
 40 | assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: AsBytes`
    |
    = help: the following other types implement trait `AsBytes`:
              bool
@@ -114,17 +114,17 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:41:18
    |
 41 | assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: Unaligned`
    |
    = help: the following other types implement trait `Unaligned`:
              bool
              i8
              u8
              TransparentStruct<T>
+             NonZero<i8>
+             NonZero<u8>
              U16<O>
              U32<O>
-             U64<O>
-             U128<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
   --> tests/ui-nightly/derive_transparent.rs:27:57

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -122,8 +122,8 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              Unaligned1
              Unaligned2
              Unaligned3
-             U16<O>
-             U32<O>
+             NonZero<i8>
+             NonZero<u8>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -142,8 +142,8 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              Unaligned1
              Unaligned2
              Unaligned3
-             U16<O>
-             U32<O>
+             NonZero<i8>
+             NonZero<u8>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -162,8 +162,8 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
              Unaligned1
              Unaligned2
              Unaligned3
-             U16<O>
-             U32<O>
+             NonZero<i8>
+             NonZero<u8>
            and $N others
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-nightly/mid_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/mid_compile_pass.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: KnownLayout` is not satisfied
   --> tests/ui-nightly/mid_compile_pass.rs:59:26
    |
 59 | fn test_kl13<T>(t: T) -> impl KnownLayout {
-   |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`
+   |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`, which is required by `KL13<T>: KnownLayout`
    |
 note: required for `KL13<T>` to implement `KnownLayout`
   --> tests/ui-nightly/mid_compile_pass.rs:55:10
@@ -83,7 +83,7 @@ error[E0277]: the trait bound `T: KnownLayout` is not satisfied
   --> tests/ui-nightly/mid_compile_pass.rs:50:15
    |
 50 |     assert_kl(kl)
-   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`
+   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`, which is required by `KL12<T>: KnownLayout`
    |     |
    |     required by a bound introduced by this call
    |

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -48,7 +48,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 31 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `KL00`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `KL00`, the trait `Sized` is not implemented for `[u8]`, which is required by `KL00: Sized`
 note: required because it appears within the type `KL00`
   --> tests/ui-nightly/struct.rs:32:8
    |
@@ -64,7 +64,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 36 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `KL02`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `KL02`, the trait `Sized` is not implemented for `[u8]`, which is required by `KL02: Sized`
 note: required because it appears within the type `KL02`
   --> tests/ui-nightly/struct.rs:37:8
    |
@@ -138,7 +138,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
   --> tests/ui-nightly/struct.rs:60:10
    |
 60 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<u8>`
+   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<u8>`, which is required by `[UnsafeCell<u8>; 0]: NoCell`
    |
    = help: the following other types implement trait `NoCell`:
              bool

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
   --> tests/ui-nightly/union.rs:24:10
    |
 24 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<()>`
+   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<()>`, which is required by `ManuallyDrop<UnsafeCell<()>>: NoCell`
    |
    = help: the following other types implement trait `NoCell`:
              bool


### PR DESCRIPTION
Add explicit `allow`s to work around Clippy false positive: https://github.com/rust-lang/rust-clippy/issues/12154

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
