### PR TITLE
[ci] Test on thumbv6m-none-eabi target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           "powerpc64-unknown-linux-gnu",
           "riscv64gc-unknown-linux-gnu",
           "s390x-unknown-linux-gnu",
+          "thumbv6m-none-eabi",
           "wasm32-wasi"
         ]
         features: [ "--no-default-features", "", "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2018"
 name = "zerocopy"
-version = "0.8.0-alpha.7"
+version = "0.8.0-alpha.8"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
@@ -66,13 +66,13 @@ simd-nightly = ["simd"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.0-alpha.7", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.0-alpha.8", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.0-alpha.7", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.0-alpha.8", path = "zerocopy-derive" }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -91,6 +91,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.0-alpha.7", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.0-alpha.8", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2018"
 name = "zerocopy-derive"
-version = "0.8.0-alpha.7"
+version = "0.8.0-alpha.8"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
Release 0.8.0-alpha.8.

Fixes #1086

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
