### PR TITLE
[derive][tests] Test IntoBytes failure #1182

### DIFF
--- a/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy-derive/tests/struct_to_bytes.rs
@@ -180,3 +180,20 @@ where
     T: 'a + 'b + imp::IntoBytes;
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::IntoBytes);
+
+// Test for the failure reported in #1182.
+
+#[derive(imp::IntoBytes)]
+#[repr(packed)]
+pub struct IndexEntryFlags(u8);
+
+#[derive(imp::IntoBytes)]
+#[repr(packed)]
+pub struct IndexEntry<const SIZE_BLOCK_ID: usize> {
+    block_number: imp::native_endian::U64,
+    flags: IndexEntryFlags,
+    block_id: [u8; SIZE_BLOCK_ID],
+}
+
+util_assert_impl_all!(IndexEntry<0>: imp::IntoBytes);
+util_assert_impl_all!(IndexEntry<1>: imp::IntoBytes);


### PR DESCRIPTION
In #1182, a failure was reported for `AsBytes` (now renamed to `IntoBytes`). We haven't yet been able to reproduce this failure, but this commit adds that failure case verbatim so that we don't regress in the future.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
