### PR TITLE
Tighten soundness of `addr_of!` uses

### DIFF
--- a/src/macro_util.rs
+++ b/src/macro_util.rs
@@ -174,6 +174,7 @@ macro_rules! trailing_field_offset {
         //   allocation addressed by `ALIGNED_64K_ALLOCATION` is guaranteed to
         //   be aligned to `_64K`, so `ptr` is guaranteed to satisfy `$ty`'s
         //   alignment.
+        // - As required by `addr_of!`, we do not write through `field`.
         //
         //   Note that, as of [2], this requirement is technically unnecessary
         //   for Rust versions >= 1.75.0, but no harm in guaranteeing it anyway

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -228,7 +228,13 @@ impl<T> Unalign<T> {
     /// documented as being sound to use with an unaligned pointer, such as
     /// [`read_unaligned`].
     ///
+    /// Even if the caller is permitted to mutate `self` (e.g. they have
+    /// ownership or a mutable borrow), it is not guaranteed to be sound to
+    /// write through the returned pointer. If writing is required, prefer
+    /// [`get_mut_ptr`] instead.
+    ///
     /// [`read_unaligned`]: core::ptr::read_unaligned
+    /// [`get_mut_ptr`]: Unalign::get_mut_ptr
     #[inline(always)]
     pub const fn get_ptr(&self) -> *const T {
         ptr::addr_of!(self.0)


### PR DESCRIPTION
Closes #1607

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
