### PR TITLE
[ci] Updates actions/cache to v4

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -11,9 +11,9 @@ description: 'Caches cargo dependencies'
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3 
-      with: 
-        path: | 
-          ~/.cargo/ 
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-        
+


### PR DESCRIPTION
This fixes the `node.js` deprecation warnings that appear in the CI runs. v4 introduces a bit more noise to the build summary (under Annotations). It can be removed if you don't find them useful (doc [link](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#removing-job-summaries)).

[Test run](https://github.com/sl4m/zerocopy/actions/runs/9388820927) on my fork.