### PR TITLE
Added conditional dependancy downloading in CI

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -8,10 +8,15 @@
 
 name: Cache
 description: 'Caches cargo dependencies'
+outputs:
+  cache-hit:
+    description: 'Cache hit status'
+    value: ${{ steps.cache.outputs.cache-hit }}
 runs:
   using: composite
   steps:
     - uses: actions/cache@v4
+      id: cache
       with:
         path: |
           ~/.cargo/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,9 +483,11 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Populate cache
+        id: populate-cache
         uses: ./.github/actions/cache
 
-      - name: Download dependencies
+      - if: ${{ steps.populate-cache.outputs.cache-hit != 'true' }}
+        name: Download dependencies
         run: |
           # Ensure all dependencies are downloaded - both for our crates and for
           # tools we use in CI. We don't care about these tools succeeding for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@
 # license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+# test
 
 # Put both crates in a single workspace so that `trybuild` compiler errors have
 # paths that are stable regardless of the path to the repository root. This
@@ -18,7 +19,13 @@ name = "zerocopy"
 version = "0.8.0-alpha.15"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Utilities for zero-copy parsing and serialization"
-categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
+categories = [
+  "embedded",
+  "encoding",
+  "no-std::no-alloc",
+  "parsing",
+  "rust-patterns",
+]
 keywords = ["cast", "convert", "transmute", "transmutation", "type-punning"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
@@ -64,7 +71,12 @@ std = ["alloc"]
 # This feature depends on all other features that work on the stable compiler.
 # We make no stability guarantees about this feature; it may be modified or
 # removed at any time.
-__internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
+__internal_use_only_features_that_work_on_stable = [
+  "alloc",
+  "derive",
+  "simd",
+  "std",
+]
 
 [dependencies]
 zerocopy-derive = { version = "=0.8.0-alpha.15", path = "zerocopy-derive", optional = true }


### PR DESCRIPTION
Progresses #1310

This will skip downloading the cargo dependencies if the cache is present. The cache gets refreshed based on the hash of the `Cargo.toml` file, so when that file doesn't change, this could save 2 - 3 minutes per run.