### PR TITLE
Rename FromBytes::ref_from[_with_elems]

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -76,7 +76,7 @@ where
     #[doc(hidden)]
     #[inline(always)]
     pub fn new_slice_unaligned(bytes: B) -> Option<Ref<B, [T]>> {
-        Ref::unaligned_from(bytes).ok()
+        Ref::unaligned_from_bytes(bytes).ok()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 //! - [`SizeError`]: the conversion source was of incorrect size
 //! - [`ValidityError`]: the conversion source contained invalid data
 //!
-//! Methods that only have one failure mode, like [`Ref::unaligned_from`],
+//! Methods that only have one failure mode, like [`Ref::unaligned_from_bytes`],
 //! return that mode's corresponding error type directly.
 //!
 //! ## Compound errors
@@ -44,11 +44,11 @@ mod private {
     /// - [`ValidityError`]: the conversion source contained invalid data
     ///
     /// However, not all conversions produce all errors. For instance,
-    /// [`FromBytes::ref_from`] may fail due to alignment or size issues, but not
-    /// validity issues. This generic error type captures these (im)possibilities
-    /// via parameterization: `A` is parameterized with [`AlignmentError`], `S` is
-    /// parameterized with [`SizeError`], and `V` is parameterized with
-    /// [`Infallible`].
+    /// [`FromBytes::ref_from_bytes`] may fail due to alignment or size issues,
+    /// but not validity issues. This generic error type captures these
+    /// (im)possibilities via parameterization: `A` is parameterized with
+    /// [`AlignmentError`], `S` is parameterized with [`SizeError`], and `V` is
+    /// parameterized with [`Infallible`].
     ///
     /// Zerocopy never uses this type directly in its API. Rather, we provide three
     /// pre-parameterized aliases:
@@ -297,7 +297,7 @@ impl<Src, Dst: ?Sized + TryFromBytes, A, S> From<ValidityError<Src, Dst>>
 
 /// The error type of reference conversions.
 ///
-/// Reference conversions, like [`FromBytes::ref_from`] may emit
+/// Reference conversions, like [`FromBytes::ref_from_bytes`] may emit
 /// [alignment](AlignmentError) and [size](SizeError) errors.
 // Bounds on generic parameters are not enforced in type aliases, but they do
 // appear in rustdoc.

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -539,11 +539,11 @@ where
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let f = Ref::<&[u8], ZSTy>::unaligned_from(&b"UU"[..]); // ⚠ Compile Error!
+    /// let f = Ref::<&[u8], ZSTy>::unaligned_from_bytes(&b"UU"[..]); // ⚠ Compile Error!
     /// ```
     #[must_use = "has no side effects"]
     #[inline(always)]
-    pub fn unaligned_from(source: B) -> Result<Ref<B, T>, SizeError<B, T>> {
+    pub fn unaligned_from_bytes(source: B) -> Result<Ref<B, T>, SizeError<B, T>> {
         static_assert_dst_is_not_zst!(T);
         match Ref::from_bytes(source) {
             Ok(dst) => Ok(dst),
@@ -1160,7 +1160,7 @@ mod tests {
         // for `new_slice`.
 
         let mut buf = [0u8; 8];
-        test_new_helper_unaligned(Ref::<_, [u8; 8]>::unaligned_from(&mut buf[..]).unwrap());
+        test_new_helper_unaligned(Ref::<_, [u8; 8]>::unaligned_from_bytes(&mut buf[..]).unwrap());
         {
             // In a block so that `r` and `suffix` don't live too long.
             buf = [0u8; 8];
@@ -1178,7 +1178,10 @@ mod tests {
         let mut buf = [0u8; 16];
         // `buf.t` should be aligned to 8 and have a length which is a multiple
         // of `size_of::AU64>()`, so this should always succeed.
-        test_new_helper_slice_unaligned(Ref::<_, [u8]>::unaligned_from(&mut buf[..]).unwrap(), 16);
+        test_new_helper_slice_unaligned(
+            Ref::<_, [u8]>::unaligned_from_bytes(&mut buf[..]).unwrap(),
+            16,
+        );
 
         buf = [0u8; 16];
         let r = Ref::<_, [u8]>::unaligned_from_bytes_with_elems(&mut buf[..], 16).unwrap();
@@ -1253,7 +1256,7 @@ mod tests {
         let buf = Align::<[u8; 16], AU64>::default();
         // `buf.t` should be aligned to 8, so only the length check should fail.
         assert!(Ref::<_, AU64>::from_bytes(&buf.t[..]).is_err());
-        assert!(Ref::<_, [u8; 8]>::unaligned_from(&buf.t[..]).is_err());
+        assert!(Ref::<_, [u8; 8]>::unaligned_from_bytes(&buf.t[..]).is_err());
 
         // Fail because the buffer is too small.
 
@@ -1261,7 +1264,7 @@ mod tests {
         let buf = Align::<[u8; 4], AU64>::default();
         // `buf.t` should be aligned to 8, so only the length check should fail.
         assert!(Ref::<_, AU64>::from_bytes(&buf.t[..]).is_err());
-        assert!(Ref::<_, [u8; 8]>::unaligned_from(&buf.t[..]).is_err());
+        assert!(Ref::<_, [u8; 8]>::unaligned_from_bytes(&buf.t[..]).is_err());
         assert!(Ref::<_, AU64>::from_prefix(&buf.t[..]).is_err());
         assert!(Ref::<_, AU64>::from_suffix(&buf.t[..]).is_err());
         assert!(Ref::<_, [u8; 8]>::unaligned_from_prefix(&buf.t[..]).is_err());
@@ -1272,7 +1275,7 @@ mod tests {
         let buf = Align::<[u8; 12], AU64>::default();
         // `buf.t` has length 12, but element size is 8.
         assert!(Ref::<_, [AU64]>::from_bytes(&buf.t[..]).is_err());
-        assert!(Ref::<_, [[u8; 8]]>::unaligned_from(&buf.t[..]).is_err());
+        assert!(Ref::<_, [[u8; 8]]>::unaligned_from_bytes(&buf.t[..]).is_err());
 
         // Fail because the buffer is too short.
         let buf = Align::<[u8; 12], AU64>::default();


### PR DESCRIPTION
...to `ref_from_bytes[_with_elems]`. This brings the names in line with the `Ref` methods of the same names, and avoids the awkward name `ref_from_with_elems`.

Similarly, rename `Ref::unaligned_from` to `unaligned_from_bytes`. We had already renamed `unaligned_from_with_elems` to `unaligned_from_bytes_with_elems`.

Makes progress on #871

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
