### PR TITLE
[ci] Pin Kani version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,23 @@ jobs:
     runs-on: ubuntu-latest        
     name: 'Run tests under Kani'
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: model-checking/kani-github-action@e621a98d839036c62e96cd5fa33ac5d076729f94 # v1.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
-          args: "--package zerocopy --all-features --output-format=terse --randomize-layout --memory-safety-checks --overflow-checks --undefined-function-checks --unwinding-checks"
+          # Use `--features __internal_use_only_features_that_work_on_stable`
+          # because the Kani GitHub Action uses its own pinned nightly
+          # toolchain. Sometimes, we make changes to our nightly features for
+          # more recent toolchains, and so our nightly features become
+          # incompatible with the toolchain that Kani uses. By only testing
+          # stable features, we ensure that this doesn't cause problems in CI.
+          #
+          # TODO(https://github.com/model-checking/kani-github-action/issues/56):
+          # Go back to testing all features once the Kani GitHub Action supports
+          # specifying a particular toolchain.
+          args: "--package zerocopy --features __internal_use_only_features_that_work_on_stable --output-format=terse --randomize-layout --memory-safety-checks --overflow-checks --undefined-function-checks --unwinding-checks"
+          # This version is automatically rolled by
+          # `roll-pinned-toolchain-versions.yml`.
+          kani-version: 0.50.0
 
   check_fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This backports the existing behavior from `main` so we can  auto-roll Kani on the `0.7.x` branch.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
