### PR TITLE
Use `copy_nonoverlapping` instead of `slice::copy_from`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -584,6 +584,29 @@ pub(crate) const fn min(a: NonZeroUsize, b: NonZeroUsize) -> NonZeroUsize {
     }
 }
 
+/// Copies `src` into the prefix of `dst`.
+///
+/// # Safety
+///
+/// The caller guarantees that `src.len() <= dst.len()`.
+#[inline(always)]
+pub(crate) unsafe fn copy_unchecked(src: &[u8], dst: &mut [u8]) {
+    debug_assert!(src.len() <= dst.len());
+    // SAFETY: This invocation satisfies the safety contract of
+    // copy_nonoverlapping [1]:
+    // - `src.as_ptr()` is trivially valid for reads of `src.len()` bytes
+    // - `dst.as_ptr()` is valid for writes of `src.len()` bytes, because the
+    //   caller has promised that `src.len() <= dst.len()`
+    // - `src` and `dst` are, trivially, properly aligned
+    // - the region of memory beginning at `src` with a size of `src.len()`
+    //   bytes does not overlap with the region of memory beginning at `dst`
+    //   with the same size, because `dst` is derived from an exclusive
+    //   reference.
+    unsafe {
+        core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), src.len());
+    };
+}
+
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those


### PR DESCRIPTION
In doing so, we eliminate a potential panic path. Although I was not able to observe panic paths emitted in toy examples, they might be emitted in complex examples in which the optimizer is low on gas. Regardless, I expect this change will ease our future adoption of call-graph analysis techniques of potential panic paths.

Ref https://github.com/google/zerocopy/issues/200#issuecomment-2181544061

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
