### PR TITLE
TransparentWrapper supports UnsafeCell variance

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -247,11 +247,12 @@ macro_rules! impl_for_transparent_wrapper {
         }
     };
     (@is_transparent_wrapper NoCell) => {
-        // SAFETY: `W: TransparentWrapper` requires that `W` has `UnsafeCell`s
-        // at the same byte offsets as `W::Inner = T`. `T: NoCell` implies that
-        // `T` does not contain any `UnsafeCell`s, and so `W` does not contain
-        // any `UnsafeCell`s. Thus, `W` can soundly implement `NoCell`.
-        fn is_transparent_wrapper<I: Invariants, T: ?Sized, W: TransparentWrapper<I, Inner=T> + ?Sized>() {}
+        // SAFETY: `W: TransparentWrapper<UnsafeCellVariance=Covariant>`
+        // requires that `W` has `UnsafeCell`s at the same byte offsets as
+        // `W::Inner = T`. `T: NoCell` implies that `T` does not contain any
+        // `UnsafeCell`s, and so `W` does not contain any `UnsafeCell`s. Thus,
+        // `W` can soundly implement `NoCell`.
+        fn is_transparent_wrapper<I: Invariants, T: ?Sized, W: TransparentWrapper<I, Inner=T, UnsafeCellVariance=Covariant> + ?Sized>() {}
     };
     (@is_transparent_wrapper FromZeros) => {
         // SAFETY: `W: TransparentWrapper<ValidityVariance=Covariant>` requires


### PR DESCRIPTION
This will allow us to implement `TransparentWrapper` for `T` where `T` and `T::Inner` do not have `UnsafeCell`s at the same byte ranges. This, in turn, will let us automatically implement traits for these types so long as those traits don't require reasoning about `UnsafeCell` ranges (in other words, all traits other than `NoCell`).

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
