### PR TITLE
Rename generic param to avoid name collision

### DIFF
--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -294,11 +294,11 @@ pub(crate) fn derive_is_bit_valid(
         // enum's tag corresponds to one of the enum's discriminants. Then, we
         // check the bit validity of each field of the corresponding variant.
         // Thus, this is a sound implementation of `is_bit_valid`.
-        fn is_bit_valid<A>(
-            mut candidate: ::zerocopy::Maybe<'_, Self, A>,
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
-            A: ::zerocopy::pointer::invariant::Aliasing
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                 + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
         {
             use ::zerocopy::util::macro_util::core_reexport;

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -420,9 +420,13 @@ fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_m
             // validity of a struct is just the composition of the bit
             // validities of its fields, so this is a sound implementation of
             // `is_bit_valid`.
-            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
-                mut candidate: ::zerocopy::Maybe<Self, A>,
-            ) -> bool {
+            fn is_bit_valid<___ZerocopyAliasing>(
+                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+            where
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
+                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            {
                 true #(&& {
                     // SAFETY:
                     // - `project` is a field projection, and so it addresses a
@@ -470,9 +474,13 @@ fn derive_try_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro
             // bit validity of a union is not yet well defined in Rust, but it
             // is guaranteed to be no more strict than this definition. See #696
             // for a more in-depth discussion.
-            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
-                mut candidate: ::zerocopy::Maybe<Self, A>
-            ) -> bool {
+            fn is_bit_valid<___ZerocopyAliasing>(
+                mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>
+            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+            where
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
+                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            {
                 false #(|| {
                     // SAFETY:
                     // - `project` is a field projection, and so it addresses a

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -147,12 +147,13 @@ fn test_try_from_bytes() {
             unsafe impl ::zerocopy::TryFromBytes for Foo {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
 
-                fn is_bit_valid<
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                where
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
-                >(
-                    mut candidate: ::zerocopy::Maybe<Self, A>,
-                ) -> bool {
+                {
                     true
                 }
             }
@@ -170,12 +171,13 @@ fn test_from_zeros() {
             unsafe impl ::zerocopy::TryFromBytes for Foo {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
 
-                fn is_bit_valid<
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                where
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
-                >(
-                    mut candidate: ::zerocopy::Maybe<Self, A>,
-                ) -> bool {
+                {
                     true
                 }
             }
@@ -198,12 +200,13 @@ fn test_from_bytes() {
             unsafe impl ::zerocopy::TryFromBytes for Foo {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
 
-                fn is_bit_valid<
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                where
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
-                >(
-                    mut candidate: ::zerocopy::Maybe<Self, A>,
-                ) -> bool {
+                {
                     true
                 }
             }
@@ -303,11 +306,11 @@ fn test_try_from_bytes_enum() {
                 PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<A>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, A>,
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
@@ -445,11 +448,11 @@ fn test_try_from_bytes_enum() {
                 PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<A>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, A>,
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
@@ -587,11 +590,11 @@ fn test_try_from_bytes_enum() {
                 PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<A>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, A>,
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    A: ::zerocopy::pointer::invariant::Aliasing
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;

--- a/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -268,3 +268,13 @@ enum GenericWithLifetimes<'a, 'b, X: 'a, Y: 'b> {
     Foo(::core::marker::PhantomData<&'a X>),
     Bar(::core::marker::PhantomData<&'b Y>),
 }
+
+#[derive(Clone, Copy, imp::TryFromBytes)]
+struct A;
+
+#[derive(imp::TryFromBytes)]
+#[repr(C)]
+enum B {
+    A(A),
+    A2 { a: A },
+}

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -216,3 +216,11 @@ fn packed_unsized() {
     let converted = <CPackedUnsized as imp::TryFromBytes>::try_ref_from_bytes(candidate);
     imp::assert!(converted.is_ok());
 }
+
+#[derive(imp::TryFromBytes)]
+struct A;
+
+#[derive(imp::TryFromBytes)]
+struct B {
+    a: A,
+}

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -144,3 +144,11 @@ where
 }
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::TryFromBytes);
+
+#[derive(Clone, Copy, imp::TryFromBytes, imp::Immutable)]
+struct A;
+
+#[derive(imp::TryFromBytes)]
+union B {
+    a: A,
+}


### PR DESCRIPTION
Also makes the signatures of is_bit_valid generated for structs, unions, and enums the same.