### PR TITLE
[derive] Improve IntoBytes error messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3837,25 +3837,26 @@ fn mut_from_prefix_suffix<T: FromBytes + KnownLayout + ?Sized>(
 ///
 /// # Error Messages
 ///
-/// Due to the way that the custom derive for `IntoBytes` is implemented, you
-/// may get an error like this:
+/// On Rust toolchains prior to 1.78.0, due to the way that the custom derive
+/// for `IntoBytes` is implemented, you may get an error like this:
 ///
 /// ```text
-/// error[E0277]: the trait bound `HasPadding<Foo, true>: ShouldBe<false>` is not satisfied
+/// error[E0277]: the trait bound `(): PaddingFree<Foo, true>` is not satisfied
 ///   --> lib.rs:23:10
 ///    |
 ///  1 | #[derive(IntoBytes)]
-///    |          ^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<Foo, true>`
+///    |          ^^^^^^^^^ the trait `PaddingFree<Foo, true>` is not implemented for `()`
 ///    |
-///    = help: the trait `ShouldBe<VALUE>` is implemented for `HasPadding<T, VALUE>`
+///    = help: the following implementations were found:
+///                   <() as PaddingFree<T, false>>
 /// ```
 ///
 /// This error indicates that the type being annotated has padding bytes, which
 /// is illegal for `IntoBytes` types. Consider reducing the alignment of some
-/// fields by using types in the [`byteorder`] module, adding explicit struct
-/// fields where those padding bytes would be, or using `#[repr(packed)]`. See
-/// the Rust Reference's page on [type layout] for more information about type
-/// layout and padding.
+/// fields by using types in the [`byteorder`] module, wrapping field types in
+/// [`Unalign`], adding explicit struct fields where those padding bytes would
+/// be, or using `#[repr(packed)]`. See the Rust Reference's page on [type
+/// layout] for more information about type layout and padding.
 ///
 /// [type layout]: https://doc.rust-lang.org/reference/type-layout.html
 ///

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -28,7 +28,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.1"
 quote = "1.0.10"
-syn = "2.0.46"
+syn = { version = "2.0.46", features = ["full"] }
 
 [dev-dependencies]
 dissimilar = "1.0.9"

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -234,6 +234,29 @@ fn test_into_bytes() {
             }
         } no_build
     }
+
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo {
+                a: u8,
+                b: u8,
+            }
+        } expands to {
+            #[allow(deprecated)]
+            unsafe impl ::zerocopy::IntoBytes for Foo
+            where
+                u8: ::zerocopy::IntoBytes,
+                u8: ::zerocopy::IntoBytes,
+                (): ::zerocopy::util::macro_util::PaddingFree<
+                    Foo,
+                    { ::zerocopy::struct_has_padding!(Foo, [u8, u8]) },
+                >,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+        } no_build
+    }
 }
 
 #[test]

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -343,35 +343,35 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes1, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, true>` is not satisfied
    --> tests/ui-msrv/enum.rs:533:10
     |
 533 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes1, true>`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+              <() as PaddingFree<T, false>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
    --> tests/ui-msrv/enum.rs:544:10
     |
 544 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+              <() as PaddingFree<T, false>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfied
    --> tests/ui-msrv/enum.rs:550:10
     |
 550 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+              <() as PaddingFree<T, false>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -110,25 +110,25 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
    --> tests/ui-msrv/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+              <() as PaddingFree<T, false>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfied
    --> tests/ui-msrv/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+              <() as PaddingFree<T, false>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -40,13 +40,13 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
   --> tests/ui-msrv/union.rs:39:10
    |
 39 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+   |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
    |
    = help: the following implementations were found:
-             <HasPadding<T, VALUE> as ShouldBe<VALUE>>
+             <() as PaddingFree<T, false>>
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -413,13 +413,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes1, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes1` has inter-field padding
    --> tests/ui-nightly/enum.rs:533:10
     |
 533 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes1, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes1, true>`
+    = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes1, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -427,13 +431,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
    --> tests/ui-nightly/enum.rs:544:10
     |
 544 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -441,13 +449,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes3` has inter-field padding
    --> tests/ui-nightly/enum.rs:550:10
     |
 550 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes3, true>`
+    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes3, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -241,13 +241,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
    --> tests/ui-nightly/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -255,13 +259,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes3` has inter-field padding
    --> tests/ui-nightly/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes3, true>`
+    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes3, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -55,13 +55,17 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
   --> tests/ui-nightly/union.rs:39:10
    |
 39 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+   |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
    |
-   = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+   = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+   = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+   = note: consider adding explicit fields where padding would be
+   = note: consider using `#[repr(packed)]` to remove inter-field padding
+   = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -385,32 +385,44 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes1, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes1` has inter-field padding
    --> tests/ui-stable/enum.rs:533:10
     |
 533 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes1, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes1, true>`
+    = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes1, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
    --> tests/ui-stable/enum.rs:544:10
     |
 544 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes3` has inter-field padding
    --> tests/ui-stable/enum.rs:550:10
     |
 550 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes3, true>`
+    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes3, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -213,23 +213,31 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
    --> tests/ui-stable/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes3, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes3` has inter-field padding
    --> tests/ui-stable/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes3, true>`
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
-    = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes3, true>`
+    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = help: the trait `PaddingFree<IntoBytes3, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui-stable/union.stderr
+++ b/zerocopy-derive/tests/ui-stable/union.stderr
@@ -51,13 +51,17 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HasPadding<IntoBytes2, true>: ShouldBe<false>` is not satisfied
+error[E0277]: `IntoBytes2` has inter-field padding
   --> tests/ui-stable/union.rs:39:10
    |
 39 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `ShouldBe<false>` is not implemented for `HasPadding<IntoBytes2, true>`
+   |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
    |
-   = help: the trait `ShouldBe<true>` is implemented for `HasPadding<IntoBytes2, true>`
+   = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+   = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+   = note: consider adding explicit fields where padding would be
+   = note: consider using `#[repr(packed)]` to remove inter-field padding
+   = help: the trait `PaddingFree<IntoBytes2, false>` is implemented for `()`
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
On Rust toolchains 1.78.0 or later, use
`#[diagnostic::on_unimplemented]` to improve the error message emitted when `IntoBytes` is derived on a type with inter-field padding.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
