### PR TITLE
Resolve Flags Handling and Improve CI Stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,9 +320,10 @@ jobs:
       run: |
         # Include arguments passed during docs.rs deployments to make sure those
         # work properly.
+        set -eo pipefail
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
-          jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\".[]" | tr '\n' ' ')"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items' || '' }} $RUSTDOCFLAGS $METADATA_DOCS_RS_RUSTDOC_ARGS"
+          jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
+        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS"
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 
     # Check semver compatibility with the most recently-published version on


### PR DESCRIPTION
This commit addresses several issues related to the generation of Rust documentation:
1. Corrects the extraction of `rustdoc-args` from `Cargo.toml`, resolving #1228
2. Transfers `rustdoc` flags that are exclusive to the `nightly` toolchain from `rustdoc-args` in `Cargo.toml` to `RUSTDOCFLAGS`. This ensures that the documentation generation process is aligned  with the correct toolchain environment.
3. Add `set -eo pipefail` in the CI job `Cargo doc` to enhance the robustness of the CI pipeline.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
