### PR TITLE
[testutil] Downgrade to edition 2018

### DIFF
--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 name = "testutil"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.18.0"


### PR DESCRIPTION
This will make it marginally easier to lower our MSRV to 1.55 in the future.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
