### PR TITLE
[error] Implement std::error::Error on errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,11 @@ alloc = []
 derive = ["zerocopy-derive"]
 simd = []
 simd-nightly = ["simd"]
+std = ["alloc"]
 # This feature depends on all other features that work on the stable compiler.
 # We make no stability guarantees about this feature; it may be modified or
 # removed at any time.
-__internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd"]
+__internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
 zerocopy-derive = { version = "=0.8.0-alpha.14", path = "zerocopy-derive", optional = true }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ for network parsing.
   the `alloc` crate is added as a dependency, and some allocation-related
   functionality is added.
 
+- **`std`**
+  By default, `zerocopy` is `no_std`. When the `std` feature is enabled, the
+  `std` crate is added as a dependency (ie, `no_std` is disabled), and
+  support for some `std` types is added. `std` implies `alloc`.
+
 - **`derive`**
   Provides derives for the core marker traits via the `zerocopy-derive`
   crate. These derives are re-exported from `zerocopy`, so it is not

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,11 @@
 //!   the `alloc` crate is added as a dependency, and some allocation-related
 //!   functionality is added.
 //!
+//! - **`std`**
+//!   By default, `zerocopy` is `no_std`. When the `std` feature is enabled, the
+//!   `std` crate is added as a dependency (ie, `no_std` is disabled), and
+//!   support for some `std` types is added. `std` implies `alloc`.
+//!
 //! - **`derive`**   
 //!   Provides derives for the core marker traits via the `zerocopy-derive`
 //!   crate. These derives are re-exported from `zerocopy`, so it is not
@@ -264,7 +269,7 @@
     clippy::arithmetic_side_effects,
     clippy::indexing_slicing,
 ))]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(
     all(feature = "simd-nightly", any(target_arch = "x86", target_arch = "x86_64")),
     feature(stdarch_x86_avx512)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -553,6 +553,7 @@ macro_rules! impl_known_layout {
         const _: () = {
             use core::ptr::NonNull;
 
+            #[allow(non_local_definitions)]
             // SAFETY: Delegates safety to `DstLayout::for_type`.
             unsafe impl<$($tyvar $(: ?$optbound)?)? $(, const $constvar : $constty)?> KnownLayout for $ty {
                 #[allow(clippy::missing_inline_in_public_items)]


### PR DESCRIPTION
While we're here, also relax `Dispaly for AlignmentError<Src, Dst>` to permit `Dst: ?Sized` in exchange for `Dst: KnownLayout`. This is an important relaxation since our APIs permit performing conversions into unsized destination types with runtime alignment checking.

Makes progress on #1297

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
