### PR TITLE
Disable coverage tracking on tests

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -855,6 +855,7 @@ module!(network_endian, NetworkEndian, "network-endian");
 module!(native_endian, NativeEndian, "native-endian");
 
 #[cfg(any(test, kani))]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -395,6 +395,7 @@ impl<Src, Dst: ?Sized + TryFromBytes> TryReadError<Src, Dst> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
     use super::*;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -892,6 +892,7 @@ mod simd {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -605,6 +605,7 @@ impl DstLayout {
 // fixed, remove this `allow`.
 #[allow(unknown_lints)]
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4832,6 +4832,7 @@ mod alloc_support {
     }
 
     #[cfg(test)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     mod tests {
         use core::convert::TryFrom as _;
 
@@ -5008,6 +5009,7 @@ pub use alloc_support::*;
 
 #[cfg(test)]
 #[allow(clippy::assertions_on_result_states, clippy::unreadable_literal)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use static_assertions::assert_impl_all;
 

--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -523,6 +523,7 @@ pub mod core_reexport {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::util::testutil::*;

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1501,6 +1501,7 @@ mod _project {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::mem::{self, MaybeUninit};
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -991,6 +991,7 @@ where
 
 #[cfg(test)]
 #[allow(clippy::assertions_on_result_states)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use core::convert::TryInto as _;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -750,6 +750,7 @@ pub(crate) mod testutil {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
This ensure that our coverage tracking more accurately reflects what percentage of production (ie, non-test) code is covered, and makes warnings about uncovered code less likely to be false positives (e.g., for test code that we add just to test whether something compiles).

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
