### PR TITLE
[derive] Make output tests insensitive to syntax

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -31,13 +31,16 @@ quote = "1.0.10"
 syn = "2.0.46"
 
 [dev-dependencies]
+dissimilar = "1.0.9"
 # We don't use this directly, but trybuild does. On the MSRV toolchain, the
 # version resolver fails to select any version for once_cell unless we
 # depend on it directly.
 once_cell = "=1.9"
+# This is the latest version which is compatible with `syn` 2.0.46, which we pin
+# to in CI for MSRV compatibility reasons.
+prettyplease = "=0.2.17"
 rustversion = "1.0"
 static_assertions = "1.1"
-synstructure = "0.13.1"
 testutil = { path = "../testutil" }
 # Pinned to a specific version so that the version used for local development
 # and the version used in CI are guaranteed to be the same. Future versions

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -421,7 +421,7 @@ fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_m
             // validity of a struct is just the composition of the bit
             // validities of its fields, so this is a sound implementation of
             // `is_bit_valid`.
-            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared> >(
+            fn is_bit_valid<A: ::zerocopy::pointer::invariant::Aliasing + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>>(
                 mut candidate: ::zerocopy::Maybe<Self, A>,
             ) -> bool {
                 true #(&& {


### PR DESCRIPTION
Our previous output tests asserted on the exact token stream, which is sensitive to subtle differences like `> >` vs `>>` in type signatures. With this change, we instead test for string equality *after* performing a pretty-printing pass, which has the effect of normalizing most such differences, thus making our tests more robust and less sensitive to these inconsequential syntax details.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
