### PR TITLE
Implement `TransparentWrapper` for `UnsafeCell`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3946,28 +3946,12 @@ impl_for_transparent_wrapper!(T: ?Sized + IntoBytes => IntoBytes for ManuallyDro
 impl_for_transparent_wrapper!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>);
 assert_unaligned!(ManuallyDrop<()>, ManuallyDrop<u8>);
 
-safety_comment! {
-    /// SAFETY:
-    /// - `FromZeros`, `FromBytes`, `IntoBytes`: `UnsafeCell<T>` has the same
-    ///   bit validity as `T` [1], and so implements these traits exactly when
-    ///   `T` does.
-    /// - `Unaligned`: `UnsafeCell<T>` has the same representation as `T`, and
-    ///   so has alignment 1 exactly when `T` does. [2]
-    ///
-    /// [1] TODO(#429): Justify this claim.
-    ///
-    /// [2] Per https://doc.rust-lang.org/core/cell/struct.UnsafeCell.html#memory-layout:
-    ///
-    ///   `UnsafeCell<T>`` has the same in-memory representation as its inner
-    ///   type `T`.
-    ///
-    /// TODO(#5): Implement `FromZeros` and `FromBytes` when `T: ?Sized`.
-    unsafe_impl!(T: FromZeros => FromZeros for UnsafeCell<T>);
-    unsafe_impl!(T: FromBytes => FromBytes for UnsafeCell<T>);
-    unsafe_impl!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>);
-    unsafe_impl!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>);
-    assert_unaligned!(UnsafeCell<()>, UnsafeCell<u8>);
-}
+// TODO(#5): Implement `FromZeros` and `FromBytes` when `T: ?Sized`.
+impl_for_transparent_wrapper!(T: FromZeros => FromZeros for UnsafeCell<T>);
+impl_for_transparent_wrapper!(T: FromBytes => FromBytes for UnsafeCell<T>);
+impl_for_transparent_wrapper!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>);
+impl_for_transparent_wrapper!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>);
+assert_unaligned!(UnsafeCell<()>, UnsafeCell<u8>);
 
 // SAFETY: See safety comment in `is_bit_valid` impl.
 //

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -247,11 +247,12 @@ macro_rules! impl_for_transparent_wrapper {
         }
     };
     (@is_transparent_wrapper NoCell) => {
-        // SAFETY: `W: TransparentWrapper` requires that `W` has `UnsafeCell`s
-        // at the same byte offsets as `W::Inner = T`. `T: NoCell` implies that
-        // `T` does not contain any `UnsafeCell`s, and so `W` does not contain
-        // any `UnsafeCell`s. Thus, `W` can soundly implement `NoCell`.
-        fn is_transparent_wrapper<I: Invariants, T: ?Sized, W: TransparentWrapper<I, Inner=T> + ?Sized>() {}
+        // SAFETY: `W: TransparentWrapper<UnsafeCellVariance=Covariant>`
+        // requires that `W` has `UnsafeCell`s at the same byte offsets as
+        // `W::Inner = T`. `T: NoCell` implies that `T` does not contain any
+        // `UnsafeCell`s, and so `W` does not contain any `UnsafeCell`s. Thus,
+        // `W` can soundly implement `NoCell`.
+        fn is_transparent_wrapper<I: Invariants, T: ?Sized, W: TransparentWrapper<I, Inner=T, UnsafeCellVariance=Covariant> + ?Sized>() {}
     };
     (@is_transparent_wrapper FromZeros) => {
         // SAFETY: `W: TransparentWrapper<ValidityVariance=Covariant>` requires


### PR DESCRIPTION
This allows us to replace unsafe implementations of core traits with
safe ones, using the `TransparentWrapper` bound to prove safety via the
`impl_for_transparent_wrapper!` macro.