### PR TITLE
Rename `TryFromBytes` methods for consistency with `FromBytes`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -513,8 +513,8 @@ impl<Src, Dst: ?Sized> CastError<Src, Dst> {
 
 /// The error type of fallible reference conversions.
 ///
-/// Fallible reference conversions, like [`TryFromBytes::try_ref_from`] may emit
-/// [alignment](AlignmentError), [size](SizeError), and
+/// Fallible reference conversions, like [`TryFromBytes::try_ref_from_bytes`]
+/// may emit [alignment](AlignmentError), [size](SizeError), and
 /// [validity](ValidityError) errors.
 // Bounds on generic parameters are not enforced in type aliases, but they do
 // appear in rustdoc.
@@ -550,7 +550,7 @@ impl<Src, Dst: ?Sized + TryFromBytes> From<CastError<Src, Dst>> for TryCastError
 
 /// The error type of fallible read-conversions.
 ///
-/// Fallible read-conversions, like [`TryFromBytes::try_read_from`] may emit
+/// Fallible read-conversions, like [`TryFromBytes::try_read_from_bytes`] may emit
 /// [size](SizeError) and [validity](ValidityError) errors, but not alignment errors.
 // Bounds on generic parameters are not enforced in type aliases, but they do
 // appear in rustdoc.

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1112,7 +1112,7 @@ mod tests {
                     &self,
                     bytes: &'bytes [u8],
                 ) -> Option<Option<&'bytes T>> {
-                    Some(T::try_ref_from(bytes).ok())
+                    Some(T::try_ref_from_bytes(bytes).ok())
                 }
             }
 
@@ -1122,7 +1122,7 @@ mod tests {
 
             impl<T: TryFromBytes> TestTryReadFrom<T> for AutorefWrapper<T> {
                 fn test_try_read_from(&self, bytes: &[u8]) -> Option<Option<T>> {
-                    Some(T::try_read_from(bytes).ok())
+                    Some(T::try_read_from_bytes(bytes).ok())
                 }
             }
 
@@ -1289,11 +1289,11 @@ mod tests {
                     let bytes = w.test_as_bytes(&*val);
 
                     // The inner closure returns
-                    // `Some($ty::try_ref_from(bytes))` if `$ty: Immutable` and
-                    // `None` otherwise.
+                    // `Some($ty::try_ref_from_bytes(bytes))` if `$ty:
+                    // Immutable` and `None` otherwise.
                     let res = bytes.and_then(|bytes| ww.test_try_from_ref(bytes));
                     if let Some(res) = res {
-                        assert!(res.is_some(), "{}::try_ref_from({:?}): got `None`, expected `Some`", stringify!($ty), val);
+                        assert!(res.is_some(), "{}::try_ref_from_bytes({:?}): got `None`, expected `Some`", stringify!($ty), val);
                     }
 
                     if let Some(bytes) = bytes {
@@ -1315,13 +1315,13 @@ mod tests {
                         let bytes_mut = &mut vec.as_mut_slice()[offset..offset+size];
                         bytes_mut.copy_from_slice(bytes);
 
-                        let res = <$ty as TryFromBytes>::try_mut_from(bytes_mut);
-                        assert!(res.is_ok(), "{}::try_mut_from({:?}): got `Err`, expected `Ok`", stringify!($ty), val);
+                        let res = <$ty as TryFromBytes>::try_mut_from_bytes(bytes_mut);
+                        assert!(res.is_ok(), "{}::try_mut_from_bytes({:?}): got `Err`, expected `Ok`", stringify!($ty), val);
                     }
 
                     let res = bytes.and_then(|bytes| ww.test_try_read_from(bytes));
                     if let Some(res) = res {
-                        assert!(res.is_some(), "{}::try_read_from({:?}): got `None`, expected `Some`", stringify!($ty), val);
+                        assert!(res.is_some(), "{}::try_read_from_bytes({:?}): got `None`, expected `Some`", stringify!($ty), val);
                     }
                 });
                 #[allow(clippy::as_conversions)]
@@ -1329,19 +1329,19 @@ mod tests {
                     #[allow(unused_mut)] // For cases where the "real" impls are used, which take `&self`.
                     let mut w = AutorefWrapper::<$ty>(PhantomData);
 
-                    // This is `Some($ty::try_ref_from(c))` if `$ty: Immutable` and
-                    // `None` otherwise.
+                    // This is `Some($ty::try_ref_from_bytes(c))` if `$ty:
+                    // Immutable` and `None` otherwise.
                     let res = w.test_try_from_ref(c);
                     if let Some(res) = res {
-                        assert!(res.is_none(), "{}::try_ref_from({:?}): got Some, expected None", stringify!($ty), c);
+                        assert!(res.is_none(), "{}::try_ref_from_bytes({:?}): got Some, expected None", stringify!($ty), c);
                     }
 
-                    let res = <$ty as TryFromBytes>::try_mut_from(c);
-                    assert!(res.is_err(), "{}::try_mut_from({:?}): got Ok, expected Err", stringify!($ty), c);
+                    let res = <$ty as TryFromBytes>::try_mut_from_bytes(c);
+                    assert!(res.is_err(), "{}::try_mut_from_bytes({:?}): got Ok, expected Err", stringify!($ty), c);
 
                     let res = w.test_try_read_from(c);
                     if let Some(res) = res {
-                        assert!(res.is_none(), "{}::try_read_from({:?}): got Some, expected None", stringify!($ty), c);
+                        assert!(res.is_none(), "{}::try_read_from_bytes({:?}): got Some, expected None", stringify!($ty), c);
                     }
                 });
 

--- a/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -22,10 +22,10 @@ util_assert_impl_all!(Foo: imp::TryFromBytes);
 
 #[test]
 fn test_foo() {
-    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from(&[0]), imp::Ok(Foo::A));
-    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[]).is_err());
-    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[1]).is_err());
-    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
+    imp::assert_eq!(<Foo as imp::TryFromBytes>::try_read_from_bytes(&[0]), imp::Ok(Foo::A));
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from_bytes(&[]).is_err());
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from_bytes(&[1]).is_err());
+    imp::assert!(<Foo as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]).is_err());
 }
 
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
@@ -38,11 +38,11 @@ util_assert_impl_all!(Bar: imp::TryFromBytes);
 
 #[test]
 fn test_bar() {
-    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0]), imp::Ok(Bar::A));
-    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[]).is_err());
-    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0]).is_err());
-    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 1]).is_err());
-    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from(&[0, 0, 0]).is_err());
+    imp::assert_eq!(<Bar as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]), imp::Ok(Bar::A));
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from_bytes(&[]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from_bytes(&[0]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from_bytes(&[0, 1]).is_err());
+    imp::assert!(<Bar as imp::TryFromBytes>::try_read_from_bytes(&[0, 0, 0]).is_err());
 }
 
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
@@ -57,18 +57,18 @@ util_assert_impl_all!(Baz: imp::TryFromBytes);
 #[test]
 fn test_baz() {
     imp::assert_eq!(
-        <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1u32)),
+        <Baz as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&1u32)),
         imp::Ok(Baz::A)
     );
     imp::assert_eq!(
-        <Baz as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0u32)),
+        <Baz as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&0u32)),
         imp::Ok(Baz::B)
     );
-    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[]).is_err());
-    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0]).is_err());
-    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
-    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0]).is_err());
-    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from(&[0, 0, 0, 0, 0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from_bytes(&[]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from_bytes(&[0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from_bytes(&[0, 0, 0]).is_err());
+    imp::assert!(<Baz as imp::TryFromBytes>::try_read_from_bytes(&[0, 0, 0, 0, 0]).is_err());
 }
 
 // Test hygiene - make sure that `i8` being shadowed doesn't cause problems for
@@ -91,24 +91,24 @@ util_assert_impl_all!(Blah: imp::TryFromBytes);
 #[test]
 fn test_blah() {
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&1i8)),
+        <Blah as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&1i8)),
         imp::Ok(Blah::A)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&0i8)),
+        <Blah as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&0i8)),
         imp::Ok(Blah::B)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&3i8)),
+        <Blah as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&3i8)),
         imp::Ok(Blah::C)
     );
     imp::assert_eq!(
-        <Blah as imp::TryFromBytes>::try_read_from(imp::IntoBytes::as_bytes(&6i8)),
+        <Blah as imp::TryFromBytes>::try_read_from_bytes(imp::IntoBytes::as_bytes(&6i8)),
         imp::Ok(Blah::D)
     );
-    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[]).is_err());
-    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[4]).is_err());
-    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from(&[0, 0]).is_err());
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[]).is_err());
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[4]).is_err());
+    imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]).is_err());
 }
 
 #[derive(
@@ -126,22 +126,23 @@ fn test_fieldless_but_not_unit_only() {
     const SIZE: usize = ::core::mem::size_of::<FieldlessButNotUnitOnly>();
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::A);
     imp::assert_eq!(
-        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(FieldlessButNotUnitOnly::A)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::B());
     imp::assert_eq!(
-        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(FieldlessButNotUnitOnly::B())
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(FieldlessButNotUnitOnly::C {});
     imp::assert_eq!(
-        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(FieldlessButNotUnitOnly::C {})
     );
-    imp::assert!(
-        <FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]).is_err()
-    );
+    imp::assert!(<FieldlessButNotUnitOnly as imp::TryFromBytes>::try_read_from_bytes(
+        &[0xFF; SIZE][..]
+    )
+    .is_err());
 }
 
 #[derive(
@@ -159,20 +160,20 @@ fn test_weird_discriminants() {
     const SIZE: usize = ::core::mem::size_of::<WeirdDiscriminants>();
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::A);
     imp::assert_eq!(
-        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(WeirdDiscriminants::A)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::B);
     imp::assert_eq!(
-        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(WeirdDiscriminants::B)
     );
     let disc: [u8; SIZE] = ::zerocopy::transmute!(WeirdDiscriminants::C);
     imp::assert_eq!(
-        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&disc[..]),
+        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from_bytes(&disc[..]),
         imp::Ok(WeirdDiscriminants::C)
     );
     imp::assert!(
-        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from(&[0xFF; SIZE][..]).is_err()
+        <WeirdDiscriminants as imp::TryFromBytes>::try_read_from_bytes(&[0xFF; SIZE][..]).is_err()
     );
 }

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -163,7 +163,7 @@ struct CPacked {
 #[test]
 fn c_packed() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
-    let converted = <CPacked as imp::TryFromBytes>::try_ref_from(candidate);
+    let converted = <CPacked as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert_eq!(converted, imp::Ok(&CPacked { a: 42, b: u32::MAX }));
 }
 
@@ -184,7 +184,7 @@ struct CPackedUnsized {
 #[test]
 fn c_packed_unsized() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
-    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
+    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert!(converted.is_ok());
 }
 
@@ -205,14 +205,14 @@ struct PackedUnsized {
 #[test]
 fn packed_unsized() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
-    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
+    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert!(converted.is_ok());
 
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
+    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert!(converted.is_err());
 
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
-    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from(candidate);
+    let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert!(converted.is_ok());
 }


### PR DESCRIPTION
- `try_mut_from` -> `try_mut_from_bytes`
- `try_read_from` -> `try_read_from_bytes`
- `try_ref_from` -> `try_ref_from_bytes`

Makes progress towards #871

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
