### PR TITLE
Implement `PartialOrd` and `Ord` where possible

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -192,6 +192,13 @@ macro_rules! impl_ops_traits {
     ($name:ident, $native:ident, "floating point number") => {
         impl_ops_traits!($name, $native, @all_types);
         impl_ops_traits!($name, $native, @signed_integer_floating_point);
+
+        impl<O: ByteOrder> PartialOrd for $name<O> {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                self.get().partial_cmp(&other.get())
+            }
+        }
     };
     ($name:ident, $native:ident, "unsigned integer") => {
         impl_ops_traits!($name, $native, @signed_unsigned_integer);
@@ -216,6 +223,20 @@ macro_rules! impl_ops_traits {
             fn not(self) -> $name<O> {
                  let self_native = $native::from_ne_bytes(self.0);
                  $name((!self_native).to_ne_bytes(), PhantomData)
+            }
+        }
+
+        impl<O: ByteOrder> PartialOrd for $name<O> {
+            #[inline(always)]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl<O: ByteOrder> Ord for $name<O> {
+            #[inline(always)]
+            fn cmp(&self, other: &Self) -> Ordering {
+                self.get().cmp(&other.get())
             }
         }
     };


### PR DESCRIPTION
All numeric types can implement `PartialOrd` and `Ord`, except floats, which can only implement `PartialOrd`.

We cannot simply implement `PartialOrd` via `@all_types` because then clippy will complain about `PartialOrd` not being implemented in terms of `Ord` (see [`clippy::non_canonical_partial_ord_impl`](https://rust-lang.github.io/rust-clippy/master/index.html#/non_canonical_partial_ord_impl) lint) for non-floats.
