### PR TITLE
Add "release new crate version" workflow

### DIFF
--- a/.github/workflows/release-crate-version.yml
+++ b/.github/workflows/release-crate-version.yml
@@ -1,0 +1,38 @@
+name: Release new crate versions
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Crate version'
+        required: true
+        default: "0.8.COOL"
+
+permissions: read-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release new crate versions
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Overwrite Cargo.toml files
+        run: |
+          set -e
+
+          sed -i -e 's/^zerocopy-derive = { version = "=[0-9a-zA-Z\.-]*"/zerocopy-derive = { version = "=${{ github.event.inputs.version }}"/' Cargo.toml
+          sed -i -e 's/^version = "[0-9a-zA-Z\.-]*"/version = "${{ github.event.inputs.version }}"/' Cargo.toml zerocopy-derive/Cargo.toml
+
+      - name: Submit PR
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        with:
+          commit-message: "Release ${{ github.event.inputs.version }}"
+          author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
+          committer: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
+          title: "Release ${{ github.event.inputs.version }}"
+          branch: release-${{ github.event.inputs.version }}
+          push-to-fork: google-pr-creation-bot/zerocopy
+          token: ${{ secrets.GOOGLE_PR_CREATION_BOT_TOKEN }}


### PR DESCRIPTION
This can be triggered manually via the GitHub web UI, and will generate a PR which updates the crate versions in both `Cargo.toml` files.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
