### PR TITLE
[ci] Roll pinned nightly toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ zerocopy-panic-in-const = "1.57.0"
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.81.0"
-pinned-nightly = "nightly-2024-09-06"
+pinned-nightly = "nightly-2024-09-09"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -770,11 +770,17 @@ macro_rules! define_float_conversion {
         }
     };
     ($ty:ty, $bits:ident, $bytes:expr, $from:ident, $to:ident) => {
+        // Clippy: The suggestion of using `from_bits()` instead doesn't work
+        // because `from_bits` is not const-stable on our MSRV.
+        #[allow(clippy::transmute_int_to_float)]
         pub(crate) const fn $from(bytes: [u8; $bytes]) -> $ty {
             transmute!($bits::$from(bytes))
         }
 
         pub(crate) const fn $to(f: $ty) -> [u8; $bytes] {
+            // Clippy: The suggestion of using `f.to_bits()` instead doesn't
+            // work because `to_bits` is not const-stable on our MSRV.
+            #[allow(clippy::transmute_float_to_int)]
             let bits: $bits = transmute!(f);
             bits.$to()
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -85,11 +85,9 @@ macro_rules! transmute {
             // contexts in which `core` was not manually imported. This is not a
             // problem for 2018 edition crates.
             let u = unsafe {
-                // Clippy:
-                // - It's okay to transmute a type to itself.
-                // - We can't annotate the types; this macro is designed to
-                //   infer the types from the calling context.
-                #[allow(clippy::useless_transmute, clippy::missing_transmute_annotations)]
+                // Clippy: We can't annotate the types; this macro is designed
+                // to infer the types from the calling context.
+                #[allow(clippy::missing_transmute_annotations)]
                 $crate::util::macro_util::core_reexport::mem::transmute(e)
             };
             $crate::util::macro_util::must_use(u)
@@ -452,8 +450,9 @@ macro_rules! try_transmute {
 
             // SAFETY: This code is never executed.
             Ok(unsafe {
-                // Clippy: It's okay to transmute a type to itself.
-                #[allow(clippy::useless_transmute, clippy::missing_transmute_annotations)]
+                // Clippy: We can't annotate the types; this macro is designed
+                // to infer the types from the calling context.
+                #[allow(clippy::missing_transmute_annotations)]
                 $crate::util::macro_util::core_reexport::mem::transmute(e)
             })
         } else {
@@ -951,6 +950,7 @@ mod tests {
     #[test]
     fn test_macros_evaluate_args_once() {
         let mut ctr = 0;
+        #[allow(clippy::useless_transmute)]
         let _: usize = transmute!({
             ctr += 1;
             0usize
@@ -972,6 +972,7 @@ mod tests {
         assert_eq!(ctr, 1);
 
         let mut ctr = 0;
+        #[allow(clippy::useless_transmute)]
         let _: usize = try_transmute!({
             ctr += 1;
             0usize


### PR DESCRIPTION
While we're here, remove some Clippy `#[allow(...)]` annotations from our transmute macros. These belong at the call sites, not in the macros themselves.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
