### PR TITLE
Parse the package manifest directly for toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,16 +119,6 @@ jobs:
 
     - name: Populate cache
       uses: ./.github/actions/cache
-    
-    # Ensure that Cargo resolves the minimum possible syn version so that if we
-    # accidentally make a change which depends upon features added in more
-    # recent versions of syn, we'll catch it in CI.
-    - name: Pin syn dependency
-      run: |
-        set -eo pipefail
-        # Override the exising `syn` dependency with one which requires an exact
-        # version.
-        cargo add -p zerocopy-derive 'syn@=2.0.46'
 
     - name: Configure environment variables
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zerocopy-panic-in-const = "1.57.0"
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.80.0"
-pinned-nightly = "nightly-2024-07-25"
+pinned-nightly = "nightly-2024-07-28"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -78,11 +78,7 @@ zerocopy-derive = { version = "=0.8.0-alpha.16", path = "zerocopy-derive" }
 [dev-dependencies]
 assert_matches = "1.5"
 itertools = "0.11"
-# We don't use this directly, but trybuild does. On the MSRV toolchain, the
-# version resolver fails to select any version for once_cell unless we
-# depend on it directly.
-once_cell = "=1.9"
-rand = { version = "0.8.5", features = ["small_rng"] }
+rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,4 +22,4 @@ publish = false
 
 [workspace.dependencies]
 regex = "1"
-serde_json = "1"
+toml = "0.8"

--- a/tools/cargo-zerocopy/Cargo.toml
+++ b/tools/cargo-zerocopy/Cargo.toml
@@ -15,4 +15,4 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
-serde_json.workspace = true
+toml = { workspace = true, features = ["parse"] }


### PR DESCRIPTION
This prevents the lockfile for the workspace from being generated by a newer version of cargo, which may choose more up-to-date dependencies than our msrv toolchain can compile.