### PR TITLE
Abort UI tests if -Wwarnings not set in RUSTFLAGS

### DIFF
--- a/tools/update-ui-test-files.sh
+++ b/tools/update-ui-test-files.sh
@@ -12,6 +12,6 @@
 
 set -e
 
-TRYBUILD=overwrite ./cargo.sh +nightly test ui --test trybuild --workspace --all-features
-TRYBUILD=overwrite ./cargo.sh +stable test ui --test trybuild --workspace --features=__internal_use_only_features_that_work_on_stable
-TRYBUILD=overwrite ./cargo.sh +msrv test ui --test trybuild --workspace --features=__internal_use_only_features_that_work_on_stable
+TRYBUILD=overwrite RUSTFLAGS="-Wwarnings" ./cargo.sh +nightly test ui --test trybuild --workspace --all-features
+TRYBUILD=overwrite RUSTFLAGS="-Wwarnings" ./cargo.sh +stable test ui --test trybuild --workspace --features=__internal_use_only_features_that_work_on_stable
+TRYBUILD=overwrite RUSTFLAGS="-Wwarnings" ./cargo.sh +msrv test ui --test trybuild --workspace --features=__internal_use_only_features_that_work_on_stable

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -6,6 +6,11 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
+use std::env;
+
+const RUSTFLAGS: &str = "RUSTFLAGS";
+const WARN_LINT_GROUP: &str = "-Wwarnings";
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn ui() {
@@ -14,6 +19,22 @@ fn ui() {
     // and why we store source files in different directories.
     let source_files_dirname = version.get_ui_source_files_dirname_and_maybe_print_warning();
 
+    assert!(
+        has_warnings_in_rustflags(),
+        "skipping {} tests. `{}` was not passed into {}.",
+        source_files_dirname,
+        WARN_LINT_GROUP,
+        RUSTFLAGS
+    );
+
     let t = trybuild::TestCases::new();
     t.compile_fail(format!("tests/{}/*.rs", source_files_dirname));
+}
+
+fn has_warnings_in_rustflags() -> bool {
+    let rustflags = match env::var(RUSTFLAGS) {
+        Ok(flags) => flags.chars().filter(|c| !c.is_whitespace()).collect(),
+        Err(_) => String::new(),
+    };
+    rustflags.contains(WARN_LINT_GROUP)
 }


### PR DESCRIPTION
Fixes #953.

This performs a rudimentary check against `RUSTFLAGS`. It trims all whitespaces in case someone passes in `RUSTFLAGS="-W warnings"` (note: the whitespace between `W` and `w`). 

It does not exhaust all scenarios like `RUSTFLAGS="-Wwarnings -Dwarnings"`. It's unclear if someone would ever do this.

I'm also not 100% sure if `RUSTFLAGS` implicitly adds `-Wwarnings` when it's absent. The code wants an explicit `-Wwarnings` set.
