### PR TITLE
[pointer] Make "at least" machinery generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1021,7 +1021,9 @@ pub unsafe trait TryFromBytes {
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid<A: invariant::at_least::Shared>(candidate: Maybe<'_, Self, A>) -> bool;
+    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
+        candidate: Maybe<'_, Self, A>,
+    ) -> bool;
 
     /// Attempts to interpret a byte slice as a `Self`.
     ///
@@ -3767,7 +3769,9 @@ unsafe impl<T: TryFromBytes> TryFromBytes for UnsafeCell<T> {
     }
 
     #[inline]
-    fn is_bit_valid<A: invariant::at_least::Shared>(candidate: Maybe<'_, Self, A>) -> bool {
+    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
+        candidate: Maybe<'_, Self, A>,
+    ) -> bool {
         // The only way to implement this function is using an exclusive-aliased
         // pointer. `UnsafeCell`s cannot be read via shared-aliased pointers
         // (other than by using `unsafe` code, which we can't use since we can't
@@ -7953,7 +7957,10 @@ mod tests {
 
             pub(super) trait TestIsBitValidShared<T: ?Sized> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<'ptr, A: invariant::at_least::Shared>(
+                fn test_is_bit_valid_shared<
+                    'ptr,
+                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
+                >(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool>;
@@ -7961,7 +7968,10 @@ mod tests {
 
             impl<T: TryFromBytes + Immutable + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<'ptr, A: invariant::at_least::Shared>(
+                fn test_is_bit_valid_shared<
+                    'ptr,
+                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
+                >(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool> {
@@ -8065,7 +8075,7 @@ mod tests {
                 #[allow(unused, non_local_definitions)]
                 impl AutorefWrapper<$ty> {
                     #[allow(clippy::needless_lifetimes)]
-                    fn test_is_bit_valid_shared<'ptr, A: invariant::at_least::Shared>(
+                    fn test_is_bit_valid_shared<'ptr, A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
                         &mut self,
                         candidate: Maybe<'ptr, $ty, A>,
                     ) -> Option<bool> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -140,7 +140,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::at_least::Shared>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The argument to `cast_unsized` is `|p| p as *mut _` as required
             //   by that method's safety precondition.
@@ -162,7 +162,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::at_least::Shared>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The argument to `cast_unsized` is `|p| p as *mut _` as required
             //   by that method's safety precondition.
@@ -184,7 +184,7 @@ macro_rules! unsafe_impl {
     (@method TryFromBytes) => {
         #[allow(clippy::missing_inline_in_public_items)]
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        #[inline(always)] fn is_bit_valid<A: invariant::at_least::Shared>(_: Maybe<'_, Self, A>) -> bool { true }
+        #[inline(always)] fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(_: Maybe<'_, Self, A>) -> bool { true }
     };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items)]
@@ -357,7 +357,7 @@ macro_rules! impl_for_transparent_wrapper {
         // TryFromBytes)` macro arm for an explanation of why this is a sound
         // implementation of `is_bit_valid`.
         #[inline]
-        fn is_bit_valid<A: crate::pointer::invariant::at_least::Shared>(candidate: Maybe<'_, Self, A>) -> bool {
+        fn is_bit_valid<A: crate::pointer::invariant::Aliasing + crate::pointer::invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, A>) -> bool {
             TryFromBytes::is_bit_valid(candidate.transparent_wrapper_into_inner())
         }
     };

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -33,7 +33,7 @@ pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant
 impl<'a, T, Aliasing, Alignment> MaybeAligned<'a, T, Aliasing, Alignment>
 where
     T: 'a + ?Sized,
-    Aliasing: invariant::at_least::Shared,
+    Aliasing: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
     Alignment: invariant::Alignment,
 {
     /// Reads the value from `MaybeAligned`.
@@ -68,7 +68,7 @@ pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
 where
     T: crate::Immutable,
     I: invariant::Invariants<Validity = invariant::Initialized>,
-    I::Aliasing: invariant::at_least::Shared,
+    I::Aliasing: invariant::AtLeast<invariant::Shared>,
 {
     ptr.as_bytes().as_ref().iter().all(|&byte| byte == 0)
 }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -378,7 +378,7 @@ fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_m
             // validity of a struct is just the composition of the bit
             // validities of its fields, so this is a sound implementation of
             // `is_bit_valid`.
-            fn is_bit_valid<A: ::zerocopy::pointer::invariant::at_least::Shared>(
+            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
                 mut candidate: ::zerocopy::Maybe<Self, A>
             ) -> bool {
                 true #(&& {
@@ -427,7 +427,7 @@ fn derive_try_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro
             // bit validity of a union is not yet well defined in Rust, but it
             // is guaranteed to be no more strict than this definition. See #696
             // for a more in-depth discussion.
-            fn is_bit_valid<A: ::zerocopy::pointer::invariant::at_least::Shared>(
+            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
                 mut candidate: ::zerocopy::Maybe<Self, A>
             ) -> bool {
                 false #(|| {
@@ -539,7 +539,7 @@ fn derive_try_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2:
         // SAFETY: We use `is_bit_valid` to validate that the bit pattern
         // corresponds to one of the field-less enum's variant discriminants.
         // Thus, this is a sound implementation of `is_bit_valid`.
-        fn is_bit_valid<A: ::zerocopy::pointer::invariant::at_least::Shared>(
+        fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
             candidate: ::zerocopy::Ptr<
                 '_,
                 Self,


### PR DESCRIPTION
This replaces `at_least::Xxx` with `AtLeast<Xxx>`, which in turn allows us to write `AtLeast<T>` in a context where `T` is generic.

The use case in this commit is to relax the bound on `Copy` and `Clone` to:

  Shared: AtLeast<I::Aliasing>

...which is equivalent to saying that `I::Aliasing` is at *most* `Shared`. This permits both `Shared` and `Any` `Ptr`s to be copied or cloned.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
