### PR TITLE
Add debug check for #[inline] attribute in public derive macro functions

### DIFF
--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -294,6 +294,7 @@ pub(crate) fn derive_is_bit_valid(
         // enum's tag corresponds to one of the enum's discriminants. Then, we
         // check the bit validity of each field of the corresponding variant.
         // Thus, this is a sound implementation of `is_bit_valid`.
+        #[inline(always)]
         fn is_bit_valid<A>(
             mut candidate: ::zerocopy::Maybe<'_, Self, A>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool


### PR DESCRIPTION
This commit introduces a debug-level check to ensure all public functions 
generated by derive macros include the #[inline] attribute. The check 
triggers an assertion if any function lacks the attribute, implemented 
manually since Clippy does not currently check for missing inline lints 
in proc macro-generated code. This may change if Clippy adds support 
for this lint in expanded code.

Additionally, this commit adds #[inline] attributes to public functions 
in the derived code.
