### PR TITLE
Introduce `invariant::Initialized` and migrate `Maybe` to it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1253,10 +1253,9 @@ pub unsafe trait TryFromBytes {
         let candidate = Ptr::from_ref(bytes).try_cast_into_no_leftover::<Self>()?;
 
         // SAFETY: `candidate` has no uninitialized sub-ranges because it
-        // derived from `bytes: &[u8]`, and is therefore at least as-initialized
-        // as `Self`.
+        // derived from `bytes: &[u8]`.
         let candidate =
-            unsafe { candidate.assume_validity::<crate::pointer::invariant::AsInitialized>() };
+            unsafe { candidate.assume_validity::<crate::pointer::invariant::Initialized>() };
 
         // This call may panic. If that happens, it doesn't cause any soundness
         // issues, as we have not generated any invalid state which we need to
@@ -1284,9 +1283,8 @@ pub unsafe trait TryFromBytes {
         let candidate = MaybeUninit::<Self>::read_from(bytes)?;
         let c_ptr = Ptr::from_maybe_uninit_ref(&candidate);
         // SAFETY: `c_ptr` has no uninitialized sub-ranges because it derived
-        // from `candidate`, which in turn derives from `bytes: &[u8]`, and is
-        // therefore at least as-initialized as `Self`.
-        let c_ptr = unsafe { c_ptr.assume_as_initialized() };
+        // from `candidate`, which in turn derives from `bytes: &[u8]`.
+        let c_ptr = unsafe { c_ptr.assume_validity::<crate::pointer::invariant::Initialized>() };
 
         if !Self::is_bit_valid(c_ptr.forget_aligned()) {
             return None;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -164,9 +164,10 @@ macro_rules! unsafe_impl {
             #[allow(clippy::as_conversions)]
             let $candidate = unsafe { candidate.cast_unsized::<$repr, _>(|p| p as *mut _) };
 
-            // SAFETY: The caller has promised that `$repr` is as-initialized as
-            // `Self`.
-            let $candidate = unsafe { $candidate.assume_validity::<crate::pointer::invariant::AsInitialized>() };
+            // Restore the invariant that the referent bytes are initialized.
+            // SAFETY: The above cast does not uninitialize any referent bytes;
+            // they remain initialized.
+            let $candidate = unsafe { $candidate.assume_validity::<crate::pointer::invariant::Initialized>() };
 
             $is_bit_valid
         }

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -17,7 +17,7 @@ use crate::{TryFromBytes, Unaligned};
 /// A shorthand for a maybe-valid, maybe-aligned reference. Used as the argument
 /// to [`TryFromBytes::is_bit_valid`].
 pub type Maybe<'a, T, Alignment = invariant::AnyAlignment> =
-    Ptr<'a, T, (invariant::Shared, Alignment, invariant::AsInitialized)>;
+    Ptr<'a, T, (invariant::Shared, Alignment, invariant::Initialized)>;
 
 // These methods are defined on the type alias, `Maybe`, so as to bring them to
 // the forefront of the rendered rustdoc.

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -420,7 +420,7 @@ fn derive_try_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2:
                 (
                     ::zerocopy::pointer::invariant::Shared,
                     ::zerocopy::pointer::invariant::AnyAlignment,
-                    ::zerocopy::pointer::invariant::AsInitialized,
+                    ::zerocopy::pointer::invariant::Initialized,
                 ),
             >,
         ) -> ::zerocopy::macro_util::core_reexport::primitive::bool {
@@ -430,14 +430,14 @@ fn derive_try_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2:
             // - By definition, `*mut Self` and `*mut [u8; size_of::<Self>()]`
             //   are types of the same size.
             let discriminant = unsafe { candidate.cast_unsized(|p: *mut Self| p as *mut [core_reexport::primitive::u8; core_reexport::mem::size_of::<Self>()]) };
-            // SAFETY: Since `candidate` has the invariant `AsInitialized`, we
+            // SAFETY: Since `candidate` has the invariant `Initialized`, we
             // know that `candidate`'s referent (and thus `discriminant`'s
-            // referent) is as-initialized as `Self`. Since all of the allowed
-            // `repr`s are types for which all bytes are always initialized, we
-            // know that `discriminant`'s referent has all of its bytes
-            // initialized. Since `[u8; N]`'s validity invariant is just that
-            // all of its bytes are initialized, we know that `discriminant`'s
-            // referent is bit-valid.
+            // referent) are fully initialized. Since all of the allowed `repr`s
+            // are types for which all bytes are always initialized, we know
+            // that `discriminant`'s referent has all of its bytes initialized.
+            // Since `[u8; N]`'s validity invariant is just that all of its
+            // bytes are initialized, we know that `discriminant`'s referent is
+            // bit-valid.
             let discriminant = unsafe { discriminant.assume_valid() };
             let discriminant = discriminant.read_unaligned();
 

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -80,7 +80,7 @@ fn two_bad() {
     let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Two) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
-    let candidate = unsafe { candidate.assume_as_initialized() };
+    let candidate = unsafe { candidate.assume_initialized() };
 
     let is_bit_valid = Two::is_bit_valid(candidate);
     assert!(!is_bit_valid);
@@ -109,7 +109,7 @@ fn un_sized() {
     let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Unsized) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
-    let candidate = unsafe { candidate.assume_as_initialized() };
+    let candidate = unsafe { candidate.assume_initialized() };
     let is_bit_valid = Unsized::is_bit_valid(candidate);
     assert!(is_bit_valid);
 }

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -75,7 +75,7 @@ fn two_bad() {
     let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Two) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
-    let candidate = unsafe { candidate.assume_as_initialized() };
+    let candidate = unsafe { candidate.assume_initialized() };
 
     let is_bit_valid = Two::is_bit_valid(candidate);
     assert!(!is_bit_valid);
@@ -101,8 +101,8 @@ fn bool_and_zst() {
     //   the size of the object referenced by `self`.
     let candidate = unsafe { candidate.cast_unsized(|p| p as *mut BoolAndZst) };
 
-    // SAFETY: `candidate`'s referent is as-initialized as `BoolAndZst`.
-    let candidate = unsafe { candidate.assume_as_initialized() };
+    // SAFETY: `candidate`'s referent is fully initialized.
+    let candidate = unsafe { candidate.assume_initialized() };
 
     let is_bit_valid = BoolAndZst::is_bit_valid(candidate);
     assert!(is_bit_valid);


### PR DESCRIPTION
This opens the door to implementing `TryFromBytes<Option<&T>>`, which is currently blocked on us needing to inspect whether the referent bytes are zeroed. We couldn't do that previously, since `AsInitialized` leaves the possibility for uninitialized bytes, which cannot be soundly checked for equality; described here: https://github.com/rust-lang/unsafe-code-guidelines/issues/488.
