### PR TITLE
Relax `NoCell` bound on `transmute_mut!`

### DIFF
--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -378,8 +378,8 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 /// # Safety
 ///
 /// The caller must guarantee that:
-/// - `Src: FromBytes + IntoBytes + NoCell`
-/// - `Dst: FromBytes + IntoBytes + NoCell`
+/// - `Src: FromBytes + IntoBytes`
+/// - `Dst: FromBytes + IntoBytes`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
 // TODO(#686): Consider removing the `NoCell` requirement.
@@ -395,9 +395,8 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     //   vice-versa because the caller has guaranteed that `Src: FromBytes +
     //   IntoBytes`, `Dst: FromBytes + IntoBytes`, and `size_of::<Src>() ==
     //   size_of::<Dst>()`.
-    // - We know that there are no `UnsafeCell`s, and thus we don't have to
-    //   worry about `UnsafeCell` overlap, because `Src: NoCell`
-    //   and `Dst: NoCell`.
+    // - We know that `src` is exclusively aliased, so there are no other active
+    //   references that could be used to create a data race with `&mut dst`.
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
@@ -47,13 +47,3 @@ error[E0308]: mismatched types
    = note:           expected type `usize`
            found mutable reference `&mut _`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
@@ -1,12 +1,25 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:50
    |
 24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Dst`
+   |                                                  ^^^^^^^^
    |
-note: required by `AssertDstIsNoCell`
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
   --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
    |
 24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:55
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                   --------------------^^^-
+   |                                   |                   |
+   |                                   |                   creates a temporary which is freed while still in use
+   |                                   temporary value is freed at the end of this statement
+   |                                   using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:50
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+   |                                                  ^^^^^^^^
    |
-note: required by `AssertSrcIsNoCell`
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
   --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:55
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
-   |
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                   --------------------^^^-
+   |                                   |                   |
+   |                                   |                   creates a temporary which is freed while still in use
+   |                                   temporary value is freed at the end of this statement
+   |                                   using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-a-reference.stderr
@@ -42,16 +42,6 @@ error[E0308]: mismatched types
   --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-nightly/transmute-mut-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
    |                                    expected `usize`, found `&mut _`

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
@@ -12,7 +12,7 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes)]
 #[repr(C)]
 struct Src;
 
@@ -20,5 +20,5 @@ struct Src;
 #[repr(C)]
 struct Dst;
 
-// `transmute_mut` requires that the destination type implements `NoCell`
+// `transmute_mut` des not require that the destination type implements `NoCell`
 const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
@@ -1,25 +1,17 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:50
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                                  ^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, Src, Dst>` in constants
   --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
    |
 24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Dst`
-   |                                   required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
-   |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.rs
@@ -16,9 +16,9 @@ fn main() {}
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes)]
 #[repr(C)]
 struct Dst;
 
-// `transmute_mut` requires that the source type implements `NoCell`
+// `transmute_mut` does not require that the source type implements `NoCell`
 const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
@@ -1,48 +1,17 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:50
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                                  ^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, Src, Dst>` in constants
   --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Src`
-   |                                   required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
-   |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-a-reference.stderr
@@ -42,16 +42,6 @@ error[E0308]: mismatched types
   --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
-   |
-   = note:           expected type `usize`
-           found mutable reference `&mut _`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0308]: mismatched types
-  --> tests/ui-stable/transmute-mut-dst-not-a-reference.rs:17:36
-   |
-17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |                                    |
    |                                    expected `usize`, found `&mut _`

--- a/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
@@ -1,25 +1,26 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:50
+   |
+24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                                  ^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, Src, Dst>` in constants
   --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
    |
 24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Dst`
-   |                                   required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:55
    |
 24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                   --------------------^^^-
+   |                                   |                   |
+   |                                   |                   creates a temporary value which is freed while still in use
+   |                                   temporary value is freed at the end of this statement
+   |                                   using this value as a constant requires that borrow lasts for `'static`

--- a/tests/ui-stable/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-nocell.stderr
@@ -1,48 +1,26 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
+error[E0658]: mutable references are not allowed in constants
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:50
+   |
+24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+   |                                                  ^^^^^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+
+error[E0015]: cannot call non-const fn `transmute_mut::<'_, '_, Src, Dst>` in constants
   --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Src`
-   |                                   required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+error[E0716]: temporary value dropped while borrowed
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:55
    |
 24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
-   |
-   = help: the following other types implement trait `NoCell`:
-             bool
-             char
-             isize
-             i8
-             i16
-             i32
-             i64
-             i128
-           and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
-   |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                   --------------------^^^-
+   |                                   |                   |
+   |                                   |                   creates a temporary value which is freed while still in use
+   |                                   temporary value is freed at the end of this statement
+   |                                   using this value as a constant requires that borrow lasts for `'static`


### PR DESCRIPTION
And document that both `T` and `U` must be `FromBytes + IntoBytes`.

Makes progress towards #686.

Partially addresses #1046.
