### PR TITLE
Always use manual impl of `KnownLayout` for `Unalign`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1711,7 +1711,7 @@ mod tests {
         // This test is important because it allows us to test our hand-rolled
         // implementation of `<Unalign<T> as TryFromBytes>::is_bit_valid`.
         assert_impls!(Unalign<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
-        assert_impls!(Unalign<NotZerocopy>: Unaligned, !Immutable, !KnownLayout, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes);
+        assert_impls!(Unalign<NotZerocopy>: KnownLayout, Unaligned, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes);
 
         assert_impls!(
             [u8]: KnownLayout,

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -57,14 +57,13 @@ use super::*;
 // [3] https://github.com/google/zerocopy/issues/209
 #[allow(missing_debug_implementations)]
 #[derive(Default, Copy)]
-#[cfg_attr(
-    any(feature = "derive", test),
-    derive(Immutable, KnownLayout, FromBytes, IntoBytes, Unaligned)
-)]
+#[cfg_attr(any(feature = "derive", test), derive(Immutable, FromBytes, IntoBytes, Unaligned))]
 #[repr(C, packed)]
 pub struct Unalign<T>(T);
 
-#[cfg(not(any(feature = "derive", test)))]
+// We do not use `derive(KnownLayout)` on `Unalign`, because the derive is not
+// smart enough to realize that `Unalign<T>` is always sized and thus emits a
+// `KnownLayout` impl bounded on `T: KnownLayout.` This is overly restrictive.
 impl_known_layout!(T => Unalign<T>);
 
 safety_comment! {


### PR DESCRIPTION
We should not use `derive(KnownLayout)` on `Unalign`, because the derive is not smart enough to realize that `Unalign<T>` is always sized and thus emits a `KnownLayout` impl bounded on `T: KnownLayout.` This is overly restrictive.

Fixes #1162

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
