### PR TITLE
Specify directories/files when caching $CARGO_HOME

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -11,9 +11,14 @@ description: 'Caches cargo dependencies'
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3 
-      with: 
-        path: | 
-          ~/.cargo/ 
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/.crates.toml
+          ~/.cargo/.crates2.json
+          ~/.cargo/bin/
+          ~/.cargo/git/db/
+          ~/.cargo/registry/cache/
+          ~/.cargo/registry/index/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-        
+


### PR DESCRIPTION
This fixes #1312.

I'm making the presumption that the issue concerns the re-installation of `cargo-nextest` in the step `Run tests under Miri`.

```
 Running Miri tests with 8 threads
    Updating crates.io index
 Downloading crates ...
  Downloaded cargo-nextest v0.9.70
  Installing cargo-nextest v0.9.70

 ....
```

The fix expands the Cargo cache path from `~/.cargo/` to the specific directories and files listed in the [Cargo book](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci). I initially just had the directories from `action/cache` Rust [example](https://github.com/actions/cache/blob/main/examples.md#rust---cargo), but also encountered the error: `binary cargo-readme already exists in destination` that Josh experienced.

Here is a [test run](https://github.com/sl4m/zerocopy/actions/runs/9322316917/job/25664391430) on the fix of my fork. It is the same Linux target that was referenced in #1312.

```
Running Miri tests with 8 threads
    Updating crates.io index
     Ignored package `cargo-nextest v0.9.72` is already installed, use --force to override
Preparing a sysroot for Miri (target: aarch64-unknown-linux-gnu)... done

 ...
```