### PR TITLE
Use compile-time assertions to deny ZSTy DSTs

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -589,6 +589,29 @@ pub(crate) const fn min(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
     }
 }
 
+/// Assert at compile time that `T` does not have a zero-sized DST component.
+pub(crate) fn assert_dst_is_not_zst<T>()
+where
+    T: crate::KnownLayout + ?Sized,
+{
+    trait ConstAssert: crate::KnownLayout {
+        const DST_IS_NOT_ZST: bool = {
+            let dst_is_zst = match Self::LAYOUT.size_info {
+                crate::SizeInfo::Sized { .. } => false,
+                crate::SizeInfo::SliceDst(crate::TrailingSliceLayout { elem_size, .. }) => {
+                    elem_size == 0
+                }
+            };
+            const_assert!(!dst_is_zst);
+            !dst_is_zst
+        };
+    }
+
+    impl<T: crate::KnownLayout + ?Sized> ConstAssert for T {}
+
+    const_assert!(<T as ConstAssert>::DST_IS_NOT_ZST);
+}
+
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those


### PR DESCRIPTION
Presently, we deny ZSTy DSTs in our APIs via panicking at runtime. However, the ZSTiness of a DST is statically detectable and can be denied instead at compile time. This PR replaces our ZSTy DST panics with compile-time assertions. Doing gives us the freedom later provide meaningful runtime semantics in such cases.

Partially addresses https://github.com/google/zerocopy/issues/325
Closes https://github.com/google/zerocopy/issues/1149