### PR TITLE
Remove .forget_exclusive from Ptr::try_into_valid

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -874,7 +874,7 @@ mod _transitions {
             // This call may panic. If that happens, it doesn't cause any soundness
             // issues, as we have not generated any invalid state which we need to
             // fix before returning.
-            if T::is_bit_valid(self.reborrow().forget_exclusive().forget_aligned()) {
+            if T::is_bit_valid(self.reborrow().forget_aligned()) {
                 // SAFETY: If `T::is_bit_valid`, code may assume that `self`
                 // contains a bit-valid instance of `Self`.
                 Ok(unsafe { self.assume_valid() })


### PR DESCRIPTION
This causes methods like `TryFromBytes::try_mut_from` to fail compilation during post-monomorphization when used with types containing `UnsafeCell`s. This wasn't caught because our tests hadn't been updated to exercise this condition. This commit also updates the tests so this can't slip through in the future.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
