### PR TITLE
Disable re-exporting renamed traits in dev and CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1667,6 +1667,8 @@ pub unsafe trait FromZeros {
 /// Deprecated: prefer [`FromZeros`] instead.
 #[deprecated(since = "0.8.0", note = "`FromZeroes` was renamed to `FromZeros`")]
 #[doc(hidden)]
+// See #960 for why we do this.
+#[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
 pub use FromZeros as FromZeroes;
 
 /// Analyzes whether a type is [`FromBytes`].
@@ -3042,6 +3044,8 @@ pub unsafe trait IntoBytes {
 /// Deprecated: prefer [`IntoBytes`] instead.
 #[deprecated(since = "0.8.0", note = "`AsBytes` was renamed to `IntoBytes`")]
 #[doc(hidden)]
+// See #960 for why we do this.
+#[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
 pub use IntoBytes as AsBytes;
 
 /// Types with no alignment requirement.

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -30,18 +30,18 @@ help: consider restricting type parameter `T`
 26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
    |                  ++++++++++++++++++++++++
 
-error[E0277]: the trait bound `T: FromZeroes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
-   |                                                                    ^^^^^^^^ the trait `FromZeroes` is not implemented for `T`
+   |                                                                    ^^^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:1
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
    | ------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `FromZeroes` for `Foo<T>`
+note: required because of the requirements on the impl of `zerocopy::FromZeros` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -94,18 +94,18 @@ help: consider restricting type parameter `T`
 28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
    |                  +++++++++++++++++++++
 
-error[E0277]: the trait bound `T: AsBytes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/macros.rs
    |
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
-   |                                                                    ^^^^^^^^ the trait `AsBytes` is not implemented for `T`
+   |                                                                    ^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
    |
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:1
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
    | ------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `AsBytes` for `Foo<T>`
+note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:21
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]

--- a/tests/ui-msrv/transmute-ptr-to-usize.stderr
+++ b/tests/ui-msrv/transmute-ptr-to-usize.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
 note: required by `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
@@ -11,11 +11,11 @@ note: required by `AssertIsIntoBytes`
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30

--- a/tests/ui-msrv/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-intobytes.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |
 note: required by `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
@@ -11,11 +11,11 @@ note: required by `AssertSrcIsIntoBytes`
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33

--- a/tests/ui-msrv/transmute-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-src-not-intobytes.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
 note: required by `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
@@ -11,11 +11,11 @@ note: required by `AssertIsIntoBytes`
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -25,13 +25,13 @@ help: consider restricting type parameter `T`
 26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
    |                  ++++++++++++++++++++++++
 
-error[E0277]: the trait bound `T: FromZeroes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:36
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`, which is required by `Foo<T>: FromZeroes`
+   |                                    ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`, which is required by `Foo<T>: zerocopy::FromZeros`
    |
-note: required for `Foo<T>` to implement `FromZeroes`
+note: required for `Foo<T>` to implement `zerocopy::FromZeros`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -79,13 +79,13 @@ help: consider restricting type parameter `T`
 28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
    |                  +++++++++++++++++++++
 
-error[E0277]: the trait bound `T: AsBytes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:29:36
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`, which is required by `Foo<T>: AsBytes`
+   |                                    ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`, which is required by `Foo<T>: zerocopy::IntoBytes`
    |
-note: required for `Foo<T>` to implement `AsBytes`
+note: required for `Foo<T>` to implement `zerocopy::IntoBytes`
   --> tests/ui-nightly/invalid-impls/invalid-impls.rs:22:21
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]

--- a/tests/ui-nightly/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
+error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-mut-dst-not-intobytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
-   |                                    the trait `AsBytes` is not implemented for `Dst`
+   |                                    the trait `IntoBytes` is not implemented for `Dst`
    |                                    required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-nightly/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
-   |                                    the trait `AsBytes` is not implemented for `Src`
+   |                                    the trait `IntoBytes` is not implemented for `Src`
    |                                    required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertSrcIsIntoBytes`
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-nightly/transmute-ptr-to-usize.stderr
+++ b/tests/ui-nightly/transmute-ptr-to-usize.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
-   |                              the trait `AsBytes` is not implemented for `*const usize`
+   |                              the trait `IntoBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
    |
-   = help: the trait `AsBytes` is implemented for `usize`
+   = help: the trait `IntoBytes` is implemented for `usize`
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |
@@ -15,13 +15,13 @@ note: required by a bound in `AssertIsIntoBytes`
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
-   = help: the trait `AsBytes` is implemented for `usize`
+   = help: the trait `IntoBytes` is implemented for `usize`
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |

--- a/tests/ui-nightly/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                 |
-   |                                 the trait `AsBytes` is not implemented for `Src`
+   |                                 the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |                                 required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertSrcIsIntoBytes`
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-nightly/transmute-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                |
-   |                                the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |                                required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertIsIntoBytes`
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-stable/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-stable/invalid-impls/invalid-impls.stderr
@@ -25,13 +25,13 @@ help: consider restricting type parameter `T`
 26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
    |                  ++++++++++++++++++++++++
 
-error[E0277]: the trait bound `T: FromZeroes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:27:36
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   |                                    ^^^^^^ the trait `FromZeroes` is not implemented for `T`
+   |                                    ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
    |
-note: required for `Foo<T>` to implement `FromZeroes`
+note: required for `Foo<T>` to implement `zerocopy::FromZeros`
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -79,13 +79,13 @@ help: consider restricting type parameter `T`
 28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
    |                  +++++++++++++++++++++
 
-error[E0277]: the trait bound `T: AsBytes` is not satisfied
+error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:29:36
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `AsBytes` is not implemented for `T`
+   |                                    ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
    |
-note: required for `Foo<T>` to implement `AsBytes`
+note: required for `Foo<T>` to implement `zerocopy::IntoBytes`
   --> tests/ui-stable/invalid-impls/invalid-impls.rs:22:21
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]

--- a/tests/ui-stable/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: AsBytes` is not satisfied
+error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-mut-dst-not-intobytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
-   |                                    the trait `AsBytes` is not implemented for `Dst`
+   |                                    the trait `IntoBytes` is not implemented for `Dst`
    |                                    required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-stable/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
-   |                                    the trait `AsBytes` is not implemented for `Src`
+   |                                    the trait `IntoBytes` is not implemented for `Src`
    |                                    required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertSrcIsIntoBytes`
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-stable/transmute-ptr-to-usize.stderr
+++ b/tests/ui-stable/transmute-ptr-to-usize.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
-   |                              the trait `AsBytes` is not implemented for `*const usize`
+   |                              the trait `IntoBytes` is not implemented for `*const usize`
    |                              required by a bound introduced by this call
    |
-   = help: the trait `AsBytes` is implemented for `usize`
+   = help: the trait `IntoBytes` is implemented for `usize`
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |
@@ -15,13 +15,13 @@ note: required by a bound in `AssertIsIntoBytes`
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `*const usize: AsBytes` is not satisfied
+error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
-   = help: the trait `AsBytes` is implemented for `usize`
+   = help: the trait `IntoBytes` is implemented for `usize`
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |

--- a/tests/ui-stable/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                 |
-   |                                 the trait `AsBytes` is not implemented for `Src`
+   |                                 the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |                                 required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertSrcIsIntoBytes`
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: AsBytes` is not satisfied
+error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `Src`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize

--- a/tests/ui-stable/transmute-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-src-not-intobytes.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                                |
-   |                                the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |                                required by a bound introduced by this call
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -24,13 +24,13 @@ note: required by a bound in `AssertIsIntoBytes`
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy<AU16>: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -201,10 +201,12 @@ fn install_toolchain_or_exit(versions: &Versions, name: &str) -> Result<(), Erro
 }
 
 fn get_rustflags(name: &str) -> &'static str {
+    // See #960 for an explanation of why we emit --cfg
+    // __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES.
     if name == "nightly" {
-        "--cfg __INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS "
+        "--cfg __INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS --cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES "
     } else {
-        ""
+        "--cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES "
     }
 }
 

--- a/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -57,11 +57,11 @@ util_assert_impl_all!(Baz: imp::TryFromBytes);
 #[test]
 fn test_baz() {
     imp::assert_eq!(
-        <Baz as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&1u32)),
+        <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1u32)),
         imp::Some(Baz::A)
     );
     imp::assert_eq!(
-        <Baz as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&0u32)),
+        <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0u32)),
         imp::Some(Baz::B)
     );
     imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[]), imp::None);
@@ -91,19 +91,19 @@ util_assert_impl_all!(Blah: imp::TryFromBytes);
 #[test]
 fn test_blah() {
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&1i8)),
+        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1i8)),
         imp::Some(Blah::A)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&0i8)),
+        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0i8)),
         imp::Some(Blah::B)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&3i8)),
+        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&3i8)),
         imp::Some(Blah::C)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::AsBytes::as_bytes(&6i8)),
+        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&6i8)),
         imp::Some(Blah::D)
     );
     imp::assert_eq!(<Blah as imp::TryFromBytes>::try_read_from(&[]), imp::None);

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -52,13 +52,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
 37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `AsBytes` for `TransparentStruct<NotZerocopy>`
+note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `TransparentStruct<NotZerocopy>`
   --> tests/ui-msrv/derive_transparent.rs:24:10
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -60,11 +60,11 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:55:10
    |
 55 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -26,13 +26,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:35:23
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: FromZeroes`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: FromZeros`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              i64
              i128
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
+note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-nightly/derive_transparent.rs:24:21
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -82,13 +82,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:37:23
    |
 37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: AsBytes`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`, which is required by `TransparentStruct<NotZerocopy>: zerocopy::IntoBytes`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -98,7 +98,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::IntoBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:10
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -46,13 +46,13 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:37:10
    |
 37 | #[derive(FromZeros)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -86,13 +86,13 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:46:10
    |
 46 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -126,13 +126,13 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:55:10
    |
 55 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -26,13 +26,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:35:23
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
              i64
              i128
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeroes`
+note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-stable/derive_transparent.rs:24:21
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -82,13 +82,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:37:23
    |
 37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize
@@ -98,7 +98,7 @@ error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
              i64
              i128
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `AsBytes`
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::IntoBytes`
   --> tests/ui-stable/derive_transparent.rs:24:10
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -44,13 +44,13 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:37:10
    |
 37 | #[derive(FromZeros)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -82,13 +82,13 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: FromZeroes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:46:10
    |
 46 | #[derive(FromBytes)]
-   |          ^^^^^^^^^ the trait `FromZeroes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `FromZeroes`:
+   = help: the following other types implement trait `FromZeros`:
              bool
              char
              isize
@@ -120,13 +120,13 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: AsBytes` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:55:10
    |
 55 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `AsBytes` is not implemented for `NotZerocopy`
+   |          ^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
-   = help: the following other types implement trait `AsBytes`:
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
              bool
              char
              isize


### PR DESCRIPTION
See #960 for an explanation of why we do this.

Closes #960

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
