### PR TITLE
Fix bug in Kani roller

### DIFF
--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -115,6 +115,9 @@ jobs:
           token: ${{ secrets.GOOGLE_PR_CREATION_BOT_TOKEN }}
   roll_kani:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ["main", "v0.7.x"]
     name: Roll pinned Kani version
     steps:
       - name: Checkout code


### PR DESCRIPTION
In a previous commit (#1190 / a49e91c), we introduced the `${{ matrix.branch }}` variable, but only one job in the file already had a "matrix" strategy. `roll_kani` did not, and so that variable is always empty.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
