### PR TITLE
[ref] Move `Ref` definition into its own module

### DIFF
--- a/src/ref.rs
+++ b/src/ref.rs
@@ -9,76 +9,199 @@
 
 use super::*;
 
-/// A typed reference derived from a byte slice.
-///
-/// A `Ref<B, T>` is a reference to a `T` which is stored in a byte slice, `B`.
-/// Unlike a native reference (`&T` or `&mut T`), `Ref<B, T>` has the same
-/// mutability as the byte slice it was constructed from (`B`).
-///
-/// # Examples
-///
-/// `Ref` can be used to treat a sequence of bytes as a structured type, and to
-/// read and write the fields of that type as if the byte slice reference were
-/// simply a reference to that type.
-///
-/// ```rust
-/// # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
-/// use zerocopy::{IntoBytes, ByteSliceMut, FromBytes, FromZeros, KnownLayout, Immutable, Ref, SplitByteSlice, Unaligned};
-///
-/// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
-/// #[repr(C)]
-/// struct UdpHeader {
-///     src_port: [u8; 2],
-///     dst_port: [u8; 2],
-///     length: [u8; 2],
-///     checksum: [u8; 2],
-/// }
-///
-/// struct UdpPacket<B> {
-///     header: Ref<B, UdpHeader>,
-///     body: B,
-/// }
-///
-/// impl<B: SplitByteSlice> UdpPacket<B> {
-///     pub fn parse(bytes: B) -> Option<UdpPacket<B>> {
-///         let (header, body) = Ref::new_unaligned_from_prefix(bytes).ok()?;
-///         Some(UdpPacket { header, body })
-///     }
-///
-///     pub fn get_src_port(&self) -> [u8; 2] {
-///         self.header.src_port
-///     }
-/// }
-///
-/// impl<B: ByteSliceMut> UdpPacket<B> {
-///     pub fn with_src_port(&mut self, src_port: [u8; 2]) {
-///         self.header.src_port = src_port;
-///     }
-/// }
-/// # }
-/// ```
-pub struct Ref<B, T: ?Sized>(
-    // INVARIANTS: The referent (via `.deref`, `.deref_mut`, `.into`) byte slice
-    // is aligned to `T`'s alignment and its size corresponds to a valid size
-    // for `T`.
-    B,
-    PhantomData<T>,
-);
+mod def {
+    use core::marker::PhantomData;
 
-impl<B: ByteSlice + Clone, T: ?Sized> Clone for Ref<B, T> {
-    #[inline]
-    fn clone(&self) -> Ref<B, T> {
-        // INVARIANTS: By invariant on `self.0`, it is aligned to `T`'s
-        // alignment and its size corresponds to a valid size for `T`. By safety
-        // invariant on `ByteSlice`, these properties are preserved by `clone`.
-        Ref(self.0.clone(), PhantomData)
+    use crate::{
+        ByteSlice, ByteSliceMut, CloneableByteSlice, CopyableByteSlice, IntoByteSlice,
+        IntoByteSliceMut,
+    };
+
+    /// A typed reference derived from a byte slice.
+    ///
+    /// A `Ref<B, T>` is a reference to a `T` which is stored in a byte slice, `B`.
+    /// Unlike a native reference (`&T` or `&mut T`), `Ref<B, T>` has the same
+    /// mutability as the byte slice it was constructed from (`B`).
+    ///
+    /// # Examples
+    ///
+    /// `Ref` can be used to treat a sequence of bytes as a structured type, and to
+    /// read and write the fields of that type as if the byte slice reference were
+    /// simply a reference to that type.
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "derive")] { // This example uses derives, and won't compile without them
+    /// use zerocopy::{IntoBytes, ByteSliceMut, FromBytes, FromZeros, KnownLayout, Immutable, Ref, SplitByteSlice, Unaligned};
+    ///
+    /// #[derive(FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+    /// #[repr(C)]
+    /// struct UdpHeader {
+    ///     src_port: [u8; 2],
+    ///     dst_port: [u8; 2],
+    ///     length: [u8; 2],
+    ///     checksum: [u8; 2],
+    /// }
+    ///
+    /// struct UdpPacket<B> {
+    ///     header: Ref<B, UdpHeader>,
+    ///     body: B,
+    /// }
+    ///
+    /// impl<B: SplitByteSlice> UdpPacket<B> {
+    ///     pub fn parse(bytes: B) -> Option<UdpPacket<B>> {
+    ///         let (header, body) = Ref::new_unaligned_from_prefix(bytes).ok()?;
+    ///         Some(UdpPacket { header, body })
+    ///     }
+    ///
+    ///     pub fn get_src_port(&self) -> [u8; 2] {
+    ///         self.header.src_port
+    ///     }
+    /// }
+    ///
+    /// impl<B: ByteSliceMut> UdpPacket<B> {
+    ///     pub fn with_src_port(&mut self, src_port: [u8; 2]) {
+    ///         self.header.src_port = src_port;
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub struct Ref<B, T: ?Sized>(
+        // INVARIANTS: The referent (via `.deref`, `.deref_mut`, `.into`) byte
+        // slice is aligned to `T`'s alignment and its size corresponds to a
+        // valid size for `T`.
+        B,
+        PhantomData<T>,
+    );
+
+    impl<B, T: ?Sized> Ref<B, T> {
+        /// Constructs a new `Ref`.
+        ///
+        /// # Safety
+        ///
+        /// `bytes` dereferences (via [`deref`], [`deref_mut`], and [`into`]) to
+        /// a byte slice which is aligned to `T`'s alignment and whose size is a
+        /// valid size for `T`.
+        ///
+        /// [`deref`]: core::ops::Deref::deref
+        /// [`deref_mut`]: core::ops::DerefMut::deref_mut
+        /// [`into`]: core::convert::Into::into
+        pub(crate) unsafe fn new_unchecked(bytes: B) -> Ref<B, T> {
+            // INVARIANTS: The caller has promised that `bytes`'s referent is
+            // validly-aligned and has a valid size.
+            Ref(bytes, PhantomData)
+        }
     }
+
+    impl<B: ByteSlice, T: ?Sized> Ref<B, T> {
+        /// Access the byte slice as a [`ByteSlice`].
+        ///
+        /// # Safety
+        ///
+        /// The caller promises not to call methods on the returned
+        /// [`ByteSlice`] other than `ByteSlice` methods (for example, via
+        /// `Any::downcast_ref`).
+        ///
+        /// `as_byte_slice` promises to return a `ByteSlice` whose referent is
+        /// validly-aligned for `T` and has a valid size for `T`.
+        pub(crate) unsafe fn as_byte_slice(&self) -> &impl ByteSlice {
+            // INVARIANTS: The caller promises not to call methods other than
+            // those on `ByteSlice`. Since `B: ByteSlice`, dereference stability
+            // guarantees that calling `ByteSlice` methods will not change the
+            // address or length of `self.0`'s referent.
+            //
+            // SAFETY: By invariant on `self.0`, the alignment and size
+            // post-conditions are upheld.
+            &self.0
+        }
+    }
+
+    impl<B: ByteSliceMut, T: ?Sized> Ref<B, T> {
+        /// Access the byte slice as a [`ByteSliceMut`].
+        ///
+        /// # Safety
+        ///
+        /// The caller promises not to call methods on the returned
+        /// [`ByteSliceMut`] other than `ByteSliceMut` methods (for example, via
+        /// `Any::downcast_mut`).
+        ///
+        /// `as_byte_slice` promises to return a `ByteSlice` whose referent is
+        /// validly-aligned for `T` and has a valid size for `T`.
+        pub(crate) unsafe fn as_byte_slice_mut(&mut self) -> &mut impl ByteSliceMut {
+            // INVARIANTS: The caller promises not to call methods other than
+            // those on `ByteSliceMut`. Since `B: ByteSlice`, dereference
+            // stability guarantees that calling `ByteSlice` methods will not
+            // change the address or length of `self.0`'s referent.
+            //
+            // SAFETY: By invariant on `self.0`, the alignment and size
+            // post-conditions are upheld.
+            &mut self.0
+        }
+    }
+
+    impl<'a, B: IntoByteSlice<'a>, T: ?Sized> Ref<B, T> {
+        /// Access the byte slice as an [`IntoByteSlice`].
+        ///
+        /// # Safety
+        ///
+        /// The caller promises not to call methods on the returned
+        /// [`IntoByteSlice`] other than `IntoByteSlice` methods (for example,
+        /// via `Any::downcast_ref`).
+        ///
+        /// `as_byte_slice` promises to return a `ByteSlice` whose referent is
+        /// validly-aligned for `T` and has a valid size for `T`.
+        pub(crate) unsafe fn into_byte_slice(self) -> impl IntoByteSlice<'a> {
+            // INVARIANTS: The caller promises not to call methods other than
+            // those on `IntoByteSlice`. Since `B: ByteSlice`, dereference
+            // stability guarantees that calling `ByteSlice` methods will not
+            // change the address or length of `self.0`'s referent.
+            //
+            // SAFETY: By invariant on `self.0`, the alignment and size
+            // post-conditions are upheld.
+            self.0
+        }
+    }
+
+    impl<'a, B: IntoByteSliceMut<'a>, T: ?Sized> Ref<B, T> {
+        /// Access the byte slice as an [`IntoByteSliceMut`].
+        ///
+        /// # Safety
+        ///
+        /// The caller promises not to call methods on the returned
+        /// [`IntoByteSliceMut`] other than `IntoByteSliceMut` methods (for
+        /// example, via `Any::downcast_mut`).
+        ///
+        /// `as_byte_slice` promises to return a `ByteSlice` whose referent is
+        /// validly-aligned for `T` and has a valid size for `T`.
+        pub(crate) unsafe fn into_byte_slice_mut(self) -> impl IntoByteSliceMut<'a> {
+            // INVARIANTS: The caller promises not to call methods other than
+            // those on `IntoByteSliceMut`. Since `B: ByteSlice`, dereference
+            // stability guarantees that calling `ByteSlice` methods will not
+            // change the address or length of `self.0`'s referent.
+            //
+            // SAFETY: By invariant on `self.0`, the alignment and size
+            // post-conditions are upheld.
+            self.0
+        }
+    }
+
+    impl<B: CloneableByteSlice + Clone, T: ?Sized> Clone for Ref<B, T> {
+        #[inline]
+        fn clone(&self) -> Ref<B, T> {
+            // INVARIANTS: Since `B: CloneableByteSlice`, `self.0.clone()` has
+            // the same address and length as `self.0`. Since `self.0` upholds
+            // the field invariants, so does `self.0.clone()`.
+            Ref(self.0.clone(), PhantomData)
+        }
+    }
+
+    // INVARIANTS: Since `B: CopyableByteSlice`, the copied `Ref`'s `.0` has the
+    // same address and length as the original `Ref`'s `.0`. Since the original
+    // upholds the field invariants, so does the copy.
+    impl<B: CopyableByteSlice + Copy, T: ?Sized> Copy for Ref<B, T> {}
 }
 
-// INVARIANTS: By invariant on `Ref`'s `.0` field, it is aligned to `T`'s
-// alignment and its size corresponds to a valid size for `T`. By safety
-// invariant on `ByteSlice`, these properties are preserved by `Copy`.
-impl<B: ByteSlice + Copy, T: ?Sized> Copy for Ref<B, T> {}
+#[allow(unreachable_pub)] // This is a false positive on our MSRV toolchain.
+pub use def::Ref;
 
 impl<B, T> Ref<B, T>
 where
@@ -92,8 +215,9 @@ where
         if !util::aligned_to::<_, T>(bytes.deref()) {
             return Err(AlignmentError::new(bytes).into());
         }
-        // INVARIANTS: We just validated size and alignment.
-        Ok(Ref(bytes, PhantomData))
+
+        // SAFETY: We just validated size and alignment.
+        Ok(unsafe { Ref::new_unchecked(bytes) })
     }
 }
 
@@ -111,12 +235,13 @@ where
         }
         let (bytes, suffix) =
             try_split_at(bytes, mem::size_of::<T>()).map_err(|b| SizeError::new(b).into())?;
-        // INVARIANTS: We just validated alignment and that `bytes` is at least
-        // as large as `T`. `try_split_at(bytes, mem::size_of::<T>())?` ensures
+        // SAFETY: We just validated alignment and that `bytes` is at least as
+        // large as `T`. `try_split_at(bytes, mem::size_of::<T>())?` ensures
         // that the new `bytes` is exactly the size of `T`. By safety
         // postcondition on `SplitByteSlice::try_split_at` we can rely on
         // `try_split_at` to produce the correct `bytes` and `suffix`.
-        Ok((Ref(bytes, PhantomData), suffix))
+        let r = unsafe { Ref::new_unchecked(bytes) };
+        Ok((r, suffix))
     }
 
     #[must_use = "has no side effects"]
@@ -132,13 +257,14 @@ where
         if !util::aligned_to::<_, T>(bytes.deref()) {
             return Err(AlignmentError::new(bytes).into());
         }
-        // INVARIANTS: Since `split_at` is defined as `bytes_len -
-        // size_of::<T>()`, the `bytes` which results from `let (prefix, bytes)
-        // = try_split_at(bytes, split_at)?` has length `size_of::<T>()`. After
+        // SAFETY: Since `split_at` is defined as `bytes_len - size_of::<T>()`,
+        // the `bytes` which results from `let (prefix, bytes) =
+        // try_split_at(bytes, split_at)?` has length `size_of::<T>()`. After
         // constructing `bytes`, we validate that it has the proper alignment.
         // By safety postcondition on `SplitByteSlice::try_split_at` we can rely
         // on `try_split_at` to produce the correct `prefix` and `bytes`.
-        Ok((prefix, Ref(bytes, PhantomData)))
+        let r = unsafe { Ref::new_unchecked(bytes) };
+        Ok((prefix, r))
     }
 }
 
@@ -179,8 +305,8 @@ where
         if let Err(e) = Ptr::from_ref(bytes.deref()).try_cast_into_no_leftover::<T>() {
             return Err(e.with_src(()).with_src(bytes));
         }
-        // INVARIANTS: `try_cast_into_no_leftover` validates size and alignment.
-        Ok(Ref(bytes, PhantomData))
+        // SAFETY: `try_cast_into_no_leftover` validates size and alignment.
+        Ok(unsafe { Ref::new_unchecked(bytes) })
     }
 }
 
@@ -236,12 +362,13 @@ where
         let split_at = unsafe { bytes.len().unchecked_sub(remainder.len()) };
         let (bytes, suffix) =
             try_split_at(bytes, split_at).map_err(|b| SizeError::new(b).into())?;
-        // INVARIANTS: `try_cast_into` validates size and alignment, and returns
-        // a `split_at` that indicates how many bytes of `bytes` correspond to a
+        // SAFETY: `try_cast_into` validates size and alignment, and returns a
+        // `split_at` that indicates how many bytes of `bytes` correspond to a
         // valid `T`. By safety postcondition on `SplitByteSlice::try_split_at`
         // we can rely on `try_split_at` to produce the correct `bytes` and
         // `suffix`.
-        Ok((Ref(bytes, PhantomData), suffix))
+        let r = unsafe { Ref::new_unchecked(bytes) };
+        Ok((r, suffix))
     }
 
     /// Constructs a new `Ref` from the suffix of a byte slice.
@@ -287,12 +414,13 @@ where
         let split_at = remainder.len();
         let (prefix, bytes) =
             try_split_at(bytes, split_at).map_err(|b| SizeError::new(b).into())?;
-        // INVARIANTS: `try_cast_into` validates size and alignment, and returns
-        // a `try_split_at` that indicates how many bytes of `bytes` correspond
-        // to a valid `T`. By safety postcondition on
+        // SAFETY: `try_cast_into` validates size and alignment, and returns a
+        // `try_split_at` that indicates how many bytes of `bytes` correspond to
+        // a valid `T`. By safety postcondition on
         // `SplitByteSlice::try_split_at` we can rely on `try_split_at` to
         // produce the correct `prefix` and `bytes`.
-        Ok((prefix, Ref(bytes, PhantomData)))
+        let r = unsafe { Ref::new_unchecked(bytes) };
+        Ok((prefix, r))
     }
 }
 
@@ -523,11 +651,16 @@ where
     pub fn into_ref(self) -> &'a T {
         // Presumably unreachable, since we've guarded each constructor of `Ref`.
         util::assert_dst_is_not_zst::<T>();
-        // PANICS: By invariant on `Ref`, `self.0.deref()`'s size and alignment
-        // are valid for `T`. By invariant on `IntoByteSlice`, `self.into()`
-        // produces a byte slice with identical address and length to that
-        // produced by `self.0.deref()`.
-        let ptr = Ptr::from_ref(self.0.into())
+
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `IntoByteSlice`.
+        let b = unsafe { self.into_byte_slice() };
+
+        // PANICS: By post-condition on `into_byte_slice`, `b`'s size and
+        // alignment are valid for `T`. By invariant on `IntoByteSlice`,
+        // `b.into()` produces a byte slice with identical address and length to
+        // that produced by `b.deref()`.
+        let ptr = Ptr::from_ref(b.into())
             .try_cast_into_no_leftover::<T>()
             .expect("zerocopy internal error: into_ref should be infallible");
         let ptr = ptr.bikeshed_recall_valid();
@@ -548,11 +681,16 @@ where
     pub fn into_mut(self) -> &'a mut T {
         // Presumably unreachable, since we've guarded each constructor of `Ref`.
         util::assert_dst_is_not_zst::<T>();
-        // PANICS: By invariant on `Ref`, `self.0.deref_mut()`'s size and
-        // alignment are valid for `T`. By invariant on `IntoByteSlice`,
-        // `self.into()` produces a byte slice with identical address and length
-        // to that produced by `self.0.deref_mut()`.
-        let ptr = Ptr::from_mut(self.0.into())
+
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `IntoByteSliceMut`.
+        let b = unsafe { self.into_byte_slice_mut() };
+
+        // PANICS: By post-condition on `into_byte_slice_mut`, `b`'s size and
+        // alignment are valid for `T`. By invariant on `IntoByteSliceMut`,
+        // `b.into()` produces a byte slice with identical address and length to
+        // that produced by `b.deref_mut()`.
+        let ptr = Ptr::from_mut(b.into())
             .try_cast_into_no_leftover::<T>()
             .expect("zerocopy internal error: into_ref should be infallible");
         let ptr = ptr.bikeshed_recall_valid();
@@ -568,7 +706,9 @@ where
     /// Gets the underlying bytes.
     #[inline]
     pub fn bytes(&self) -> &[u8] {
-        self.0.deref()
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSlice`.
+        unsafe { self.as_byte_slice().deref() }
     }
 }
 
@@ -580,7 +720,9 @@ where
     /// Gets the underlying bytes mutably.
     #[inline]
     pub fn bytes_mut(&mut self) -> &mut [u8] {
-        self.0.deref_mut()
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSliceMut`.
+        unsafe { self.as_byte_slice_mut().deref_mut() }
     }
 }
 
@@ -593,13 +735,15 @@ where
     #[must_use = "has no side effects"]
     #[inline]
     pub fn read(&self) -> T {
-        // SAFETY: Because of the invariants on `Ref`, we know that `self.0` was
-        // at least `size_of::<T>()` bytes long when it was validated, and that
-        // it was at least as aligned as `align_of::<T>()`. Because of the
-        // safety invariant on `ByteSlice`, we know that these must still hold
-        // when we dereference here. Because `T: FromBytes`, it is sound to
-        // interpret these bytes as a `T`.
-        unsafe { ptr::read(self.0.deref().as_ptr().cast::<T>()) }
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSlice`.
+        let b = unsafe { self.as_byte_slice() };
+
+        // SAFETY: By postcondition on `as_byte_slice`, we know that `b` is a
+        // valid size and ailgnment for `T`. By safety invariant on `ByteSlice`,
+        // we know that this is preserved via `.deref()`. Because `T:
+        // FromBytes`, it is sound to interpret these bytes as a `T`.
+        unsafe { ptr::read(b.deref().as_ptr().cast::<T>()) }
     }
 }
 
@@ -611,14 +755,16 @@ where
     /// Writes the bytes of `t` and then forgets `t`.
     #[inline]
     pub fn write(&mut self, t: T) {
-        // SAFETY: Because of the invariants on `Ref`, we know that `self.0` was
-        // at least `size_of::<T>()` bytes long when it was validated, and that
-        // it was at least as aligned as `align_of::<T>()`. Because of the
-        // safety invariant on `ByteSlice`, we know that these must still hold
-        // when we dereference here. Writing `t` to the buffer will allow all of
-        // the bytes of `t` to be accessed as a `[u8]`, but because `T:
-        // IntoBytes`, we know that this is sound.
-        unsafe { ptr::write(self.0.deref_mut().as_mut_ptr().cast::<T>(), t) }
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSliceMut`.
+        let b = unsafe { self.as_byte_slice_mut() };
+
+        // SAFETY: By postcondition on `as_byte_slice_mut`, we know that `b` is
+        // a valid size and ailgnment for `T`. By safety invariant on
+        // `ByteSlice`, we know that this is preserved via `.deref()`. Writing
+        // `t` to the buffer will allow all of the bytes of `t` to be accessed
+        // as a `[u8]`, but because `T: IntoBytes`, we know that this is sound.
+        unsafe { ptr::write(b.deref_mut().as_mut_ptr().cast::<T>(), t) }
     }
 }
 
@@ -631,9 +777,15 @@ where
     #[inline]
     fn deref(&self) -> &T {
         util::assert_dst_is_not_zst::<T>();
-        // PANICS: By invariant on `Ref`, `self.0`'s size and alignment are
-        // valid for `T`, and so this `unwrap` will not panic.
-        let ptr = Ptr::from_ref(self.0.deref())
+
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSlice`.
+        let b = unsafe { self.as_byte_slice() };
+
+        // PANICS: By postcondition on `as_byte_slice`, `b`'s size and alignment
+        // are valid for `T`, and by invariant on `ByteSlice`, these are
+        // preserved through `.deref()`, so this `unwrap` will not panic.
+        let ptr = Ptr::from_ref(b.deref())
             .try_cast_into_no_leftover::<T>()
             .expect("zerocopy internal error: Deref::deref should be infallible");
         let ptr = ptr.bikeshed_recall_valid();
@@ -649,9 +801,16 @@ where
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
         util::assert_dst_is_not_zst::<T>();
-        // PANICS: By invariant on `Ref`, `self.0`'s size and alignment are
-        // valid for `T`, and so this `unwrap` will not panic.
-        let ptr = Ptr::from_mut(self.0.deref_mut())
+
+        // SAFETY: We don't call any methods on `b` other than those provided by
+        // `ByteSliceMut`.
+        let b = unsafe { self.as_byte_slice_mut() };
+
+        // PANICS: By postcondition on `as_byte_slice_mut`, `b`'s size and
+        // alignment are valid for `T`, and by invariant on `ByteSlice`, these
+        // are preserved through `.deref_mut()`, so this `unwrap` will not
+        // panic.
+        let ptr = Ptr::from_mut(b.deref_mut())
             .try_cast_into_no_leftover::<T>()
             .expect("zerocopy internal error: DerefMut::deref_mut should be infallible");
         let ptr = ptr.bikeshed_recall_valid();


### PR DESCRIPTION
This allows us to more strictly enforce the requirement that, for `Ref`'s `ByteSlice` field, methods are never called other than those defined on the `ByteSlice`, `ByteSliceMut`, `IntoByteSlice`, and `IntoByteSliceMut` traits. We accomplish this by keeping the field private, and only exposing unsafe getters which return, for example, `&impl ByteSlice`.

We also introduce new traits - `CopyableByteSlice` and `CloneableByteSlice`. We tighten the `Copy` and `Clone` impls for `Ref` to require these bounds. Previously, `ByteSlice` required that its "dereference stability" requirement applied to any `Copy` or `Clone` impls, but this would have prevented us from implementing `ByteSlice` for `Vec`. By splitting the requirement into separate traits, we open the door to supporting `Vec` (#992).

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
