### PR TITLE
Implement Inline Size Assertion Annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,8 @@ jobs:
         set -eo pipefail
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS
+        echo "matt_testing METADATA_DOCS_RS_RUSTDOC_ARGS = $METADATA_DOCS_RS_RUSTDOC_ARGS"
+        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }}" $RUSTDOCFLAGS
         echo "matt_testing RUSTDOCFLAGS = $RUSTDOCFLAGS"
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,8 +323,7 @@ jobs:
         set -eo pipefail
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items --generate-link-to-definition --cfg doc_cfg' || '' }} $RUSTDOCFLAGS $METADATA_DOCS_RS_RUSTDOC_ARGS"
-        echo $METADATA_DOCS_RS_RUSTDOC_ARGS
+        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 
     # Check semver compatibility with the most recently-published version on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,7 @@ jobs:
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
         export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS
+        echo "matt_testing RUSTDOCFLAGS = $RUSTDOCFLAGS"
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 
     # Check semver compatibility with the most recently-published version on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,9 +320,11 @@ jobs:
       run: |
         # Include arguments passed during docs.rs deployments to make sure those
         # work properly.
+        set -eo pipefail
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
-          jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\".[]" | tr '\n' ' ')"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items' || '' }} $RUSTDOCFLAGS $METADATA_DOCS_RS_RUSTDOC_ARGS"
+          jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
+        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items --generate-link-to-definition --cfg doc_cfg' || '' }} $RUSTDOCFLAGS $METADATA_DOCS_RS_RUSTDOC_ARGS"
+        echo $METADATA_DOCS_RS_RUSTDOC_ARGS
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 
     # Check semver compatibility with the most recently-published version on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
         echo "matt_testing METADATA_DOCS_RS_RUSTDOC_ARGS = $METADATA_DOCS_RS_RUSTDOC_ARGS"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }}" $RUSTDOCFLAGS
+        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS"
         echo "matt_testing RUSTDOCFLAGS = $RUSTDOCFLAGS"
         ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pinned-nightly = "nightly-2024-06-02"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = []
+rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
 
 [package.metadata.playground]
 features = ["__internal_use_only_features_that_work_on_stable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pinned-nightly = "nightly-2024-06-02"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = []
 
 [package.metadata.playground]
 features = ["__internal_use_only_features_that_work_on_stable"]

--- a/tests/ui-nightly/inline_assert_size_eq_failed.rs
+++ b/tests/ui-nightly/inline_assert_size_eq_failed.rs
@@ -1,0 +1,10 @@
+#![allow(unused)]
+extern crate zerocopy_derive;
+extern crate static_assertions;
+use zerocopy_derive::*;
+use static_assertions;
+
+#[zerocopy_derive::inline_assert_size_eq(1)]
+struct test_size_neq_struct {
+    i: i8
+}

--- a/tests/ui-nightly/inline_assert_size_eq_failed.stderr
+++ b/tests/ui-nightly/inline_assert_size_eq_failed.stderr
@@ -1,0 +1,24 @@
+error[E0254]: the name `static_assertions` is defined multiple times
+ --> tests/ui-stable/inline_assert_size_eq_failed.rs:5:5
+  |
+3 | extern crate static_assertions;
+  | ------------------------------- previous import of the extern crate `static_assertions` here
+4 | use zerocopy_derive::*;
+5 | use static_assertions;
+  |     ^^^^^^^^^^^^^^^^^ `static_assertions` reimported here
+  |
+  = note: `static_assertions` must be defined only once in the type namespace of this module
+
+warning: type `test_size_neq_struct` should have an upper camel case name
+ --> tests/ui-stable/inline_assert_size_eq_failed.rs:8:8
+  |
+8 | struct test_size_neq_struct {
+  |        ^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `TestSizeNeqStruct`
+  |
+  = note: `#[warn(non_camel_case_types)]` on by default
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui-stable/inline_assert_size_eq_failed.rs:10:2
+   |
+10 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui-stable/inline_assert_size_eq_failed.rs`

--- a/tests/ui-stable/inline_assert_size_eq_failed.rs
+++ b/tests/ui-stable/inline_assert_size_eq_failed.rs
@@ -1,0 +1,1 @@
+../ui-nightly/inline_assert_size_eq_failed.rs

--- a/tests/ui-stable/inline_assert_size_eq_failed.stderr
+++ b/tests/ui-stable/inline_assert_size_eq_failed.stderr
@@ -1,0 +1,24 @@
+error[E0254]: the name `static_assertions` is defined multiple times
+ --> tests/ui-stable/inline_assert_size_eq_failed.rs:5:5
+  |
+3 | extern crate static_assertions;
+  | ------------------------------- previous import of the extern crate `static_assertions` here
+4 | use zerocopy_derive::*;
+5 | use static_assertions;
+  |     ^^^^^^^^^^^^^^^^^ `static_assertions` reimported here
+  |
+  = note: `static_assertions` must be defined only once in the type namespace of this module
+
+warning: type `test_size_neq_struct` should have an upper camel case name
+ --> tests/ui-stable/inline_assert_size_eq_failed.rs:8:8
+  |
+8 | struct test_size_neq_struct {
+  |        ^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `TestSizeNeqStruct`
+  |
+  = note: `#[warn(non_camel_case_types)]` on by default
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui-stable/inline_assert_size_eq_failed.rs:10:2
+   |
+10 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui-stable/inline_assert_size_eq_failed.rs`

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -55,6 +55,43 @@ macro_rules! try_or_print {
     };
 }
 
+/// Inline size assertion annotations
+/// Any non-generic type can be check if the size is as expected or not in compile time
+/// # Implementation
+/// ```
+/// # use zerocopy_derive::inline_assert_size_eq;
+/// # use static_assertions;
+/// #[inline_assert_size_eq(4)]
+/// struct MyStruct {
+///     val: i32
+/// }
+/// ```
+/// # Example that will fail
+/// ```compile_fail
+/// # use zero_derive::inline_assert_size_eq;
+/// # use static_assertions;
+/// #[inline_assert_size_eq(1)]
+/// struct MyStruct {
+///     val: i32
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn inline_assert_size_eq(args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast: Result<DeriveInput, _> = syn::parse(input.clone());
+    let expected_size: Result<usize, _> = args.to_string().trim().parse();
+    if let (Ok(ast), Ok(size)) = (ast, expected_size) {
+        let name  =&ast.ident;
+        return quote! {
+            #ast
+            static_assertions::const_assert!(core::mem::size_of::<#name>() == #size);
+        }.into()
+    }
+    else {
+        return input;
+    }
+
+}
+
 // TODO(https://github.com/rust-lang/rust/issues/54140): Some errors could be
 // made better if we could add multiple lines of error output like this:
 //


### PR DESCRIPTION
Implement the procedural macro `inline_assert_size_eq` to check the size of a type at compile time. Additionally, add the test file `inline_assert_size_eq_failed.rs` to ensure that the macro triggers a compile-time error when the size is not as expected.

Fixes #1329 