### PR TITLE
Roll nightly toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zerocopy-panic-in-const = "1.57.0"
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.79.0"
-pinned-nightly = "nightly-2024-06-05"
+pinned-nightly = "nightly-2024-06-19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,6 @@
     unreachable_pub,
     unsafe_op_in_unsafe_fn,
     unused_extern_crates,
-    unused_qualifications,
     variant_size_differences
 )]
 #![deny(

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -976,16 +976,13 @@ mod tests {
             (@methods @success $($success_case:expr),* $(, @failure $($failure_case:expr),*)?) => {
                 fn with_passing_test_cases<F: Fn(Box<Self>)>(_f: F) {
                     $(
-                        _f(Box::<Self>::from($success_case));//.borrow());
+                        _f(Box::<Self>::from($success_case));
                     )*
                 }
 
                 fn with_failing_test_cases<F: Fn(&mut [u8])>(_f: F) {
                     $($(
-                        // `unused_qualifications` is spuriously triggered on
-                        // `Option::<Self>::None`.
-                        #[allow(unused_qualifications)]
-                        let mut case = $failure_case;//.as_mut_bytes();
+                        let mut case = $failure_case;
                         _f(case.as_mut_bytes());
                     )*)?
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,16 @@
     unreachable_pub,
     unsafe_op_in_unsafe_fn,
     unused_extern_crates,
-    unused_qualifications,
+    // We intentionally choose not to deny `unused_qualifications`. When items
+    // are added to the prelude (e.g., `core::mem::size_of`), this has the
+    // consequence of making some uses trigger this lint on the latest toolchain
+    // (e.g., `mem::size_of`), but fixing it (e.g. by replacing with `size_of`)
+    // does not work on older toolchains.
+    //
+    // We tested a more complicated fix in #1413, but ultimately decided that,
+    // since this lint is just a minor style lint, the complexity isn't worth it
+    // - it's fine to occasionally have unused qualifications slip through,
+    // especially since these do not affect our user-facing API in any way.
     variant_size_differences
 )]
 #![cfg_attr(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -561,7 +561,6 @@ macro_rules! impl_known_layout {
 
                 type PointerMetadata = ();
 
-                #[allow(unused_qualifications)]
                 const LAYOUT: crate::DstLayout = crate::DstLayout::for_type::<$ty>();
 
                 // SAFETY: `.cast` preserves address and provenance.
@@ -613,7 +612,6 @@ macro_rules! unsafe_impl_known_layout {
                 // TODO(#429): Add documentation to `NonNull::new_unchecked`
                 // that it preserves provenance.
                 #[inline(always)]
-                #[allow(unused_qualifications)] // for `core::ptr::NonNull`
                 fn raw_from_ptr_len(bytes: NonNull<u8>, meta: <$repr as KnownLayout>::PointerMetadata) -> NonNull<Self> {
                     #[allow(clippy::as_conversions)]
                     let ptr = <$repr>::raw_from_ptr_len(bytes, meta).as_ptr() as *mut Self;

--- a/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-mut-src-dst-not-references.stderr
@@ -14,6 +14,23 @@ help: consider mutably borrowing here
 17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(&mut 0usize);
    |                                                           ++++
 
+warning: this function depends on never type fallback being `()`
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:1
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: FromBytes` will fail
+  --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
+   |
+17 | const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: this warning originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: never type fallback affects this call to an `unsafe` function
   --> tests/ui-nightly/transmute-mut-src-dst-not-references.rs:17:44
    |

--- a/tests/ui-nightly/transmute-mut-src-immutable.stderr
+++ b/tests/ui-nightly/transmute-mut-src-immutable.stderr
@@ -10,6 +10,23 @@ error[E0308]: mismatched types
    = note: expected mutable reference `&mut _`
                       found reference `&u8`
 
+warning: this function depends on never type fallback being `()`
+  --> tests/ui-nightly/transmute-mut-src-immutable.rs:15:1
+   |
+15 | fn ref_src_immutable() {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: FromBytes` will fail
+  --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
+   |
+17 |     let _: &mut u8 = transmute_mut!(&0u8);
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: this warning originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: never type fallback affects this call to an `unsafe` function
   --> tests/ui-nightly/transmute-mut-src-immutable.rs:17:22
    |

--- a/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-a-reference.stderr
@@ -14,6 +14,23 @@ help: consider mutably borrowing here
 17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(&mut 0usize);
    |                                                     ++++
 
+warning: this function depends on never type fallback being `()`
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:1
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: FromBytes` will fail
+  --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
+   |
+17 | const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: this warning originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: never type fallback affects this call to an `unsafe` function
   --> tests/ui-nightly/transmute-mut-src-not-a-reference.rs:17:38
    |

--- a/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-nightly/transmute-ref-src-dst-not-references.stderr
@@ -77,6 +77,23 @@ note: function defined here
    |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+warning: this function depends on never type fallback being `()`
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:1
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: IntoBytes` will fail
+  --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
+   |
+17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: this warning originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: never type fallback affects this call to an `unsafe` function
   --> tests/ui-nightly/transmute-ref-src-dst-not-references.rs:17:39
    |

--- a/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-a-reference.stderr
@@ -14,6 +14,23 @@ help: consider borrowing here
 17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(&0usize);
    |                                                 +
 
+warning: this function depends on never type fallback being `()`
+  --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:17:1
+   |
+17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: IntoBytes` will fail
+  --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:17:34
+   |
+17 | const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+   = note: this warning originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: never type fallback affects this call to an `unsafe` function
   --> tests/ui-nightly/transmute-ref-src-not-a-reference.rs:17:34
    |


### PR DESCRIPTION
This supercedes #1413, taking the simpler approach of removing the `unused_qualifications` lint from our list of denied lints.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
