### PR TITLE
[ci] Build/test Windows targets natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ contains(matrix.target, 'windows') && 'windows-2019' || 'ubuntu-latest' }}
     # Generate and populate the global Cargo registry and cache first. Each
     # job in the matrix runs in parallel, so without populating the cache
     # first, most jobs would duplicate the work of downloading crates from
@@ -215,12 +215,12 @@ jobs:
           -- \
           --skip ui
 
-      # Only run tests when targetting Linux x86 (32- or 64-bit) - we're
-      # executing on Linux x86_64, so we can't run tests for any non-x86 target.
+      # Only run tests when targetting x86 (32- or 64-bit) - we're executing on
+      # x86_64, so we can't run tests for any non-x86 target.
       #
       # TODO(https://github.com/dtolnay/trybuild/issues/184#issuecomment-1269097742):
       # Run compile tests when building for other targets.
-      if: contains(matrix.target, 'linux') && (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686'))
+      if: contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686')
 
     - name: Run UI tests
       run: |
@@ -240,8 +240,8 @@ jobs:
           --verbose \
           ui
 
-      # Only run tests when targetting Linux x86 (32- or 64-bit) - we're
-      # executing on Linux x86_64, so we can't run tests for any non-x86 target.
+      # Only run tests when targetting x86 (32- or 64-bit) - we're executing on
+      # x86_64, so we can't run tests for any non-x86 target.
       #
       # TODO(https://github.com/dtolnay/trybuild/issues/184#issuecomment-1269097742):
       # Run compile tests when building for other targets.
@@ -256,7 +256,6 @@ jobs:
       # would need a new set of UI test files per toolchain, which would be a
       # maintenance burden not worth the (at present, zero) benefit.
       if: |
-        (!contains(matrix.target, 'windows')) &&
         (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686')) &&
           (matrix.crate == 'zerocopy-derive' ||
             (matrix.features != '' && matrix.features != '--no-default-features')) &&


### PR DESCRIPTION
When building and testing Windows targets, use a Windows runner rather than a Linux runner. This allows us to run tests natively - previously, they were only run under Miri. It also allows us to run UI tests on Windows, which we previously skipped.

Closes #1371

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
