### PR TITLE
[ci] Test some targets only in the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,20 @@ jobs:
       # Only nightly has a working Miri, so we skip installing on all other
       # toolchains.
       #
+      # We skip Miri tests on pull request, but run them in the merge queue.
+      # Miri tests are far and away the most expensive aspect of our CI tests,
+      # but they rarely surface issues (ie, tests that pass `cargo test` but
+      # fail `cargo miri test`). Skipping them during PR development
+      # significantly speeds up our development flow, while still ensuring that
+      # Miri can catch any errors before a PR is merged into main.
+      #
       # TODO(#22): Re-enable testing on riscv64gc-unknown-linux-gnu and/or
       # wasm32-wasi once those work.
-      if: matrix.toolchain == 'nightly' && matrix.target != 'riscv64gc-unknown-linux-gnu' && matrix.target != 'wasm32-wasi'
+      if: |
+        matrix.toolchain == 'nightly' &&
+        matrix.target != 'riscv64gc-unknown-linux-gnu' &&
+        matrix.target != 'wasm32-wasi' &&
+        github.event_name != 'pull_request'
 
     - name: Clippy check
       run: ./cargo.sh +${{ matrix.toolchain }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --tests --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         ]
         features: [ "--no-default-features", "", "--features __internal_use_only_features_that_work_on_stable", "--all-features" ]
         crate: [ "zerocopy", "zerocopy-derive" ]
+        event_name: [ "${{ github.event_name }}" ]
         exclude:
           # Exclude any combination which uses a non-nightly toolchain but
           # enables nightly features.
@@ -73,7 +74,6 @@ jobs:
             features: "--all-features"
           - toolchain: "zerocopy-panic-in-const"
             features: "--all-features"
-
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
           - crate: "zerocopy-derive"
@@ -92,6 +92,24 @@ jobs:
             toolchain: "zerocopy-aarch64-simd"
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-panic-in-const"
+          # Exclude most targets during PR development, but allow them in the
+          # merge queue. This speeds up our development flow, while still
+          # ensuring that errors on these targets are caught before a PR is
+          # merged to main.
+          - target: "arm-unknown-linux-gnueabi"
+            event_name: "pull_request"
+          - target: "aarch64-unknown-linux-gnu"
+            event_name: "pull_request"
+          - target: "powerpc-unknown-linux-gnu"
+            event_name: "pull_request"
+          - target: "powerpc64-unknown-linux-gnu"
+            event_name: "pull_request"
+          - target: "riscv64gc-unknown-linux-gnu"
+            event_name: "pull_request"
+          - target: "s390x-unknown-linux-gnu"
+            event_name: "pull_request"
+          - target: "wasm32-wasi"
+            event_name: "pull_request"
 
     name: Build & Test (${{ matrix.crate }} / ${{ matrix.toolchain }} / ${{ matrix.features }} / ${{ matrix.target }})
 


### PR DESCRIPTION
Comparing [1] (run with the parent commit) and [2] (run with this commit), we see an overall speedup of 6m54s -> 5m36s, or ~19%. These gains will only be realized during PR development; the CI test execution time in the merge queue will remain unchanged.

Makes progress on https://github.com/google/zerocopy/issues/1310

[1] https://github.com/google/zerocopy/actions/runs/9149561660
[2] https://github.com/google/zerocopy/actions/runs/9149620991?pr=1314