### PR TITLE
[Ref] Make methods into associated functions

### DIFF
--- a/src/deprecated.rs
+++ b/src/deprecated.rs
@@ -131,7 +131,7 @@ where
     #[doc(hidden)]
     #[inline(always)]
     pub fn into_slice(self) -> &'a [T] {
-        self.into_ref()
+        Ref::into_ref(self)
     }
 }
 
@@ -144,7 +144,7 @@ where
     #[doc(hidden)]
     #[inline(always)]
     pub fn into_mut_slice(self) -> &'a mut [T] {
-        self.into_mut()
+        Ref::into_mut(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3397,7 +3397,7 @@ pub unsafe trait FromBytes: FromZeros {
         Self: Sized,
     {
         match Ref::<_, Unalign<Self>>::sized_from(source) {
-            Ok(r) => Ok(r.read().into_inner()),
+            Ok(r) => Ok(Ref::read(&r).into_inner()),
             Err(CastError::Size(e)) => Err(e.with_dst()),
             Err(CastError::Alignment(_)) => unreachable!(),
             Err(CastError::Validity(i)) => match i {},
@@ -3443,7 +3443,7 @@ pub unsafe trait FromBytes: FromZeros {
         Self: Sized,
     {
         match Ref::<_, Unalign<Self>>::sized_from_prefix(source) {
-            Ok((r, suffix)) => Ok((r.read().into_inner(), suffix)),
+            Ok((r, suffix)) => Ok((Ref::read(&r).into_inner(), suffix)),
             Err(CastError::Size(e)) => Err(e.with_dst()),
             Err(CastError::Alignment(_)) => unreachable!(),
             Err(CastError::Validity(i)) => match i {},
@@ -3483,7 +3483,7 @@ pub unsafe trait FromBytes: FromZeros {
         Self: Sized,
     {
         match Ref::<_, Unalign<Self>>::sized_from_suffix(source) {
-            Ok((prefix, r)) => Ok((prefix, r.read().into_inner())),
+            Ok((prefix, r)) => Ok((prefix, Ref::read(&r).into_inner())),
             Err(CastError::Size(e)) => Err(CastError::Size(e.with_dst())),
             Err(CastError::Alignment(_)) => unreachable!(),
             Err(CastError::Validity(i)) => match i {},


### PR DESCRIPTION
Since `Ref` implements `Deref`, methods risk conflicting with methods of the same names on the target type.

Note that, in #210, we considered applying the same change to `Unalign`. We choose not to do that because most uses of `Unalign` involve types with alignments greater than 1, and for these types, `Unalign` does not implement `Deref`. It's not worth making the API significantly more cumbersome in order to make it easier for this niche use case.

Closes #210

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
