### PR TITLE
Overhaul error reporting (struct version)

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -21,7 +21,7 @@ where
     #[doc(hidden)]
     #[inline]
     pub fn new_slice(bytes: B) -> Option<Ref<B, [T]>> {
-        Self::new(bytes)
+        Self::new(bytes).ok()
     }
 }
 
@@ -34,7 +34,7 @@ where
     #[doc(hidden)]
     #[inline(always)]
     pub fn new_slice_unaligned(bytes: B) -> Option<Ref<B, [T]>> {
-        Ref::new_unaligned(bytes)
+        Ref::new_unaligned(bytes).ok()
     }
 }
 
@@ -74,7 +74,7 @@ where
     #[doc(hidden)]
     #[inline]
     pub fn new_slice_from_prefix(bytes: B, count: usize) -> Option<(Ref<B, [T]>, B)> {
-        Ref::with_trailing_elements_from_prefix(bytes, count)
+        Ref::with_trailing_elements_from_prefix(bytes, count).ok()
     }
 
     #[deprecated(since = "0.8.0", note = "replaced by `Ref::with_trailing_elements_from_suffix`")]
@@ -82,7 +82,7 @@ where
     #[doc(hidden)]
     #[inline]
     pub fn new_slice_from_suffix(bytes: B, count: usize) -> Option<(B, Ref<B, [T]>)> {
-        Ref::with_trailing_elements_from_suffix(bytes, count)
+        Ref::with_trailing_elements_from_suffix(bytes, count).ok()
     }
 }
 
@@ -99,7 +99,7 @@ where
     #[must_use = "has no side effects"]
     #[inline(always)]
     pub fn new_slice_unaligned_from_prefix(bytes: B, count: usize) -> Option<(Ref<B, [T]>, B)> {
-        Ref::with_trailing_elements_unaligned_from_prefix(bytes, count)
+        Ref::with_trailing_elements_unaligned_from_prefix(bytes, count).ok()
     }
 
     #[deprecated(
@@ -110,6 +110,6 @@ where
     #[must_use = "has no side effects"]
     #[inline(always)]
     pub fn new_slice_unaligned_from_suffix(bytes: B, count: usize) -> Option<(B, Ref<B, [T]>)> {
-        Ref::with_trailing_elements_unaligned_from_suffix(bytes, count)
+        Ref::with_trailing_elements_unaligned_from_suffix(bytes, count).ok()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,153 @@
+//! Types related to error reporting.
+
+use core::{
+    convert::Infallible,
+    fmt::{self, Debug, Display},
+    marker::PhantomData,
+};
+
+#[cfg(doc)]
+use crate::{FromBytes, Ref, TryFromBytes};
+
+#[derive(PartialEq, Eq, Copy, Clone)]
+pub struct Error<Src, Dst: ?Sized, E> {
+    pub(crate) src: Src,
+    pub(crate) dst: PhantomData<Dst>,
+    pub(crate) error: E,
+}
+
+impl<Src, Dst: ?Sized, E: Default> Error<Src, Dst, E> {
+    pub(crate) fn new(src: Src) -> Error<Src, Dst, E> {
+        Error::with_error(src, E::default())
+    }
+}
+
+impl<Src, Dst: ?Sized, E> Error<Src, Dst, E> {
+    pub(crate) fn with_error<EE: Into<E>>(src: Src, error: EE) -> Error<Src, Dst, E> {
+        Error { src, dst: PhantomData, error: error.into() }
+    }
+
+    pub(crate) fn map_src<SS, F: FnOnce(Src) -> SS>(self, f: F) -> Error<SS, Dst, E> {
+        let Error { src, dst, error } = self;
+        Error { src: f(src), dst, error }
+    }
+
+    pub(crate) fn map_err<EE, F: FnOnce(E) -> EE>(self, f: F) -> Error<Src, Dst, EE> {
+        let Error { src, dst, error } = self;
+        Error { src, dst, error: f(error) }
+    }
+}
+
+impl<Src, Dst: ?Sized, E: Debug> Debug for Error<Src, Dst, E> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Error").field("error", &self.error).finish()
+    }
+}
+
+/// Produces a human-readable error message.
+impl<Src, Dst: ?Sized, E: Display> Display for Error<Src, Dst, E> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "the conversion ({} -> {}) failed: {}",
+            core::any::type_name::<Src>(),
+            core::any::type_name::<Dst>(),
+            self.error
+        )
+    }
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum ConvertError<A, S, V> {
+    /// The conversion source was improperly aligned.
+    Alignment(A),
+    /// The conversion source was of incorrect size.
+    Size(S),
+    /// The conversion source contained invalid data.
+    Validity(V),
+}
+
+/// Produces a human-readable error message.
+impl<A: Display, S: Display, V: Display> Display for ConvertError<A, S, V> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Alignment(e) => e.fmt(f),
+            Self::Size(e) => e.fmt(f),
+            Self::Validity(e) => e.fmt(f),
+        }
+    }
+}
+
+impl<S, V> From<Alignment> for ConvertError<Alignment, S, V> {
+    fn from(e: Alignment) -> ConvertError<Alignment, S, V> {
+        ConvertError::Alignment(e)
+    }
+}
+
+impl<A, V> From<Size> for ConvertError<A, Size, V> {
+    fn from(e: Size) -> ConvertError<A, Size, V> {
+        ConvertError::Size(e)
+    }
+}
+
+impl<A, S> From<Validity> for ConvertError<A, S, Validity> {
+    fn from(e: Validity) -> ConvertError<A, S, Validity> {
+        ConvertError::Validity(e)
+    }
+}
+
+/// The error emitted if the conversion source is improperly aligned.
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+pub struct Alignment;
+
+/// Produces a human-readable error message.
+// The bounds on this impl are intentionally conservative, and can be relaxed
+// either once a `?Sized` alignment accessor is stabilized, or by storing the
+// alignment as a runtime value.
+impl Display for Alignment {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "the address of the source is not a multiple of the alignment of the destination type",
+        )
+    }
+}
+
+/// The error emitted if the conversion source is of incorrect size.
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+pub struct Size;
+
+/// Produces a human-readable error message.
+impl Display for Size {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            "the source is incorrectly sized to complete the conversion into the destination type",
+        )
+    }
+}
+
+/// The error emitted if the conversion source contains invalid data.
+#[derive(PartialEq, Eq, Debug, Default, Copy, Clone)]
+pub struct Validity;
+
+/// Produces a human-readable error message.
+impl Display for Validity {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("the source is not a valid value of the destination type")
+    }
+}
+
+pub type AlignmentError<Src, Dst> = Error<Src, Dst, Alignment>;
+pub type SizeError<Src, Dst> = Error<Src, Dst, Size>;
+pub type ValidityError<Src, Dst> = Error<Src, Dst, Validity>;
+
+pub type CastError<Src, Dst> = Error<Src, Dst, ConvertError<Alignment, Size, Infallible>>;
+
+pub type TryCastError<Src, Dst> = Error<Src, Dst, ConvertError<Alignment, Size, Validity>>;
+
+pub type TryReadError<Src, Dst> = Error<Src, Dst, ConvertError<Infallible, Size, Validity>>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -589,6 +589,13 @@ pub(crate) const fn min(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
     }
 }
 
+/// A safe alternative to [`core::hint::unreachable_unchecked`].
+pub(crate) const fn unreachable_infallible<T>(_: core::convert::Infallible) -> T {
+    // SAFETY: Since the argument type `Infallible` is uninhabited, this
+    // function cannot be executed with a value of it.
+    unsafe { core::hint::unreachable_unchecked() }
+}
+
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those

--- a/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -22,10 +22,10 @@ util_assert_impl_all!(Foo: imp::TryFromBytes);
 
 #[test]
 fn test_foo() {
-    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[0]), imp::Some(Foo::A));
-    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[]), imp::None);
-    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[1]), imp::None);
-    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::None);
+    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[0]), imp::Ok(Foo::A));
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[]).is_err());
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[1]).is_err());
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
 }
 
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
@@ -38,11 +38,11 @@ util_assert_impl_all!(Bar: imp::TryFromBytes);
 
 #[test]
 fn test_bar() {
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::Some(Bar::A));
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[]), imp::None);
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0]), imp::None);
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 1]), imp::None);
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0, 0]), imp::None);
+    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::Ok(Bar::A));
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 1]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0, 0]).is_err());
 }
 
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
@@ -58,17 +58,17 @@ util_assert_impl_all!(Baz: imp::TryFromBytes);
 fn test_baz() {
     imp::assert_eq!(
         <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1u32)),
-        imp::Some(Baz::A)
+        imp::Ok(Baz::A)
     );
     imp::assert_eq!(
         <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0u32)),
-        imp::Some(Baz::B)
+        imp::Ok(Baz::B)
     );
-    imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[]), imp::None);
-    imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[0]), imp::None);
-    imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::None);
-    imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0]), imp::None);
-    imp::assert_eq!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0, 0, 0]), imp::None);
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0, 0, 0]).is_err());
 }
 
 // Test hygiene - make sure that `i8` being shadowed doesn't cause problems for
@@ -92,23 +92,23 @@ util_assert_impl_all!(Blah: imp::TryFromBytes);
 fn test_blah() {
     imp::assert_eq!(
         <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1i8)),
-        imp::Some(Blah::A)
+        imp::Ok(Blah::A)
     );
     imp::assert_eq!(
         <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0i8)),
-        imp::Some(Blah::B)
+        imp::Ok(Blah::B)
     );
     imp::assert_eq!(
         <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&3i8)),
-        imp::Some(Blah::C)
+        imp::Ok(Blah::C)
     );
     imp::assert_eq!(
         <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&6i8)),
-        imp::Some(Blah::D)
+        imp::Ok(Blah::D)
     );
-    imp::assert_eq!(<Blah as imp::TryFromBytes>::try_read_from(&[]), imp::None);
-    imp::assert_eq!(<Blah as imp::TryFromBytes>::try_read_from(&[4]), imp::None);
-    imp::assert_eq!(<Blah as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::None);
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[]).is_err());
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[4]).is_err());
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
 }
 
 #[derive(
@@ -127,21 +127,20 @@ fn test_fieldless_but_not_unit_only() {
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::A);
     imp::assert_eq!(
         <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(FieldlessButNotUnitOnly::A)
+        imp::Ok(FieldlessButNotUnitOnly::A)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::B());
     imp::assert_eq!(
         <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(FieldlessButNotUnitOnly::B())
+        imp::Ok(FieldlessButNotUnitOnly::B())
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::C {});
     imp::assert_eq!(
         <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(FieldlessButNotUnitOnly::C {})
+        imp::Ok(FieldlessButNotUnitOnly::C {})
     );
-    imp::assert_eq!(
-        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]),
-        imp::None
+    imp::assert!(
+        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]).is_err()
     );
 }
 
@@ -161,20 +160,19 @@ fn test_weird_discriminants() {
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::A);
     imp::assert_eq!(
         <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(WeirdDiscriminants::A)
+        imp::Ok(WeirdDiscriminants::A)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::B);
     imp::assert_eq!(
         <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(WeirdDiscriminants::B)
+        imp::Ok(WeirdDiscriminants::B)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::C);
     imp::assert_eq!(
         <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
-        imp::Some(WeirdDiscriminants::C)
+        imp::Ok(WeirdDiscriminants::C)
     );
-    imp::assert_eq!(
-        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]),
-        imp::None
+    imp::assert!(
+        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]).is_err()
     );
 }

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -167,7 +167,7 @@ struct CPacked {
 fn c_packed() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPacked as imp::TryFromBytes>::try_ref_from(candidate);
-    imp::assert_eq!(converted, imp::Some(&CPacked { a: 42, b: u32::MAX }));
+    imp::assert_eq!(converted, imp::Ok(&CPacked { a: 42, b: u32::MAX }));
 }
 
 #[derive(imp::TryFromBytes, imp::KnownLayout, imp::Immutable)]
@@ -188,7 +188,7 @@ struct CPackedUnsized {
 fn c_packed_unsized() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
-    imp::assert!(converted.is_some());
+    imp::assert!(converted.is_ok());
 }
 
 #[derive(imp::TryFromBytes)]
@@ -209,13 +209,13 @@ struct PackedUnsized {
 fn packed_unsized() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
-    imp::assert!(converted.is_some());
+    imp::assert!(converted.is_err());
 
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
-    imp::assert!(converted.is_none());
+    imp::assert!(converted.is_err());
 
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
-    imp::assert!(converted.is_some());
+    imp::assert!(converted.is_ok());
 }


### PR DESCRIPTION
Alternative to https://github.com/google/zerocopy/pull/1144 with a struct as the top-level error type, and the source and destination fields in this struct instead of in enum variants.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
