### PR TITLE
Seal `ByteOrder` trait

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -87,9 +87,18 @@ use super::*;
 /// big-endian byte order.
 ///
 /// [`U32<BigEndian>`]: U32
-pub trait ByteOrder: Copy + Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd {
+pub trait ByteOrder:
+    Copy + Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd + private::Sealed
+{
     #[doc(hidden)]
     const ORDER: Order;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for super::BigEndian {}
+    impl Sealed for super::LittleEndian {}
 }
 
 #[allow(missing_copy_implementations, missing_debug_implementations)]


### PR DESCRIPTION
This will allow us to add additional supertraits without breaking users.

Makes progress towards #1692

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
