### PR TITLE
Remove unsound `Ptr::forget_valid`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8059,7 +8059,13 @@ mod tests {
         macro_rules! assert_impls {
             ($ty:ty: TryFromBytes) => {
                 <$ty as TryFromBytesTestable>::with_passing_test_cases(|val| {
-                    let c = Ptr::from_ref(val).forget_valid().forget_aligned();
+                    let c = Ptr::from_ref(val).forget_aligned();
+                    let c = c.forget_aligned();
+                    // SAFETY:
+                    // TODO(#899): This is unsound. `$ty` is not necessarily
+                    // `IntoBytes`, but that's the corner we've backed ourselves
+                    // into by using `Ptr::from_ref`.
+                    let c = unsafe { c.assume_initialized() };
                     let res = <$ty as TryFromBytes>::is_bit_valid(c);
                     assert!(res, "{}::is_bit_valid({:?}): got false, expected true", stringify!($ty), val);
 

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -612,16 +612,6 @@ mod _transitions {
             // SAFETY: `AnyAlignment` is less restrictive than `Aligned`.
             unsafe { Ptr::from_ptr(self) }
         }
-
-        /// Forgets that `Ptr`'s referent is bit-valid for `T`.
-        #[doc(hidden)]
-        #[inline]
-        pub fn forget_valid(
-            self,
-        ) -> Ptr<'a, T, (I::Aliasing, I::Alignment, invariant::Initialized)> {
-            // SAFETY: `AnyValidity` is less restrictive than `Valid`.
-            unsafe { Ptr::from_ptr(self) }
-        }
     }
 }
 

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -19,7 +19,9 @@ include!("include.rs");
 fn zst() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&());
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&()` trivially consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
     let is_bit_valid = <() as imp::TryFromBytes>::is_bit_valid(candidate);
     imp::assert!(is_bit_valid);
 }
@@ -36,7 +38,9 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 fn one() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&One` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
     let is_bit_valid = <One as imp::TryFromBytes>::is_bit_valid(candidate);
     imp::assert!(is_bit_valid);
 }
@@ -54,7 +58,9 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 fn two() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&Two { a: false, b: () });
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&Two` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
     let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate);
     imp::assert!(is_bit_valid);
 }
@@ -63,7 +69,9 @@ fn two() {
 fn two_bad() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&Two` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
 
     // SAFETY:
     // - The cast `cast(p)` is implemented exactly as follows: `|p: *mut T| p as
@@ -91,7 +99,9 @@ util_assert_impl_all!(Unsized: imp::TryFromBytes);
 fn un_sized() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[16, 12, 42][..]);
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&Unsized` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
 
     // SAFETY:
     // - The cast `cast(p)` is implemented exactly as follows: `|p: *mut T| p as

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -26,7 +26,9 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 fn one() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&One` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
     let is_bit_valid = <One as imp::TryFromBytes>::is_bit_valid(candidate);
     assert!(is_bit_valid);
 }
@@ -44,12 +46,16 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 fn two() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate_a = ::zerocopy::Ptr::from_ref(&Two { a: false });
-    let candidate_a = candidate_a.forget_aligned().forget_valid();
+    let candidate_a = candidate_a.forget_aligned();
+    // SAFETY: `&Two` consists entirely of initialized bytes.
+    let candidate_a = unsafe { candidate_a.assume_initialized() };
     let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate_a);
     assert!(is_bit_valid);
 
     let candidate_b = ::zerocopy::Ptr::from_ref(&Two { b: true });
-    let candidate_b = candidate_b.forget_aligned().forget_valid();
+    let candidate_b = candidate_b.forget_aligned();
+    // SAFETY: `&Two` consists entirely of initialized bytes.
+    let candidate_b = unsafe { candidate_b.assume_initialized() };
     let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate_b);
     assert!(is_bit_valid);
 }
@@ -58,7 +64,9 @@ fn two() {
 fn two_bad() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&[u8]` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
 
     // SAFETY:
     // - The cast `cast(p)` is implemented exactly as follows: `|p: *mut T| p as
@@ -85,7 +93,9 @@ union BoolAndZst {
 fn bool_and_zst() {
     // TODO(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
-    let candidate = candidate.forget_aligned().forget_valid();
+    let candidate = candidate.forget_aligned();
+    // SAFETY: `&[u8]` consists entirely of initialized bytes.
+    let candidate = unsafe { candidate.assume_initialized() };
 
     // SAFETY:
     // - The cast `cast(p)` is implemented exactly as follows: `|p: *mut T| p as


### PR DESCRIPTION
With the addition of `Initialized`, validity is no longer totally ordered.
