### PR TITLE
Add trybuild test to ensure deprecated types are derivable.

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -1205,8 +1205,6 @@ fn impl_block<D: DataExt>(
     });
 
     quote! {
-        // TODO(#553): Add a test that generates a warning when
-        // `#[allow(deprecated)]` isn't present.
         #[allow(deprecated)]
         unsafe impl < #(#params),* > #trait_path for #type_ident < #(#param_idents),* >
         where

--- a/zerocopy-derive/tests/ui-nightly/absence_of_deprecated_warning.rs
+++ b/zerocopy-derive/tests/ui-nightly/absence_of_deprecated_warning.rs
@@ -1,0 +1,33 @@
+// Copyright 2024 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+//! See: https://github.com/google/zerocopy/issues/553
+//! zerocopy must still allow derives of deprecated types.
+//! This test has a hand-written impl of a deprecated type, and should result in a compilation
+//! error. If zerocopy does not tack an allow(deprecated) annotation onto its impls, then this
+//! test will fail because more than one compile error will be generated.
+#![deny(deprecated)]
+
+extern crate zerocopy;
+
+use zerocopy::IntoBytes;
+
+#[deprecated = "Do not use"]
+#[derive(IntoBytes)]
+#[repr(C)]
+struct OldHeader {
+    field_a: usize,
+    collection: [u8; 8],
+}
+
+trait T {}
+
+// Intentionally trigger a deprecation error
+impl T for OldHeader {}
+
+fn main() {}

--- a/zerocopy-derive/tests/ui-nightly/absence_of_deprecated_warning.stderr
+++ b/zerocopy-derive/tests/ui-nightly/absence_of_deprecated_warning.stderr
@@ -1,0 +1,11 @@
+error: use of deprecated struct `OldHeader`: Do not use
+  --> tests/ui-nightly/absence_of_deprecated_warning.rs:31:12
+   |
+31 | impl T for OldHeader {}
+   |            ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui-nightly/absence_of_deprecated_warning.rs:14:9
+   |
+14 | #![deny(deprecated)]
+   |         ^^^^^^^^^^


### PR DESCRIPTION
Addresses https://github.com/google/zerocopy/issues/553.

#553 talks about warnings, but trybuild tests operate on compile errors. I think this change still manages to meet the spirit of #553. The docstring at the top of `absence_of_deprecated_warning.rs` explains the test. In short, there is "only" one compile error in the test.

If you comment out the `#[allow(deprecated)]` attribute in `zerocopy-derive/src/lib.rs`, then this test will fail.