### PR TITLE
[byteorder] Make some methods const

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # See `INTERNAL.md` for an explanation of these pinned toolchain
         # versions.
-        toolchain: [ "msrv", "stable", "nightly", "zerocopy-aarch64-simd" ]
+        toolchain: [ "msrv", "stable", "nightly", "zerocopy-aarch64-simd", "zerocopy-generic-bounds-in-const-fn" ]
         target: [
           "i686-unknown-linux-gnu",
           "x86_64-unknown-linux-gnu",
@@ -61,6 +61,8 @@ jobs:
             features: "--all-features"
           - toolchain: "zerocopy-aarch64-simd"
             features: "--all-features"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+            features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
           - crate: "zerocopy-derive"
@@ -75,6 +77,8 @@ jobs:
           # zerocopy-derive doesn't behave different on these toolchains.
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-aarch64-simd"
+          - crate: "zerocopy-derive"
+            toolchain: "zerocopy-generic-bounds-in-const-fn"
 
     name: Build & Test (crate:${{ matrix.crate }}, toolchain:${{ matrix.toolchain }}, target:${{ matrix.target }}, features:${{ matrix.features }})
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ exclude = [".*"]
 # versions, these types require the "simd-nightly" feature.
 zerocopy-aarch64-simd = "1.59.0"
 
+# From 1.61.0, Rust supports generic types with trait bounds in `const fn`.
+zerocopy-generic-bounds-in-const-fn = "1.61.0"
+
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.75.0"

--- a/build.rs
+++ b/build.rs
@@ -73,13 +73,14 @@ fn main() {
     }
 }
 
-#[derive(Ord, PartialEq, PartialOrd, Eq)]
+#[derive(Debug, Ord, PartialEq, PartialOrd, Eq)]
 struct Version {
     major: usize,
     minor: usize,
     patch: usize,
 }
 
+#[derive(Debug)]
 struct VersionCfg {
     version: Version,
     cfg_name: String,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -416,3 +416,19 @@ macro_rules! assert_unaligned {
         $(assert_unaligned!($ty);)*
     };
 }
+
+/// Emits a function definition as either `const fn` or `fn` depending on
+/// whether the current toolchain version supports `const fn` with generic trait
+/// bounds.
+macro_rules! maybe_const_trait_bounded_fn {
+    // This case handles both `self` methods (where `self` is by value) and
+    // non-method functions. Each `$args` may optionally be followed by `:
+    // $arg_tys:ty`, which can be omitted for `self`.
+    ($(#[$attr:meta])* $vis:vis const fn $name:ident($($args:ident $(: $arg_tys:ty)?),* $(,)?) $(-> $ret_ty:ty)? $body:block) => {
+        #[cfg(zerocopy_generic_bounds_in_const_fn)]
+        $(#[$attr])* $vis const fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
+
+        #[cfg(not(zerocopy_generic_bounds_in_const_fn))]
+        $(#[$attr])* $vis fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
+    };
+}


### PR DESCRIPTION
For methods which have generic types with trait bounds (other than `Sized`), conditionally compile as `const` only on Rust 1.61.0 or later.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
