### PR TITLE
Make extend_vec_zeroed, insert_vec_zeroed fallible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           "zerocopy-generic-bounds-in-const-fn",
           "zerocopy-target-has-atomics",
           "zerocopy-aarch64-simd",
-          "zerocopy-panic-in-const"
+          "zerocopy-panic-in-const-and-vec-try-reserve"
         ]
         target: [
           "i686-unknown-linux-gnu",
@@ -93,7 +93,7 @@ jobs:
             features: "--all-features"
           - toolchain: "zerocopy-aarch64-simd"
             features: "--all-features"
-          - toolchain: "zerocopy-panic-in-const"
+          - toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
             features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
@@ -114,7 +114,7 @@ jobs:
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-aarch64-simd"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-panic-in-const"
+            toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
           # Exclude non-aarch64 targets from the `zerocopy-aarch64-simd`
           # toolchain.
           - toolchain: "zerocopy-aarch64-simd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ zerocopy-target-has-atomics = "1.60.0"
 # versions, these types require the "simd-nightly" feature.
 zerocopy-aarch64-simd = "1.59.0"
 
-# Permit panicking in `const fn`s.
-zerocopy-panic-in-const = "1.57.0"
+# Permit panicking in `const fn`s and calling `Vec::try_reserve`.
+zerocopy-panic-in-const-and-vec-try-reserve = "1.57.0"
 
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -880,7 +880,7 @@ mod tests {
                             layout(size_info, align).validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
                         }).map_err(|d| {
                             let msg = d.downcast::<&'static str>().ok().map(|s| *s.as_ref());
-                            assert!(msg.is_some() || cfg!(not(zerocopy_panic_in_const)), "non-string panic messages are not permitted when `--cfg zerocopy_panic_in_const` is set");
+                            assert!(msg.is_some() || cfg!(not(zerocopy_panic_in_const_and_vec_try_reserve)), "non-string panic messages are not permitted when `--cfg zerocopy_panic_in_const_and_vec_try_reserve` is set");
                             msg
                         });
                         std::panic::set_hook(previous_hook);

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -640,9 +640,9 @@ macro_rules! maybe_const_trait_bounded_fn {
 /// non-panicking desugaring will fail to compile.
 macro_rules! const_panic {
     ($fmt:literal) => {{
-        #[cfg(zerocopy_panic_in_const)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         panic!($fmt);
-        #[cfg(not(zerocopy_panic_in_const))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
         const_panic!(@non_panic $fmt)
     }};
     (@non_panic $fmt:expr) => {{
@@ -661,9 +661,9 @@ macro_rules! const_panic {
 /// accommodate old toolchains.
 macro_rules! const_assert {
     ($e:expr) => {{
-        #[cfg(zerocopy_panic_in_const)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         assert!($e);
-        #[cfg(not(zerocopy_panic_in_const))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
         {
             let e = $e;
             if !e {
@@ -676,9 +676,9 @@ macro_rules! const_assert {
 /// Like `const_assert!`, but relative to `debug_assert!`.
 macro_rules! const_debug_assert {
     ($e:expr $(, $msg:expr)?) => {{
-        #[cfg(zerocopy_panic_in_const)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         debug_assert!($e $(, $msg)?);
-        #[cfg(not(zerocopy_panic_in_const))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
         {
             // Use this (rather than `#[cfg(debug_assertions)]`) to ensure that
             // `$e` is always compiled even if it will never be evaluated at
@@ -697,10 +697,10 @@ macro_rules! const_debug_assert {
 /// toolchain supports panicking in `const fn`.
 macro_rules! const_unreachable {
     () => {{
-        #[cfg(zerocopy_panic_in_const)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         unreachable!();
 
-        #[cfg(not(zerocopy_panic_in_const))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
         loop {}
     }};
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -628,7 +628,7 @@ pub(crate) const fn round_down_to_next_multiple_of_alignment(
     align: NonZeroUsize,
 ) -> usize {
     let align = align.get();
-    #[cfg(zerocopy_panic_in_const)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     debug_assert!(align.is_power_of_two());
 
     // Subtraction can't underflow because `align.get() >= 1`.
@@ -865,7 +865,7 @@ mod tests {
     #[rustversion::since(1.57.0)]
     #[test]
     #[should_panic]
-    fn test_round_down_to_next_multiple_of_alignment_panic_in_const() {
+    fn test_round_down_to_next_multiple_of_alignment_zerocopy_panic_in_const_and_vec_try_reserve() {
         round_down_to_next_multiple_of_alignment(0, NonZeroUsize::new(3).unwrap());
     }
 }


### PR DESCRIPTION
They now return `AllocError` on allocation failure. `insert_vec_zeroed` still panics if its `position` argument is out-of-bounds.

Closes #1653

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
