### PR TITLE
Fix incorrect trailing field offset test (#1370)

### DIFF
--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -493,7 +493,7 @@ mod tests {
 
         test!(#[repr(C)] #[repr(transparent)] #[repr(packed)](; u8) => Some(0));
         test!(#[repr(C)] #[repr(transparent)] #[repr(packed)](; [u8]) => Some(0));
-        test!(#[repr(C)] #[repr(packed)] (u8; u8) => Some(1));
+        test!(#[repr(C)] #[repr(C, packed)] (u8; u8) => Some(1));
         test!(#[repr(C)] (; AU64) => Some(0));
         test!(#[repr(C)] (; [AU64]) => Some(0));
         test!(#[repr(C)] (u8; AU64) => Some(8));


### PR DESCRIPTION
Removes previous warning on `trailing_field_offset!` macro.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
