### PR TITLE
[ci] Run Miri tests on multiple threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,14 +244,23 @@ jobs:
 
     - name: Run tests under Miri
       run: |
+        set -eo pipefail
+
         # Work around https://github.com/rust-lang/miri/issues/3125
         [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ] && cargo clean
-      
+
+        # Spawn twice the number of workers as there are CPU cores.
+        THREADS=$(echo "$(nproc) * 2" | bc)
+        echo "Running Miri tests with $THREADS threads" | tee -a $GITHUB_STEP_SUMMARY
+
+        cargo install cargo-nextest
+
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
           MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +${{ matrix.toolchain }} \
-            miri test \
+            miri nextest run \
+            --test-threads "$THREADS" \
             --package ${{ matrix.crate }} \
             --target ${{ matrix.target }} \
             ${{ matrix.features }}
@@ -464,6 +473,7 @@ jobs:
           cargo metadata                             &> /dev/null &
           cargo install cargo-readme --version 3.2.0 &> /dev/null &
           cargo install --locked kani-verifier       &> /dev/null &
+          cargo install cargo-nextest                &> /dev/null &
           cargo kani setup                           &> /dev/null &
 
           wait


### PR DESCRIPTION
Use `cargo nextest` to run Miri tests on twice the number of threads as there are CPU cores.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our CONTRIBUTING.md file in its entirety. -->
