### PR TITLE
Make old names errors instead of warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1823,12 +1823,28 @@ pub unsafe trait FromZeros: TryFromBytes {
     }
 }
 
-/// Deprecated: prefer [`FromZeros`] instead.
-#[deprecated(since = "0.8.0", note = "`FromZeroes` was renamed to `FromZeros`")]
-#[doc(hidden)]
+// This exists so that code which was written against the old name will get a
+// less confusing error message when they upgrade to a more recent version of
+// zerocopy. On our MSRV toolchain, the error message reads:
+//
+//   error[E0603]: trait `FromZeroes` is private
+//       --> examples/deprecated.rs:1:15
+//        |
+//   1    | use zerocopy::FromZeroes;
+//        |               ^^^^^^^^^^ private trait
+//        |
+//   note: the trait `FromZeroes` is defined here
+//       --> /Users/josh/workspace/zerocopy/src/lib.rs:1845:5
+//        |
+//   1845 | use FromZeros as FromZeroes;
+//        |     ^^^^^^^^^^^^^^^^^^^^^^^
+//
+// The "note" provides enough context to make it easy to figure out how to fix
+// the error.
+#[allow(unused)]
 // See #960 for why we do this.
 #[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
-pub use FromZeros as FromZeroes;
+use FromZeros as FromZeroes;
 
 /// Analyzes whether a type is [`FromBytes`].
 ///
@@ -3180,9 +3196,25 @@ pub unsafe trait IntoBytes {
     }
 }
 
-/// Deprecated: prefer [`IntoBytes`] instead.
-#[deprecated(since = "0.8.0", note = "`AsBytes` was renamed to `IntoBytes`")]
-#[doc(hidden)]
+// This exists so that code which was written against the old name will get a
+// less confusing error message when they upgrade to a more recent version of
+// zerocopy. On our MSRV toolchain, the error message reads:
+//
+//   error[E0603]: trait `AsBytes` is private
+//       --> examples/deprecated.rs:1:15
+//        |
+//   1    | use zerocopy::AsBytes;
+//        |               ^^^^^^^ private trait
+//        |
+//   note: the trait `AsBytes` is defined here
+//       --> /Users/josh/workspace/zerocopy/src/lib.rs:3216:5
+//        |
+//   3216 | use IntoBytes as AsBytes;
+//        |     ^^^^^^^^^^^^^^^^^^^^
+//
+// The "note" provides enough context to make it easy to figure out how to fix
+// the error.
+#[allow(unused)]
 // See #960 for why we do this.
 #[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
 pub use IntoBytes as AsBytes;


### PR DESCRIPTION
Previously, we re-exported renamed traits as their old names via `pub use`. Despite including `#[deprecated]` attributes on each `pub use`, it still caused problems for us as described in #960.

In this commit, we replace `pub use` with just `use`. This has the effect of making it so that using the old names is an error rather than a warning, which accomplishes two things: first, it ensures that the issue described in #960 can't happen, as the compiler will never generate suggestions to write code which generates errors. Second, it ensures that callers are forced to update to the new names, which makes it less likely for us to cause breakage when we eventually remove the `use` path.

Note that, despite no longer having an explicit deprecation warning that explains what's happening, the error message still provides plenty of breadcrumb as to what happened. Consider this example error message:

```text
  error[E0603]: trait `FromZeroes` is private
      --> examples/deprecated.rs:1:15
       |
  1    | use zerocopy::FromZeroes;
       |               ^^^^^^^^^^ private trait
       |
  note: the trait `FromZeroes` is defined here
      --> /Users/josh/workspace/zerocopy/src/lib.rs:1845:5
       |
  1845 | use FromZeros as FromZeroes;
```

The fact that the original source code is included makes it easy to see what's gone wrong - there's another item called `FromZeros` that can be used instead.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
