### PR TITLE
[testutil] Pin windows-sys to 0.52.0

### DIFF
--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -22,3 +22,6 @@ rustc_version = "0.4.0"
 # than our MSRV.
 time = { version = "=0.3.0", default-features = false, features = ["formatting", "macros", "parsing"] }
 toml = "0.5.11"
+# Pin to 0.52.0 because more recent versions require a Rust version more recent
+# than our MSRV.
+windows-sys = "=0.52.0"


### PR DESCRIPTION
windows-sys 0.59.0 (the next version after 0.52.0) has an MSRV of 1.60, which is higher than our MSRV of 1.56.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
