### PR TITLE
Remove dependency on assert_matches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ zerocopy-derive = { version = "=0.8.0-alpha.16", path = "zerocopy-derive", optio
 zerocopy-derive = { version = "=0.8.0-alpha.16", path = "zerocopy-derive" }
 
 [dev-dependencies]
-assert_matches = "1.5"
 itertools = "0.11"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = "1.0"

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -836,7 +836,7 @@ mod tests {
         /// The final argument uses the same syntax, but it has a different
         /// meaning:
         /// - If it is `Ok(pat)`, then the pattern `pat` is supplied to
-        ///   `assert_matches!` to validate the computed result for each
+        ///   a matching assert to validate the computed result for each
         ///   combination of input values.
         /// - If it is `Err(Some(msg) | None)`, then `test!` validates that the
         ///   call to `validate_cast_and_convert_metadata` panics with the given
@@ -885,8 +885,8 @@ mod tests {
                         });
                         std::panic::set_hook(previous_hook);
 
-                        assert_matches::assert_matches!(
-                            actual, $expect,
+                        assert!(
+                            matches!(actual, $expect),
                             "layout({:?}, {}).validate_cast_and_convert_metadata({}, {}, {:?})" ,size_info, align, addr, bytes_len, cast_type
                         );
                     });


### PR DESCRIPTION
We can just replace this with assert! and matches!, which are both stable before 1.56.