### PR TITLE
Improve UI/UX of post-monomorphization errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1177,7 +1177,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout + Immutable,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         match Ptr::from_ref(candidate).try_cast_into_no_leftover::<Self, BecauseImmutable>(None) {
             Ok(candidate) => {
                 // This call may panic. If that happens, it doesn't cause any soundness
@@ -1274,7 +1274,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout + Immutable,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         try_ref_from_prefix_suffix(candidate, CastType::Prefix, None)
     }
 
@@ -1354,7 +1354,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout + Immutable,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         try_ref_from_prefix_suffix(candidate, CastType::Suffix, None).map(swap)
     }
 
@@ -1431,7 +1431,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         match Ptr::from_mut(bytes).try_cast_into_no_leftover::<Self, BecauseExclusive>(None) {
             Ok(candidate) => {
                 // This call may panic. If that happens, it doesn't cause any soundness
@@ -1536,7 +1536,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         try_mut_from_prefix_suffix(candidate, CastType::Prefix, None)
     }
 
@@ -1624,7 +1624,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         try_mut_from_prefix_suffix(candidate, CastType::Suffix, None).map(swap)
     }
 
@@ -2339,7 +2339,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: KnownLayout + Immutable,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         match Ptr::from_ref(source).try_cast_into_no_leftover::<_, BecauseImmutable>(None) {
             Ok(ptr) => Ok(ptr.bikeshed_recall_valid().as_ref()),
             Err(err) => Err(err.map_src(|src| src.as_ref())),
@@ -2417,7 +2417,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: KnownLayout + Immutable,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         ref_from_prefix_suffix(source, None, CastType::Prefix)
     }
 
@@ -2478,7 +2478,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: Immutable + KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         ref_from_prefix_suffix(source, None, CastType::Suffix).map(swap)
     }
 
@@ -2547,7 +2547,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: IntoBytes + KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         match Ptr::from_mut(source).try_cast_into_no_leftover::<_, BecauseExclusive>(None) {
             Ok(ptr) => Ok(ptr.bikeshed_recall_valid().as_mut()),
             Err(err) => Err(err.map_src(|src| src.as_mut())),
@@ -2626,7 +2626,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: IntoBytes + KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         mut_from_prefix_suffix(source, None, CastType::Prefix)
     }
 
@@ -2693,7 +2693,7 @@ pub unsafe trait FromBytes: FromZeros {
     where
         Self: IntoBytes + KnownLayout,
     {
-        util::assert_dst_is_not_zst::<Self>();
+        static_assert_dst_is_not_zst!(Self);
         mut_from_prefix_suffix(source, None, CastType::Suffix).map(swap)
     }
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -300,7 +300,7 @@ where
     #[must_use = "has no side effects"]
     #[inline]
     pub fn from_bytes(source: B) -> Result<Ref<B, T>, CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         if let Err(e) =
             Ptr::from_ref(source.deref()).try_cast_into_no_leftover::<T, BecauseImmutable>(None)
         {
@@ -346,7 +346,7 @@ where
     #[must_use = "has no side effects"]
     #[inline]
     pub fn from_prefix(source: B) -> Result<(Ref<B, T>, B), CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         let remainder = match Ptr::from_ref(source.deref())
             .try_cast_into::<T, BecauseImmutable>(CastType::Prefix, None)
         {
@@ -404,7 +404,7 @@ where
     #[must_use = "has no side effects"]
     #[inline]
     pub fn from_suffix(source: B) -> Result<(B, Ref<B, T>), CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         let remainder = match Ptr::from_ref(source.deref())
             .try_cast_into::<T, BecauseImmutable>(CastType::Suffix, None)
         {
@@ -443,7 +443,7 @@ where
     /// aligned, this returns `Err`.
     #[inline]
     pub fn from_bytes_with_elems(source: B, count: usize) -> Result<Ref<B, T>, CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         let expected_len = match count.size_for_metadata(T::LAYOUT) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
@@ -472,7 +472,7 @@ where
         source: B,
         count: usize,
     ) -> Result<(Ref<B, T>, B), CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         let expected_len = match count.size_for_metadata(T::LAYOUT) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
@@ -496,7 +496,7 @@ where
         source: B,
         count: usize,
     ) -> Result<(B, Ref<B, T>), CastError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         let expected_len = match count.size_for_metadata(T::LAYOUT) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
@@ -544,7 +544,7 @@ where
     #[must_use = "has no side effects"]
     #[inline(always)]
     pub fn unaligned_from(source: B) -> Result<Ref<B, T>, SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         match Ref::from_bytes(source) {
             Ok(dst) => Ok(dst),
             Err(CastError::Size(e)) => Err(e),
@@ -589,7 +589,7 @@ where
     #[must_use = "has no side effects"]
     #[inline(always)]
     pub fn unaligned_from_prefix(source: B) -> Result<(Ref<B, T>, B), SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         Ref::from_prefix(source).map_err(|e| match e {
             CastError::Size(e) => e,
             CastError::Alignment(_) => unreachable!(),
@@ -627,7 +627,7 @@ where
     #[must_use = "has no side effects"]
     #[inline(always)]
     pub fn unaligned_from_suffix(source: B) -> Result<(B, Ref<B, T>), SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         Ref::from_suffix(source).map_err(|e| match e {
             CastError::Size(e) => e,
             CastError::Alignment(_) => unreachable!(),
@@ -653,7 +653,7 @@ where
         source: B,
         count: usize,
     ) -> Result<Ref<B, T>, SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         Self::from_bytes_with_elems(source, count).map_err(|e| match e {
             CastError::Size(e) => e,
             CastError::Alignment(_) => unreachable!(),
@@ -679,7 +679,7 @@ where
         source: B,
         count: usize,
     ) -> Result<(Ref<B, T>, B), SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         Self::from_prefix_with_elems(source, count).map_err(|e| match e {
             CastError::Size(e) => e,
             CastError::Alignment(_) => unreachable!(),
@@ -699,7 +699,7 @@ where
         source: B,
         count: usize,
     ) -> Result<(B, Ref<B, T>), SizeError<B, T>> {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
         Self::from_suffix_with_elems(source, count).map_err(|e| match e {
             CastError::Size(e) => e,
             CastError::Alignment(_) => unreachable!(),
@@ -720,7 +720,7 @@ where
     #[inline(always)]
     pub fn into_ref(self) -> &'a T {
         // Presumably unreachable, since we've guarded each constructor of `Ref`.
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
 
         // SAFETY: We don't call any methods on `b` other than those provided by
         // `IntoByteSlice`.
@@ -750,7 +750,7 @@ where
     #[inline(always)]
     pub fn into_mut(self) -> &'a mut T {
         // Presumably unreachable, since we've guarded each constructor of `Ref`.
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
 
         // SAFETY: We don't call any methods on `b` other than those provided by
         // `IntoByteSliceMut`.
@@ -846,7 +846,7 @@ where
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
 
         // SAFETY: We don't call any methods on `b` other than those provided by
         // `ByteSlice`.
@@ -873,7 +873,7 @@ where
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        util::assert_dst_is_not_zst::<T>();
+        static_assert_dst_is_not_zst!(T);
 
         // SAFETY: We don't call any methods on `b` other than those provided by
         // `ByteSliceMut`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -584,46 +584,6 @@ pub(crate) const fn min(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
     }
 }
 
-/// Assert at compile time that `T` does not have a zero-sized DST component.
-pub(crate) fn assert_dst_is_not_zst<T>()
-where
-    T: crate::KnownLayout + ?Sized,
-{
-    trait ConstAssert: crate::KnownLayout {
-        const DST_IS_NOT_ZST: bool = {
-            let dst_is_zst = match Self::LAYOUT.size_info {
-                crate::SizeInfo::Sized { .. } => false,
-                crate::SizeInfo::SliceDst(crate::TrailingSliceLayout { elem_size, .. }) => {
-                    elem_size == 0
-                }
-            };
-            const_assert!(!dst_is_zst);
-            !dst_is_zst
-        };
-    }
-
-    impl<T: crate::KnownLayout + ?Sized> ConstAssert for T {}
-
-    const_assert!(<T as ConstAssert>::DST_IS_NOT_ZST);
-}
-
-/// Assert at compile time that the size of `Dst` <= the size of `Src`.
-pub(crate) const fn assert_dst_not_bigger_than_src<Src, Dst>() {
-    trait ConstAssert {
-        const DST_NOT_BIGGER_THAN_SRC: bool;
-    }
-
-    impl<Src, Dst> ConstAssert for (Src, Dst) {
-        const DST_NOT_BIGGER_THAN_SRC: bool = {
-            let dst_bigger_than_src = mem::size_of::<Dst>() > mem::size_of::<Src>();
-            const_assert!(!dst_bigger_than_src);
-            !dst_bigger_than_src
-        };
-    }
-
-    const_assert!(<(Src, Dst) as ConstAssert>::DST_NOT_BIGGER_THAN_SRC);
-}
-
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those


### PR DESCRIPTION
By asserting in a macro, rather than a helper function, rustc's diagnostics point to the user's callsite, rather than our own.