### PR TITLE
Rename `NoCell` to `Immutable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ functionality themselves, but are required to call certain methods provided
 by the conversion traits:
 - `KnownLayout` indicates that zerocopy can reason about certain layout
   qualities of a type
-- `NoCell` indicates that a type does not contain any `UnsafeCell`s
+- `Immutable` indicates that a type does not contain any `UnsafeCell`s
 - `Unaligned` indicates that a type's alignment requirement is 1
 
 You should generally derive these marker traits whenever possible.

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -35,10 +35,10 @@
 //!
 //! ```rust,edition2021
 //! # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
-//! use zerocopy::{IntoBytes, FromBytes, KnownLayout, NoCell, Ref, SplitByteSlice, Unaligned};
+//! use zerocopy::{IntoBytes, FromBytes, KnownLayout, Immutable, Ref, SplitByteSlice, Unaligned};
 //! use zerocopy::byteorder::network_endian::U16;
 //!
-//! #[derive(FromBytes, IntoBytes, KnownLayout, NoCell, Unaligned)]
+//! #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
 //! #[repr(C)]
 //! struct UdpHeader {
 //!     src_port: U16,
@@ -378,7 +378,7 @@ example of how it can be used for parsing UDP packets.
 [`IntoBytes`]: crate::IntoBytes
 [`Unaligned`]: crate::Unaligned"),
             #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-            #[cfg_attr(any(feature = "derive", test), derive(KnownLayout, NoCell, FromBytes, IntoBytes, Unaligned))]
+            #[cfg_attr(any(feature = "derive", test), derive(KnownLayout, Immutable, FromBytes, IntoBytes, Unaligned))]
             #[repr(transparent)]
             pub struct $name<O>([u8; $bytes], PhantomData<O>);
         }
@@ -390,9 +390,9 @@ example of how it can be used for parsing UDP packets.
             /// SAFETY:
             /// `$name<O>` is `repr(transparent)`, and so it has the same layout
             /// as its only non-zero field, which is a `u8` array. `u8` arrays
-            /// are `NoCell`, `TryFromBytes`, `FromZeros`, `FromBytes`,
+            /// are `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`,
             /// `IntoBytes`, and `Unaligned`.
-            impl_or_verify!(O => NoCell for $name<O>);
+            impl_or_verify!(O => Immutable for $name<O>);
             impl_or_verify!(O => TryFromBytes for $name<O>);
             impl_or_verify!(O => FromZeros for $name<O>);
             impl_or_verify!(O => FromBytes for $name<O>);
@@ -903,7 +903,7 @@ mod tests {
     use compatibility::*;
 
     // A native integer type (u16, i32, etc).
-    trait Native: Arbitrary + FromBytes + IntoBytes + NoCell + Copy + PartialEq + Debug {
+    trait Native: Arbitrary + FromBytes + IntoBytes + Immutable + Copy + PartialEq + Debug {
         const ZERO: Self;
         const MAX_VALUE: Self;
 
@@ -948,7 +948,7 @@ mod tests {
     }
 
     trait ByteArray:
-        FromBytes + IntoBytes + NoCell + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq
+        FromBytes + IntoBytes + Immutable + Copy + AsRef<[u8]> + AsMut<[u8]> + Debug + Default + Eq
     {
         /// Invert the order of the bytes in the array.
         fn invert(self) -> Self;

--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -15,7 +15,7 @@ use super::*;
 impl<B, T> Ref<B, [T]>
 where
     B: ByteSlice,
-    T: NoCell,
+    T: Immutable,
 {
     #[deprecated(since = "0.8.0", note = "`Ref::new` now supports slices")]
     #[doc(hidden)]
@@ -28,7 +28,7 @@ where
 impl<B, T> Ref<B, [T]>
 where
     B: ByteSlice,
-    T: Unaligned + NoCell,
+    T: Unaligned + Immutable,
 {
     #[deprecated(since = "0.8.0", note = "`Ref::new_unaligned` now supports slices")]
     #[doc(hidden)]
@@ -41,7 +41,7 @@ where
 impl<'a, B, T> Ref<B, [T]>
 where
     B: 'a + IntoByteSlice<'a>,
-    T: FromBytes + NoCell,
+    T: FromBytes + Immutable,
 {
     #[deprecated(since = "0.8.0", note = "`Ref::into_ref` now supports slices")]
     #[doc(hidden)]
@@ -54,7 +54,7 @@ where
 impl<'a, B, T> Ref<B, [T]>
 where
     B: 'a + IntoByteSliceMut<'a>,
-    T: FromBytes + IntoBytes + NoCell,
+    T: FromBytes + IntoBytes + Immutable,
 {
     #[deprecated(since = "0.8.0", note = "`Ref::into_mut` now supports slices")]
     #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! by the conversion traits:
 //! - [`KnownLayout`] indicates that zerocopy can reason about certain layout
 //!   qualities of a type
-//! - [`NoCell`] indicates that a type does not contain any [`UnsafeCell`]s
+//! - [`Immutable`] indicates that a type does not contain any [`UnsafeCell`]s
 //! - [`Unaligned`] indicates that a type's alignment requirement is 1
 //!
 //! You should generally derive these marker traits whenever possible.
@@ -1214,7 +1214,7 @@ safety_comment! {
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{FromZeros, NoCell};
+/// # use zerocopy_derive::{FromZeros, Immutable};
 /// #[derive(FromZeros)]
 /// struct MyStruct {
 /// # /*
@@ -1231,7 +1231,7 @@ safety_comment! {
 /// # */
 /// }
 ///
-/// #[derive(FromZeros, NoCell)]
+/// #[derive(FromZeros, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -1296,22 +1296,23 @@ safety_comment! {
 #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
 pub use zerocopy_derive::FromZeros;
 
-/// Analyzes whether a type is [`NoCell`].
+/// Analyzes whether a type is [`Immutable`].
 ///
 /// This derive analyzes, at compile time, whether the annotated type satisfies
-/// the [safety conditions] of `NoCell` and implements `NoCell` if it is sound
-/// to do so. This derive can be applied to structs, enums, and unions; e.g.:
+/// the [safety conditions] of `Immutable` and implements `Immutable` if it is
+/// sound to do so. This derive can be applied to structs, enums, and unions;
+/// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::NoCell;
-/// #[derive(NoCell)]
+/// # use zerocopy_derive::Immutable;
+/// #[derive(Immutable)]
 /// struct MyStruct {
 /// # /*
 ///     ...
 /// # */
 /// }
 ///
-/// #[derive(NoCell)]
+/// #[derive(Immutable)]
 /// enum MyEnum {
 /// #   Variant0,
 /// # /*
@@ -1319,7 +1320,7 @@ pub use zerocopy_derive::FromZeros;
 /// # */
 /// }
 ///
-/// #[derive(NoCell)]
+/// #[derive(Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -1331,54 +1332,54 @@ pub use zerocopy_derive::FromZeros;
 /// # Analysis
 ///
 /// *This section describes, roughly, the analysis performed by this derive to
-/// determine whether it is sound to implement `NoCell` for a given type.
+/// determine whether it is sound to implement `Immutable` for a given type.
 /// Unless you are modifying the implementation of this derive, or attempting to
-/// manually implement `NoCell` for a type yourself, you don't need to read
+/// manually implement `Immutable` for a type yourself, you don't need to read
 /// this section.*
 ///
 /// If a type has the following properties, then this derive can implement
-/// `NoCell` for that type:
+/// `Immutable` for that type:
 ///
-/// - All fields must be `NoCell`.
+/// - All fields must be `Immutable`.
 ///
 /// This analysis is subject to change. Unsafe code may *only* rely on the
-/// documented [safety conditions] of `NoCell`, and must *not* rely on the
+/// documented [safety conditions] of `Immutable`, and must *not* rely on the
 /// implementation details of this derive.
 ///
-/// [safety conditions]: trait@NoCell#safety
+/// [safety conditions]: trait@Immutable#safety
 #[cfg(any(feature = "derive", test))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
-pub use zerocopy_derive::NoCell;
+pub use zerocopy_derive::Immutable;
 
-/// Types which do not contain any [`UnsafeCell`]s.
+/// Types which do not directly contain any [`UnsafeCell`]s.
 ///
-/// `T: NoCell` indicates that `T` does not contain any `UnsafeCell`s in its
+/// `T: Immutable` indicates that `T` does not contain any `UnsafeCell`s in its
 /// fields. `T` may still refer to types which contain `UnsafeCell`s: for
-/// example, `&UnsafeCell<T>` implements `NoCell`.
+/// example, `&UnsafeCell<T>` implements `Immutable`.
 ///
 /// # Implementation
 ///
 /// **Do not implement this trait yourself!** Instead, use
-/// [`#[derive(NoCell)]`][derive] (requires the `derive` Cargo feature);
+/// [`#[derive(Immutable)]`][derive] (requires the `derive` Cargo feature);
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::NoCell;
-/// #[derive(NoCell)]
+/// # use zerocopy_derive::Immutable;
+/// #[derive(Immutable)]
 /// struct MyStruct {
 /// # /*
 ///     ...
 /// # */
 /// }
 ///
-/// #[derive(NoCell)]
+/// #[derive(Immutable)]
 /// enum MyEnum {
 /// # /*
 ///     ...
 /// # */
 /// }
 ///
-/// #[derive(NoCell)]
+/// #[derive(Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -1388,37 +1389,37 @@ pub use zerocopy_derive::NoCell;
 /// ```
 ///
 /// This derive performs a sophisticated, compile-time safety analysis to
-/// determine whether a type is `NoCell`.
+/// determine whether a type is `Immutable`.
 ///
 /// # Safety
 ///
-/// If `T: NoCell`, unsafe code *inside of this crate* may assume that, given
+/// If `T: Immutable`, unsafe code *inside of this crate* may assume that, given
 /// `t: &T`, `t` does not contain any [`UnsafeCell`]s at any byte location
 /// within the byte range addressed by `t`. This includes ranges of length 0
 /// (e.g., `UnsafeCell<()>` and `[UnsafeCell<u8>; 0]`). If a type implements
-/// `NoCell` which violates this assumptions, it may cause this crate to exhibit
-/// [undefined behavior].
+/// `Immutable` which violates this assumptions, it may cause this crate to
+/// exhibit [undefined behavior].
 ///
 /// Unsafe code outside of this crate must not make any assumptions about `T`
-/// based on `T: NoCell`. We reserve the right to relax the requirements for
-/// `NoCell` in the future, and if unsafe code outside of this crate makes
-/// assumptions based on `T: NoCell`, future relaxations may cause that code to
-/// become unsound.
+/// based on `T: Immutable`. We reserve the right to relax the requirements for
+/// `Immutable` in the future, and if unsafe code outside of this crate makes
+/// assumptions based on `T: Immutable`, future relaxations may cause that code
+/// to become unsound.
 ///
 /// [`UnsafeCell`]: core::cell::UnsafeCell
 /// [undefined behavior]: https://raphlinus.github.io/programming/rust/2018/08/17/undefined-behavior.html
 #[cfg_attr(
     feature = "derive",
-    doc = "[derive]: zerocopy_derive::NoCell",
-    doc = "[derive-analysis]: zerocopy_derive::NoCell#analysis"
+    doc = "[derive]: zerocopy_derive::Immutable",
+    doc = "[derive-analysis]: zerocopy_derive::Immutable#analysis"
 )]
 #[cfg_attr(
     not(feature = "derive"),
-    doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.NoCell.html"),
-    doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.NoCell.html#analysis"),
+    doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Immutable.html"),
+    doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Immutable.html#analysis"),
 )]
-pub unsafe trait NoCell {
-    // The `Self: Sized` bound makes it so that `NoCell` is still object
+pub unsafe trait Immutable {
+    // The `Self: Sized` bound makes it so that `Immutable` is still object
     // safe.
     #[doc(hidden)]
     fn only_derive_is_allowed_to_implement_this_trait()
@@ -1433,7 +1434,7 @@ pub unsafe trait NoCell {
 /// This derive can be applied to structs, enums, and unions; e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{TryFromBytes, NoCell};
+/// # use zerocopy_derive::{TryFromBytes, Immutable};
 /// #[derive(TryFromBytes)]
 /// struct MyStruct {
 /// # /*
@@ -1450,7 +1451,7 @@ pub unsafe trait NoCell {
 /// # */
 /// }
 ///
-/// #[derive(TryFromBytes, NoCell)]
+/// #[derive(TryFromBytes, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -1479,7 +1480,7 @@ pub use zerocopy_derive::TryFromBytes;
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{TryFromBytes, NoCell};
+/// # use zerocopy_derive::{TryFromBytes, Immutable};
 /// #[derive(TryFromBytes)]
 /// struct MyStruct {
 /// # /*
@@ -1496,7 +1497,7 @@ pub use zerocopy_derive::TryFromBytes;
 /// # */
 /// }
 ///
-/// #[derive(TryFromBytes, NoCell)]
+/// #[derive(TryFromBytes, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -1590,7 +1591,7 @@ pub unsafe trait TryFromBytes {
     ///
     /// Besides user-defined validation routines panicking, `is_bit_valid` will
     /// either panic or fail to compile if called on a pointer with [`Shared`]
-    /// aliasing when `Self: !NoCell`.
+    /// aliasing when `Self: !Immutable`.
     ///
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
@@ -1611,7 +1612,7 @@ pub unsafe trait TryFromBytes {
     #[inline]
     fn try_ref_from(bytes: &[u8]) -> Option<&Self>
     where
-        Self: KnownLayout + NoCell,
+        Self: KnownLayout + Immutable,
     {
         let candidate = Ptr::from_ref(bytes).try_cast_into_no_leftover::<Self>()?;
 
@@ -1621,7 +1622,7 @@ pub unsafe trait TryFromBytes {
         //
         // Note that one panic or post-monomorphization error condition is
         // calling `try_into_valid` (and thus `is_bit_valid`) with a shared
-        // pointer when `Self: !NoCell`. Since `Self: NoCell`, this panic
+        // pointer when `Self: !Immutable`. Since `Self: Immutable`, this panic
         // condition will not happen.
         let candidate = candidate.try_into_valid();
 
@@ -1642,7 +1643,7 @@ pub unsafe trait TryFromBytes {
     #[inline]
     fn try_mut_from(bytes: &mut [u8]) -> Option<&mut Self>
     where
-        Self: KnownLayout + NoCell, // TODO(#251): Remove the `NoCell` bound.
+        Self: KnownLayout + Immutable, // TODO(#251): Remove the `Immutable` bound.
     {
         let candidate = Ptr::from_mut(bytes).try_cast_into_no_leftover::<Self>()?;
 
@@ -1652,7 +1653,7 @@ pub unsafe trait TryFromBytes {
         //
         // Note that one panic or post-monomorphization error condition is
         // calling `try_into_valid` (and thus `is_bit_valid`) with a shared
-        // pointer when `Self: !NoCell`. Since `Self: NoCell`, this panic
+        // pointer when `Self: !Immutable`. Since `Self: Immutable`, this panic
         // condition will not happen.
         let candidate = candidate.try_into_valid();
 
@@ -1675,7 +1676,7 @@ pub unsafe trait TryFromBytes {
         Self: Sized,
     {
         // Note that we have to call `is_bit_valid` on an exclusive-aliased
-        // pointer since we don't require `Self: NoCell`. That's why we do `let
+        // pointer since we don't require `Self: Immutable`. That's why we do `let
         // mut` and `Ptr::from_mut` here. See the doc comment on `is_bit_valid`
         // and the implementation of `TryFromBytes` for `UnsafeCell` for more
         // details.
@@ -1692,7 +1693,7 @@ pub unsafe trait TryFromBytes {
         //
         // Note that one panic or post-monomorphization error condition is
         // calling `try_into_valid` (and thus `is_bit_valid`) with a shared
-        // pointer when `Self: !NoCell`. Since `Self: NoCell`, this panic
+        // pointer when `Self: !Immutable`. Since `Self: Immutable`, this panic
         // condition will not happen.
         if !Self::is_bit_valid(c_ptr.forget_aligned()) {
             return None;
@@ -1718,7 +1719,7 @@ pub unsafe trait TryFromBytes {
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{FromZeros, NoCell};
+/// # use zerocopy_derive::{FromZeros, Immutable};
 /// #[derive(FromZeros)]
 /// struct MyStruct {
 /// # /*
@@ -1735,7 +1736,7 @@ pub unsafe trait TryFromBytes {
 /// # */
 /// }
 ///
-/// #[derive(FromZeros, NoCell)]
+/// #[derive(FromZeros, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -2020,7 +2021,7 @@ pub unsafe trait FromZeros: TryFromBytes {
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{FromBytes, FromZeros, NoCell};
+/// # use zerocopy_derive::{FromBytes, FromZeros, Immutable};
 /// #[derive(FromBytes)]
 /// struct MyStruct {
 /// # /*
@@ -2054,7 +2055,7 @@ pub unsafe trait FromZeros: TryFromBytes {
 /// # */
 /// }
 ///
-/// #[derive(FromBytes, NoCell)]
+/// #[derive(FromBytes, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -2135,7 +2136,7 @@ pub use zerocopy_derive::FromBytes;
 /// e.g.:
 ///
 /// ```
-/// # use zerocopy_derive::{FromBytes, NoCell};
+/// # use zerocopy_derive::{FromBytes, Immutable};
 /// #[derive(FromBytes)]
 /// struct MyStruct {
 /// # /*
@@ -2169,7 +2170,7 @@ pub use zerocopy_derive::FromBytes;
 /// # */
 /// }
 ///
-/// #[derive(FromBytes, NoCell)]
+/// #[derive(FromBytes, Immutable)]
 /// union MyUnion {
 /// #   variant: u8,
 /// # /*
@@ -2226,7 +2227,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -2235,7 +2236,7 @@ pub unsafe trait FromBytes: FromZeros {
     ///     checksum: [u8; 2],
     /// }
     ///
-    /// #[derive(FromBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct Packet {
     ///     header: PacketHeader,
@@ -2257,7 +2258,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn ref_from(bytes: &[u8]) -> Option<&Self>
     where
-        Self: KnownLayout + NoCell,
+        Self: KnownLayout + Immutable,
     {
         Ref::<&[u8], Self>::bikeshed_new_known_layout(bytes).map(Ref::into_ref)
     }
@@ -2275,7 +2276,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -2284,7 +2285,7 @@ pub unsafe trait FromBytes: FromZeros {
     ///     checksum: [u8; 2],
     /// }
     ///
-    /// #[derive(FromBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct Packet {
     ///     header: PacketHeader,
@@ -2307,7 +2308,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn ref_from_prefix(bytes: &[u8]) -> Option<(&Self, &[u8])>
     where
-        Self: KnownLayout + NoCell,
+        Self: KnownLayout + Immutable,
     {
         Ref::<&[u8], Self>::bikeshed_new_from_prefix_known_layout(bytes)
             .map(|(r, s)| (r.into_ref(), s))
@@ -2326,7 +2327,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, NoCell, KnownLayout)]
+    /// #[derive(FromBytes, Immutable, KnownLayout)]
     /// #[repr(C)]
     /// struct PacketTrailer {
     ///     frame_check_sequence: [u8; 4],
@@ -2344,7 +2345,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn ref_from_suffix(bytes: &[u8]) -> Option<(&[u8], &Self)>
     where
-        Self: NoCell + KnownLayout,
+        Self: Immutable + KnownLayout,
     {
         Ref::<&[u8], Self>::bikeshed_new_from_suffix_known_layout(bytes)
             .map(|(p, r)| (p, r.into_ref()))
@@ -2361,7 +2362,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, IntoBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -2388,7 +2389,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_from(bytes: &mut [u8]) -> Option<&mut Self>
     where
-        Self: IntoBytes + KnownLayout + NoCell,
+        Self: IntoBytes + KnownLayout + Immutable,
     {
         Ref::<&mut [u8], Self>::bikeshed_new_known_layout(bytes).map(Ref::into_mut)
     }
@@ -2407,7 +2408,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, IntoBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -2436,7 +2437,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_from_prefix(bytes: &mut [u8]) -> Option<(&mut Self, &mut [u8])>
     where
-        Self: IntoBytes + KnownLayout + NoCell,
+        Self: IntoBytes + KnownLayout + Immutable,
     {
         Ref::<&mut [u8], Self>::bikeshed_new_from_prefix_known_layout(bytes)
             .map(|(r, s)| (r.into_mut(), s))
@@ -2456,7 +2457,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// use zerocopy::FromBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(FromBytes, IntoBytes, KnownLayout, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
     /// #[repr(C)]
     /// struct PacketTrailer {
     ///     frame_check_sequence: [u8; 4],
@@ -2479,7 +2480,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_from_suffix(bytes: &mut [u8]) -> Option<(&mut [u8], &mut Self)>
     where
-        Self: IntoBytes + KnownLayout + NoCell,
+        Self: IntoBytes + KnownLayout + Immutable,
     {
         Ref::<&mut [u8], Self>::bikeshed_new_from_suffix_known_layout(bytes)
             .map(|(p, r)| (p, r.into_mut()))
@@ -2506,7 +2507,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Debug, PartialEq, Eq)]
-    /// #[derive(FromBytes, NoCell)]
+    /// #[derive(FromBytes, Immutable)]
     /// #[repr(C)]
     /// struct Pixel {
     ///     r: u8,
@@ -2531,7 +2532,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn slice_from_prefix(bytes: &[u8], count: usize) -> Option<(&[Self], &[u8])>
     where
-        Self: Sized + NoCell,
+        Self: Sized + Immutable,
     {
         Ref::<_, [Self]>::new_slice_from_prefix(bytes, count).map(|(r, b)| (r.into_ref(), b))
     }
@@ -2557,7 +2558,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Debug, PartialEq, Eq)]
-    /// #[derive(FromBytes, NoCell)]
+    /// #[derive(FromBytes, Immutable)]
     /// #[repr(C)]
     /// struct Pixel {
     ///     r: u8,
@@ -2582,7 +2583,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn slice_from_suffix(bytes: &[u8], count: usize) -> Option<(&[u8], &[Self])>
     where
-        Self: Sized + NoCell,
+        Self: Sized + Immutable,
     {
         Ref::<_, [Self]>::new_slice_from_suffix(bytes, count).map(|(b, r)| (b, r.into_ref()))
     }
@@ -2607,7 +2608,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Debug, PartialEq, Eq)]
-    /// #[derive(FromBytes, IntoBytes, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct Pixel {
     ///     r: u8,
@@ -2634,7 +2635,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_slice_from(bytes: &mut [u8]) -> Option<&mut [Self]>
     where
-        Self: Sized + IntoBytes + NoCell,
+        Self: Sized + IntoBytes + Immutable,
     {
         Ref::<_, [Self]>::new(bytes).map(|r| r.into_mut())
     }
@@ -2660,7 +2661,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Debug, PartialEq, Eq)]
-    /// #[derive(FromBytes, IntoBytes, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct Pixel {
     ///     r: u8,
@@ -2690,7 +2691,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_slice_from_prefix(bytes: &mut [u8], count: usize) -> Option<(&mut [Self], &mut [u8])>
     where
-        Self: Sized + IntoBytes + NoCell,
+        Self: Sized + IntoBytes + Immutable,
     {
         Ref::<_, [Self]>::new_slice_from_prefix(bytes, count).map(|(r, b)| (r.into_mut(), b))
     }
@@ -2716,7 +2717,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Debug, PartialEq, Eq)]
-    /// #[derive(FromBytes, IntoBytes, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct Pixel {
     ///     r: u8,
@@ -2746,7 +2747,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn mut_slice_from_suffix(bytes: &mut [u8], count: usize) -> Option<(&mut [u8], &mut [Self])>
     where
-        Self: Sized + IntoBytes + NoCell,
+        Self: Sized + IntoBytes + Immutable,
     {
         Ref::<_, [Self]>::new_slice_from_suffix(bytes, count).map(|(b, r)| (b, r.into_mut()))
     }
@@ -2869,7 +2870,7 @@ pub unsafe trait FromBytes: FromZeros {
     #[inline]
     fn slice_from(bytes: &[u8]) -> Option<&[Self]>
     where
-        Self: Sized + NoCell,
+        Self: Sized + Immutable,
     {
         <[Self]>::ref_from(bytes)
     }
@@ -3063,7 +3064,7 @@ pub unsafe trait IntoBytes {
     /// use zerocopy::IntoBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(IntoBytes, NoCell)]
+    /// #[derive(IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -3087,7 +3088,7 @@ pub unsafe trait IntoBytes {
     #[inline(always)]
     fn as_bytes(&self) -> &[u8]
     where
-        Self: NoCell,
+        Self: Immutable,
     {
         // Note that this method does not have a `Self: Sized` bound;
         // `size_of_val` works for unsized values too.
@@ -3108,7 +3109,7 @@ pub unsafe trait IntoBytes {
         // - Since `slf` is derived from `self`, and `self` is an immutable
         //   reference, the only other references to this memory region that
         //   could exist are other immutable references, and those don't allow
-        //   mutation. `Self: NoCell` prohibits types which contain
+        //   mutation. `Self: Immutable` prohibits types which contain
         //   `UnsafeCell`s, which are the only types for which this rule
         //   wouldn't be sufficient.
         // - The total size of the resulting slice is no larger than
@@ -3131,7 +3132,7 @@ pub unsafe trait IntoBytes {
     /// # use zerocopy_derive::*;
     ///
     /// # #[derive(Eq, PartialEq, Debug)]
-    /// #[derive(FromBytes, IntoBytes, NoCell)]
+    /// #[derive(FromBytes, IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -3164,7 +3165,7 @@ pub unsafe trait IntoBytes {
     #[inline(always)]
     fn as_mut_bytes(&mut self) -> &mut [u8]
     where
-        Self: FromBytes + NoCell,
+        Self: FromBytes + Immutable,
     {
         // Note that this method does not have a `Self: Sized` bound;
         // `size_of_val` works for unsized values too.
@@ -3204,7 +3205,7 @@ pub unsafe trait IntoBytes {
     /// use zerocopy::IntoBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(IntoBytes, NoCell)]
+    /// #[derive(IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -3244,7 +3245,7 @@ pub unsafe trait IntoBytes {
     #[inline]
     fn write_to(&self, bytes: &mut [u8]) -> Option<()>
     where
-        Self: NoCell,
+        Self: Immutable,
     {
         if bytes.len() != mem::size_of_val(self) {
             return None;
@@ -3265,7 +3266,7 @@ pub unsafe trait IntoBytes {
     /// use zerocopy::IntoBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(IntoBytes, NoCell)]
+    /// #[derive(IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -3305,7 +3306,7 @@ pub unsafe trait IntoBytes {
     #[inline]
     fn write_to_prefix(&self, bytes: &mut [u8]) -> Option<()>
     where
-        Self: NoCell,
+        Self: Immutable,
     {
         let size = mem::size_of_val(self);
         bytes.get_mut(..size)?.copy_from_slice(self.as_bytes());
@@ -3323,7 +3324,7 @@ pub unsafe trait IntoBytes {
     /// use zerocopy::IntoBytes;
     /// # use zerocopy_derive::*;
     ///
-    /// #[derive(IntoBytes, NoCell)]
+    /// #[derive(IntoBytes, Immutable)]
     /// #[repr(C)]
     /// struct PacketHeader {
     ///     src_port: [u8; 2],
@@ -3370,7 +3371,7 @@ pub unsafe trait IntoBytes {
     #[inline]
     fn write_to_suffix(&self, bytes: &mut [u8]) -> Option<()>
     where
-        Self: NoCell,
+        Self: Immutable,
     {
         let start = bytes.len().checked_sub(mem::size_of_val(self))?;
         bytes
@@ -3385,7 +3386,7 @@ pub unsafe trait IntoBytes {
     #[inline]
     fn as_bytes_mut(&mut self) -> &mut [u8]
     where
-        Self: FromBytes + NoCell,
+        Self: FromBytes + Immutable,
     {
         self.as_mut_bytes()
     }
@@ -3534,20 +3535,21 @@ safety_comment! {
     /// SAFETY:
     /// Per the reference [1], "the unit tuple (`()`) ... is guaranteed as a
     /// zero-sized type to have a size of 0 and an alignment of 1."
-    /// - `NoCell`: `()` self-evidently does not contain any `UnsafeCell`s.
+    /// - `Immutable`: `()` self-evidently does not contain any `UnsafeCell`s.
     /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is
     ///   only one possible sequence of 0 bytes, and `()` is inhabited.
     /// - `IntoBytes`: Since `()` has size 0, it contains no padding bytes.
     /// - `Unaligned`: `()` has alignment 1.
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#tuple-layout
-    unsafe_impl!((): NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+    unsafe_impl!((): Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     assert_unaligned!(());
 }
 
 safety_comment! {
     /// SAFETY:
-    /// - `NoCell`: These types self-evidently do not contain any `UnsafeCell`s.
+    /// - `Immutable`: These types self-evidently do not contain any
+    ///   `UnsafeCell`s.
     /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: all bit
     ///   patterns are valid for numeric types [1]
     /// - `IntoBytes`: numeric types have no padding bytes [1]
@@ -3580,26 +3582,26 @@ safety_comment! {
     /// TODO(#278): Once we've updated the trait docs to refer to `u8`s rather
     /// than bits or bytes, update this comment, especially the reference to
     /// [1].
-    unsafe_impl!(u8: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
-    unsafe_impl!(i8: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+    unsafe_impl!(u8: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+    unsafe_impl!(i8: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     assert_unaligned!(u8, i8);
-    unsafe_impl!(u16: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(i16: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(u32: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(i32: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(u64: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(i64: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(u128: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(i128: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(usize: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(isize: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(f32: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-    unsafe_impl!(f64: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(u16: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(i16: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(u32: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(i32: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(u64: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(i64: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(u128: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(i128: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(usize: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(isize: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(f32: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
+    unsafe_impl!(f64: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
 }
 
 safety_comment! {
     /// SAFETY:
-    /// - `NoCell`: `bool` self-evidently does not contain any `UnsafeCell`s.
+    /// - `Immutable`: `bool` self-evidently does not contain any `UnsafeCell`s.
     /// - `FromZeros`: Valid since "[t]he value false has the bit pattern 0x00"
     ///   [1].
     /// - `IntoBytes`: Since "the boolean type has a size and alignment of 1
@@ -3610,7 +3612,7 @@ safety_comment! {
     ///   has a size and alignment of 1 each."
     ///
     /// [1] https://doc.rust-lang.org/reference/types/boolean.html
-    unsafe_impl!(bool: NoCell, FromZeros, IntoBytes, Unaligned);
+    unsafe_impl!(bool: Immutable, FromZeros, IntoBytes, Unaligned);
     assert_unaligned!(bool);
     /// SAFETY:
     /// - The safety requirements for `unsafe_impl!` with an `is_bit_valid`
@@ -3655,7 +3657,7 @@ safety_comment! {
 }
 safety_comment! {
     /// SAFETY:
-    /// - `NoCell`: `char` self-evidently does not contain any `UnsafeCell`s.
+    /// - `Immutable`: `char` self-evidently does not contain any `UnsafeCell`s.
     /// - `FromZeros`: Per reference [1], "[a] value of type char is a Unicode
     ///   scalar value (i.e. a code point that is not a surrogate), represented
     ///   as a 32-bit unsigned word in the 0x0000 to 0xD7FF or 0xE000 to
@@ -3665,7 +3667,7 @@ safety_comment! {
     ///   not all bit patterns are valid for `char`.
     ///
     /// [1] https://doc.rust-lang.org/reference/types/textual.html
-    unsafe_impl!(char: NoCell, FromZeros, IntoBytes);
+    unsafe_impl!(char: Immutable, FromZeros, IntoBytes);
     /// SAFETY:
     /// - The safety requirements for `unsafe_impl!` with an `is_bit_valid`
     ///   closure:
@@ -3710,7 +3712,7 @@ safety_comment! {
 safety_comment! {
     /// SAFETY:
     /// Per the Reference [1], `str` has the same layout as `[u8]`.
-    /// - `NoCell`: `[u8]` does not contain any `UnsafeCell`s.
+    /// - `Immutable`: `[u8]` does not contain any `UnsafeCell`s.
     /// - `FromZeros`, `IntoBytes`, `Unaligned`: `[u8]` is `FromZeros`,
     ///   `IntoBytes`, and `Unaligned`.
     ///
@@ -3723,7 +3725,7 @@ safety_comment! {
     ///   layout as `[u8]` isn't sufficient.
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#str-layout
-    unsafe_impl!(str: NoCell, FromZeros, IntoBytes, Unaligned);
+    unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unaligned);
     /// SAFETY:
     /// - The safety requirements for `unsafe_impl!` with an `is_bit_valid`
     ///   closure:
@@ -3779,7 +3781,7 @@ safety_comment! {
     ///
     /// TODO(#429):
     /// - Add quotes from documentation.
-    /// - Add safety comment for `NoCell`. How can we prove that `NonZeroXxx`
+    /// - Add safety comment for `Immutable`. How can we prove that `NonZeroXxx`
     ///   doesn't contain any `UnsafeCell`s? It's obviously true, but it's not
     ///   clear how we'd prove it short of adding text to the stdlib docs that
     ///   says so explicitly, which likely wouldn't be accepted.
@@ -3788,19 +3790,19 @@ safety_comment! {
     /// [2] https://doc.rust-lang.org/stable/std/num/struct.NonZeroI8.html
     /// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
     /// that layout is the same as primitive layout.
-    unsafe_impl!(NonZeroU8: NoCell, IntoBytes, Unaligned);
-    unsafe_impl!(NonZeroI8: NoCell, IntoBytes, Unaligned);
+    unsafe_impl!(NonZeroU8: Immutable, IntoBytes, Unaligned);
+    unsafe_impl!(NonZeroI8: Immutable, IntoBytes, Unaligned);
     assert_unaligned!(NonZeroU8, NonZeroI8);
-    unsafe_impl!(NonZeroU16: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroI16: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroU32: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroI32: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroU64: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroI64: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroU128: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroI128: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroUsize: NoCell, IntoBytes);
-    unsafe_impl!(NonZeroIsize: NoCell, IntoBytes);
+    unsafe_impl!(NonZeroU16: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroI16: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroU32: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroI32: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroU64: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroI64: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroU128: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroI128: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroUsize: Immutable, IntoBytes);
+    unsafe_impl!(NonZeroIsize: Immutable, IntoBytes);
     /// SAFETY:
     /// - The safety requirements for `unsafe_impl!` with an `is_bit_valid`
     ///   closure:
@@ -3889,7 +3891,7 @@ safety_comment! {
     #[cfg(feature = "alloc")]
     unsafe_impl!(
         #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-        T: Sized => NoCell for Box<T>
+        T: Sized => Immutable for Box<T>
     );
 }
 
@@ -3956,8 +3958,8 @@ safety_comment! {
 safety_comment! {
     /// SAFETY:
     /// TODO(#896): Write this safety proof before the next stable release.
-    unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => NoCell for opt_fn!(...));
-    unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => NoCell for opt_extern_c_fn!(...));
+    unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => Immutable for opt_fn!(...));
+    unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => Immutable for opt_extern_c_fn!(...));
 }
 
 macro_rules! impl_traits_for_atomics {
@@ -4009,7 +4011,7 @@ safety_comment! {
     /// size_of::<PhantomData<T>>() == 0
     /// align_of::<PhantomData<T>>() == 1".
     /// This gives:
-    /// - `NoCell`: `PhantomData` has no fields.
+    /// - `Immutable`: `PhantomData` has no fields.
     /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is
     ///   only one possible sequence of 0 bytes, and `PhantomData` is inhabited.
     /// - `IntoBytes`: Since `PhantomData` has size 0, it contains no padding
@@ -4018,7 +4020,7 @@ safety_comment! {
     ///   1.
     ///
     /// [1] https://doc.rust-lang.org/std/marker/struct.PhantomData.html#layout-1
-    unsafe_impl!(T: ?Sized => NoCell for PhantomData<T>);
+    unsafe_impl!(T: ?Sized => Immutable for PhantomData<T>);
     unsafe_impl!(T: ?Sized => TryFromBytes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => FromZeros for PhantomData<T>);
     unsafe_impl!(T: ?Sized => FromBytes for PhantomData<T>);
@@ -4027,7 +4029,7 @@ safety_comment! {
     assert_unaligned!(PhantomData<()>, PhantomData<u8>, PhantomData<u64>);
 }
 
-impl_for_transparent_wrapper!(T: NoCell => NoCell for Wrapping<T>);
+impl_for_transparent_wrapper!(T: Immutable => Immutable for Wrapping<T>);
 impl_for_transparent_wrapper!(T: TryFromBytes => TryFromBytes for Wrapping<T>);
 impl_for_transparent_wrapper!(T: FromZeros => FromZeros for Wrapping<T>);
 impl_for_transparent_wrapper!(T: FromBytes => FromBytes for Wrapping<T>);
@@ -4044,11 +4046,11 @@ safety_comment! {
     unsafe_impl!(T => FromBytes for MaybeUninit<T>);
 }
 
-impl_for_transparent_wrapper!(T: NoCell => NoCell for MaybeUninit<T>);
+impl_for_transparent_wrapper!(T: Immutable => Immutable for MaybeUninit<T>);
 impl_for_transparent_wrapper!(T: Unaligned => Unaligned for MaybeUninit<T>);
 assert_unaligned!(MaybeUninit<()>, MaybeUninit<u8>);
 
-impl_for_transparent_wrapper!(T: ?Sized + NoCell => NoCell for ManuallyDrop<T>);
+impl_for_transparent_wrapper!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>);
 impl_for_transparent_wrapper!(T: ?Sized + TryFromBytes => TryFromBytes for ManuallyDrop<T>);
 impl_for_transparent_wrapper!(T: ?Sized + FromZeros => FromZeros for ManuallyDrop<T>);
 impl_for_transparent_wrapper!(T: ?Sized + FromBytes => FromBytes for ManuallyDrop<T>);
@@ -4156,7 +4158,7 @@ safety_comment! {
     ///
     /// In other words, the layout of a `[T]` or `[T; N]` is a sequence of `T`s
     /// laid out back-to-back with no bytes in between. Therefore, `[T]` or `[T;
-    /// N]` are `NoCell`, `TryFromBytes`, `FromZeros`, `FromBytes`, and
+    /// N]` are `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`, and
     /// `IntoBytes` if `T` is (respectively). Furthermore, since an array/slice
     /// has "the same alignment of `T`", `[T]` and `[T; N]` are `Unaligned` if
     /// `T` is.
@@ -4165,7 +4167,7 @@ safety_comment! {
     /// `assert_unaligned!` uses `align_of`, which only works for `Sized` types.
     ///
     /// [1] https://doc.rust-lang.org/reference/type-layout.html#array-layout
-    unsafe_impl!(const N: usize, T: NoCell => NoCell for [T; N]);
+    unsafe_impl!(const N: usize, T: Immutable => Immutable for [T; N]);
     unsafe_impl!(const N: usize, T: TryFromBytes => TryFromBytes for [T; N]; |c: Maybe<[T; N]>| {
         // Note that this call may panic, but it would still be sound even if it
         // did. `is_bit_valid` does not promise that it will not panic (in fact,
@@ -4178,7 +4180,7 @@ safety_comment! {
     unsafe_impl!(const N: usize, T: IntoBytes => IntoBytes for [T; N]);
     unsafe_impl!(const N: usize, T: Unaligned => Unaligned for [T; N]);
     assert_unaligned!([(); 0], [(); 1], [u8; 0], [u8; 1]);
-    unsafe_impl!(T: NoCell => NoCell for [T]);
+    unsafe_impl!(T: Immutable => Immutable for [T]);
     unsafe_impl!(T: TryFromBytes => TryFromBytes for [T]; |c: Maybe<[T]>| {
         // SAFETY: Per the reference [1]:
         //
@@ -4209,7 +4211,7 @@ safety_comment! {
 }
 safety_comment! {
     /// SAFETY:
-    /// - `NoCell`: Raw pointers do not contain any `UnsafeCell`s.
+    /// - `Immutable`: Raw pointers do not contain any `UnsafeCell`s.
     /// - `FromZeros`: For thin pointers (note that `T: Sized`), the zero
     ///   pointer is considered "null". [1] No operations which require
     ///   provenance are legal on null pointers, so this is not a footgun.
@@ -4224,8 +4226,8 @@ safety_comment! {
     ///
     /// [1] TODO(https://github.com/rust-lang/rust/pull/116988): Cite the
     /// documentation once this PR lands.
-    unsafe_impl!(T: ?Sized => NoCell for *const T);
-    unsafe_impl!(T: ?Sized => NoCell for *mut T);
+    unsafe_impl!(T: ?Sized => Immutable for *const T);
+    unsafe_impl!(T: ?Sized => Immutable for *mut T);
     unsafe_impl!(T => TryFromBytes for *const T; |c: Maybe<*const T>| {
         pointer::is_zeroed(c)
     });
@@ -4240,14 +4242,14 @@ safety_comment! {
     /// SAFETY:
     ///
     /// TODO(#896): Write this safety proof before the next stable release.
-    unsafe_impl!(T: ?Sized => NoCell for NonNull<T>);
+    unsafe_impl!(T: ?Sized => Immutable for NonNull<T>);
 }
 
 safety_comment! {
     /// SAFETY:
     /// Reference types do not contain any `UnsafeCell`s.
-    unsafe_impl!(T: ?Sized => NoCell for &'_ T);
-    unsafe_impl!(T: ?Sized => NoCell for &'_ mut T);
+    unsafe_impl!(T: ?Sized => Immutable for &'_ T);
+    unsafe_impl!(T: ?Sized => Immutable for &'_ mut T);
 }
 
 safety_comment! {
@@ -4257,7 +4259,7 @@ safety_comment! {
     /// `Option<T>` does not contain any `UnsafeCell`s outside of `T`. [1]
     ///
     /// [1] https://doc.rust-lang.org/core/option/enum.Option.html
-    unsafe_impl!(T: NoCell => NoCell for Option<T>);
+    unsafe_impl!(T: Immutable => Immutable for Option<T>);
 }
 
 // SIMD support
@@ -4305,8 +4307,8 @@ safety_comment! {
 // Given this background, we can observe that:
 // - The size and bit pattern requirements of a SIMD type are equivalent to the
 //   equivalent array type. Thus, for any SIMD type whose primitive `T` is
-//   `NoCell`, `TryFromBytes`, `FromZeros`, `FromBytes`, or `IntoBytes`, that
-//   SIMD type is also `NoCell`, `TryFromBytes`, `FromZeros`, `FromBytes`, or
+//   `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`, or `IntoBytes`, that
+//   SIMD type is also `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`, or
 //   `IntoBytes` respectively.
 // - Since no upper bound is placed on the alignment, no SIMD type can be
 //   guaranteed to be `Unaligned`.
@@ -4350,7 +4352,7 @@ mod simd {
                 safety_comment! {
                     /// SAFETY:
                     /// See comment on module definition for justification.
-                    $( unsafe_impl!($typ: NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes); )*
+                    $( unsafe_impl!($typ: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes); )*
                 }
             }
         };
@@ -4503,8 +4505,8 @@ macro_rules! transmute {
 /// const fn transmute_ref<'src, 'dst, Src, Dst>(src: &'src Src) -> &'dst Dst
 /// where
 ///     'src: 'dst,
-///     Src: IntoBytes + NoCell,
-///     Dst: FromBytes + NoCell,
+///     Src: IntoBytes + Immutable,
+///     Dst: FromBytes + Immutable,
 ///     size_of::<Src>() == size_of::<Dst>(),
 ///     align_of::<Src>() >= align_of::<Dst>(),
 /// {
@@ -4576,20 +4578,20 @@ macro_rules! transmute_ref {
         #[allow(unused, clippy::diverging_sub_expression)]
         if false {
             // This branch, though never taken, ensures that the type of `e` is
-            // `&T` where `T: 't + Sized + IntoBytes + NoCell`, that the type of
+            // `&T` where `T: 't + Sized + IntoBytes + Immutable`, that the type of
             // this macro expression is `&U` where `U: 'u + Sized + FromBytes +
-            // NoCell`, and that `'t` outlives `'u`.
+            // Immutable`, and that `'t` outlives `'u`.
 
             struct AssertSrcIsSized<'a, T: ::core::marker::Sized>(&'a T);
             struct AssertSrcIsIntoBytes<'a, T: ?::core::marker::Sized + $crate::IntoBytes>(&'a T);
-            struct AssertSrcIsNoCell<'a, T: ?::core::marker::Sized + $crate::NoCell>(&'a T);
+            struct AssertSrcIsImmutable<'a, T: ?::core::marker::Sized + $crate::Immutable>(&'a T);
             struct AssertDstIsSized<'a, T: ::core::marker::Sized>(&'a T);
             struct AssertDstIsFromBytes<'a, U: ?::core::marker::Sized + $crate::FromBytes>(&'a U);
-            struct AssertDstIsNoCell<'a, T: ?::core::marker::Sized + $crate::NoCell>(&'a T);
+            struct AssertDstIsImmutable<'a, T: ?::core::marker::Sized + $crate::Immutable>(&'a T);
 
             let _ = AssertSrcIsSized(e);
             let _ = AssertSrcIsIntoBytes(e);
-            let _ = AssertSrcIsNoCell(e);
+            let _ = AssertSrcIsImmutable(e);
 
             if true {
                 #[allow(unused, unreachable_code)]
@@ -4601,7 +4603,7 @@ macro_rules! transmute_ref {
                 u.0
             } else {
                 #[allow(unused, unreachable_code)]
-                let u = AssertDstIsNoCell(loop {});
+                let u = AssertDstIsImmutable(loop {});
                 u.0
             }
         } else if false {
@@ -4624,10 +4626,10 @@ macro_rules! transmute_ref {
             &u
         } else {
             // SAFETY: For source type `Src` and destination type `Dst`:
-            // - We know that `Src: IntoBytes + NoCell` and `Dst: FromBytes +
-            //   NoCell` thanks to the uses of `AssertSrcIsIntoBytes`,
-            //   `AssertSrcIsNoCell`, `AssertDstIsFromBytes`, and
-            //   `AssertDstIsNoCell`` above.
+            // - We know that `Src: IntoBytes + Immutable` and `Dst: FromBytes +
+            //   Immutable` thanks to the uses of `AssertSrcIsIntoBytes`,
+            //   `AssertSrcIsImmutable`, `AssertDstIsFromBytes`, and
+            //   `AssertDstIsImmutable` above.
             // - We know that `size_of::<Src>() == size_of::<Dst>()` thanks to
             //   the use of `assert_size_eq!` above.
             // - We know that `align_of::<Src>() >= align_of::<Dst>()` thanks to
@@ -4647,8 +4649,8 @@ macro_rules! transmute_ref {
 /// const fn transmute_mut<'src, 'dst, Src, Dst>(src: &'src mut Src) -> &'dst mut Dst
 /// where
 ///     'src: 'dst,
-///     Src: FromBytes + IntoBytes + NoCell,
-///     Dst: FromBytes + IntoBytes + NoCell,
+///     Src: FromBytes + IntoBytes + Immutable,
+///     Dst: FromBytes + IntoBytes + Immutable,
 ///     size_of::<Src>() == size_of::<Dst>(),
 ///     align_of::<Src>() >= align_of::<Dst>(),
 /// {
@@ -4723,9 +4725,9 @@ macro_rules! transmute_mut {
         #[allow(unused, clippy::diverging_sub_expression)]
         if false {
             // This branch, though never taken, ensures that the type of `e` is
-            // `&mut T` where `T: 't + Sized + FromBytes + IntoBytes + NoCell`
+            // `&mut T` where `T: 't + Sized + FromBytes + IntoBytes + Immutable`
             // and that the type of this macro expression is `&mut U` where `U:
-            // 'u + Sized + FromBytes + IntoBytes + NoCell`.
+            // 'u + Sized + FromBytes + IntoBytes + Immutable`.
 
             // We use immutable references here rather than mutable so that, if
             // this macro is used in a const context (in which, as of this
@@ -4735,11 +4737,11 @@ macro_rules! transmute_mut {
             struct AssertSrcIsSized<'a, T: ::core::marker::Sized>(&'a T);
             struct AssertSrcIsFromBytes<'a, T: ?::core::marker::Sized + $crate::FromBytes>(&'a T);
             struct AssertSrcIsIntoBytes<'a, T: ?::core::marker::Sized + $crate::IntoBytes>(&'a T);
-            struct AssertSrcIsNoCell<'a, T: ?::core::marker::Sized + $crate::NoCell>(&'a T);
+            struct AssertSrcIsImmutable<'a, T: ?::core::marker::Sized + $crate::Immutable>(&'a T);
             struct AssertDstIsSized<'a, T: ::core::marker::Sized>(&'a T);
             struct AssertDstIsFromBytes<'a, T: ?::core::marker::Sized + $crate::FromBytes>(&'a T);
             struct AssertDstIsIntoBytes<'a, T: ?::core::marker::Sized + $crate::IntoBytes>(&'a T);
-            struct AssertDstIsNoCell<'a, T: ?::core::marker::Sized + $crate::NoCell>(&'a T);
+            struct AssertDstIsImmutable<'a, T: ?::core::marker::Sized + $crate::Immutable>(&'a T);
 
             if true {
                 let _ = AssertSrcIsSized(&*e);
@@ -4748,7 +4750,7 @@ macro_rules! transmute_mut {
             } else if true {
                 let _ = AssertSrcIsIntoBytes(&*e);
             } else {
-                let _ = AssertSrcIsNoCell(&*e);
+                let _ = AssertSrcIsImmutable(&*e);
             }
 
             if true {
@@ -4765,7 +4767,7 @@ macro_rules! transmute_mut {
                 &mut *u.0
             } else {
                 #[allow(unused, unreachable_code)]
-                let u = AssertDstIsNoCell(loop {});
+                let u = AssertDstIsImmutable(loop {});
                 &mut *u.0
             }
         } else if false {
@@ -4788,11 +4790,11 @@ macro_rules! transmute_mut {
             &mut u
         } else {
             // SAFETY: For source type `Src` and destination type `Dst`:
-            // - We know that `Src: FromBytes + IntoBytes + NoCell` and `Dst:
-            //   FromBytes + IntoBytes + NoCell` thanks to the uses of
+            // - We know that `Src: FromBytes + IntoBytes + Immutable` and `Dst:
+            //   FromBytes + IntoBytes + Immutable` thanks to the uses of
             //   `AssertSrcIsFromBytes`, `AssertSrcIsIntoBytes`,
-            //   `AssertSrcIsNoCell`, `AssertDstIsFromBytes`,
-            //   `AssertDstIsIntoBytes`, and `AssertDstIsNoCell` above.
+            //   `AssertSrcIsImmutable`, `AssertDstIsFromBytes`,
+            //   `AssertDstIsIntoBytes`, and `AssertDstIsImmutable` above.
             // - We know that `size_of::<Src>() == size_of::<Dst>()` thanks to
             //   the use of `assert_size_eq!` above.
             // - We know that `align_of::<Src>() >= align_of::<Dst>()` thanks to
@@ -4869,9 +4871,9 @@ macro_rules! include_value {
 ///
 /// ```rust
 /// # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
-/// use zerocopy::{IntoBytes, ByteSliceMut, FromBytes, FromZeros, KnownLayout, NoCell, Ref, SplitByteSlice, Unaligned};
+/// use zerocopy::{IntoBytes, ByteSliceMut, FromBytes, FromZeros, KnownLayout, Immutable, Ref, SplitByteSlice, Unaligned};
 ///
-/// #[derive(FromBytes, IntoBytes, KnownLayout, NoCell, Unaligned)]
+/// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
 /// #[repr(C)]
 /// struct UdpHeader {
 ///     src_port: [u8; 2],
@@ -4928,7 +4930,7 @@ impl<B: ByteSlice + Copy, T: ?Sized> Copy for Ref<B, T> {}
 impl<B, T> Ref<B, T>
 where
     B: ByteSlice,
-    T: KnownLayout + NoCell + ?Sized,
+    T: KnownLayout + Immutable + ?Sized,
 {
     #[must_use = "has no side effects"]
     fn bikeshed_new_known_layout(bytes: B) -> Option<Ref<B, T>> {
@@ -4941,7 +4943,7 @@ where
 impl<B, T> Ref<B, T>
 where
     B: SplitByteSlice,
-    T: KnownLayout + NoCell + ?Sized,
+    T: KnownLayout + Immutable + ?Sized,
 {
     #[must_use = "has no side effects"]
     fn bikeshed_new_from_prefix_known_layout(bytes: B) -> Option<(Ref<B, T>, B)> {
@@ -5021,7 +5023,7 @@ where
 impl<B, T> Ref<B, T>
 where
     B: ByteSlice,
-    T: KnownLayout + NoCell + ?Sized,
+    T: KnownLayout + Immutable + ?Sized,
 {
     /// Constructs a new `Ref`.
     ///
@@ -5040,7 +5042,7 @@ where
 impl<B, T> Ref<B, T>
 where
     B: SplitByteSlice,
-    T: KnownLayout + NoCell + ?Sized,
+    T: KnownLayout + Immutable + ?Sized,
 {
     /// Constructs a new `Ref` from the prefix of a byte slice.
     ///
@@ -5087,7 +5089,7 @@ where
 impl<B, T> Ref<B, [T]>
 where
     B: SplitByteSlice,
-    T: NoCell,
+    T: Immutable,
 {
     /// Constructs a new `Ref` of a slice type from the prefix of a byte slice.
     ///
@@ -5143,7 +5145,7 @@ where
 impl<B, T> Ref<B, T>
 where
     B: ByteSlice,
-    T: Unaligned + KnownLayout + NoCell + ?Sized,
+    T: Unaligned + KnownLayout + Immutable + ?Sized,
 {
     /// Constructs a new `Ref` for a type with no alignment requirement.
     ///
@@ -5159,7 +5161,7 @@ where
 impl<B, T> Ref<B, T>
 where
     B: SplitByteSlice,
-    T: Unaligned + KnownLayout + NoCell + ?Sized,
+    T: Unaligned + KnownLayout + Immutable + ?Sized,
 {
     /// Constructs a new `Ref` from the prefix of a byte slice for a type with
     /// no alignment requirement.
@@ -5191,7 +5193,7 @@ where
 impl<B, T> Ref<B, [T]>
 where
     B: SplitByteSlice,
-    T: Unaligned + NoCell,
+    T: Unaligned + Immutable,
 {
     /// Constructs a new `Ref` of a slice type with no alignment requirement
     /// from the prefix of a byte slice.
@@ -5234,7 +5236,7 @@ where
 impl<'a, B, T> Ref<B, T>
 where
     B: 'a + IntoByteSlice<'a>,
-    T: FromBytes + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + KnownLayout + Immutable + ?Sized,
 {
     /// Converts this `Ref` into a reference.
     ///
@@ -5255,7 +5257,7 @@ where
 impl<'a, B, T> Ref<B, T>
 where
     B: 'a + IntoByteSliceMut<'a>,
-    T: FromBytes + IntoBytes + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + IntoBytes + KnownLayout + Immutable + ?Sized,
 {
     /// Converts this `Ref` into a mutable reference.
     ///
@@ -5338,7 +5340,7 @@ where
 impl<B, T> Deref for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + KnownLayout + Immutable + ?Sized,
 {
     type Target = T;
     #[inline]
@@ -5356,7 +5358,7 @@ where
 impl<B, T> DerefMut for Ref<B, T>
 where
     B: ByteSliceMut,
-    T: FromBytes + IntoBytes + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + IntoBytes + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
@@ -5373,7 +5375,7 @@ where
 impl<T, B> Display for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + Display + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + Display + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
@@ -5385,7 +5387,7 @@ where
 impl<T, B> Debug for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + Debug + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + Debug + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
@@ -5397,14 +5399,14 @@ where
 impl<T, B> Eq for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + Eq + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + Eq + KnownLayout + Immutable + ?Sized,
 {
 }
 
 impl<T, B> PartialEq for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + PartialEq + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + PartialEq + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -5415,7 +5417,7 @@ where
 impl<T, B> Ord for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + Ord + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + Ord + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
@@ -5428,7 +5430,7 @@ where
 impl<T, B> PartialOrd for Ref<B, T>
 where
     B: ByteSlice,
-    T: FromBytes + PartialOrd + KnownLayout + NoCell + ?Sized,
+    T: FromBytes + PartialOrd + KnownLayout + Immutable + ?Sized,
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -5930,7 +5932,7 @@ mod tests {
     //
     // This is used to test the custom derives of our traits. The `[u8]` type
     // gets a hand-rolled impl, so it doesn't exercise our custom derives.
-    #[derive(Debug, Eq, PartialEq, FromBytes, IntoBytes, Unaligned, NoCell)]
+    #[derive(Debug, Eq, PartialEq, FromBytes, IntoBytes, Unaligned, Immutable)]
     #[repr(transparent)]
     struct Unsized([u8]);
 
@@ -7185,7 +7187,7 @@ mod tests {
 
     #[test]
     fn test_object_safety() {
-        fn _takes_no_cell(_: &dyn NoCell) {}
+        fn _takes_no_cell(_: &dyn Immutable) {}
         fn _takes_unaligned(_: &dyn Unaligned) {}
     }
 
@@ -7304,7 +7306,7 @@ mod tests {
         const X: [[u8; 2]; 4] = transmute!(ARRAY_OF_U8S);
         assert_eq!(X, ARRAY_OF_ARRAYS);
 
-        // Test that `transmute!` works with `!NoCell` types.
+        // Test that `transmute!` works with `!Immutable` types.
         let x: usize = transmute!(UnsafeCell::new(1usize));
         assert_eq!(x, 1);
         let x: UnsafeCell<usize> = transmute!(1usize);
@@ -7848,7 +7850,7 @@ mod tests {
         /// has had its bits flipped (by applying `^= 0xFF`).
         ///
         /// `N` is the size of `t` in bytes.
-        fn test<T: FromBytes + IntoBytes + NoCell + Debug + Eq + ?Sized, const N: usize>(
+        fn test<T: FromBytes + IntoBytes + Immutable + Debug + Eq + ?Sized, const N: usize>(
             t: &mut T,
             bytes: &[u8],
             post_mutation: &T,
@@ -7905,7 +7907,7 @@ mod tests {
             assert_eq!(too_many_bytes[0], 123);
         }
 
-        #[derive(Debug, Eq, PartialEq, FromBytes, IntoBytes, NoCell)]
+        #[derive(Debug, Eq, PartialEq, FromBytes, IntoBytes, Immutable)]
         #[repr(C)]
         struct Foo {
             a: u32,
@@ -7934,7 +7936,7 @@ mod tests {
 
     #[test]
     fn test_array() {
-        #[derive(FromBytes, IntoBytes, NoCell)]
+        #[derive(FromBytes, IntoBytes, Immutable)]
         #[repr(C)]
         struct Foo {
             a: [u16; 33],
@@ -8208,7 +8210,7 @@ mod tests {
                 ) -> Option<bool>;
             }
 
-            impl<T: TryFromBytes + NoCell + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
+            impl<T: TryFromBytes + Immutable + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
                 fn test_is_bit_valid_shared<'ptr, A: invariant::at_least::Shared>(
                     &self,
@@ -8232,7 +8234,7 @@ mod tests {
                 ) -> Option<Option<&'bytes mut T>>;
             }
 
-            impl<T: TryFromBytes + NoCell + KnownLayout + ?Sized> TestTryFromRef<T> for AutorefWrapper<T> {
+            impl<T: TryFromBytes + Immutable + KnownLayout + ?Sized> TestTryFromRef<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
                 fn test_try_from_ref<'bytes>(
                     &self,
@@ -8265,7 +8267,7 @@ mod tests {
                 fn test_as_bytes<'slf, 't>(&'slf self, t: &'t T) -> Option<&'t [u8]>;
             }
 
-            impl<T: IntoBytes + NoCell + ?Sized> TestAsBytes<T> for AutorefWrapper<T> {
+            impl<T: IntoBytes + Immutable + ?Sized> TestAsBytes<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
                 fn test_as_bytes<'slf, 't>(&'slf self, t: &'t T) -> Option<&'t [u8]> {
                     Some(t.as_bytes())
@@ -8429,11 +8431,11 @@ mod tests {
                     assert!(res, "{}::is_bit_valid({:?}) (exclusive `Ptr`): got false, expected true", stringify!($ty), val);
 
                     // `bytes` is `Some(val.as_bytes())` if `$ty: IntoBytes +
-                    // NoCell` and `None` otherwise.
+                    // Immutable` and `None` otherwise.
                     let bytes = w.test_as_bytes(&*val);
 
                     // The inner closure returns
-                    // `Some($ty::try_ref_from(bytes))` if `$ty: NoCell` and
+                    // `Some($ty::try_ref_from(bytes))` if `$ty: Immutable` and
                     // `None` otherwise.
                     let res = bytes.and_then(|bytes| ww.test_try_from_ref(bytes));
                     if let Some(res) = res {
@@ -8475,7 +8477,7 @@ mod tests {
                     #[allow(unused_mut)] // For cases where the "real" impls are used, which take `&self`.
                     let mut w = AutorefWrapper::<$ty>(PhantomData);
 
-                    // This is `Some($ty::try_ref_from(c))` if `$ty: NoCell` and
+                    // This is `Some($ty::try_ref_from(c))` if `$ty: Immutable` and
                     // `None` otherwise.
                     let res = w.test_try_from_ref(c);
                     if let Some(res) = res {
@@ -8523,7 +8525,7 @@ mod tests {
 
         assert_impls!(
             (): KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8532,7 +8534,7 @@ mod tests {
         );
         assert_impls!(
             u8: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8541,7 +8543,7 @@ mod tests {
         );
         assert_impls!(
             i8: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8550,7 +8552,7 @@ mod tests {
         );
         assert_impls!(
             u16: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8559,7 +8561,7 @@ mod tests {
         );
         assert_impls!(
             i16: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8568,7 +8570,7 @@ mod tests {
         );
         assert_impls!(
             u32: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8577,7 +8579,7 @@ mod tests {
         );
         assert_impls!(
             i32: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8586,7 +8588,7 @@ mod tests {
         );
         assert_impls!(
             u64: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8595,7 +8597,7 @@ mod tests {
         );
         assert_impls!(
             i64: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8604,7 +8606,7 @@ mod tests {
         );
         assert_impls!(
             u128: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8613,7 +8615,7 @@ mod tests {
         );
         assert_impls!(
             i128: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8622,7 +8624,7 @@ mod tests {
         );
         assert_impls!(
             usize: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8631,7 +8633,7 @@ mod tests {
         );
         assert_impls!(
             isize: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8640,7 +8642,7 @@ mod tests {
         );
         assert_impls!(
             f32: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8649,7 +8651,7 @@ mod tests {
         );
         assert_impls!(
             f64: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8659,7 +8661,7 @@ mod tests {
 
         assert_impls!(
             bool: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             IntoBytes,
@@ -8668,7 +8670,7 @@ mod tests {
         );
         assert_impls!(
             char: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             IntoBytes,
@@ -8677,7 +8679,7 @@ mod tests {
         );
         assert_impls!(
             str: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             IntoBytes,
@@ -8687,7 +8689,7 @@ mod tests {
 
         assert_impls!(
             NonZeroU8: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             Unaligned,
@@ -8696,7 +8698,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroI8: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             Unaligned,
@@ -8705,7 +8707,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroU16: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8713,7 +8715,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroI16: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8721,7 +8723,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroU32: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8729,7 +8731,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroI32: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8737,7 +8739,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroU64: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8745,7 +8747,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroI64: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8753,7 +8755,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroU128: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8761,7 +8763,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroI128: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8769,7 +8771,7 @@ mod tests {
         );
         assert_impls!(
             NonZeroUsize: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
@@ -8777,25 +8779,25 @@ mod tests {
         );
         assert_impls!(
             NonZeroIsize: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             IntoBytes,
             !FromBytes,
             !Unaligned
         );
 
-        assert_impls!(Option<NonZeroU8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
-        assert_impls!(Option<NonZeroI8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
-        assert_impls!(Option<NonZeroU16>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI16>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU32>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI32>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU64>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI64>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroU128>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroI128>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroUsize>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
-        assert_impls!(Option<NonZeroIsize>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(Option<NonZeroI8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(Option<NonZeroU16>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI16>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU32>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI32>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU64>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI64>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroU128>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroI128>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroUsize>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
+        assert_impls!(Option<NonZeroIsize>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned);
 
         // Implements none of the ZC traits.
         struct NotZerocopy;
@@ -8813,57 +8815,57 @@ mod tests {
         ) -> (NotZerocopy, NotZerocopy);
 
         #[cfg(feature = "alloc")]
-        assert_impls!(Option<Box<UnsafeCell<NotZerocopy>>>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<Box<[UnsafeCell<NotZerocopy>]>>: KnownLayout, !NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<&'static UnsafeCell<NotZerocopy>>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<&'static [UnsafeCell<NotZerocopy>]>: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<&'static mut UnsafeCell<NotZerocopy>>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<&'static mut [UnsafeCell<NotZerocopy>]>: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<NonNull<UnsafeCell<NotZerocopy>>>: KnownLayout, TryFromBytes, FromZeros, NoCell, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<NonNull<[UnsafeCell<NotZerocopy>]>>: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<fn()>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<FnManyArgs>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<extern "C" fn()>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Option<ECFnManyArgs>: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<Box<UnsafeCell<NotZerocopy>>>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<Box<[UnsafeCell<NotZerocopy>]>>: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<&'static UnsafeCell<NotZerocopy>>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<&'static [UnsafeCell<NotZerocopy>]>: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<&'static mut UnsafeCell<NotZerocopy>>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<&'static mut [UnsafeCell<NotZerocopy>]>: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<NonNull<UnsafeCell<NotZerocopy>>>: KnownLayout, TryFromBytes, FromZeros, Immutable, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<NonNull<[UnsafeCell<NotZerocopy>]>>: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<fn()>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<FnManyArgs>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<extern "C" fn()>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Option<ECFnManyArgs>: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
 
-        assert_impls!(PhantomData<NotZerocopy>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
-        assert_impls!(PhantomData<UnsafeCell<()>>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
-        assert_impls!(PhantomData<[u8]>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(PhantomData<NotZerocopy>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(PhantomData<UnsafeCell<()>>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(PhantomData<[u8]>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
 
-        assert_impls!(ManuallyDrop<u8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(ManuallyDrop<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
         // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_bit_valid`.
-        assert_impls!(ManuallyDrop<bool>: KnownLayout, NoCell, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
-        assert_impls!(ManuallyDrop<[u8]>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(ManuallyDrop<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
+        assert_impls!(ManuallyDrop<[u8]>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
         // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_bit_valid`.
-        assert_impls!(ManuallyDrop<[bool]>: KnownLayout, NoCell, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
-        assert_impls!(ManuallyDrop<NotZerocopy>: !NoCell, !TryFromBytes, !KnownLayout, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(ManuallyDrop<[NotZerocopy]>: KnownLayout, !NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(ManuallyDrop<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !NoCell);
-        assert_impls!(ManuallyDrop<[UnsafeCell<u8>]>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !NoCell);
-        assert_impls!(ManuallyDrop<[UnsafeCell<bool>]>: KnownLayout, TryFromBytes, FromZeros, IntoBytes, Unaligned, !NoCell, !FromBytes);
+        assert_impls!(ManuallyDrop<[bool]>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
+        assert_impls!(ManuallyDrop<NotZerocopy>: !Immutable, !TryFromBytes, !KnownLayout, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(ManuallyDrop<[NotZerocopy]>: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(ManuallyDrop<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !Immutable);
+        assert_impls!(ManuallyDrop<[UnsafeCell<u8>]>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !Immutable);
+        assert_impls!(ManuallyDrop<[UnsafeCell<bool>]>: KnownLayout, TryFromBytes, FromZeros, IntoBytes, Unaligned, !Immutable, !FromBytes);
 
-        assert_impls!(MaybeUninit<u8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, Unaligned, !IntoBytes);
-        assert_impls!(MaybeUninit<NotZerocopy>: KnownLayout, TryFromBytes, FromZeros, FromBytes, !NoCell, !IntoBytes, !Unaligned);
-        assert_impls!(MaybeUninit<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, Unaligned, !NoCell, !IntoBytes);
+        assert_impls!(MaybeUninit<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, Unaligned, !IntoBytes);
+        assert_impls!(MaybeUninit<NotZerocopy>: KnownLayout, TryFromBytes, FromZeros, FromBytes, !Immutable, !IntoBytes, !Unaligned);
+        assert_impls!(MaybeUninit<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, Unaligned, !Immutable, !IntoBytes);
 
-        assert_impls!(Wrapping<u8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(Wrapping<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
         // implementation of `<Wrapping<T> as TryFromBytes>::is_bit_valid`.
-        assert_impls!(Wrapping<bool>: KnownLayout, NoCell, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
-        assert_impls!(Wrapping<NotZerocopy>: KnownLayout, !NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(Wrapping<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !NoCell);
+        assert_impls!(Wrapping<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
+        assert_impls!(Wrapping<NotZerocopy>: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(Wrapping<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !Immutable);
 
-        assert_impls!(Unalign<u8>: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
+        assert_impls!(Unalign<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
         // implementation of `<Unalign<T> as TryFromBytes>::is_bit_valid`.
-        assert_impls!(Unalign<bool>: KnownLayout, NoCell, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
-        assert_impls!(Unalign<NotZerocopy>: Unaligned, !NoCell, !KnownLayout, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes);
+        assert_impls!(Unalign<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
+        assert_impls!(Unalign<NotZerocopy>: Unaligned, !Immutable, !KnownLayout, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes);
 
         assert_impls!(
             [u8]: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8872,17 +8874,17 @@ mod tests {
         );
         assert_impls!(
             [bool]: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             IntoBytes,
             Unaligned,
             !FromBytes
         );
-        assert_impls!([NotZerocopy]: KnownLayout, !NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!([NotZerocopy]: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
         assert_impls!(
             [u8; 0]: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8891,7 +8893,7 @@ mod tests {
         );
         assert_impls!(
             [NotZerocopy; 0]: KnownLayout,
-            !NoCell,
+            !Immutable,
             !TryFromBytes,
             !FromZeros,
             !FromBytes,
@@ -8900,7 +8902,7 @@ mod tests {
         );
         assert_impls!(
             [u8; 1]: KnownLayout,
-            NoCell,
+            Immutable,
             TryFromBytes,
             FromZeros,
             FromBytes,
@@ -8909,7 +8911,7 @@ mod tests {
         );
         assert_impls!(
             [NotZerocopy; 1]: KnownLayout,
-            !NoCell,
+            !Immutable,
             !TryFromBytes,
             !FromZeros,
             !FromBytes,
@@ -8917,12 +8919,12 @@ mod tests {
             !Unaligned
         );
 
-        assert_impls!(*const NotZerocopy: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(*mut NotZerocopy: KnownLayout, NoCell, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(*const [NotZerocopy]: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(*mut [NotZerocopy]: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(*const dyn Debug: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
-        assert_impls!(*mut dyn Debug: KnownLayout, NoCell, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*const NotZerocopy: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*mut NotZerocopy: KnownLayout, Immutable, TryFromBytes, FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*const [NotZerocopy]: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*mut [NotZerocopy]: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*const dyn Debug: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
+        assert_impls!(*mut dyn Debug: KnownLayout, Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
 
         #[cfg(feature = "simd")]
         {
@@ -8932,7 +8934,7 @@ mod tests {
                     {
                         use core::arch::$arch::{$($typ),*};
                         use crate::*;
-                        $( assert_impls!($typ: KnownLayout, NoCell, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned); )*
+                        $( assert_impls!($typ: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, !Unaligned); )*
                     }
                 };
             }

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -351,8 +351,8 @@ macro_rules! assert_size_eq {
 /// # Safety
 ///
 /// The caller must guarantee that:
-/// - `Src: IntoBytes + NoCell`
-/// - `Dst: FromBytes + NoCell`
+/// - `Src: IntoBytes + Immutable`
+/// - `Dst: FromBytes + Immutable`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
 #[inline(always)]
@@ -367,8 +367,8 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     //   caller has guaranteed that `Src: IntoBytes`, `Dst: FromBytes`, and
     //   `size_of::<Src>() == size_of::<Dst>()`.
     // - We know that there are no `UnsafeCell`s, and thus we don't have to
-    //   worry about `UnsafeCell` overlap, because `Src: NoCell` and `Dst:
-    //   NoCell`.
+    //   worry about `UnsafeCell` overlap, because `Src: Immutable` and `Dst:
+    //   Immutable`.
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.
@@ -386,11 +386,11 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 /// # Safety
 ///
 /// The caller must guarantee that:
-/// - `Src: FromBytes + IntoBytes + NoCell`
-/// - `Dst: FromBytes + IntoBytes + NoCell`
+/// - `Src: FromBytes + IntoBytes + Immutable`
+/// - `Dst: FromBytes + IntoBytes + Immutable`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
-// TODO(#686): Consider removing the `NoCell` requirement.
+// TODO(#686): Consider removing the `Immutable` requirement.
 #[inline(always)]
 pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     src: &'src mut Src,
@@ -404,8 +404,8 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     //   IntoBytes`, `Dst: FromBytes + IntoBytes`, and `size_of::<Src>() ==
     //   size_of::<Dst>()`.
     // - We know that there are no `UnsafeCell`s, and thus we don't have to
-    //   worry about `UnsafeCell` overlap, because `Src: NoCell`
-    //   and `Dst: NoCell`.
+    //   worry about `UnsafeCell` overlap, because `Src: Immutable`
+    //   and `Dst: Immutable`.
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -297,12 +297,12 @@ macro_rules! impl_for_transparent_wrapper {
             impl_for_transparent_wrapper!(@is_bit_valid $trait for $ty);
         }
     };
-    (@is_transparent_wrapper NoCell) => {
+    (@is_transparent_wrapper Immutable) => {
         // SAFETY: `W: TransparentWrapper<UnsafeCellVariance=Covariant>`
         // requires that `W` has `UnsafeCell`s at the same byte offsets as
-        // `W::Inner = T`. `T: NoCell` implies that `T` does not contain any
+        // `W::Inner = T`. `T: Immutable` implies that `T` does not contain any
         // `UnsafeCell`s, and so `W` does not contain any `UnsafeCell`s. Thus,
-        // `W` can soundly implement `NoCell`.
+        // `W` can soundly implement `Immutable`.
         fn is_transparent_wrapper<I: Invariants, T: ?Sized, W: TransparentWrapper<I, Inner=T, UnsafeCellVariance=Covariant> + ?Sized>() {}
     };
     (@is_transparent_wrapper FromZeros) => {

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -66,7 +66,7 @@ where
 /// Checks if the referent is zeroed.
 pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
 where
-    T: crate::NoCell,
+    T: crate::Immutable,
     I: invariant::Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::at_least::Shared,
 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -654,7 +654,7 @@ pub(crate) mod testutil {
     // By contrast, `AU64` is guaranteed to have alignment 8.
     #[derive(
         KnownLayout,
-        NoCell,
+        Immutable,
         FromBytes,
         IntoBytes,
         Eq,
@@ -682,7 +682,7 @@ pub(crate) mod testutil {
         }
     }
 
-    #[derive(NoCell, FromBytes, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Copy, Clone)]
+    #[derive(Immutable, FromBytes, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Copy, Clone)]
     #[repr(C)]
     pub(crate) struct Nested<T, U: ?Sized> {
         _t: T,

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -53,7 +53,7 @@ use super::*;
 #[derive(Default, Copy)]
 #[cfg_attr(
     any(feature = "derive", test),
-    derive(NoCell, KnownLayout, FromBytes, IntoBytes, Unaligned)
+    derive(Immutable, KnownLayout, FromBytes, IntoBytes, Unaligned)
 )]
 #[repr(C, packed)]
 pub struct Unalign<T>(T);
@@ -67,7 +67,7 @@ safety_comment! {
     ///   alignment of `T`, and so we don't require that `T: Unaligned`
     /// - `Unalign<T>` has the same bit validity as `T`, and so it is
     ///   `FromZeros`, `FromBytes`, or `IntoBytes` exactly when `T` is as well.
-    /// - `NoCell`: `Unalign<T>` has the same fields as `T`, so it contains
+    /// - `Immutable`: `Unalign<T>` has the same fields as `T`, so it contains
     ///   `UnsafeCell`s exactly when `T` does.
     /// - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as
     ///   `T`, so `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
@@ -78,7 +78,7 @@ safety_comment! {
     ///     `UnsafeCell`s at the same byte ranges (as required by
     ///     `unsafe_impl!`).
     impl_or_verify!(T => Unaligned for Unalign<T>);
-    impl_or_verify!(T: NoCell => NoCell for Unalign<T>);
+    impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
         T: TryFromBytes => TryFromBytes for Unalign<T>;
         |c: Maybe<T>| T::is_bit_valid(c)

--- a/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-nocell.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
+error[E0277]: the trait bound `Dst: Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Dst`
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Immutable` is not implemented for `Dst`
    |
-note: required by `AssertDstIsNoCell`
-  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:35
+note: required by `AssertDstIsImmutable`
+  --> tests/ui-msrv/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-nocell.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Immutable` is not implemented for `Src`
    |
-note: required by `AssertSrcIsNoCell`
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+note: required by `AssertSrcIsImmutable`
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Immutable` is not implemented for `Src`
    |
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:35
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-msrv/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
@@ -1,12 +1,12 @@
-error[E0277]: the trait bound `Dst: zerocopy::NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:31
+error[E0277]: the trait bound `Dst: zerocopy::Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::NoCell` is not implemented for `Dst`
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Dst`
    |
-note: required by `AssertDstIsNoCell`
-  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:31
+note: required by `AssertDstIsImmutable`
+  --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
@@ -1,25 +1,25 @@
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `zerocopy::NoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `zerocopy::Immutable`
    |
-note: required by `AssertSrcIsNoCell`
-  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:32
+note: required by `AssertSrcIsImmutable`
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::NoCell` is not implemented for `Src`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Src`
    |
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:32
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, FromBytes, IntoBytes, NoCell};
+use zerocopy::{transmute_mut, FromBytes, Immutable, IntoBytes};
 
 fn main() {}
 
-fn transmute_mut<T: IntoBytes + FromBytes + NoCell>(u: &mut u8) -> &mut T {
+fn transmute_mut<T: IntoBytes + FromBytes + Immutable>(u: &mut u8) -> &mut T {
     // `transmute_mut!` requires the destination type to be concrete.
     transmute_mut!(u)
 }

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-intobytes.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-intobytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.rs
@@ -12,7 +12,7 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Src;
 
@@ -20,5 +20,5 @@ struct Src;
 #[repr(C)]
 struct Dst;
 
-// `transmute_mut` requires that the destination type implements `NoCell`
-const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+// `transmute_mut` requires that the destination type implements `Immutable`
+const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
+error[E0277]: the trait bound `Dst: Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Dst`
-   |                                   required by a bound introduced by this call
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     |
+   |                                     the trait `Immutable` is not implemented for `Dst`
+   |                                     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              &T
              &mut T
              ()
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `Dst: NoCell` is not satisfied
              F32<O>
              F64<O>
            and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:35
+note: required by a bound in `AssertDstIsImmutable`
+  --> tests/ui-nightly/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-mut-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, FromBytes, IntoBytes, NoCell};
+use zerocopy::{transmute_mut, FromBytes, Immutable, IntoBytes};
 
 fn main() {}
 
-fn transmute_mut<T: IntoBytes + FromBytes + NoCell, U: IntoBytes + FromBytes + NoCell>(
+fn transmute_mut<T: IntoBytes + FromBytes + Immutable, U: IntoBytes + FromBytes + Immutable>(
     t: &mut T,
 ) -> &mut U {
     // `transmute_mut!` requires the source and destination types to be

--- a/tests/ui-nightly/transmute-mut-src-generic.rs
+++ b/tests/ui-nightly/transmute-mut-src-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_mut, FromBytes, IntoBytes, NoCell};
+use zerocopy::{transmute_mut, FromBytes, Immutable, IntoBytes};
 
 fn main() {}
 
-fn transmute_mut<T: IntoBytes + FromBytes + NoCell>(t: &mut T) -> &mut u8 {
+fn transmute_mut<T: IntoBytes + FromBytes + Immutable>(t: &mut T) -> &mut u8 {
     // `transmute_mut!` requires the source type to be concrete.
     transmute_mut!(t)
 }

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-intobytes.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-intobytes.rs
@@ -12,11 +12,11 @@ use zerocopy::transmute_mut;
 
 fn main() {}
 
-#[derive(zerocopy::FromBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Dst;
 

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.rs
@@ -16,9 +16,9 @@ fn main() {}
 #[repr(C)]
 struct Src;
 
-#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::NoCell)]
+#[derive(zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Immutable)]
 #[repr(C)]
 struct Dst;
 
-// `transmute_mut` requires that the source type implements `NoCell`
-const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
+// `transmute_mut` requires that the source type implements `Immutable`
+const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);

--- a/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Src`
-   |                                   required by a bound introduced by this call
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     |
+   |                                     the trait `Immutable` is not implemented for `Src`
+   |                                     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              &T
              &mut T
              ()
@@ -17,20 +17,20 @@ error[E0277]: the trait bound `Src: NoCell` is not satisfied
              Dst
              F32<O>
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Immutable` is not implemented for `Src`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              &T
              &mut T
              ()
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `Src: NoCell` is not satisfied
              Dst
              F32<O>
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:35
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-nightly/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, FromBytes, NoCell};
+use zerocopy::{transmute_ref, FromBytes, Immutable};
 
 fn main() {}
 
-fn transmute_ref<T: FromBytes + NoCell>(u: &u8) -> &T {
+fn transmute_ref<T: FromBytes + Immutable>(u: &u8) -> &T {
     // `transmute_ref!` requires the destination type to be concrete.
     transmute_ref!(u)
 }

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.rs
@@ -15,7 +15,7 @@ use zerocopy::transmute_ref;
 
 fn main() {}
 
-#[derive(zerocopy::NoCell)]
+#[derive(zerocopy::Immutable)]
 #[repr(transparent)]
 struct Dst(AU16);
 

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.rs
@@ -19,5 +19,5 @@ fn main() {}
 #[repr(transparent)]
 struct Dst(AU16);
 
-// `transmute_ref` requires that the destination type implements `NoCell`
-const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
+// `transmute_ref` requires that the destination type implements `Immutable`
+const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: zerocopy::NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:23:31
+error[E0277]: the trait bound `Dst: zerocopy::Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                               |
-   |                               the trait `zerocopy::NoCell` is not implemented for `Dst`
-   |                               required by a bound introduced by this call
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `zerocopy::Immutable` is not implemented for `Dst`
+   |                                 required by a bound introduced by this call
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `Dst: zerocopy::NoCell` is not satisfied
              Box<T>
              F32<O>
            and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:23:31
+note: required by a bound in `AssertDstIsImmutable`
+  --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ref-src-dst-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-dst-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, FromBytes, IntoBytes, NoCell};
+use zerocopy::{transmute_ref, FromBytes, Immutable, IntoBytes};
 
 fn main() {}
 
-fn transmute_ref<T: IntoBytes + NoCell, U: FromBytes + NoCell>(t: &T) -> &U {
+fn transmute_ref<T: IntoBytes + Immutable, U: FromBytes + Immutable>(t: &T) -> &U {
     // `transmute_ref!` requires the source and destination types to be
     // concrete.
     transmute_ref!(t)

--- a/tests/ui-nightly/transmute-ref-src-generic.rs
+++ b/tests/ui-nightly/transmute-ref-src-generic.rs
@@ -8,11 +8,11 @@
 
 extern crate zerocopy;
 
-use zerocopy::{transmute_ref, IntoBytes, NoCell};
+use zerocopy::{transmute_ref, Immutable, IntoBytes};
 
 fn main() {}
 
-fn transmute_ref<T: IntoBytes + NoCell>(t: &T) -> &u8 {
+fn transmute_ref<T: IntoBytes + Immutable>(t: &T) -> &u8 {
     // `transmute_ref!` requires the source type to be concrete.
     transmute_ref!(t)
 }

--- a/tests/ui-nightly/transmute-ref-src-not-intobytes.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-intobytes.rs
@@ -15,7 +15,7 @@ use zerocopy::transmute_ref;
 
 fn main() {}
 
-#[derive(zerocopy::NoCell)]
+#[derive(zerocopy::Immutable)]
 #[repr(transparent)]
 struct Src(AU16);
 

--- a/tests/ui-nightly/transmute-ref-src-not-nocell.rs
+++ b/tests/ui-nightly/transmute-ref-src-not-nocell.rs
@@ -19,5 +19,5 @@ fn main() {}
 #[repr(transparent)]
 struct Src(AU16);
 
-// `transmute_ref` requires that the source type implements `NoCell`
-const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
+// `transmute_ref` requires that the source type implements `Immutable`
+const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));

--- a/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                the trait `zerocopy::NoCell` is not implemented for `Src`
-   |                                required by a bound introduced by this call
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `zerocopy::Immutable` is not implemented for `Src`
+   |                                  required by a bound introduced by this call
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -17,20 +17,20 @@ error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
              Box<T>
              F32<O>
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:32
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::NoCell` is not implemented for `Src`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Src`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
              Box<T>
              F32<O>
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:32
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: NoCell` is not satisfied
-  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
+error[E0277]: the trait bound `Dst: Immutable` is not satisfied
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Dst`
-   |                                   required by a bound introduced by this call
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     |
+   |                                     the trait `Immutable` is not implemented for `Dst`
+   |                                     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              bool
              char
              isize
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `Dst: NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:35
+note: required by a bound in `AssertDstIsImmutable`
+  --> tests/ui-stable/transmute-mut-dst-not-nocell.rs:24:37
    |
-24 | const DST_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+24 | const DST_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-mut-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   the trait `NoCell` is not implemented for `Src`
-   |                                   required by a bound introduced by this call
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     |
+   |                                     the trait `Immutable` is not implemented for `Src`
+   |                                     required by a bound introduced by this call
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              bool
              char
              isize
@@ -17,20 +17,20 @@ error[E0277]: the trait bound `Src: NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: NoCell` is not satisfied
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+error[E0277]: the trait bound `Src: Immutable` is not satisfied
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NoCell` is not implemented for `Src`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Immutable` is not implemented for `Src`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              bool
              char
              isize
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `Src: NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:35
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-stable/transmute-mut-src-not-nocell.rs:24:37
    |
-24 | const SRC_NOT_NO_CELL: &mut Dst = transmute_mut!(&mut Src);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+24 | const SRC_NOT_IMMUTABLE: &mut Dst = transmute_mut!(&mut Src);
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Dst: zerocopy::NoCell` is not satisfied
-  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:23:31
+error[E0277]: the trait bound `Dst: zerocopy::Immutable` is not satisfied
+  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                               |
-   |                               the trait `zerocopy::NoCell` is not implemented for `Dst`
-   |                               required by a bound introduced by this call
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `zerocopy::Immutable` is not implemented for `Dst`
+   |                                 required by a bound introduced by this call
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -17,9 +17,9 @@ error[E0277]: the trait bound `Dst: zerocopy::NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertDstIsNoCell`
-  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:23:31
+note: required by a bound in `AssertDstIsImmutable`
+  --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:23:33
    |
-23 | const DST_NOT_NO_CELL: &Dst = transmute_ref!(&AU16(0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsNoCell`
+23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-nocell.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                |
-   |                                the trait `zerocopy::NoCell` is not implemented for `Src`
-   |                                required by a bound introduced by this call
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `zerocopy::Immutable` is not implemented for `Src`
+   |                                  required by a bound introduced by this call
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -17,20 +17,20 @@ error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:32
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
-  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:32
+error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::NoCell` is not implemented for `Src`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Src`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `Src: zerocopy::NoCell` is not satisfied
              i64
              i128
            and $N others
-note: required by a bound in `AssertSrcIsNoCell`
-  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:32
+note: required by a bound in `AssertSrcIsImmutable`
+  --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34
    |
-23 | const SRC_NOT_NO_CELL: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsNoCell`
+23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/enum_no_cell.rs
+++ b/zerocopy-derive/tests/enum_no_cell.rs
@@ -8,40 +8,40 @@
 
 include!("include.rs");
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 enum Foo {
     A,
 }
 
-util_assert_impl_all!(Foo: imp::NoCell);
+util_assert_impl_all!(Foo: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 enum Bar {
     A = 0,
 }
 
-util_assert_impl_all!(Bar: imp::NoCell);
+util_assert_impl_all!(Bar: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 enum Baz {
     A = 1,
     B = 0,
 }
 
-util_assert_impl_all!(Baz: imp::NoCell);
+util_assert_impl_all!(Baz: imp::Immutable);
 
-// Deriving `NoCell` should work if the enum has bounded parameters.
+// Deriving `Immutable` should work if the enum has bounded parameters.
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 #[repr(C)]
-enum WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::NoCell, const N: ::core::primitive::usize>
+enum WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::Immutable, const N: ::core::primitive::usize>
 where
     'a: 'b,
     'b: 'a,
-    T: 'a + 'b + imp::NoCell,
+    T: 'a + 'b + imp::Immutable,
 {
     Variant([T; N], imp::PhantomData<&'a &'b ()>),
     UnsafeCell(imp::PhantomData<imp::UnsafeCell<()>>, &'a imp::UnsafeCell<()>),
 }
 
-util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::NoCell);
+util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::Immutable);

--- a/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -12,7 +12,7 @@
 
 include!("include.rs");
 
-#[derive(Eq, PartialEq, Debug, imp::NoCell, imp::KnownLayout, imp::TryFromBytes)]
+#[derive(Eq, PartialEq, Debug, imp::Immutable, imp::KnownLayout, imp::TryFromBytes)]
 #[repr(u8)]
 enum Foo {
     A,
@@ -28,7 +28,7 @@ fn test_foo() {
     imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::None);
 }
 
-#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::NoCell, imp::TryFromBytes)]
+#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
 #[repr(u16)]
 enum Bar {
     A = 0,
@@ -45,7 +45,7 @@ fn test_bar() {
     imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0, 0]), imp::None);
 }
 
-#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::NoCell, imp::TryFromBytes)]
+#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
 #[repr(u32)]
 enum Baz {
     A = 1,
@@ -77,7 +77,7 @@ type i8 = bool;
 
 const THREE: ::core::primitive::i8 = 3;
 
-#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::NoCell, imp::TryFromBytes)]
+#[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
 #[repr(i8)]
 enum Blah {
     A = 1,
@@ -112,7 +112,7 @@ fn test_blah() {
 }
 
 #[derive(
-    Eq, PartialEq, Debug, imp::KnownLayout, imp::NoCell, imp::TryFromBytes, imp::IntoBytes,
+    Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes, imp::IntoBytes,
 )]
 #[repr(C)]
 enum FieldlessButNotUnitOnly {
@@ -146,7 +146,7 @@ fn test_fieldless_but_not_unit_only() {
 }
 
 #[derive(
-    Eq, PartialEq, Debug, imp::KnownLayout, imp::NoCell, imp::TryFromBytes, imp::IntoBytes,
+    Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes, imp::IntoBytes,
 )]
 #[repr(C)]
 enum WeirdDiscriminants {

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -46,7 +46,7 @@ pub mod util {
     /// contrast, `util::AU16` is guaranteed to have alignment 2.
     #[derive(
         super::imp::KnownLayout,
-        super::imp::NoCell,
+        super::imp::Immutable,
         super::imp::FromBytes,
         super::imp::IntoBytes,
         Copy,

--- a/zerocopy-derive/tests/struct_no_cell.rs
+++ b/zerocopy-derive/tests/struct_no_cell.rs
@@ -8,41 +8,41 @@
 
 include!("include.rs");
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct Zst;
 
-util_assert_impl_all!(Zst: imp::NoCell);
+util_assert_impl_all!(Zst: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct One {
     a: bool,
 }
 
-util_assert_impl_all!(One: imp::NoCell);
+util_assert_impl_all!(One: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct Two {
     a: bool,
     b: Zst,
 }
 
-util_assert_impl_all!(Two: imp::NoCell);
+util_assert_impl_all!(Two: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct Three {
     a: [u8],
 }
 
-util_assert_impl_all!(Three: imp::NoCell);
+util_assert_impl_all!(Three: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct Four<'a> {
     field: &'a imp::UnsafeCell<u8>,
 }
 
-util_assert_impl_all!(Four<'static>: imp::NoCell);
+util_assert_impl_all!(Four<'static>: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct TypeParams<'a, T, U, I: imp::Iterator> {
     a: I::Item,
     b: u8,
@@ -53,12 +53,12 @@ struct TypeParams<'a, T, U, I: imp::Iterator> {
     g: T,
 }
 
-util_assert_impl_all!(TypeParams<'static, (), (), imp::IntoIter<()>>: imp::NoCell);
-util_assert_impl_all!(TypeParams<'static, util::AU16, util::AU16, imp::IntoIter<()>>: imp::NoCell);
-util_assert_impl_all!(TypeParams<'static, util::AU16, imp::UnsafeCell<u8>, imp::IntoIter<()>>: imp::NoCell);
-util_assert_not_impl_any!(TypeParams<'static, imp::UnsafeCell<()>, (), imp::IntoIter<()>>: imp::NoCell);
-util_assert_not_impl_any!(TypeParams<'static, [imp::UnsafeCell<u8>; 0], (), imp::IntoIter<()>>: imp::NoCell);
-util_assert_not_impl_any!(TypeParams<'static, (), (), imp::IntoIter<imp::UnsafeCell<()>>>: imp::NoCell);
+util_assert_impl_all!(TypeParams<'static, (), (), imp::IntoIter<()>>: imp::Immutable);
+util_assert_impl_all!(TypeParams<'static, util::AU16, util::AU16, imp::IntoIter<()>>: imp::Immutable);
+util_assert_impl_all!(TypeParams<'static, util::AU16, imp::UnsafeCell<u8>, imp::IntoIter<()>>: imp::Immutable);
+util_assert_not_impl_any!(TypeParams<'static, imp::UnsafeCell<()>, (), imp::IntoIter<()>>: imp::Immutable);
+util_assert_not_impl_any!(TypeParams<'static, [imp::UnsafeCell<u8>; 0], (), imp::IntoIter<()>>: imp::Immutable);
+util_assert_not_impl_any!(TypeParams<'static, (), (), imp::IntoIter<imp::UnsafeCell<()>>>: imp::Immutable);
 
 trait Trait {
     type Assoc;
@@ -68,18 +68,18 @@ impl<T> Trait for imp::UnsafeCell<T> {
     type Assoc = T;
 }
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 struct WithAssocType<T: Trait> {
     field: <T as Trait>::Assoc,
 }
 
-util_assert_impl_all!(WithAssocType<imp::UnsafeCell<u8>>: imp::NoCell);
+util_assert_impl_all!(WithAssocType<imp::UnsafeCell<u8>>: imp::Immutable);
 
-// Deriving `NoCell` should work if the struct has bounded parameters.
+// Deriving `Immutable` should work if the struct has bounded parameters.
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 #[repr(C)]
-struct WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::NoCell, const N: usize>(
+struct WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::Immutable, const N: usize>(
     [T; N],
     imp::PhantomData<&'a &'b ()>,
     imp::PhantomData<imp::UnsafeCell<()>>,
@@ -88,6 +88,6 @@ struct WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::NoCell, const N: usize>(
 where
     'a: 'b,
     'b: 'a,
-    T: 'a + 'b + imp::NoCell;
+    T: 'a + 'b + imp::Immutable;
 
-util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::NoCell);
+util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::Immutable);

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -149,7 +149,7 @@ where
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::TryFromBytes);
 
-#[derive(Debug, PartialEq, Eq, imp::TryFromBytes, imp::NoCell, imp::KnownLayout)]
+#[derive(Debug, PartialEq, Eq, imp::TryFromBytes, imp::Immutable, imp::KnownLayout)]
 #[repr(C, packed)]
 struct CPacked {
     a: u8,
@@ -170,7 +170,7 @@ fn c_packed() {
     imp::assert_eq!(converted, imp::Some(&CPacked { a: 42, b: u32::MAX }));
 }
 
-#[derive(imp::TryFromBytes, imp::KnownLayout, imp::NoCell)]
+#[derive(imp::TryFromBytes, imp::KnownLayout, imp::Immutable)]
 #[repr(C, packed)]
 struct CPackedUnsized {
     a: u8,

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -231,20 +231,20 @@ error[E0566]: conflicting representation hints
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
-error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
   --> tests/ui-msrv/enum.rs:51:10
    |
-51 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<()>`
+51 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
   --> tests/ui-msrv/enum.rs:59:10
    |
-59 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<u8>`
+59 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -82,24 +82,24 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/struct.rs:55:10
    |
-55 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`
+55 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/struct.rs:60:10
    |
-60 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<u8>`
+60 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<u8>`
    |
-   = note: required because of the requirements on the impl of `zerocopy::NoCell` for `[UnsafeCell<u8>; 0]`
+   = note: required because of the requirements on the impl of `zerocopy::Immutable` for `[UnsafeCell<u8>; 0]`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
    --> tests/ui-msrv/struct.rs:100:10

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -30,15 +30,15 @@ error: cannot derive Unaligned with repr(align(N > 1))
 79 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/union.rs:24:10
    |
-24 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`
+24 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = note: required because of the requirements on the impl of `zerocopy::NoCell` for `ManuallyDrop<UnsafeCell<()>>`
+   = note: required because of the requirements on the impl of `zerocopy::Immutable` for `ManuallyDrop<UnsafeCell<()>>`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
   --> tests/ui-msrv/union.rs:39:10

--- a/zerocopy-derive/tests/ui-nightly/enum.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum.rs
@@ -45,19 +45,19 @@ enum Generic5 {
 }
 
 //
-// NoCell errors
+// Immutable errors
 //
 
-#[derive(NoCell)]
-enum NoCell1 {
+#[derive(Immutable)]
+enum Immutable1 {
     A(core::cell::UnsafeCell<()>),
 }
 
-#[derive(NoCell)]
+#[derive(Immutable)]
 enum Never {}
 
-#[derive(NoCell)]
-enum NoCell2 {
+#[derive(Immutable)]
+enum Immutable2 {
     Uninhabited(Never, core::cell::UnsafeCell<u8>),
     Inhabited(u8),
 }

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -233,13 +233,13 @@ error[E0566]: conflicting representation hints
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
    = note: `#[deny(conflicting_repr_hints)]` on by default
 
-error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
   --> tests/ui-nightly/enum.rs:51:10
    |
-51 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<()>`
+51 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              &T
              &mut T
              ()
@@ -250,19 +250,19 @@ error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
              I128<O>
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
   --> tests/ui-nightly/enum.rs:59:10
    |
-59 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<u8>`
+59 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              &T
              &mut T
              ()
@@ -273,7 +273,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
              I128<O>
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 9  + #![feature(trivial_bounds)]

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -49,16 +49,16 @@ struct KL08(u8, NotKnownLayoutDst);
 struct KL09(NotKnownLayout, NotKnownLayout);
 
 //
-// NoCell errors
+// Immutable errors
 //
 
-#[derive(NoCell)]
-struct NoCell1 {
+#[derive(Immutable)]
+struct Immutable1 {
     a: core::cell::UnsafeCell<()>,
 }
 
-#[derive(NoCell)]
-struct NoCell2 {
+#[derive(Immutable)]
+struct Immutable2 {
     a: [core::cell::UnsafeCell<u8>; 0],
 }
 

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -118,13 +118,13 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-nightly/struct.rs:55:10
    |
-55 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`
+55 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -135,19 +135,19 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfie
              F64<O>
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satisfied
   --> tests/ui-nightly/struct.rs:60:10
    |
-60 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<u8>`, which is required by `[UnsafeCell<u8>; 0]: zerocopy::NoCell`
+60 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<u8>`, which is required by `[UnsafeCell<u8>; 0]: zerocopy::Immutable`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -157,9 +157,9 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::NoCell` is not satisfie
              F32<O>
              F64<O>
            and $N others
-   = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::NoCell`
+   = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::Immutable`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 9  + #![feature(trivial_bounds)]

--- a/zerocopy-derive/tests/ui-nightly/union.rs
+++ b/zerocopy-derive/tests/ui-nightly/union.rs
@@ -18,11 +18,11 @@ use std::mem::ManuallyDrop;
 fn main() {}
 
 //
-// NoCell errors
+// Immutable errors
 //
 
-#[derive(NoCell)]
-union NoCell1 {
+#[derive(Immutable)]
+union Immutable1 {
     a: ManuallyDrop<core::cell::UnsafeCell<()>>,
 }
 

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -30,13 +30,13 @@ error: cannot derive Unaligned with repr(align(N > 1))
 79 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-nightly/union.rs:24:10
    |
-24 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`, which is required by `ManuallyDrop<UnsafeCell<()>>: zerocopy::NoCell`
+24 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`, which is required by `ManuallyDrop<UnsafeCell<()>>: zerocopy::Immutable`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              &T
              &mut T
              ()
@@ -46,9 +46,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfie
              F32<O>
              F64<O>
            and $N others
-   = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::NoCell`
+   = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::Immutable`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 9  + #![feature(trivial_bounds)]

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -233,13 +233,13 @@ error[E0566]: conflicting representation hints
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
    = note: `#[deny(conflicting_repr_hints)]` on by default
 
-error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
   --> tests/ui-stable/enum.rs:51:10
    |
-51 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<()>`
+51 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              bool
              char
              isize
@@ -250,15 +250,15 @@ error[E0277]: the trait bound `UnsafeCell<()>: NoCell` is not satisfied
              i128
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
   --> tests/ui-stable/enum.rs:59:10
    |
-59 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `NoCell` is not implemented for `UnsafeCell<u8>`
+59 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
-   = help: the following other types implement trait `NoCell`:
+   = help: the following other types implement trait `Immutable`:
              bool
              char
              isize
@@ -269,4 +269,4 @@ error[E0277]: the trait bound `UnsafeCell<u8>: NoCell` is not satisfied
              i128
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -102,13 +102,13 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-stable/struct.rs:55:10
    |
-55 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`
+55 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -119,15 +119,15 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfie
              i128
            and $N others
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satisfied
   --> tests/ui-stable/struct.rs:60:10
    |
-60 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<u8>`, which is required by `[UnsafeCell<u8>; 0]: zerocopy::NoCell`
+60 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<u8>`, which is required by `[UnsafeCell<u8>; 0]: zerocopy::Immutable`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -137,9 +137,9 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::NoCell` is not satisfie
              i64
              i128
            and $N others
-   = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::NoCell`
+   = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::Immutable`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
   --> tests/ui-stable/struct.rs:71:1

--- a/zerocopy-derive/tests/ui-stable/union.stderr
+++ b/zerocopy-derive/tests/ui-stable/union.stderr
@@ -30,13 +30,13 @@ error: cannot derive Unaligned with repr(align(N > 1))
 79 | #[repr(align(2), align(4))]
    |        ^^^^^^^^
 
-error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfied
+error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-stable/union.rs:24:10
    |
-24 | #[derive(NoCell)]
-   |          ^^^^^^ the trait `zerocopy::NoCell` is not implemented for `UnsafeCell<()>`, which is required by `ManuallyDrop<UnsafeCell<()>>: zerocopy::NoCell`
+24 | #[derive(Immutable)]
+   |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`, which is required by `ManuallyDrop<UnsafeCell<()>>: zerocopy::Immutable`
    |
-   = help: the following other types implement trait `zerocopy::NoCell`:
+   = help: the following other types implement trait `zerocopy::Immutable`:
              bool
              char
              isize
@@ -46,9 +46,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::NoCell` is not satisfie
              i64
              i128
            and $N others
-   = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::NoCell`
+   = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::Immutable`
    = help: see issue #48214
-   = note: this error originates in the derive macro `NoCell` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
   --> tests/ui-stable/union.rs:39:10

--- a/zerocopy-derive/tests/union_from_bytes.rs
+++ b/zerocopy-derive/tests/union_from_bytes.rs
@@ -15,21 +15,21 @@ include!("include.rs");
 // A union is `imp::FromBytes` if:
 // - all fields are `imp::FromBytes`
 
-#[derive(Clone, Copy, imp::NoCell, imp::FromBytes)]
+#[derive(Clone, Copy, imp::Immutable, imp::FromBytes)]
 union Zst {
     a: (),
 }
 
 util_assert_impl_all!(Zst: imp::FromBytes);
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 union One {
     a: u8,
 }
 
 util_assert_impl_all!(One: imp::FromBytes);
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 union Two {
     a: u8,
     b: Zst,
@@ -37,7 +37,7 @@ union Two {
 
 util_assert_impl_all!(Two: imp::FromBytes);
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 union TypeParams<'a, T: imp::Copy, I: imp::Iterator>
 where
     I::Item: imp::Copy,
@@ -54,7 +54,7 @@ util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::FromBytes
 
 // Deriving `imp::FromBytes` should work if the union has bounded parameters.
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 #[repr(C)]
 union WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::FromBytes, const N: usize>
 where

--- a/zerocopy-derive/tests/union_from_zeros.rs
+++ b/zerocopy-derive/tests/union_from_zeros.rs
@@ -15,21 +15,21 @@ include!("include.rs");
 // A union is `imp::FromZeros` if:
 // - all fields are `imp::FromZeros`
 
-#[derive(Clone, Copy, imp::NoCell, imp::FromZeros)]
+#[derive(Clone, Copy, imp::Immutable, imp::FromZeros)]
 union Zst {
     a: (),
 }
 
 util_assert_impl_all!(Zst: imp::FromZeros);
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 union One {
     a: bool,
 }
 
 util_assert_impl_all!(One: imp::FromZeros);
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 union Two {
     a: bool,
     b: Zst,
@@ -37,7 +37,7 @@ union Two {
 
 util_assert_impl_all!(Two: imp::FromZeros);
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 union TypeParams<'a, T: imp::Copy, I: imp::Iterator>
 where
     I::Item: imp::Copy,
@@ -54,7 +54,7 @@ util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::FromZeros
 
 // Deriving `imp::FromZeros` should work if the union has bounded parameters.
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 #[repr(C)]
 union WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::FromZeros, const N: usize>
 where

--- a/zerocopy-derive/tests/union_no_cell.rs
+++ b/zerocopy-derive/tests/union_no_cell.rs
@@ -8,29 +8,29 @@
 
 include!("include.rs");
 
-#[derive(Clone, Copy, imp::NoCell)]
+#[derive(Clone, Copy, imp::Immutable)]
 union Zst {
     a: (),
 }
 
-util_assert_impl_all!(Zst: imp::NoCell);
+util_assert_impl_all!(Zst: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 union One {
     a: bool,
 }
 
-util_assert_impl_all!(One: imp::NoCell);
+util_assert_impl_all!(One: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 union Two {
     a: bool,
     b: Zst,
 }
 
-util_assert_impl_all!(Two: imp::NoCell);
+util_assert_impl_all!(Two: imp::Immutable);
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 union TypeParams<'a, T: imp::Copy, I: imp::Iterator>
 where
     I::Item: imp::Copy,
@@ -43,17 +43,17 @@ where
     g: imp::PhantomData<imp::String>,
 }
 
-util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::NoCell);
+util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::Immutable);
 
-// Deriving `imp::NoCell` should work if the union has bounded parameters.
+// Deriving `imp::Immutable` should work if the union has bounded parameters.
 
-#[derive(imp::NoCell)]
+#[derive(imp::Immutable)]
 #[repr(C)]
-union WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::NoCell, const N: usize>
+union WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::Immutable, const N: usize>
 where
     'a: 'b,
     'b: 'a,
-    T: 'a + 'b + imp::Copy + imp::NoCell,
+    T: 'a + 'b + imp::Copy + imp::Immutable,
 {
     a: [T; N],
     b: imp::PhantomData<&'a &'b ()>,
@@ -61,4 +61,4 @@ where
     d: &'a imp::UnsafeCell<()>,
 }
 
-util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::NoCell);
+util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::Immutable);

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -15,7 +15,7 @@ include!("include.rs");
 // A struct is `imp::TryFromBytes` if:
 // - any of its fields are `imp::TryFromBytes`
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 union One {
     a: u8,
 }
@@ -33,7 +33,7 @@ fn one() {
     assert!(is_bit_valid);
 }
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 #[repr(C)]
 union Two {
     a: bool,
@@ -83,7 +83,7 @@ fn two_bad() {
     assert!(!is_bit_valid);
 }
 
-#[derive(imp::NoCell, imp::FromZeros)]
+#[derive(imp::Immutable, imp::FromZeros)]
 #[repr(C)]
 union BoolAndZst {
     a: bool,
@@ -113,7 +113,7 @@ fn bool_and_zst() {
     assert!(is_bit_valid);
 }
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 #[repr(C)]
 union TypeParams<'a, T: imp::Copy, I: imp::Iterator>
 where
@@ -133,7 +133,7 @@ util_assert_impl_all!(TypeParams<'static, [util::AU16; 2], imp::IntoIter<()>>: i
 
 // Deriving `imp::TryFromBytes` should work if the union has bounded parameters.
 
-#[derive(imp::NoCell, imp::FromBytes)]
+#[derive(imp::Immutable, imp::FromBytes)]
 #[repr(C)]
 union WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::TryFromBytes, const N: usize>
 where


### PR DESCRIPTION
We selected `Immutable` on @rcoh's suggestion that our name for this be a single, evocative word, like `Send` and `Sync`. As with `Send` and `Sync`, we do not hope that `Immutable`, on its own, captures the entire semantics of this trait; the burden of entirely capturing its semantics rests on its documentation.

We are not overly concerned with the risk of future conflict with Rust. If and when Rust stabilizes its own version of this trait, we will adjust zerocopy to use Rust's trait instead.

Closes #994

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
