### PR TITLE
Consolodate and improve use of old names

### DIFF
--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -86,12 +86,9 @@ jobs:
             cargo "+$VERSION_FOR_CARGO" fix --allow-dirty --tests --package zerocopy $ZEROCOPY_FEATURES || true
             cargo "+$VERSION_FOR_CARGO" fix --allow-dirty --tests --package zerocopy-derive             || true
 
-            # See #960 for an explanation of this `--cfg`.
-            RUSTFLAGS="--cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES"
-
             # Update `.stderr` files as needed for the new version.
-            RUSTFLAGS="$RUSTFLAGS" TRYBUILD=overwrite cargo "+$VERSION_FOR_CARGO" test --package zerocopy $ZEROCOPY_FEATURES
-            RUSTFLAGS="$RUSTFLAGS" TRYBUILD=overwrite cargo "+$VERSION_FOR_CARGO" test --package zerocopy-derive
+            TRYBUILD=overwrite cargo "+$VERSION_FOR_CARGO" test --package zerocopy $ZEROCOPY_FEATURES
+            TRYBUILD=overwrite cargo "+$VERSION_FOR_CARGO" test --package zerocopy-derive
           }
 
           if [ "${{ matrix.toolchain }}" == stable ]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,6 +339,27 @@ const _: () = {
     _WARNING
 };
 
+// These exist so that code which was written against the old names will get
+// less confusing error messages when they upgrade to a more recent version of
+// zerocopy. On our MSRV toolchain, the error messages read, for example:
+//
+//   error[E0603]: trait `FromZeroes` is private
+//       --> examples/deprecated.rs:1:15
+//        |
+//   1    | use zerocopy::FromZeroes;
+//        |               ^^^^^^^^^^ private trait
+//        |
+//   note: the trait `FromZeroes` is defined here
+//       --> /Users/josh/workspace/zerocopy/src/lib.rs:1845:5
+//        |
+//   1845 | use FromZeros as FromZeroes;
+//        |     ^^^^^^^^^^^^^^^^^^^^^^^
+//
+// The "note" provides enough context to make it easy to figure out how to fix
+// the error.
+#[allow(unused)]
+use {FromZeros as FromZeroes, IntoBytes as AsBytes, Ref as LayoutVerified};
+
 /// The target pointer width, counted in bits.
 const POINTER_WIDTH_BITS: usize = mem::size_of::<usize>() * 8;
 
@@ -1845,29 +1866,6 @@ pub unsafe trait FromZeros: TryFromBytes {
     }
 }
 
-// This exists so that code which was written against the old name will get a
-// less confusing error message when they upgrade to a more recent version of
-// zerocopy. On our MSRV toolchain, the error message reads:
-//
-//   error[E0603]: trait `FromZeroes` is private
-//       --> examples/deprecated.rs:1:15
-//        |
-//   1    | use zerocopy::FromZeroes;
-//        |               ^^^^^^^^^^ private trait
-//        |
-//   note: the trait `FromZeroes` is defined here
-//       --> /Users/josh/workspace/zerocopy/src/lib.rs:1845:5
-//        |
-//   1845 | use FromZeros as FromZeroes;
-//        |     ^^^^^^^^^^^^^^^^^^^^^^^
-//
-// The "note" provides enough context to make it easy to figure out how to fix
-// the error.
-#[allow(unused)]
-// See #960 for why we do this.
-#[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
-use FromZeros as FromZeroes;
-
 /// Analyzes whether a type is [`FromBytes`].
 ///
 /// This derive analyzes, at compile time, whether the annotated type satisfies
@@ -3217,29 +3215,6 @@ pub unsafe trait IntoBytes {
         Some(())
     }
 }
-
-// This exists so that code which was written against the old name will get a
-// less confusing error message when they upgrade to a more recent version of
-// zerocopy. On our MSRV toolchain, the error message reads:
-//
-//   error[E0603]: trait `AsBytes` is private
-//       --> examples/deprecated.rs:1:15
-//        |
-//   1    | use zerocopy::AsBytes;
-//        |               ^^^^^^^ private trait
-//        |
-//   note: the trait `AsBytes` is defined here
-//       --> /Users/josh/workspace/zerocopy/src/lib.rs:3216:5
-//        |
-//   3216 | use IntoBytes as AsBytes;
-//        |     ^^^^^^^^^^^^^^^^^^^^
-//
-// The "note" provides enough context to make it easy to figure out how to fix
-// the error.
-#[allow(unused)]
-// See #960 for why we do this.
-#[cfg(not(__INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES))]
-pub use IntoBytes as AsBytes;
 
 /// Analyzes whether a type is [`Unaligned`].
 ///
@@ -4774,11 +4749,6 @@ pub struct Ref<B, T: ?Sized>(
     B,
     PhantomData<T>,
 );
-
-/// Deprecated: prefer [`Ref`] instead.
-#[deprecated(since = "0.7.0", note = "`LayoutVerified` was renamed to `Ref`")]
-#[doc(hidden)]
-pub use Ref as LayoutVerified;
 
 impl<B, T> Ref<B, T>
 where

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -201,12 +201,10 @@ fn install_toolchain_or_exit(versions: &Versions, name: &str) -> Result<(), Erro
 }
 
 fn get_rustflags(name: &str) -> &'static str {
-    // See #960 for an explanation of why we emit --cfg
-    // __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES.
     if name == "nightly" {
-        "--cfg __INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS --cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES "
+        "--cfg __INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS "
     } else {
-        "--cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES "
+        ""
     }
 }
 


### PR DESCRIPTION
This commit builds on #980 in a few ways:
- Consolodates `use` lines so we can avoid repeating the same comment multiple times.
- Applies the same technique to the old `LayoutVerified` name (for what is now called `Ref`)
- In #980, we spuriously left `IntoBytes as AsBytes` as a `pub use` rather than just a `use`, which caused us to need to keep the `--cfg __INTERNAL_USE_ONLY_DISABLE_DEPRECATED_TRAIT_ALIASES` in order to keep CI passing. We fix that in this commit, and thus can remove that `--cfg`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
