### PR TITLE
Implement `<Unalign as TryFromBytes>::is_bit_valid`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -268,6 +268,9 @@ macro_rules! opt_fn {
 /// impl in this case, and also provides useful documentation for readers of the
 /// code.
 ///
+/// Finally, if a `TryFromBytes::is_bit_valid` impl is provided, it must adhere
+/// to the safety preconditions of [`unsafe_impl!`].
+///
 /// ## Example
 ///
 /// ```rust,ignore
@@ -304,24 +307,15 @@ macro_rules! impl_or_verify {
     };
     (
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
+        => $trait:ident for $ty:ty $(; |$candidate:ident $(: MaybeAligned<$ref_repr:ty>)? $(: Maybe<$ptr_repr:ty>)?| $is_bit_valid:expr)?
     ) => {
         impl_or_verify!(@impl { unsafe_impl!(
             $($tyvar $(: $(? $optbound +)* $($bound +)*)?),* => $trait for $ty
+            $(; |$candidate $(: MaybeAligned<$ref_repr>)? $(: Maybe<$ptr_repr>)?| $is_bit_valid)?
         ); });
         impl_or_verify!(@verify $trait, {
             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
         });
-    };
-    (
-        $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty
-    ) => {
-        unsafe_impl!(
-            @inner
-            $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty
-        );
     };
     (@impl $impl_block:tt) => {
         #[cfg(not(any(feature = "derive", test)))]

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -76,9 +76,20 @@ safety_comment! {
     ///   `FromZeros`, `FromBytes`, or `IntoBytes` exactly when `T` is as well.
     /// - `NoCell`: `Unalign<T>` has the same fields as `T`, so it contains
     ///   `UnsafeCell`s exactly when `T` does.
+    /// - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as
+    ///   `T`, so `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
+    ///   Furthermore:
+    ///   - Since `T` and `Unalign<T>` have the same layout, they have the same
+    ///     size (as required by `unsafe_impl!`).
+    ///   - Since `T` and `Unalign<T>` have the same fields, they have
+    ///     `UnsafeCell`s at the same byte ranges (as required by
+    ///     `unsafe_impl!`).
     impl_or_verify!(T => Unaligned for Unalign<T>);
     impl_or_verify!(T: NoCell => NoCell for Unalign<T>);
-    impl_or_verify!(T: TryFromBytes => TryFromBytes for Unalign<T>);
+    impl_or_verify!(
+        T: TryFromBytes => TryFromBytes for Unalign<T>;
+        |c: Maybe<T>| T::is_bit_valid(c)
+    );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
     impl_or_verify!(T: IntoBytes => IntoBytes for Unalign<T>);


### PR DESCRIPTION
This replaces the implicit implementation, which accepted all values as bit-valid, which was unsound.

While we're here, add more test cases to `test_impls` to test hand-rolled `is_bit_valid` impls for other types.

Closes #897

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
