### PR TITLE
Detect atomic support using target_has_atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           # `build.rs`. Each of these represents the minimum Rust version for
           # which a particular feature is supported.
           "zerocopy-generic-bounds-in-const-fn",
+          "zerocopy-target-has-atomics",
           "zerocopy-aarch64-simd",
           "zerocopy-panic-in-const"
         ]
@@ -68,6 +69,7 @@ jobs:
           "riscv64gc-unknown-linux-gnu",
           "s390x-unknown-linux-gnu",
           "x86_64-pc-windows-msvc",
+          "thumbv6m-none-eabi",
           "wasm32-wasi"
         ]
         features: [
@@ -87,6 +89,8 @@ jobs:
             features: "--all-features"
           - toolchain: "zerocopy-generic-bounds-in-const-fn"
             features: "--all-features"
+          - toolchain: "zerocopy-target-has-atomics"
+            features: "--all-features"
           - toolchain: "zerocopy-aarch64-simd"
             features: "--all-features"
           - toolchain: "zerocopy-panic-in-const"
@@ -105,6 +109,8 @@ jobs:
           # zerocopy-derive doesn't behave different on these toolchains.
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - crate: "zerocopy-derive"
+            toolchain: "zerocopy-target-has-atomics"
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-aarch64-simd"
           - crate: "zerocopy-derive"
@@ -128,6 +134,8 @@ jobs:
           - toolchain: "zerocopy-aarch64-simd"
             target: "x86_64-pc-windows-msvc"
           - toolchain: "zerocopy-aarch64-simd"
+            target: "thumbv6m-none-eabi"
+          - toolchain: "zerocopy-aarch64-simd"
             target: "wasm32-wasi"
           # Exclude most targets targets from the
           # `zerocopy-generic-bounds-in-const-fn` toolchain since the
@@ -148,7 +156,16 @@ jobs:
           - toolchain: "zerocopy-generic-bounds-in-const-fn"
             target: "x86_64-pc-windows-msvc"
           - toolchain: "zerocopy-generic-bounds-in-const-fn"
+            target: "thumbv6m-none-eabi"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn"
             target: "wasm32-wasi"
+          # Exclude `thumbv6m-none-eabi` combined with any feature that implies
+          # the `std` feature since `thumbv6m-none-eabi` does not include a
+          # pre-compiled std.
+          - target: "thumbv6m-none-eabi"
+            features: "--features __internal_use_only_features_that_work_on_stable"
+          - target: "thumbv6m-none-eabi"
+            features: "--all-features"
           # Exclude most targets during PR development, but allow them in the
           # merge queue. This speeds up our development flow, while still
           # ensuring that errors on these targets are caught before a PR is
@@ -165,6 +182,8 @@ jobs:
             event_name: "pull_request"
           - target: "s390x-unknown-linux-gnu"
             event_name: "pull_request"
+          - target: "thumbv6m-none-eabi"
+            event_name: "pull_request"
           - target: "wasm32-wasi"
             event_name: "pull_request"
 
@@ -175,6 +194,19 @@ jobs:
 
     - name: Populate cache
       uses: ./.github/actions/cache
+
+    # Ensure that Cargo resolves the minimum possible syn version so that if we
+    # accidentally make a change which depends upon features added in more
+    # recent versions of syn, we'll catch it in CI.
+    #
+    # TODO(#1595): Debug why this step is still necessary after #1564 and maybe
+    # remove it.
+    - name: Pin syn dependency
+      run: |
+        set -eo pipefail
+        # Override the exising `syn` dependency with one which requires an exact
+        # version.
+        cargo add -p zerocopy-derive 'syn@=2.0.46'
 
     - name: Configure environment variables
       run: |
@@ -240,11 +272,19 @@ jobs:
       with:
         key: "${{ matrix.target }}"
 
+    # On the `thumbv6m-none-eabi` target, we can't run `cargo check --tests` due
+    # to the `memchr` crate, so we just do `cargo check` instead.
+    - name: Check
+      run: ./cargo.sh +${{ matrix.toolchain }} check --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      if: matrix.target == 'thumbv6m-none-eabi'
+
     - name: Check tests
       run: ./cargo.sh +${{ matrix.toolchain }} check --tests --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      if: matrix.target != 'thumbv6m-none-eabi'
 
     - name: Build
       run: ./cargo.sh +${{ matrix.toolchain }} build --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      if: matrix.target != 'thumbv6m-none-eabi'
 
     # When building tests for the i686 target, we need certain libraries which
     # are not installed by default; `gcc-multilib` includes these libraries.
@@ -356,16 +396,23 @@ jobs:
       if: |
         matrix.toolchain == 'nightly' &&
         matrix.target != 'riscv64gc-unknown-linux-gnu' &&
+        matrix.target != 'thumbv6m-none-eabi' &&
         matrix.target != 'wasm32-wasi' &&
         github.event_name != 'pull_request'
 
-    - name: Clippy check
+    # On the `thumbv6m-none-eabi` target, we can't run `cargo clippy --tests`
+    # due to the `memchr` crate, so we just do `cargo clippy` instead.
+    - name: Clippy
+      run: ./cargo.sh +${{ matrix.toolchain }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      if: matrix.toolchain == 'nightly' && matrix.target == 'thumbv6m-none-eabi'
+
+    - name: Clippy tests
       run: ./cargo.sh +${{ matrix.toolchain }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --tests --verbose
       # Clippy improves the accuracy of lints over time, and fixes bugs. Only
       # running Clippy on nightly allows us to avoid having to write code which
       # is compatible with older versions of Clippy, which sometimes requires
       # hacks to work around limitations that are fixed in more recent versions.
-      if: matrix.toolchain == 'nightly'
+      if: matrix.toolchain == 'nightly' && matrix.target != 'thumbv6m-none-eabi'
 
     - name: Cargo doc
       # We pass --document-private-items and --document-hidden items to ensure that 
@@ -544,6 +591,9 @@ jobs:
           # See comment on "Pin syn dependency" job for why we do this. It needs
           # to happen before the subsequent `cargo check`, so we don't
           # background it.
+          #
+          # TODO(#1595): Debug why this step is still necessary after #1564 and
+          # maybe remove it.
           cargo add -p zerocopy-derive 'syn@=2.0.46' &> /dev/null
 
           cargo check --workspace --tests            &> /dev/null &

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ exclude = [".*"]
 # From 1.61.0, Rust supports generic types with trait bounds in `const fn`.
 zerocopy-generic-bounds-in-const-fn = "1.61.0"
 
+# From 1.60.0, Rust supports `cfg(target_has_atomics)`, which allows us to
+# detect whether a target supports particular sets of atomics.
+zerocopy-target-has-atomics = "1.60.0"
+
 # When the "simd" feature is enabled, include SIMD types from the
 # `core::arch::aarch64` module, which was stabilized in 1.59.0. On earlier Rust
 # versions, these types require the "simd-nightly" feature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,8 @@ extern crate self as zerocopy;
 
 #[macro_use]
 mod macros;
+#[macro_use]
+mod util;
 
 pub mod byte_slice;
 pub mod byteorder;
@@ -313,7 +315,6 @@ pub mod macro_util;
 #[doc(hidden)]
 pub mod pointer;
 mod r#ref;
-mod util;
 // TODO(#252): If we make this pub, come up with a better name.
 mod wrappers;
 
@@ -337,10 +338,6 @@ use core::{
     ops::{Deref, DerefMut},
     ptr::{self, NonNull},
     slice,
-    sync::atomic::{
-        AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicPtr, AtomicU16, AtomicU32,
-        AtomicU8, AtomicUsize,
-    },
 };
 
 use crate::pointer::{invariant, BecauseExclusive, BecauseImmutable};
@@ -819,9 +816,7 @@ impl_known_layout!(
     u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize, f32, f64,
     bool, char,
     NonZeroU8, NonZeroI8, NonZeroU16, NonZeroI16, NonZeroU32, NonZeroI32,
-    NonZeroU64, NonZeroI64, NonZeroU128, NonZeroI128, NonZeroUsize, NonZeroIsize,
-    AtomicBool, AtomicI16, AtomicI32, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-    AtomicU8, AtomicUsize
+    NonZeroU64, NonZeroI64, NonZeroU128, NonZeroI128, NonZeroUsize, NonZeroIsize
 );
 #[rustfmt::skip]
 impl_known_layout!(
@@ -830,8 +825,7 @@ impl_known_layout!(
     T         => Wrapping<T>,
     T         => MaybeUninit<T>,
     T: ?Sized => *const T,
-    T: ?Sized => *mut T,
-    T         => AtomicPtr<T>
+    T: ?Sized => *mut T
 );
 impl_known_layout!(const N: usize, T => [T; N]);
 

--- a/tests/ui-nightly/include_value_not_from_bytes.stderr
+++ b/tests/ui-nightly/include_value_not_from_bytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/include_value_not_from_bytes.rs:15:42

--- a/tests/ui-nightly/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-dst-not-frombytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:19:41

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
@@ -11,11 +11,11 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-nightly/transmute-mut-dst-not-frombytes.rs:24:38

--- a/tests/ui-nightly/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-intobytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertDstIsIntoBytes`
   --> tests/ui-nightly/transmute-mut-dst-not-intobytes.rs:24:36

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
@@ -11,11 +11,11 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38
@@ -34,11 +34,11 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-nightly/transmute-mut-src-not-frombytes.rs:24:38

--- a/tests/ui-nightly/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-intobytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-nightly/transmute-mut-src-not-intobytes.rs:24:36
@@ -35,10 +35,10 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-nightly/transmute-mut-src-not-intobytes.rs:24:36

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Dst: zerocopy::FromBytes` is not satisfied
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:23:34

--- a/tests/ui-nightly/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-intobytes.stderr
@@ -13,9 +13,9 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-nightly/transmute-ref-src-not-intobytes.rs:23:33
@@ -36,9 +36,9 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-nightly/transmute-ref-src-not-intobytes.rs:23:33

--- a/tests/ui-nightly/transmute-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-src-not-intobytes.stderr
@@ -13,9 +13,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
@@ -36,9 +36,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32

--- a/tests/ui-nightly/try_transmute-dst-not-tryfrombytes.stderr
+++ b/tests/ui-nightly/try_transmute-dst-not-tryfrombytes.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `try_transmute`
   --> src/macro_util.rs
@@ -60,7 +60,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs

--- a/tests/ui-nightly/try_transmute-src-not-intobytes.stderr
+++ b/tests/ui-nightly/try_transmute-src-not-intobytes.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `try_transmute`
   --> src/macro_util.rs

--- a/tests/ui-stable/include_value_not_from_bytes.stderr
+++ b/tests/ui-stable/include_value_not_from_bytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/include_value_not_from_bytes.rs:15:42

--- a/tests/ui-stable/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-dst-not-frombytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:19:41

--- a/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
@@ -11,11 +11,11 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-stable/transmute-mut-dst-not-frombytes.rs:24:38

--- a/tests/ui-stable/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-intobytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertDstIsIntoBytes`
   --> tests/ui-stable/transmute-mut-dst-not-intobytes.rs:24:36

--- a/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
@@ -11,11 +11,11 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38
@@ -34,11 +34,11 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
              ()
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
              AtomicU32
-             AtomicU8
            and $N others
 note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-stable/transmute-mut-src-not-frombytes.rs:24:38

--- a/tests/ui-stable/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-intobytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-stable/transmute-mut-src-not-intobytes.rs:24:36
@@ -35,10 +35,10 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-stable/transmute-mut-src-not-intobytes.rs:24:36

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
@@ -12,10 +12,10 @@ error[E0277]: the trait bound `Dst: zerocopy::FromBytes` is not satisfied
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:23:34

--- a/tests/ui-stable/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-intobytes.stderr
@@ -13,9 +13,9 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-stable/transmute-ref-src-not-intobytes.rs:23:33
@@ -36,9 +36,9 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-stable/transmute-ref-src-not-intobytes.rs:23:33

--- a/tests/ui-stable/transmute-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-src-not-intobytes.stderr
@@ -13,9 +13,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
@@ -36,9 +36,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32

--- a/tests/ui-stable/try_transmute-dst-not-tryfrombytes.stderr
+++ b/tests/ui-stable/try_transmute-dst-not-tryfrombytes.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `try_transmute`
   --> src/macro_util.rs
@@ -60,7 +60,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs

--- a/tests/ui-stable/try_transmute-src-not-intobytes.stderr
+++ b/tests/ui-stable/try_transmute-src-not-intobytes.stderr
@@ -10,9 +10,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required by a bound in `try_transmute`
   --> src/macro_util.rs

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -16,6 +16,9 @@ cargo_metadata = "0.18.0"
 # Pin to 0.1.5 because more recent versions require a Rust version more recent
 # than our MSRV.
 cargo-platform = "=0.1.5"
+# Pin to 2.5.0 because more recent versions require a Rust version more recent
+# than our MSRV.
+memchr = "=2.5.0"
 parking_lot = "=0.12.1"
 rustc_version = "0.4.0"
 # Pin to 0.3.0 because more recent versions require a Rust version more recent

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `TryFromBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:21
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-nightly/derive_transparent.rs:24:21
@@ -65,10 +65,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::FromBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:21
@@ -94,9 +94,9 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::IntoBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:10

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -43,7 +43,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -66,7 +66,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -89,7 +89,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -112,7 +112,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -132,10 +132,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -156,9 +156,9 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -86,7 +86,7 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -109,7 +109,7 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `TryFromBytes`
   --> tests/ui-stable/derive_transparent.rs:24:21
@@ -40,7 +40,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-stable/derive_transparent.rs:24:21
@@ -65,10 +65,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::FromBytes`
   --> tests/ui-stable/derive_transparent.rs:24:21
@@ -94,9 +94,9 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::IntoBytes`
   --> tests/ui-stable/derive_transparent.rs:24:10

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -39,7 +39,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -58,7 +58,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -77,7 +77,7 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -96,7 +96,7 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -112,10 +112,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AU16
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
              AtomicU16
-             AtomicU32
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -132,9 +132,9 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
              AtomicBool
              AtomicI16
              AtomicI32
+             AtomicI64
              AtomicI8
              AtomicIsize
-             AtomicU16
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -97,7 +97,7 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
              AtomicBool
              AtomicI16
              AtomicI32
-             AtomicI8
+             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Implements `TryFromBytes` and `FromZeros` for `AtomicPtr`; `FromBytes` and `IntoBytes` are blocked by https://github.com/google/zerocopy/issues/170.

This is adapted from @josephlr's similar implementation in https://github.com/google/zerocopy/pull/1092.

Fixes https://github.com/google/zerocopy/issues/1086