### PR TITLE
Delevel headers in crate-level documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ so you don't have to.
 
 ## Overview
 
-####### Conversion Traits
+###### Conversion Traits
 
 Zerocopy provides four derivable traits for zero-cost conversions:
 - `TryFromBytes` indicates that a type may safely be converted from
@@ -37,7 +37,7 @@ Zerocopy provides four derivable traits for zero-cost conversions:
 - `IntoBytes` indicates that a type may safely be converted *to* a byte
   sequence
 
-####### Marker Traits
+###### Marker Traits
 
 Zerocopy provides three derivable marker traits that do not provide any
 functionality themselves, but are required to call certain methods provided
@@ -49,7 +49,7 @@ by the conversion traits:
 
 You should generally derive these marker traits whenever possible.
 
-####### Conversion Macros
+###### Conversion Macros
 
 Zerocopy provides three macros for safe, zero-cost casting between types:
 
@@ -64,7 +64,7 @@ These macros perform *compile-time* alignment and size checks, but cannot be
 used in generic contexts. For generic conversions, use the methods defined
 by the [conversion traits](#conversion-traits).
 
-####### Byteorder-Aware Numerics
+###### Byteorder-Aware Numerics
 
 Zerocopy provides byte-order aware integer types that support these
 conversions; see the `byteorder` module. These types are especially useful

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! # Overview
 //!
-//! ###### Conversion Traits
+//! ##### Conversion Traits
 //!
 //! Zerocopy provides four derivable traits for zero-cost conversions:
 //! - [`TryFromBytes`] indicates that a type may safely be converted from
@@ -37,7 +37,7 @@
 //! - [`IntoBytes`] indicates that a type may safely be converted *to* a byte
 //!   sequence
 //!
-//! ###### Marker Traits
+//! ##### Marker Traits
 //!
 //! Zerocopy provides three derivable marker traits that do not provide any
 //! functionality themselves, but are required to call certain methods provided
@@ -49,7 +49,7 @@
 //!
 //! You should generally derive these marker traits whenever possible.
 //!
-//! ###### Conversion Macros
+//! ##### Conversion Macros
 //!
 //! Zerocopy provides three macros for safe, zero-cost casting between types:
 //!
@@ -64,7 +64,7 @@
 //! used in generic contexts. For generic conversions, use the methods defined
 //! by the [conversion traits](#conversion-traits).
 //!
-//! ###### Byteorder-Aware Numerics
+//! ##### Byteorder-Aware Numerics
 //!
 //! Zerocopy provides byte-order aware integer types that support these
 //! conversions; see the [`byteorder`] module. These types are especially useful


### PR DESCRIPTION
In #983 we utilized H6 level headers is our overview documentation. Unfortunately, the readme generator up-levels all headers by one degree, and there's no such thing as an H7.

Closes #998

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
