### PR TITLE
Fix UI tests

### DIFF
--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -31,6 +31,8 @@ fn ui() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn ui_invalid_impls() {
+    assert!(cfg!(feature = "derive"), "ui tests cannot be run without the `derive` feature");
+
     let version = ToolchainVersion::extract_from_pwd().unwrap();
     // See the doc comment on this method for an explanation of what this does
     // and why we store source files in different directories.

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -12,8 +12,8 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
 note: required because of the requirements on the impl of `zerocopy::TryFromBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |          ^^^^^^^^^^^^
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -42,10 +42,10 @@ error[E0277]: the trait bound `T: FromZeroes` is not satisfied
    | ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `FromZeroes` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:24
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                        ^^^^^^^^^
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -74,10 +74,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    | ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::FromBytes` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:35
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                   ^^^^^^^^^
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -106,10 +106,10 @@ error[E0277]: the trait bound `T: AsBytes` is not satisfied
    | ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `AsBytes` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:46
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                              ^^^^^^^^^
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                     ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
@@ -138,10 +138,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    | ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::Unaligned` for `Foo<T>`
-  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:57
+  --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                                         ^^^^^^^^^
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                                ^^^^^^^^^
 note: required by a bound in `_::Subtrait`
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |

--- a/tests/ui-msrv/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-intobytes.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
+error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-dst-not-intobytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Dst`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Dst`
    |
 note: required by `AssertDstIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-dst-not-intobytes.rs:24:36

--- a/tests/ui-msrv/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-intobytes.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
 note: required by `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
@@ -11,11 +11,11 @@ note: required by `AssertSrcIsIntoBytes`
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
+error[E0277]: the trait bound `Src: AsBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
    |
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36

--- a/tests/ui-msrv/transmute-ptr-to-usize.stderr
+++ b/tests/ui-msrv/transmute-ptr-to-usize.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
 note: required by `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
@@ -11,11 +11,11 @@ note: required by `AssertIsIntoBytes`
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30

--- a/tests/ui-nightly/invalid-impls/invalid-impls.rs
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.rs
@@ -19,7 +19,7 @@ use zerocopy_derive::*;
 
 fn main() {}
 
-#[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
+#[derive(FromBytes, IntoBytes, Unaligned)]
 #[repr(transparent)]
 struct Foo<T>(T);
 

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -7,8 +7,8 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
 note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |          ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -19,7 +19,7 @@ note: required by a bound in `_::Subtrait`
    |
 26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
    | --------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `TryFromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
@@ -32,10 +32,10 @@ error[E0277]: the trait bound `T: FromZeroes` is not satisfied
    |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`, which is required by `Foo<T>: FromZeroes`
    |
 note: required for `Foo<T>` to implement `FromZeroes`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:24
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                        ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -46,7 +46,7 @@ note: required by a bound in `_::Subtrait`
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
    | ------------------------------------------ in this macro invocation
-   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`, which is required by `Foo<T>: zerocopy::FromBytes`
    |
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:35
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `T: AsBytes` is not satisfied
    |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`, which is required by `Foo<T>: AsBytes`
    |
 note: required for `Foo<T>` to implement `AsBytes`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:46
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |
@@ -113,10 +113,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`, which is required by `Foo<T>: zerocopy::Unaligned`
    |
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:57
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                                ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-nightly/invalid-impls/../../../src/macros.rs
    |

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
@@ -12,7 +12,7 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-intobytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-intobytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
@@ -16,7 +16,7 @@ fn main() {}
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-intobytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-intobytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
@@ -15,7 +15,7 @@ use zerocopy::transmute_ref;
 
 fn main() {}
 
-#[derive(zerocopy::FromZeros, zerocopy::FromBytes)]
+#[derive(zerocopy::FromBytes)]
 #[repr(transparent)]
 struct Dst(AU16);
 

--- a/tests/ui-stable/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-stable/invalid-impls/invalid-impls.stderr
@@ -7,8 +7,8 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
 note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |          ^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -19,7 +19,7 @@ note: required by a bound in `_::Subtrait`
    |
 26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
    | --------------------------------------------- in this macro invocation
-   = note: this error originates in the derive macro `TryFromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
@@ -32,10 +32,10 @@ error[E0277]: the trait bound `T: FromZeroes` is not satisfied
    |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `FromZeroes`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:24
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                        ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -46,7 +46,7 @@ note: required by a bound in `_::Subtrait`
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
    | ------------------------------------------ in this macro invocation
-   = note: this error originates in the derive macro `FromZeros` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
@@ -59,10 +59,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:35
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:10
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                   ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -86,10 +86,10 @@ error[E0277]: the trait bound `T: AsBytes` is not satisfied
    |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `AsBytes`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:46
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:21
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                              ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |
@@ -113,10 +113,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:57
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:32
    |
-22 | #[derive(TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned)]
-   |                                                         ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+22 | #[derive(FromBytes, IntoBytes, Unaligned)]
+   |                                ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::Subtrait`
   --> tests/ui-stable/invalid-impls/../../../src/macros.rs
    |


### PR DESCRIPTION
This shouldn't have made it onto `main`, but was able to as a result of the bug described in #947.

While we're here, add an `assert!` that prevents us from running UI tests when the `derive` feature is disabled. The `derive` feature is required in order for UI tests to produce sensible output, and running without it enabled is a common source of mis-steps when developing that ends up slowing us down.

This will need to merge before #948 can merge.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
