### PR TITLE
Make Ptr::reborrow public

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -515,8 +515,9 @@ mod _conversions {
         /// Since `self` is borrowed immutably, this prevents any mutable
         /// methods from being called on `self` as long as the returned `Ptr`
         /// exists.
+        #[doc(hidden)]
         #[allow(clippy::needless_lifetimes)] // Allows us to name the lifetime in the safety comment below.
-        pub(crate) fn reborrow<'b>(&'b mut self) -> Ptr<'b, T, I>
+        pub fn reborrow<'b>(&'b mut self) -> Ptr<'b, T, I>
         where
             'a: 'b,
         {


### PR DESCRIPTION
This shouldn't have made it onto `main`, but was able to as a result of the bug described in #947.

This will need to merge before #948 can merge.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
