### PR TITLE
Annotate public macros/functions with `#[must_use]`

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -419,6 +419,7 @@ example of how it can be used for parsing UDP packets.
 
             /// Constructs a new value from bytes which are already in `O` byte
             /// order.
+            #[must_use = "has no side effects"]
             #[inline(always)]
             pub const fn from_bytes(bytes: [u8; $bytes]) -> $name<O> {
                 $name(bytes, PhantomData)
@@ -427,6 +428,7 @@ example of how it can be used for parsing UDP packets.
             /// Extracts the bytes of `self` without swapping the byte order.
             ///
             /// The returned bytes will be in `O` byte order.
+            #[must_use = "has no side effects"]
             #[inline(always)]
             pub const fn to_bytes(self) -> [u8; $bytes] {
                 self.0
@@ -438,6 +440,7 @@ example of how it can be used for parsing UDP packets.
                 /// Constructs a new value, possibly performing an endianness
                 /// swap to guarantee that the returned value has endianness
                 /// `O`.
+                #[must_use = "has no side effects"]
                 #[inline(always)]
                 pub const fn new(n: $native) -> $name<O> {
                     let bytes = match O::ORDER {
@@ -453,6 +456,7 @@ example of how it can be used for parsing UDP packets.
                 /// Returns the value as a primitive type, possibly performing
                 /// an endianness swap to guarantee that the return value has
                 /// the endianness of the native platform.
+                #[must_use = "has no side effects"]
                 #[inline(always)]
                 pub const fn get(self) -> $native {
                     match O::ORDER {

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -404,6 +404,13 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     unsafe { &mut *dst }
 }
 
+/// A function which emits a warning if its return value is not used.
+#[must_use]
+#[inline(always)]
+pub const fn must_use<T>(t: T) -> T {
+    t
+}
+
 // NOTE: We can't change this to a `pub use core as core_reexport` until [1] is
 // fixed or we update to a semver-breaking version (as of this writing, 0.8.0)
 // on the `main` branch.

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -37,6 +37,7 @@ where
     Alignment: invariant::Alignment,
 {
     /// Reads the value from `MaybeAligned`.
+    #[must_use]
     #[inline]
     pub fn read_unaligned(self) -> T
     where
@@ -52,6 +53,7 @@ where
     /// Views the value as an aligned reference.
     ///
     /// This is only available if `T` is [`Unaligned`].
+    #[must_use]
     #[inline]
     pub fn unaligned_as_ref(self) -> &'a T
     where

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -788,6 +788,7 @@ mod _transitions {
         /// The caller promises that `Ptr`'s referent conforms to the validity
         /// requirement of `V`.
         #[doc(hidden)]
+        #[must_use]
         #[inline]
         pub unsafe fn assume_validity<V: invariant::Validity>(
             self,
@@ -804,6 +805,7 @@ mod _transitions {
         /// The caller promises to uphold the safety preconditions of
         /// `self.assume_validity<invariant::Initialized>()`.
         #[doc(hidden)]
+        #[must_use]
         #[inline]
         pub unsafe fn assume_initialized(
             self,
@@ -820,6 +822,7 @@ mod _transitions {
         /// The caller promises to uphold the safety preconditions of
         /// `self.assume_validity<invariant::Valid>()`.
         #[doc(hidden)]
+        #[must_use]
         #[inline]
         pub unsafe fn assume_valid(
             self,
@@ -878,6 +881,7 @@ mod _transitions {
         /// Forgets that `Ptr`'s referent exclusively references `T`,
         /// downgrading to a shared reference.
         #[doc(hidden)]
+        #[must_use]
         #[inline]
         pub fn forget_exclusive(self) -> Ptr<'a, T, (invariant::Shared, I::Alignment, I::Validity)>
         where
@@ -889,6 +893,7 @@ mod _transitions {
 
         /// Forgets that `Ptr`'s referent is validly-aligned for `T`.
         #[doc(hidden)]
+        #[must_use]
         #[inline]
         pub fn forget_aligned(self) -> Ptr<'a, T, (I::Aliasing, invariant::Any, I::Validity)> {
             // SAFETY: `Any` is less restrictive than `Aligned`.

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
@@ -52,8 +52,21 @@ error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found `&mut _`
+   |                                    arguments to this function are incorrect
    |
    = note:           expected type `usize`
            found mutable reference `&mut _`
+help: the return type of this call is `&mut _` due to the type of the argument passed
+  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-mutable.stderr
@@ -42,8 +42,21 @@ error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
    |
 18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      types differ in mutability
+   |                      arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-nightly/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-a-reference.stderr
@@ -42,8 +42,21 @@ error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |                                    ^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found `&_`
+   |                                    arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-nightly/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -58,8 +58,21 @@ error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       |
+   |                                       expected `usize`, found `&_`
+   |                                       arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
@@ -52,8 +52,21 @@ error[E0308]: mismatched types
   --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found `&mut _`
+   |                                    arguments to this function are incorrect
    |
    = note:           expected type `usize`
            found mutable reference `&mut _`
+help: the return type of this call is `&mut _` due to the type of the argument passed
+  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-stable/transmute-ref-dst-mutable.stderr
@@ -42,8 +42,21 @@ error[E0308]: mismatched types
   --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
    |
 18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      types differ in mutability
+   |                      arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-stable/transmute-ref-dst-mutable.rs:18:22
+   |
+18 |     let _: &mut u8 = transmute_ref!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-a-reference.stderr
@@ -42,8 +42,21 @@ error[E0308]: mismatched types
   --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |                                    ^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found `&_`
+   |                                    arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-stable/transmute-ref-dst-not-a-reference.rs:17:36
+   |
+17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+   |                                    ^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-stable/transmute-ref-src-dst-not-references.stderr
@@ -58,8 +58,21 @@ error[E0308]: mismatched types
   --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&_`
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       |
+   |                                       expected `usize`, found `&_`
+   |                                       arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+help: the return type of this call is `&_` due to the type of the argument passed
+  --> tests/ui-stable/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^ this argument influences the return type of `$crate`
+note: function defined here
+  --> src/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Add Clippy lints to help prevent regressions.

Closes #188

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
