### PR TITLE
Hide large enums from rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.cargo.cfgs": {
+        // This adds an extra cfg to rust-analyzer so we can prevent it from
+        // analyzing tests with a lot of generated code. These can cause it to
+        // hang or run slowly in general, which is bad for workflows.
+        "rust_analyzer": null,
+    }
+}

--- a/zerocopy-derive/tests/enum_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_from_bytes.rs
@@ -10,6 +10,8 @@
 #![no_implicit_prelude]
 #![allow(warnings)]
 #![deny(deprecated)]
+// The giant enums in this file cause rust-analyzer to hang during analysis.
+#![cfg(not(rust_analyzer))]
 
 include!("include.rs");
 


### PR DESCRIPTION
The large enums in zerocopy-derive's `enum_from_bytes` test make rust-analyzer hang during analysis. This change adds a VSCode config that allows us to hide that test from rust-analyzer. The test is still run as normal.

(split out from #879)