### PR TITLE
Add Ref more `with_elems` `Ref` constructors

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -22,7 +22,7 @@ where
     #[must_use = "has no side effects"]
     #[inline]
     pub fn new(bytes: B) -> Result<Ref<B, T>, CastError<B, T>> {
-        Self::from(bytes)
+        Self::from_bytes(bytes)
     }
 }
 
@@ -63,7 +63,7 @@ where
     #[doc(hidden)]
     #[inline]
     pub fn new_slice(bytes: B) -> Option<Ref<B, [T]>> {
-        Self::from(bytes).ok()
+        Self::from_bytes(bytes).ok()
     }
 }
 


### PR DESCRIPTION
While we're here, rename `from` to `from_bytes` so that naming is consistent (otherwise, we'd have to add `from_with_elems` rather than `from_bytes_with_elems`, which is a weird name).

Makes progress on #29

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
