### PR TITLE
[derive] Overhaul repr parsing

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -48,17 +48,6 @@ use {
 
 use {crate::ext::*, crate::repr::*};
 
-/// Unwraps a `Result<_, Vec<Error>>`, converting any `Err` value into a
-/// `TokenStream` and returning it.
-macro_rules! try_or_print {
-    ($e:expr) => {
-        match $e {
-            Ok(x) => x,
-            Err(errors) => return print_all_errors(errors).into(),
-        }
-    };
-}
-
 // TODO(https://github.com/rust-lang/rust/issues/54140): Some errors could be
 // made better if we could add multiple lines of error output like this:
 //
@@ -87,9 +76,28 @@ macro_rules! derive {
         #[proc_macro_derive($trait)]
         pub fn $outer(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let ast = syn::parse_macro_input!(ts as DeriveInput);
-            $inner(&ast).into()
+            $inner(&ast).into_ts().into()
         }
     };
+}
+
+trait IntoTokenStream {
+    fn into_ts(self) -> TokenStream;
+}
+
+impl IntoTokenStream for TokenStream {
+    fn into_ts(self) -> TokenStream {
+        self
+    }
+}
+
+impl IntoTokenStream for Result<TokenStream, Error> {
+    fn into_ts(self) -> TokenStream {
+        match self {
+            Ok(ts) => ts,
+            Err(err) => err.to_compile_error(),
+        }
+    }
 }
 
 derive!(KnownLayout => derive_known_layout => derive_known_layout_inner);
@@ -116,12 +124,12 @@ pub fn derive_as_bytes(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
     derive_into_bytes(ts)
 }
 
-fn derive_known_layout_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
+fn derive_known_layout_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
     let is_repr_c_struct = match &ast.data {
         Data::Struct(..) => {
-            let reprs = try_or_print!(repr::reprs::<Repr>(&ast.attrs));
-            if reprs.iter().any(|(_meta, repr)| repr == &Repr::C) {
-                Some(reprs)
+            let repr = StructUnionRepr::from_attrs(&ast.attrs)?;
+            if repr.is_c() {
+                Some(repr)
             } else {
                 None
             }
@@ -131,36 +139,27 @@ fn derive_known_layout_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
 
     let fields = ast.data.fields();
 
-    let (self_bounds, extras) = if let (Some(reprs), Some((trailing_field, leading_fields))) =
+    let (self_bounds, extras) = if let (Some(repr), Some((trailing_field, leading_fields))) =
         (is_repr_c_struct, fields.split_last())
     {
         let (_name, trailing_field_ty) = trailing_field;
         let leading_fields_tys = leading_fields.iter().map(|(_name, ty)| ty);
 
         let core_path = quote!(::zerocopy::util::macro_util::core_reexport);
-        let repr_align = reprs
-            .iter()
-            .find_map(
-                |(_meta, repr)| {
-                    if let Repr::Align(repr_align) = repr {
-                        Some(repr_align)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .map(|repr_align| quote!(#core_path::num::NonZeroUsize::new(#repr_align as usize)))
-            .unwrap_or(quote!(#core_path::option::Option::None));
-
-        let repr_packed = reprs
-            .iter()
-            .find_map(|(_meta, repr)| match repr {
-                Repr::Packed => Some(1),
-                Repr::PackedN(repr_packed) => Some(*repr_packed),
-                _ => None,
+        let repr_align = repr
+            .get_align()
+            .map(|align| {
+                let align = align.t.get();
+                quote!(#core_path::num::NonZeroUsize::new(#align as usize))
             })
-            .map(|repr_packed| quote!(#core_path::num::NonZeroUsize::new(#repr_packed as usize)))
-            .unwrap_or(quote!(#core_path::option::Option::None));
+            .unwrap_or_else(|| quote!(#core_path::option::Option::None));
+        let repr_packed = repr
+            .get_packed()
+            .map(|packed| {
+                let packed = packed.get();
+                quote!(#core_path::num::NonZeroUsize::new(#packed as usize))
+            })
+            .unwrap_or_else(|| quote!(#core_path::option::Option::None));
 
         (
             SelfBounds::None,
@@ -279,7 +278,7 @@ fn derive_known_layout_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
         )
     };
 
-    match &ast.data {
+    Ok(match &ast.data {
         Data::Struct(strct) => {
             let require_trait_bound_on_field_types = if self_bounds == SelfBounds::SIZED {
                 FieldBounds::None
@@ -327,10 +326,10 @@ fn derive_known_layout_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
                 Some(extras),
             )
         }
-    }
+    })
 }
 
-fn derive_no_cell_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
+fn derive_no_cell_inner(ast: &DeriveInput) -> TokenStream {
     match &ast.data {
         Data::Struct(strct) => impl_block(
             ast,
@@ -362,36 +361,36 @@ fn derive_no_cell_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
     }
 }
 
-fn derive_try_from_bytes_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
+fn derive_try_from_bytes_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
     match &ast.data {
         Data::Struct(strct) => derive_try_from_bytes_struct(ast, strct),
         Data::Enum(enm) => derive_try_from_bytes_enum(ast, enm),
-        Data::Union(unn) => derive_try_from_bytes_union(ast, unn),
+        Data::Union(unn) => Ok(derive_try_from_bytes_union(ast, unn)),
     }
 }
 
-fn derive_from_zeros_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
-    let try_from_bytes = derive_try_from_bytes_inner(ast);
+fn derive_from_zeros_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
+    let try_from_bytes = derive_try_from_bytes_inner(ast)?;
     let from_zeros = match &ast.data {
         Data::Struct(strct) => derive_from_zeros_struct(ast, strct),
-        Data::Enum(enm) => derive_from_zeros_enum(ast, enm),
+        Data::Enum(enm) => derive_from_zeros_enum(ast, enm)?,
         Data::Union(unn) => derive_from_zeros_union(ast, unn),
     };
-    IntoIterator::into_iter([try_from_bytes, from_zeros]).collect()
+    Ok(IntoIterator::into_iter([try_from_bytes, from_zeros]).collect())
 }
 
-fn derive_from_bytes_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
-    let from_zeros = derive_from_zeros_inner(ast);
+fn derive_from_bytes_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
+    let from_zeros = derive_from_zeros_inner(ast)?;
     let from_bytes = match &ast.data {
         Data::Struct(strct) => derive_from_bytes_struct(ast, strct),
-        Data::Enum(enm) => derive_from_bytes_enum(ast, enm),
+        Data::Enum(enm) => derive_from_bytes_enum(ast, enm)?,
         Data::Union(unn) => derive_from_bytes_union(ast, unn),
     };
 
-    IntoIterator::into_iter([from_zeros, from_bytes]).collect()
+    Ok(IntoIterator::into_iter([from_zeros, from_bytes]).collect())
 }
 
-fn derive_into_bytes_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
+fn derive_into_bytes_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
     match &ast.data {
         Data::Struct(strct) => derive_into_bytes_struct(ast, strct),
         Data::Enum(enm) => derive_into_bytes_enum(ast, enm),
@@ -399,7 +398,7 @@ fn derive_into_bytes_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
     }
 }
 
-fn derive_unaligned_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
+fn derive_unaligned_inner(ast: &DeriveInput) -> Result<TokenStream, Error> {
     match &ast.data {
         Data::Struct(strct) => derive_unaligned_struct(ast, strct),
         Data::Enum(enm) => derive_unaligned_enum(ast, enm),
@@ -409,7 +408,10 @@ fn derive_unaligned_inner(ast: &DeriveInput) -> proc_macro2::TokenStream {
 
 /// A struct is `TryFromBytes` if:
 /// - all fields are `TryFromBytes`
-fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
+fn derive_try_from_bytes_struct(
+    ast: &DeriveInput,
+    strct: &DataStruct,
+) -> Result<TokenStream, Error> {
     let extras = Some({
         let fields = strct.fields();
         let field_names = fields.iter().map(|(name, _ty)| name);
@@ -447,7 +449,7 @@ fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_m
             }
         )
     });
-    impl_block(
+    Ok(impl_block(
         ast,
         strct,
         Trait::TryFromBytes,
@@ -455,12 +457,12 @@ fn derive_try_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_m
         SelfBounds::None,
         None,
         extras,
-    )
+    ))
 }
 
 /// A union is `TryFromBytes` if:
 /// - all of its fields are `TryFromBytes` and `Immutable`
-fn derive_try_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
+fn derive_try_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> TokenStream {
     // TODO(#5): Remove the `Immutable` bound.
     let field_type_trait_bounds =
         FieldBounds::All(&[TraitBound::Slf, TraitBound::Other(Trait::Immutable)]);
@@ -512,58 +514,26 @@ fn derive_try_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro
     )
 }
 
-const STRUCT_UNION_ALLOWED_REPR_COMBINATIONS: &[&[StructRepr]] = &[
-    &[StructRepr::C],
-    &[StructRepr::Transparent],
-    &[StructRepr::Packed],
-    &[StructRepr::C, StructRepr::Packed],
-];
-
-fn derive_try_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::TokenStream {
-    let reprs = try_or_print!(ENUM_TRY_FROM_BYTES_CFG.validate_reprs(ast));
+fn derive_try_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> Result<TokenStream, Error> {
+    let repr = EnumRepr::from_attrs(&ast.attrs)?;
 
     // The enum derive requires some extra scaffolding
-    let extra = Some(r#enum::derive_is_bit_valid(&ast.ident, &reprs, &ast.generics, enm));
+    let extra = Some(r#enum::derive_is_bit_valid(&ast.ident, &repr, &ast.generics, enm)?);
 
-    impl_block(ast, enm, Trait::TryFromBytes, FieldBounds::ALL_SELF, SelfBounds::None, None, extra)
+    Ok(impl_block(
+        ast,
+        enm,
+        Trait::TryFromBytes,
+        FieldBounds::ALL_SELF,
+        SelfBounds::None,
+        None,
+        extra,
+    ))
 }
-
-#[rustfmt::skip]
-const ENUM_TRY_FROM_BYTES_CFG: Config<EnumRepr> = {
-    use EnumRepr::*;
-    Config {
-        allowed_combinations_message: r#"TryFromBytes requires an enum repr of a primitive, "C", or "C" with a primitive"#,
-        derive_unaligned: false,
-        allowed_combinations: &[
-            &[U8],
-            &[U16],
-            &[U32],
-            &[U64],
-            &[Usize],
-            &[I8],
-            &[I16],
-            &[I32],
-            &[I64],
-            &[Isize],
-            &[C],
-            &[C, U8],
-            &[C, U16],
-            &[C, U32],
-            &[C, U64],
-            &[C, Usize],
-            &[C, I8],
-            &[C, I16],
-            &[C, I32],
-            &[C, I64],
-            &[C, Isize],
-        ],
-        disallowed_but_legal_combinations: &[],
-    }
-};
 
 /// A struct is `FromZeros` if:
 /// - all fields are `FromZeros`
-fn derive_from_zeros_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
+fn derive_from_zeros_struct(ast: &DeriveInput, strct: &DataStruct) -> TokenStream {
     impl_block(ast, strct, Trait::FromZeros, FieldBounds::ALL_SELF, SelfBounds::None, None, None)
 }
 
@@ -648,31 +618,38 @@ fn find_zero_variant(enm: &DataEnum) -> Result<usize, bool> {
 /// An enum is `FromZeros` if:
 /// - one of the variants has a discriminant of `0`
 /// - that variant's fields are all `FromZeros`
-fn derive_from_zeros_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::TokenStream {
+fn derive_from_zeros_enum(ast: &DeriveInput, enm: &DataEnum) -> Result<TokenStream, Error> {
+    let repr = EnumRepr::from_attrs(&ast.attrs)?;
+
     // We don't actually care what the repr is; we just care that it's one of
     // the allowed ones.
-    try_or_print!(ENUM_FROM_ZEROS_INTO_BYTES_CFG.validate_reprs(ast));
+    match repr {
+         Repr::Compound(
+            Spanned { t: CompoundRepr::C | CompoundRepr::Primitive(_), span: _ },
+            _,
+        ) => {}
+        Repr::Transparent(_)
+        | Repr::Compound(Spanned { t: CompoundRepr::Rust, span: _ }, _) => return Err(Error::new(Span::call_site(), "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout")),
+    }
 
     let zero_variant = match find_zero_variant(enm) {
         Ok(index) => enm.variants.iter().nth(index).unwrap(),
         // Has unknown variants
         Err(true) => {
-            return Error::new_spanned(
+            return Err(Error::new_spanned(
                 ast,
                 "FromZeros only supported on enums with a variant that has a discriminant of `0`\n\
                 help: This enum has discriminants which are not literal integers. One of those may \
                 define or imply which variant has a discriminant of zero. Use a literal integer to \
                 define or imply the variant with a discriminant of zero.",
-            )
-            .to_compile_error();
+            ));
         }
         // Does not have unknown variants
         Err(false) => {
-            return Error::new_spanned(
+            return Err(Error::new_spanned(
                 ast,
                 "FromZeros only supported on enums with a variant that has a discriminant of `0`",
-            )
-            .to_compile_error();
+            ));
         }
     };
 
@@ -685,7 +662,7 @@ fn derive_from_zeros_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Tok
         })
         .collect::<Vec<WherePredicate>>();
 
-    impl_block(
+    Ok(impl_block(
         ast,
         enm,
         Trait::FromZeros,
@@ -693,12 +670,12 @@ fn derive_from_zeros_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Tok
         SelfBounds::None,
         None,
         None,
-    )
+    ))
 }
 
 /// Unions are `FromZeros` if
 /// - all fields are `FromZeros` and `Immutable`
-fn derive_from_zeros_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
+fn derive_from_zeros_union(ast: &DeriveInput, unn: &DataUnion) -> TokenStream {
     // TODO(#5): Remove the `Immutable` bound. It's only necessary for
     // compatibility with `derive(TryFromBytes)` on unions; not for soundness.
     let field_type_trait_bounds =
@@ -708,7 +685,7 @@ fn derive_from_zeros_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::T
 
 /// A struct is `FromBytes` if:
 /// - all fields are `FromBytes`
-fn derive_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
+fn derive_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> TokenStream {
     impl_block(ast, strct, Trait::FromBytes, FieldBounds::ALL_SELF, SelfBounds::None, None, None)
 }
 
@@ -726,62 +703,41 @@ fn derive_from_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro
 ///   platform-specific and, b) even on Rust's smallest bit width platform (32),
 ///   this would require ~4 billion enum variants, which obviously isn't a thing.
 /// - All fields of all variants are `FromBytes`.
-fn derive_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::TokenStream {
-    let reprs = try_or_print!(ENUM_FROM_BYTES_CFG.validate_reprs(ast));
+fn derive_from_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> Result<TokenStream, Error> {
+    let repr = EnumRepr::from_attrs(&ast.attrs)?;
 
-    let variants_required = 1usize
-        << enum_size_from_repr(reprs.as_slice())
-            .expect("internal error: `validate_reprs` has already validated that the reprs guarantee the enum's size");
+    let variants_required = 1usize << enum_size_from_repr(&repr)?;
     if enm.variants.len() != variants_required {
-        return Error::new_spanned(
+        return Err(Error::new_spanned(
             ast,
             format!(
                 "FromBytes only supported on {} enum with {} variants",
-                reprs[0], variants_required
+                repr.repr_type_name(),
+                variants_required
             ),
-        )
-        .to_compile_error();
+        ));
     }
 
-    impl_block(ast, enm, Trait::FromBytes, FieldBounds::ALL_SELF, SelfBounds::None, None, None)
+    Ok(impl_block(ast, enm, Trait::FromBytes, FieldBounds::ALL_SELF, SelfBounds::None, None, None))
 }
 
 // Returns `None` if the enum's size is not guaranteed by the repr.
-fn enum_size_from_repr(reprs: &[EnumRepr]) -> Option<usize> {
-    match reprs {
-        [EnumRepr::U8] | [EnumRepr::I8] => Some(8),
-        [EnumRepr::U16] | [EnumRepr::I16] => Some(16),
-        _ => None,
+fn enum_size_from_repr(repr: &EnumRepr) -> Result<usize, Error> {
+    use {CompoundRepr::*, PrimitiveRepr::*, Repr::*};
+    match repr {
+        Transparent(span)
+        | Compound(
+            Spanned { t: C | Rust | Primitive(U32 | I32 | U64 | I64 | Usize | Isize), span },
+            _,
+        ) => Err(Error::new(*span, "`FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`")),
+        Compound(Spanned { t: Primitive(U8 | I8), span: _ }, _align) => Ok(8),
+        Compound(Spanned { t: Primitive(U16 | I16), span: _ }, _align) => Ok(16),
     }
 }
 
-#[rustfmt::skip]
-const ENUM_FROM_BYTES_CFG: Config<EnumRepr> = {
-    use EnumRepr::*;
-    Config {
-        allowed_combinations_message: r#"FromBytes requires repr of "u8", "u16", "i8", or "i16""#,
-        derive_unaligned: false,
-        allowed_combinations: &[
-            &[U8],
-            &[U16],
-            &[I8],
-            &[I16],
-        ],
-        disallowed_but_legal_combinations: &[
-            &[C],
-            &[U32],
-            &[I32],
-            &[U64],
-            &[I64],
-            &[Usize],
-            &[Isize],
-        ],
-    }
-};
-
 /// Unions are `FromBytes` if
 /// - all fields are `FromBytes` and `Immutable`
-fn derive_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
+fn derive_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> TokenStream {
     // TODO(#5): Remove the `Immutable` bound. It's only necessary for
     // compatibility with `derive(TryFromBytes)` on unions; not for soundness.
     let field_type_trait_bounds =
@@ -789,13 +745,15 @@ fn derive_from_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::T
     impl_block(ast, unn, Trait::FromBytes, field_type_trait_bounds, SelfBounds::None, None, None)
 }
 
-fn derive_into_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
-    let reprs = try_or_print!(STRUCT_UNION_INTO_BYTES_CFG.validate_reprs(ast));
-    let is_transparent = reprs.contains(&StructRepr::Transparent);
-    let is_packed = reprs.contains(&StructRepr::Packed);
+fn derive_into_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> Result<TokenStream, Error> {
+    let repr = StructUnionRepr::from_attrs(&ast.attrs)?;
+
+    let is_transparent = repr.is_transparent();
+    let is_c = repr.is_c();
+    let is_packed_1 = repr.is_packed_1();
     let num_fields = strct.fields().len();
 
-    let (padding_check, require_unaligned_fields) = if is_transparent || is_packed {
+    let (padding_check, require_unaligned_fields) = if is_transparent || is_packed_1 {
         // No padding check needed.
         // - repr(transparent): The layout and ABI of the whole struct is the
         //   same as its only non-ZST field (meaning there's no padding outside
@@ -806,20 +764,20 @@ fn derive_into_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro
         //   which we require to be `IntoBytes` (meaning they don't have any
         //   padding).
         (None, false)
-    } else if reprs.contains(&StructRepr::C) && num_fields <= 1 {
+    } else if is_c && num_fields <= 1 {
         // No padding check needed. A repr(C) struct with zero or one field has
         // no padding.
+        //
+        // TODO(#1763): This is probably unsound! Fix it.
         (None, false)
     } else if ast.generics.params.is_empty() {
         // Since there are no generics, we can emit a padding check. This is
         // more permissive than the next case, which requires that all field
         // types implement `Unaligned`.
+        //
+        // TODO(#1764): This is probably unsound! Fix it.
         (Some(PaddingCheck::Struct), false)
-    } else {
-        // Based on the allowed reprs, we know that this type must be repr(C) by
-        // the time we get here, but the soundness of this impl relies on it, so
-        // let's double-check.
-        assert!(reprs.contains(&StructRepr::C));
+    } else if is_c {
         // We can't use a padding check since there are generic type arguments.
         // Instead, we require all field types to implement `Unaligned`. This
         // ensures that the `repr(C)` layout algorithm will not insert any
@@ -827,7 +785,11 @@ fn derive_into_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro
         //
         // TODO(#10): Support type parameters for non-transparent, non-packed
         // structs without requiring `Unaligned`.
+        //
+        // TODO(#1763): This is probably unsound! Fix it.
         (None, true)
+    } else {
+        return Err(Error::new(Span::call_site(), "must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout"));
     };
 
     let field_bounds = if require_unaligned_fields {
@@ -836,32 +798,30 @@ fn derive_into_bytes_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro
         FieldBounds::ALL_SELF
     };
 
-    impl_block(ast, strct, Trait::IntoBytes, field_bounds, SelfBounds::None, padding_check, None)
+    Ok(impl_block(
+        ast,
+        strct,
+        Trait::IntoBytes,
+        field_bounds,
+        SelfBounds::None,
+        padding_check,
+        None,
+    ))
 }
-
-const STRUCT_UNION_INTO_BYTES_CFG: Config<StructRepr> = Config {
-    // Since `disallowed_but_legal_combinations` is empty, this message will
-    // never actually be emitted.
-    allowed_combinations_message: r#"IntoBytes requires either a) repr "C" or "transparent" with all fields implementing IntoBytes or, b) repr "packed""#,
-    derive_unaligned: false,
-    allowed_combinations: STRUCT_UNION_ALLOWED_REPR_COMBINATIONS,
-    disallowed_but_legal_combinations: &[],
-};
 
 /// If the type is an enum:
 /// - It must have a defined representation (`repr`s `C`, `u8`, `u16`, `u32`,
 ///   `u64`, `usize`, `i8`, `i16`, `i32`, `i64`, or `isize`).
 /// - It must have no padding bytes.
 /// - Its fields must be `IntoBytes`.
-fn derive_into_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::TokenStream {
-    // We don't care what the repr is; we only care that it is one of the
-    // allowed ones.
-    let reprs = try_or_print!(ENUM_FROM_ZEROS_INTO_BYTES_CFG.validate_reprs(ast));
-    let repr = r#enum::tag_repr(&reprs)
-        .expect("cannot derive IntoBytes for enum without a well-defined repr");
-    let tag_type_definition = r#enum::generate_tag_enum(repr, enm);
+fn derive_into_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> Result<TokenStream, Error> {
+    let repr = EnumRepr::from_attrs(&ast.attrs)?;
+    if !repr.is_c() && !repr.is_primitive() {
+        return Err(Error::new(Span::call_site(), "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout"));
+    }
 
-    impl_block(
+    let tag_type_definition = r#enum::generate_tag_enum(&repr, enm);
+    Ok(impl_block(
         ast,
         enm,
         Trait::IntoBytes,
@@ -869,58 +829,25 @@ fn derive_into_bytes_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::Tok
         SelfBounds::None,
         Some(PaddingCheck::Enum { tag_type_definition }),
         None,
-    )
+    ))
 }
-
-#[rustfmt::skip]
-const ENUM_FROM_ZEROS_INTO_BYTES_CFG: Config<EnumRepr> = {
-    use EnumRepr::*;
-    Config {
-        // Since `disallowed_but_legal_combinations` is empty, this message will
-        // never actually be emitted.
-        allowed_combinations_message: r#"FromZeros requires an enum repr of a primitive, "C", or "C" with a primitive"#,
-        derive_unaligned: false,
-        allowed_combinations: &[
-            &[U8],
-            &[U16],
-            &[U32],
-            &[U64],
-            &[Usize],
-            &[I8],
-            &[I16],
-            &[I32],
-            &[I64],
-            &[Isize],
-            &[C],
-            &[C, U8],
-            &[C, U16],
-            &[C, U32],
-            &[C, U64],
-            &[C, Usize],
-            &[C, I8],
-            &[C, I16],
-            &[C, I32],
-            &[C, I64],
-            &[C, Isize],
-        ],
-        disallowed_but_legal_combinations: &[],
-    }
-};
 
 /// A union is `IntoBytes` if:
 /// - all fields are `IntoBytes`
 /// - `repr(C)`, `repr(transparent)`, or `repr(packed)`
 /// - no padding (size of union equals size of each field type)
-fn derive_into_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
+fn derive_into_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> Result<TokenStream, Error> {
     // TODO(#10): Support type parameters.
     if !ast.generics.params.is_empty() {
-        return Error::new(Span::call_site(), "unsupported on types with type parameters")
-            .to_compile_error();
+        return Err(Error::new(Span::call_site(), "unsupported on types with type parameters"));
     }
 
-    try_or_print!(STRUCT_UNION_INTO_BYTES_CFG.validate_reprs(ast));
+    let repr = StructUnionRepr::from_attrs(&ast.attrs)?;
+    if !repr.is_c() && !repr.is_transparent() && !repr.is_packed_1() {
+        return Err(Error::new(Span::call_site(), "must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout"));
+    }
 
-    impl_block(
+    Ok(impl_block(
         ast,
         unn,
         Trait::IntoBytes,
@@ -928,7 +855,7 @@ fn derive_into_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::T
         SelfBounds::None,
         Some(PaddingCheck::Union),
         None,
-    )
+    ))
 }
 
 /// A struct is `Unaligned` if:
@@ -936,87 +863,61 @@ fn derive_into_bytes_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::T
 ///   - `repr(C)` or `repr(transparent)` and
 ///     - all fields `Unaligned`
 ///   - `repr(packed)`
-fn derive_unaligned_struct(ast: &DeriveInput, strct: &DataStruct) -> proc_macro2::TokenStream {
-    let reprs = try_or_print!(STRUCT_UNION_UNALIGNED_CFG.validate_reprs(ast));
-    let field_bounds = if !reprs.contains(&StructRepr::Packed) {
+fn derive_unaligned_struct(ast: &DeriveInput, strct: &DataStruct) -> Result<TokenStream, Error> {
+    let repr = StructUnionRepr::from_attrs(&ast.attrs)?;
+    repr.unaligned_validate_no_align_gt_1()?;
+
+    let field_bounds = if repr.is_packed_1() {
+        FieldBounds::None
+    } else if repr.is_c() || repr.is_transparent() {
         FieldBounds::ALL_SELF
     } else {
-        FieldBounds::None
+        return Err(Error::new(Span::call_site(), "must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment"));
     };
 
-    impl_block(ast, strct, Trait::Unaligned, field_bounds, SelfBounds::None, None, None)
+    Ok(impl_block(ast, strct, Trait::Unaligned, field_bounds, SelfBounds::None, None, None))
 }
-
-const STRUCT_UNION_UNALIGNED_CFG: Config<StructRepr> = Config {
-    // Since `disallowed_but_legal_combinations` is empty, this message will
-    // never actually be emitted.
-    allowed_combinations_message: r#"Unaligned requires either a) repr "C" or "transparent" with all fields implementing Unaligned or, b) repr "packed""#,
-    derive_unaligned: true,
-    allowed_combinations: STRUCT_UNION_ALLOWED_REPR_COMBINATIONS,
-    disallowed_but_legal_combinations: &[],
-};
 
 /// An enum is `Unaligned` if:
 /// - No `repr(align(N > 1))`
 /// - `repr(u8)` or `repr(i8)`
-fn derive_unaligned_enum(ast: &DeriveInput, enm: &DataEnum) -> proc_macro2::TokenStream {
-    // The only valid reprs are `u8` and `i8`, and optionally `align(1)`. We
-    // don't actually care what the reprs are so long as they satisfy that
-    // requirement.
-    let _: Vec<repr::EnumRepr> = try_or_print!(ENUM_UNALIGNED_CFG.validate_reprs(ast));
+fn derive_unaligned_enum(ast: &DeriveInput, enm: &DataEnum) -> Result<TokenStream, Error> {
+    let repr = EnumRepr::from_attrs(&ast.attrs)?;
+    repr.unaligned_validate_no_align_gt_1()?;
 
-    impl_block(ast, enm, Trait::Unaligned, FieldBounds::ALL_SELF, SelfBounds::None, None, None)
-}
-
-#[rustfmt::skip]
-const ENUM_UNALIGNED_CFG: Config<EnumRepr> = {
-    use EnumRepr::*;
-    Config {
-        allowed_combinations_message:
-            r#"Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))"#,
-        derive_unaligned: true,
-        allowed_combinations: &[
-            &[U8],
-            &[I8],
-            &[C, U8],
-            &[C, I8],
-        ],
-        disallowed_but_legal_combinations: &[
-            &[U16],
-            &[U32],
-            &[U64],
-            &[Usize],
-            &[I16],
-            &[I32],
-            &[I64],
-            &[Isize],
-            &[C],
-            &[C, U16],
-            &[C, U32],
-            &[C, U64],
-            &[C, Usize],
-            &[C, I16],
-            &[C, I32],
-            &[C, I64],
-            &[C, Isize],
-        ],
+    if !repr.is_u8() && !repr.is_i8() {
+        return Err(Error::new(Span::call_site(), "must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment"));
     }
-};
+
+    Ok(impl_block(ast, enm, Trait::Unaligned, FieldBounds::ALL_SELF, SelfBounds::None, None, None))
+}
 
 /// Like structs, a union is `Unaligned` if:
 /// - `repr(align)` is no more than 1 and either
 ///   - `repr(C)` or `repr(transparent)` and
 ///     - all fields `Unaligned`
 ///   - `repr(packed)`
-fn derive_unaligned_union(ast: &DeriveInput, unn: &DataUnion) -> proc_macro2::TokenStream {
-    let reprs = try_or_print!(STRUCT_UNION_UNALIGNED_CFG.validate_reprs(ast));
-    let field_type_trait_bounds = if !reprs.contains(&StructRepr::Packed) {
+fn derive_unaligned_union(ast: &DeriveInput, unn: &DataUnion) -> Result<TokenStream, Error> {
+    let repr = StructUnionRepr::from_attrs(&ast.attrs)?;
+    repr.unaligned_validate_no_align_gt_1()?;
+
+    let field_type_trait_bounds = if repr.is_packed_1() {
+        FieldBounds::None
+    } else if repr.is_c() || repr.is_transparent() {
         FieldBounds::ALL_SELF
     } else {
-        FieldBounds::None
+        return Err(Error::new(Span::call_site(), "must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment"));
     };
 
-    impl_block(ast, unn, Trait::Unaligned, field_type_trait_bounds, SelfBounds::None, None, None)
+    Ok(impl_block(
+        ast,
+        unn,
+        Trait::Unaligned,
+        field_type_trait_bounds,
+        SelfBounds::None,
+        None,
+        None,
+    ))
 }
 
 /// This enum describes what kind of padding check needs to be generated for the
@@ -1128,8 +1029,8 @@ fn impl_block<D: DataExt>(
     field_type_trait_bounds: FieldBounds,
     self_type_trait_bounds: SelfBounds,
     padding_check: Option<PaddingCheck>,
-    extras: Option<proc_macro2::TokenStream>,
-) -> proc_macro2::TokenStream {
+    extras: Option<TokenStream>,
+) -> TokenStream {
     // In this documentation, we will refer to this hypothetical struct:
     //
     //   #[derive(FromBytes)]
@@ -1290,10 +1191,6 @@ fn impl_block<D: DataExt>(
     }
 }
 
-fn print_all_errors(errors: Vec<Error>) -> proc_macro2::TokenStream {
-    errors.iter().map(Error::to_compile_error).collect()
-}
-
 // A polyfill for `Option::then_some`, which was added after our MSRV.
 //
 // The `#[allow(unused)]` is necessary because, on sufficiently recent toolchain
@@ -1313,57 +1210,5 @@ impl BoolExt for bool {
         } else {
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_config_repr_orderings() {
-        // Validate that the repr lists in the various configs are in the
-        // canonical order. If they aren't, then our algorithm to look up in
-        // those lists won't work.
-
-        // TODO(https://github.com/rust-lang/rust/issues/53485): Remove once
-        // `Vec::is_sorted` is stabilized.
-        fn is_sorted_and_deduped<T: Clone + Ord>(ts: &[T]) -> bool {
-            let mut sorted = ts.to_vec();
-            sorted.sort();
-            sorted.dedup();
-            ts == sorted.as_slice()
-        }
-
-        fn elements_are_sorted_and_deduped<T: Clone + Ord>(lists: &[&[T]]) -> bool {
-            lists.iter().all(|list| is_sorted_and_deduped(list))
-        }
-
-        fn config_is_sorted<T: KindRepr + Clone>(config: &Config<T>) -> bool {
-            elements_are_sorted_and_deduped(config.allowed_combinations)
-                && elements_are_sorted_and_deduped(config.disallowed_but_legal_combinations)
-        }
-
-        assert!(config_is_sorted(&STRUCT_UNION_UNALIGNED_CFG));
-        assert!(config_is_sorted(&ENUM_FROM_BYTES_CFG));
-        assert!(config_is_sorted(&ENUM_UNALIGNED_CFG));
-    }
-
-    #[test]
-    fn test_config_repr_no_overlap() {
-        // Validate that no set of reprs appears in both the
-        // `allowed_combinations` and `disallowed_but_legal_combinations` lists.
-
-        fn overlap<T: Eq>(a: &[T], b: &[T]) -> bool {
-            a.iter().any(|elem| b.contains(elem))
-        }
-
-        fn config_overlaps<T: KindRepr + Eq>(config: &Config<T>) -> bool {
-            overlap(config.allowed_combinations, config.disallowed_but_legal_combinations)
-        }
-
-        assert!(!config_overlaps(&STRUCT_UNION_UNALIGNED_CFG));
-        assert!(!config_overlaps(&ENUM_FROM_BYTES_CFG));
-        assert!(!config_overlaps(&ENUM_UNALIGNED_CFG));
     }
 }

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -6,6 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
+use crate::IntoTokenStream;
 use dissimilar::Chunk;
 use proc_macro2::TokenStream;
 
@@ -52,7 +53,7 @@ macro_rules! test {
             let ast = syn::parse2::<syn::DeriveInput>(ts).unwrap();
             let res = $name(&ast);
             let expected_toks = quote::quote!( $($o)* );
-            assert_eq_streams(expected_toks.into(), res.into());
+            assert_eq_streams(expected_toks.into(), res.into_ts().into());
         }
     };
 }

--- a/zerocopy-derive/src/repr.rs
+++ b/zerocopy-derive/src/repr.rs
@@ -6,202 +6,44 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use core::fmt::{self, Display, Formatter};
-
-use proc_macro2::Ident;
-use quote::{ToTokens, TokenStreamExt as _};
-
-use {
-    proc_macro2::Span,
-    syn::punctuated::Punctuated,
-    syn::spanned::Spanned,
-    syn::token::Comma,
-    syn::{Attribute, DeriveInput, Error, LitInt, Meta},
+use core::{
+    convert::{Infallible, TryFrom},
+    num::NonZeroU32,
 };
 
-pub(crate) struct Config<Repr: KindRepr> {
-    // A human-readable message describing what combinations of representations
-    // are allowed. This will be printed to the user if they use an invalid
-    // combination.
-    pub(crate) allowed_combinations_message: &'static str,
-    // Whether we're checking as part of `derive(Unaligned)`. If not, we can
-    // ignore `repr(align)`, which makes the code (and the list of valid repr
-    // combinations we have to enumerate) somewhat simpler. If we're checking
-    // for `Unaligned`, then in addition to checking against illegal
-    // combinations, we also check to see if there exists a `repr(align(N > 1))`
-    // attribute.
-    pub(crate) derive_unaligned: bool,
-    // Combinations which are valid for the trait.
-    pub(crate) allowed_combinations: &'static [&'static [Repr]],
-    // Combinations which are not valid for the trait, but are legal according
-    // to Rust. Any combination not in this or `allowed_combinations` is either
-    // illegal according to Rust or the behavior is unspecified. If the behavior
-    // is unspecified, it might become specified in the future, and that
-    // specification might not play nicely with our requirements. Thus, we
-    // reject combinations with unspecified behavior in addition to illegal
-    // combinations.
-    pub(crate) disallowed_but_legal_combinations: &'static [&'static [Repr]],
+use proc_macro2::{Span, TokenStream};
+use quote::{quote_spanned, ToTokens, TokenStreamExt as _};
+use syn::{
+    punctuated::Punctuated, spanned::Spanned as _, token::Comma, Attribute, Error, LitInt, Meta,
+    MetaList,
+};
+
+/// The computed representation of a type.
+///
+/// This is the result of processing all `#[repr(...)]` attributes on a type, if
+/// any. A `Repr` is only capable of representing legal combinations of
+/// `#[repr(...)]` attributes.
+#[cfg_attr(test, derive(Copy, Clone, Debug))]
+pub(crate) enum Repr<Prim, Packed> {
+    /// `#[repr(transparent)]`
+    Transparent(Span),
+    /// A compound representation: `repr(C)`, `repr(Rust)`, or `repr(Int)`
+    /// optionally combined with `repr(packed(...))` or `repr(align(...))`
+    Compound(Spanned<CompoundRepr<Prim>>, Option<Spanned<AlignRepr<Packed>>>),
 }
 
-impl<R: KindRepr> Config<R> {
-    /// Validate that `input`'s representation attributes conform to the
-    /// requirements specified by this `Config`.
-    ///
-    /// `validate_reprs` extracts the `repr` attributes, validates that they
-    /// conform to the requirements of `self`, and returns them. Regardless of
-    /// whether `align` attributes are considered during validation, they are
-    /// stripped out of the returned value since no callers care about them.
-    pub(crate) fn validate_reprs(&self, input: &DeriveInput) -> Result<Vec<R>, Vec<Error>> {
-        let mut metas_reprs = reprs(&input.attrs)?;
-        metas_reprs.sort_by(|a: &(_, R), b| a.1.partial_cmp(&b.1).unwrap());
-
-        if self.derive_unaligned {
-            if let Some((meta, _)) =
-                metas_reprs.iter().find(|&repr: &&(_, R)| repr.1.is_align_gt_one())
-            {
-                return Err(vec![Error::new_spanned(
-                    meta,
-                    "cannot derive Unaligned with repr(align(N > 1))",
-                )]);
-            }
-        }
-
-        let mut metas = Vec::new();
-        let mut reprs = Vec::new();
-        metas_reprs.into_iter().filter(|(_, repr)| !repr.is_align()).for_each(|(meta, repr)| {
-            metas.push(meta);
-            reprs.push(repr)
-        });
-
-        if reprs.is_empty() {
-            // Use `Span::call_site` to report this error on the
-            // `#[derive(...)]` itself.
-            return Err(vec![Error::new(Span::call_site(), "must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout")]);
-        }
-
-        let initial_sp = metas[0].span();
-        let err_span = metas.iter().skip(1).try_fold(initial_sp, |sp, meta| sp.join(meta.span()));
-
-        if self.allowed_combinations.contains(&reprs.as_slice()) {
-            Ok(reprs)
-        } else if self.disallowed_but_legal_combinations.contains(&reprs.as_slice()) {
-            Err(vec![Error::new(
-                err_span.unwrap_or_else(|| input.span()),
-                self.allowed_combinations_message,
-            )])
-        } else {
-            Err(vec![Error::new(
-                err_span.unwrap_or_else(|| input.span()),
-                "conflicting representation hints",
-            )])
-        }
-    }
+/// A compound representation: `repr(C)`, `repr(Rust)`, or `repr(Int)`.
+#[cfg_attr(test, derive(Copy, Clone, Debug, Eq, PartialEq))]
+pub(crate) enum CompoundRepr<Prim> {
+    C,
+    Rust,
+    Primitive(Prim),
 }
 
-// The type of valid reprs for a particular kind (enum, struct, union).
-pub(crate) trait KindRepr: 'static + Sized + Ord {
-    fn is_align(&self) -> bool;
-    fn is_align_gt_one(&self) -> bool;
-    fn parse(meta: &Meta) -> syn::Result<Self>;
-}
-
-// Defines an enum for reprs which are valid for a given kind (structs, enums,
-// etc), and provide implementations of `KindRepr`, `Ord`, and `Display`, and
-// those traits' super-traits.
-macro_rules! define_kind_specific_repr {
-    ($type_name:expr, $repr_name:ident, [ $($repr_variant:ident),* ] , [ $($repr_variant_aligned:ident),* ]) => {
-        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-        pub(crate) enum $repr_name {
-            $($repr_variant,)*
-            $($repr_variant_aligned(u64),)*
-        }
-
-        impl KindRepr for $repr_name {
-            fn is_align(&self) -> bool {
-                match self {
-                    $($repr_name::$repr_variant_aligned(_) => true,)*
-                    _ => false,
-                }
-            }
-
-            fn is_align_gt_one(&self) -> bool {
-                match self {
-                    // `packed(n)` only lowers alignment
-                    $repr_name::Align(n) => n > &1,
-                    _ => false,
-                }
-            }
-
-            fn parse(meta: &Meta) -> syn::Result<$repr_name> {
-                match Repr::from_meta(meta)? {
-                    $(Repr::$repr_variant => Ok($repr_name::$repr_variant),)*
-                    $(Repr::$repr_variant_aligned(u) => Ok($repr_name::$repr_variant_aligned(u)),)*
-                    _ => Err(Error::new_spanned(meta, concat!("unsupported representation for deriving zerocopy trait(s) on ", $type_name)))
-                }
-            }
-        }
-
-        // Define a stable ordering so we can canonicalize lists of reprs. The
-        // ordering itself doesn't matter so long as it's stable.
-        impl PartialOrd for $repr_name {
-            fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        impl Ord for $repr_name {
-            fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-                format!("{:?}", self).cmp(&format!("{:?}", other))
-            }
-        }
-
-        impl core::fmt::Display for $repr_name {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                match self {
-                    $($repr_name::$repr_variant => Repr::$repr_variant,)*
-                    $($repr_name::$repr_variant_aligned(u) => Repr::$repr_variant_aligned(*u),)*
-                }.fmt(f)
-            }
-        }
-    }
-}
-
-define_kind_specific_repr!("a struct", StructRepr, [C, Transparent, Packed], [Align, PackedN]);
-define_kind_specific_repr!(
-    "an enum",
-    EnumRepr,
-    [C, U8, U16, U32, U64, Usize, I8, I16, I32, I64, Isize],
-    [Align]
-);
-
-impl EnumRepr {
-    fn as_str(&self) -> &'static str {
-        match self {
-            EnumRepr::C => "C",
-            EnumRepr::U8 => "u8",
-            EnumRepr::U16 => "u16",
-            EnumRepr::U32 => "u32",
-            EnumRepr::U64 => "u64",
-            EnumRepr::Usize => "usize",
-            EnumRepr::I8 => "i8",
-            EnumRepr::I16 => "i16",
-            EnumRepr::I32 => "i32",
-            EnumRepr::I64 => "i64",
-            EnumRepr::Isize => "isize",
-            EnumRepr::Align(_) => unimplemented!("repr not yet supported"),
-        }
-    }
-}
-
-impl ToTokens for EnumRepr {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        tokens.append(Ident::new(self.as_str(), Span::call_site()));
-    }
-}
-
-// All representations known to Rust.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) enum Repr {
+/// `repr(Int)`
+#[derive(Copy, Clone)]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub(crate) enum PrimitiveRepr {
     U8,
     U16,
     U32,
@@ -212,128 +54,773 @@ pub(crate) enum Repr {
     I32,
     I64,
     Isize,
-    C,
-    Transparent,
-    Packed,
-    PackedN(u64),
-    Align(u64),
 }
 
-impl Repr {
-    fn from_meta(meta: &Meta) -> Result<Repr, Error> {
-        let (path, list) = match meta {
-            Meta::Path(path) => (path, None),
-            Meta::List(list) => (&list.path, Some(list)),
-            _ => return Err(Error::new_spanned(meta, "unrecognized representation hint")),
-        };
-
-        let ident = path
-            .get_ident()
-            .ok_or_else(|| Error::new_spanned(meta, "unrecognized representation hint"))?;
-
-        Ok(match (ident.to_string().as_str(), list) {
-            ("u8", None) => Repr::U8,
-            ("u16", None) => Repr::U16,
-            ("u32", None) => Repr::U32,
-            ("u64", None) => Repr::U64,
-            ("usize", None) => Repr::Usize,
-            ("i8", None) => Repr::I8,
-            ("i16", None) => Repr::I16,
-            ("i32", None) => Repr::I32,
-            ("i64", None) => Repr::I64,
-            ("isize", None) => Repr::Isize,
-            ("C", None) => Repr::C,
-            ("transparent", None) => Repr::Transparent,
-            ("packed", None) => Repr::Packed,
-            ("packed", Some(list)) => {
-                Repr::PackedN(list.parse_args::<LitInt>()?.base10_parse::<u64>()?)
-            }
-            ("align", Some(list)) => {
-                Repr::Align(list.parse_args::<LitInt>()?.base10_parse::<u64>()?)
-            }
-            _ => return Err(Error::new_spanned(meta, "unrecognized representation hint")),
-        })
-    }
+/// `repr(packed(...))` or `repr(align(...))`
+#[cfg_attr(test, derive(Copy, Clone, Debug, Eq, PartialEq))]
+pub(crate) enum AlignRepr<Packed> {
+    Packed(Packed),
+    Align(NonZeroU32),
 }
 
-impl KindRepr for Repr {
-    fn is_align(&self) -> bool {
-        false
-    }
+/// The representations which can legally appear on a struct or union type.
+pub(crate) type StructUnionRepr = Repr<Infallible, NonZeroU32>;
 
-    fn is_align_gt_one(&self) -> bool {
-        false
-    }
+/// The representations which can legally appear on an enum type.
+pub(crate) type EnumRepr = Repr<PrimitiveRepr, Infallible>;
 
-    fn parse(meta: &Meta) -> syn::Result<Self> {
-        Self::from_meta(meta)
-    }
-}
-
-impl Display for Repr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        if let Repr::Align(n) = self {
-            return write!(f, "repr(align({}))", n);
+impl<Prim, Packed> Repr<Prim, Packed> {
+    /// Gets the name of this "repr type" - the non-align `repr(X)` that is used
+    /// in prose to refer to this type.
+    ///
+    /// For example, we would refer to `#[repr(C, align(4))] struct Foo { ... }`
+    /// as a "`repr(C)` struct".
+    pub(crate) fn repr_type_name(&self) -> &str
+    where
+        Prim: Copy + With<PrimitiveRepr>,
+    {
+        use {CompoundRepr::*, PrimitiveRepr::*, Repr::*};
+        match self {
+            Transparent(_span) => "repr(transparent)",
+            Compound(Spanned { t: repr, span: _ }, _align) => match repr {
+                C => "repr(C)",
+                Rust => "repr(Rust)",
+                Primitive(prim) => prim.with(|prim| match prim {
+                    U8 => "repr(u8)",
+                    U16 => "repr(u16)",
+                    U32 => "repr(u32)",
+                    U64 => "repr(u64)",
+                    Usize => "repr(usize)",
+                    I8 => "repr(i8)",
+                    I16 => "repr(i16)",
+                    I32 => "repr(i32)",
+                    I64 => "repr(i64)",
+                    Isize => "repr(isize)",
+                }),
+            },
         }
-        if let Repr::PackedN(n) = self {
-            return write!(f, "repr(packed({}))", n);
+    }
+
+    pub(crate) fn is_transparent(&self) -> bool {
+        matches!(self, Repr::Transparent(_))
+    }
+
+    pub(crate) fn is_c(&self) -> bool {
+        use CompoundRepr::*;
+        matches!(self, Repr::Compound(Spanned { t: C, span: _ }, _align))
+    }
+
+    pub(crate) fn is_primitive(&self) -> bool {
+        use CompoundRepr::*;
+        matches!(self, Repr::Compound(Spanned { t: Primitive(_), span: _ }, _align))
+    }
+
+    pub(crate) fn get_packed(&self) -> Option<&Packed> {
+        use {AlignRepr::*, Repr::*};
+        if let Compound(_, Some(Spanned { t: Packed(p), span: _ })) = self {
+            Some(p)
+        } else {
+            None
         }
-        write!(
-            f,
-            "repr({})",
-            match self {
-                Repr::U8 => "u8",
-                Repr::U16 => "u16",
-                Repr::U32 => "u32",
-                Repr::U64 => "u64",
-                Repr::Usize => "usize",
-                Repr::I8 => "i8",
-                Repr::I16 => "i16",
-                Repr::I32 => "i32",
-                Repr::I64 => "i64",
-                Repr::Isize => "isize",
-                Repr::C => "C",
-                Repr::Transparent => "transparent",
-                Repr::Packed => "packed",
-                _ => unreachable!(),
-            }
-        )
+    }
+
+    pub(crate) fn get_align(&self) -> Option<Spanned<NonZeroU32>> {
+        use {AlignRepr::*, Repr::*};
+        if let Compound(_, Some(Spanned { t: Align(n), span })) = self {
+            Some(Spanned::new(*n, *span))
+        } else {
+            None
+        }
     }
 }
 
-pub(crate) fn reprs<R: KindRepr>(attrs: &[Attribute]) -> Result<Vec<(Meta, R)>, Vec<Error>> {
-    let mut reprs = Vec::new();
-    let mut errors = Vec::new();
-    for attr in attrs {
-        // Ignore documentation attributes.
-        if attr.path().is_ident("doc") {
-            continue;
+impl<Prim, Packed> Repr<Prim, Packed> {
+    /// When deriving `Unaligned`, validate that the decorated type has no
+    /// `#[repr(align(N))]` attribute where `N > 1`. If no such attribute exists
+    /// (including if `N == 1`), this returns `Ok(())`, and otherwise it returns
+    /// a descriptive error.
+    pub(crate) fn unaligned_validate_no_align_gt_1(&self) -> Result<(), Error> {
+        if let Some(n) = self.get_align().filter(|n| n.t.get() > 1) {
+            Err(Error::new(
+                n.span,
+                "cannot derive `Unaligned` on type with alignment greater than 1",
+            ))
+        } else {
+            Ok(())
         }
-        if let Meta::List(ref meta_list) = attr.meta {
-            if meta_list.path.is_ident("repr") {
-                let parsed: Punctuated<Meta, Comma> =
-                    match meta_list.parse_args_with(Punctuated::parse_terminated) {
-                        Ok(parsed) => parsed,
-                        Err(_) => {
-                            errors.push(Error::new_spanned(
-                                &meta_list.tokens,
-                                "unrecognized representation hint",
-                            ));
-                            continue;
-                        }
-                    };
-                for meta in parsed {
-                    match R::parse(&meta) {
-                        Ok(repr) => reprs.push((meta, repr)),
-                        Err(err) => errors.push(err),
-                    }
+    }
+}
+
+impl<Prim> Repr<Prim, NonZeroU32> {
+    /// Does `self` describe a `#[repr(packed)]` or `#[repr(packed(1))]` type?
+    pub(crate) fn is_packed_1(&self) -> bool {
+        self.get_packed().map(|n| n.get() == 1).unwrap_or(false)
+    }
+}
+
+impl<Packed> Repr<PrimitiveRepr, Packed> {
+    fn get_primitive(&self) -> Option<&PrimitiveRepr> {
+        use {CompoundRepr::*, Repr::*};
+        if let Compound(Spanned { t: Primitive(p), span: _ }, _align) = self {
+            Some(p)
+        } else {
+            None
+        }
+    }
+
+    /// Does `self` describe a `#[repr(u8)]` type?
+    pub(crate) fn is_u8(&self) -> bool {
+        matches!(self.get_primitive(), Some(PrimitiveRepr::U8))
+    }
+
+    /// Does `self` describe a `#[repr(i8)]` type?
+    pub(crate) fn is_i8(&self) -> bool {
+        matches!(self.get_primitive(), Some(PrimitiveRepr::I8))
+    }
+}
+
+impl<Prim, Packed> ToTokens for Repr<Prim, Packed>
+where
+    Prim: With<PrimitiveRepr> + Copy,
+    Packed: With<NonZeroU32> + Copy,
+{
+    fn to_tokens(&self, ts: &mut TokenStream) {
+        use Repr::*;
+        match self {
+            Transparent(span) => ts.append_all(quote_spanned! { *span=> #[repr(transparent)] }),
+            Compound(repr, align) => {
+                repr.to_tokens(ts);
+                if let Some(align) = align {
+                    align.to_tokens(ts);
                 }
             }
         }
     }
+}
 
-    if !errors.is_empty() {
-        return Err(errors);
+impl<Prim: With<PrimitiveRepr> + Copy> ToTokens for Spanned<CompoundRepr<Prim>> {
+    fn to_tokens(&self, ts: &mut TokenStream) {
+        use CompoundRepr::*;
+        match &self.t {
+            C => ts.append_all(quote_spanned! { self.span=> #[repr(C)] }),
+            Rust => ts.append_all(quote_spanned! { self.span=> #[repr(Rust)] }),
+            Primitive(prim) => prim.with(|prim| Spanned::new(prim, self.span).to_tokens(ts)),
+        }
     }
-    Ok(reprs)
+}
+
+impl ToTokens for Spanned<PrimitiveRepr> {
+    fn to_tokens(&self, ts: &mut TokenStream) {
+        use PrimitiveRepr::*;
+        match self.t {
+            U8 => ts.append_all(quote_spanned! { self.span => #[repr(u8)] }),
+            U16 => ts.append_all(quote_spanned! { self.span => #[repr(u16)] }),
+            U32 => ts.append_all(quote_spanned! { self.span => #[repr(u32)] }),
+            U64 => ts.append_all(quote_spanned! { self.span => #[repr(u64)] }),
+            Usize => ts.append_all(quote_spanned! { self.span => #[repr(usize)] }),
+            I8 => ts.append_all(quote_spanned! { self.span => #[repr(i8)] }),
+            I16 => ts.append_all(quote_spanned! { self.span => #[repr(i16)] }),
+            I32 => ts.append_all(quote_spanned! { self.span => #[repr(i32)] }),
+            I64 => ts.append_all(quote_spanned! { self.span => #[repr(i64)] }),
+            Isize => ts.append_all(quote_spanned! { self.span => #[repr(isize)] }),
+        }
+    }
+}
+
+impl<Packed: With<NonZeroU32> + Copy> ToTokens for Spanned<AlignRepr<Packed>> {
+    fn to_tokens(&self, ts: &mut TokenStream) {
+        use AlignRepr::*;
+        // We use `syn::Index` instead of `u32` because `quote_spanned!`
+        // serializes `u32` literals as `123u32`, not just `123`. Rust doesn't
+        // recognize that as a valid argument to `#[repr(align(...))]` or
+        // `#[repr(packed(...))]`.
+        let to_index = |n: NonZeroU32| syn::Index { index: n.get(), span: self.span };
+        match self.t {
+            Packed(n) => n.with(|n| {
+                let n = to_index(n);
+                ts.append_all(quote_spanned! { self.span => #[repr(packed(#n))] })
+            }),
+            Align(n) => {
+                let n = to_index(n);
+                ts.append_all(quote_spanned! { self.span => #[repr(align(#n))] })
+            }
+        }
+    }
+}
+
+/// The result of parsing a single `#[repr(...)]` attribute or a single
+/// directive inside a compound `#[repr(..., ...)]` attribute.
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(test, derive(Debug))]
+pub(crate) enum RawRepr {
+    Transparent,
+    C,
+    Rust,
+    U8,
+    U16,
+    U32,
+    U64,
+    Usize,
+    I8,
+    I16,
+    I32,
+    I64,
+    Isize,
+    Align(NonZeroU32),
+    PackedN(NonZeroU32),
+    Packed,
+}
+
+/// The error from converting from a `RawRepr`.
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub(crate) enum FromRawReprError<E> {
+    /// The `RawRepr` doesn't affect the high-level repr we're parsing (e.g.
+    /// it's `align(...)` and we're parsing a `CompoundRepr`).
+    None,
+    /// The `RawRepr` is invalid for the high-level repr we're parsing (e.g.
+    /// it's `packed` repr and we're parsing an `AlignRepr` for an enum type).
+    Err(E),
+}
+
+/// The representation hint is not supported for the decorated type.
+#[cfg_attr(test, derive(Copy, Clone, Debug, Eq, PartialEq))]
+pub(crate) struct UnsupportedReprError;
+
+impl<Prim: With<PrimitiveRepr>> TryFrom<RawRepr> for CompoundRepr<Prim> {
+    type Error = FromRawReprError<UnsupportedReprError>;
+    fn try_from(
+        raw: RawRepr,
+    ) -> Result<CompoundRepr<Prim>, FromRawReprError<UnsupportedReprError>> {
+        use RawRepr::*;
+        match raw {
+            C => Ok(CompoundRepr::C),
+            Rust => Ok(CompoundRepr::Rust),
+            raw @ (U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize) => {
+                Prim::try_with_or(
+                    || match raw {
+                        U8 => Ok(PrimitiveRepr::U8),
+                        U16 => Ok(PrimitiveRepr::U16),
+                        U32 => Ok(PrimitiveRepr::U32),
+                        U64 => Ok(PrimitiveRepr::U64),
+                        Usize => Ok(PrimitiveRepr::Usize),
+                        I8 => Ok(PrimitiveRepr::I8),
+                        I16 => Ok(PrimitiveRepr::I16),
+                        I32 => Ok(PrimitiveRepr::I32),
+                        I64 => Ok(PrimitiveRepr::I64),
+                        Isize => Ok(PrimitiveRepr::Isize),
+                        Transparent | C | Rust | Align(_) | PackedN(_) | Packed => {
+                            Err(UnsupportedReprError)
+                        }
+                    },
+                    UnsupportedReprError,
+                )
+                .map(CompoundRepr::Primitive)
+                .map_err(FromRawReprError::Err)
+            }
+            Transparent | Align(_) | PackedN(_) | Packed => Err(FromRawReprError::None),
+        }
+    }
+}
+
+impl<Pcked: With<NonZeroU32>> TryFrom<RawRepr> for AlignRepr<Pcked> {
+    type Error = FromRawReprError<UnsupportedReprError>;
+    fn try_from(raw: RawRepr) -> Result<AlignRepr<Pcked>, FromRawReprError<UnsupportedReprError>> {
+        use RawRepr::*;
+        match raw {
+            Packed | PackedN(_) => Pcked::try_with_or(
+                || match raw {
+                    Packed => Ok(NonZeroU32::new(1).unwrap()),
+                    PackedN(n) => Ok(n),
+                    U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize | Transparent
+                    | C | Rust | Align(_) => Err(UnsupportedReprError),
+                },
+                UnsupportedReprError,
+            )
+            .map(AlignRepr::Packed)
+            .map_err(FromRawReprError::Err),
+            Align(n) => Ok(AlignRepr::Align(n)),
+            U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize | Transparent | C
+            | Rust => Err(FromRawReprError::None),
+        }
+    }
+}
+
+/// The error from extracting a high-level repr type from a list of `RawRepr`s.
+#[cfg_attr(test, derive(Copy, Clone, Debug, Eq, PartialEq))]
+enum FromRawReprsError<E> {
+    /// One of the `RawRepr`s is invalid for the high-level repr we're parsing
+    /// (e.g. there's a `packed` repr and we're parsing an `AlignRepr` for an
+    /// enum type).
+    Single(E),
+    /// Two `RawRepr`s appear which both affect the high-level repr we're
+    /// parsing (e.g., the list is `#[repr(align(2), packed)]`). Note that we
+    /// conservatively treat redundant reprs as conflicting (e.g.
+    /// `#[repr(packed, packed)]`).
+    Conflict,
+}
+
+/// Tries to extract a high-level repr from a list of `RawRepr`s.
+fn try_from_raw_reprs<'a, E, R: TryFrom<RawRepr, Error = FromRawReprError<E>>>(
+    r: impl IntoIterator<Item = &'a Spanned<RawRepr>>,
+) -> Result<Option<Spanned<R>>, Spanned<FromRawReprsError<E>>> {
+    // Walk the list of `RawRepr`s and attempt to convert each to an `R`. Bail
+    // if we find any errors. If we find more than one which converts to an `R`,
+    // bail with a `Conflict` error.
+    r.into_iter().try_fold(None, |found: Option<Spanned<R>>, raw| {
+        let new = match Spanned::<R>::try_from(*raw) {
+            Ok(r) => r,
+            // This `RawRepr` doesn't convert to an `R`, so keep the current
+            // found `R`, if any.
+            Err(FromRawReprError::None) => return Ok(found),
+            // This repr is unsupported for the decorated type (e.g.
+            // `repr(packed)` on an enum).
+            Err(FromRawReprError::Err(Spanned { t: err, span })) => {
+                return Err(Spanned::new(FromRawReprsError::Single(err), span))
+            }
+        };
+
+        if let Some(found) = found {
+            // We already found an `R`, but this `RawRepr` also converts to an
+            // `R`, so that's a conflict.
+            //
+            // `Span::join` returns `None` if the two spans are from different
+            // files or if we're not on the nightly compiler. In that case, just
+            // use `new`'s span.
+            let span = found.span.join(new.span).unwrap_or(new.span);
+            Err(Spanned::new(FromRawReprsError::Conflict, span))
+        } else {
+            Ok(Some(new))
+        }
+    })
+}
+
+/// The error returned from [`Repr::from_attrs`].
+#[cfg_attr(test, derive(Copy, Clone, Debug, Eq, PartialEq))]
+enum FromAttrsError {
+    FromRawReprs(FromRawReprsError<UnsupportedReprError>),
+    Unrecognized,
+}
+
+impl From<FromRawReprsError<UnsupportedReprError>> for FromAttrsError {
+    fn from(err: FromRawReprsError<UnsupportedReprError>) -> FromAttrsError {
+        FromAttrsError::FromRawReprs(err)
+    }
+}
+
+impl From<UnrecognizedReprError> for FromAttrsError {
+    fn from(_err: UnrecognizedReprError) -> FromAttrsError {
+        FromAttrsError::Unrecognized
+    }
+}
+
+impl From<Spanned<FromAttrsError>> for Error {
+    fn from(err: Spanned<FromAttrsError>) -> Error {
+        let Spanned { t: err, span } = err;
+        match err {
+            FromAttrsError::FromRawReprs(FromRawReprsError::Single(
+                _err @ UnsupportedReprError,
+            )) => Error::new(span, "unsupported representation hint for the decorated type"),
+            FromAttrsError::FromRawReprs(FromRawReprsError::Conflict) => {
+                // NOTE: This says "another" rather than "a preceding" because
+                // when one of the reprs involved is `transparent`, we detect
+                // that condition in `Repr::from_attrs`, and at that point we
+                // can't tell which repr came first, so we might report this on
+                // the first involved repr rather than the second, third, etc.
+                Error::new(span, "this conflicts with another representation hint")
+            }
+            FromAttrsError::Unrecognized => Error::new(span, "unrecognized representation hint"),
+        }
+    }
+}
+
+impl<Prim, Packed> Repr<Prim, Packed> {
+    fn from_attrs_inner(attrs: &[Attribute]) -> Result<Repr<Prim, Packed>, Spanned<FromAttrsError>>
+    where
+        Prim: With<PrimitiveRepr>,
+        Packed: With<NonZeroU32>,
+    {
+        let raw_reprs = RawRepr::from_attrs(attrs).map_err(Spanned::from)?;
+
+        let transparent = {
+            let mut transparents = raw_reprs.iter().filter_map(|Spanned { t, span }| match t {
+                RawRepr::Transparent => Some(span),
+                _ => None,
+            });
+            let first = transparents.next();
+            let second = transparents.next();
+            match (first, second) {
+                (None, None) => None,
+                (Some(span), None) => Some(*span),
+                (Some(_), Some(second)) => {
+                    return Err(Spanned::new(
+                        FromAttrsError::FromRawReprs(FromRawReprsError::Conflict),
+                        *second,
+                    ))
+                }
+                // An iterator can't produce a value only on the second call to
+                // `.next()`.
+                (None, Some(_)) => unreachable!(),
+            }
+        };
+
+        let compound: Option<Spanned<CompoundRepr<Prim>>> =
+            try_from_raw_reprs(raw_reprs.iter()).map_err(Spanned::from)?;
+        let align: Option<Spanned<AlignRepr<Packed>>> =
+            try_from_raw_reprs(raw_reprs.iter()).map_err(Spanned::from)?;
+
+        if let Some(span) = transparent {
+            if compound.is_some() || align.is_some() {
+                // Arbitrarily report the problem on the `transparent` span. Any
+                // span will do.
+                return Err(Spanned::new(FromRawReprsError::Conflict.into(), span));
+            }
+
+            Ok(Repr::Transparent(span))
+        } else {
+            Ok(Repr::Compound(
+                compound.unwrap_or(Spanned::new(CompoundRepr::Rust, Span::call_site())),
+                align,
+            ))
+        }
+    }
+}
+
+impl<Prim, Packed> Repr<Prim, Packed> {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> Result<Repr<Prim, Packed>, Error>
+    where
+        Prim: With<PrimitiveRepr>,
+        Packed: With<NonZeroU32>,
+    {
+        Repr::from_attrs_inner(attrs).map_err(Into::into)
+    }
+}
+
+/// The representation hint could not be parsed or was unrecognized.
+struct UnrecognizedReprError;
+
+impl RawRepr {
+    fn from_attrs(
+        attrs: &[Attribute],
+    ) -> Result<Vec<Spanned<RawRepr>>, Spanned<UnrecognizedReprError>> {
+        let mut reprs = Vec::new();
+        for attr in attrs {
+            // Ignore documentation attributes.
+            if attr.path().is_ident("doc") {
+                continue;
+            }
+            if let Meta::List(ref meta_list) = attr.meta {
+                if meta_list.path.is_ident("repr") {
+                    let parsed: Punctuated<Meta, Comma> =
+                        match meta_list.parse_args_with(Punctuated::parse_terminated) {
+                            Ok(parsed) => parsed,
+                            Err(_) => {
+                                return Err(Spanned::new(
+                                    UnrecognizedReprError,
+                                    meta_list.tokens.span(),
+                                ))
+                            }
+                        };
+                    for meta in parsed {
+                        let s = meta.span();
+                        reprs.push(
+                            RawRepr::from_meta(&meta)
+                                .map(|r| Spanned::new(r, s))
+                                .map_err(|e| Spanned::new(e, s))?,
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(reprs)
+    }
+
+    fn from_meta(meta: &Meta) -> Result<RawRepr, UnrecognizedReprError> {
+        let (path, list) = match meta {
+            Meta::Path(path) => (path, None),
+            Meta::List(list) => (&list.path, Some(list)),
+            _ => return Err(UnrecognizedReprError),
+        };
+
+        let ident = path.get_ident().ok_or(UnrecognizedReprError)?;
+
+        // Only returns `Ok` for non-zero power-of-two values.
+        let parse_nzu64 = |list: &MetaList| {
+            list.parse_args::<LitInt>()
+                .and_then(|int| int.base10_parse::<NonZeroU32>())
+                .map_err(|_| UnrecognizedReprError)
+                .and_then(|nz| {
+                    if nz.get().is_power_of_two() {
+                        Ok(nz)
+                    } else {
+                        Err(UnrecognizedReprError)
+                    }
+                })
+        };
+
+        use RawRepr::*;
+        Ok(match (ident.to_string().as_str(), list) {
+            ("u8", None) => U8,
+            ("u16", None) => U16,
+            ("u32", None) => U32,
+            ("u64", None) => U64,
+            ("usize", None) => Usize,
+            ("i8", None) => I8,
+            ("i16", None) => I16,
+            ("i32", None) => I32,
+            ("i64", None) => I64,
+            ("isize", None) => Isize,
+            ("C", None) => C,
+            ("transparent", None) => Transparent,
+            ("Rust", None) => Rust,
+            ("packed", None) => Packed,
+            ("packed", Some(list)) => PackedN(parse_nzu64(list)?),
+            ("align", Some(list)) => Align(parse_nzu64(list)?),
+            _ => return Err(UnrecognizedReprError),
+        })
+    }
+}
+
+pub(crate) use util::*;
+mod util {
+    use super::*;
+    /// A value with an associated span.
+    #[derive(Copy, Clone)]
+    #[cfg_attr(test, derive(Debug))]
+    pub(crate) struct Spanned<T> {
+        pub(crate) t: T,
+        pub(crate) span: Span,
+    }
+
+    impl<T> Spanned<T> {
+        pub(super) fn new(t: T, span: Span) -> Spanned<T> {
+            Spanned { t, span }
+        }
+
+        pub(super) fn from<U>(s: Spanned<U>) -> Spanned<T>
+        where
+            T: From<U>,
+        {
+            let Spanned { t: u, span } = s;
+            Spanned::new(u.into(), span)
+        }
+
+        /// Delegates to `T: TryFrom`, preserving span information in both the
+        /// success and error cases.
+        pub(super) fn try_from<E, U>(
+            u: Spanned<U>,
+        ) -> Result<Spanned<T>, FromRawReprError<Spanned<E>>>
+        where
+            T: TryFrom<U, Error = FromRawReprError<E>>,
+        {
+            let Spanned { t: u, span } = u;
+            T::try_from(u).map(|t| Spanned { t, span }).map_err(|err| match err {
+                FromRawReprError::None => FromRawReprError::None,
+                FromRawReprError::Err(e) => FromRawReprError::Err(Spanned::new(e, span)),
+            })
+        }
+    }
+
+    // Used to permit implementing `With<T> for T: Inhabited` and for
+    // `Infallible` without a blanket impl conflict.
+    pub(crate) trait Inhabited {}
+    impl Inhabited for PrimitiveRepr {}
+    impl Inhabited for NonZeroU32 {}
+
+    pub(crate) trait With<T> {
+        fn with<O, F: FnOnce(T) -> O>(self, f: F) -> O;
+        fn try_with_or<E, F: FnOnce() -> Result<T, E>>(f: F, err: E) -> Result<Self, E>
+        where
+            Self: Sized;
+    }
+
+    impl<T: Inhabited> With<T> for T {
+        fn with<O, F: FnOnce(T) -> O>(self, f: F) -> O {
+            f(self)
+        }
+
+        fn try_with_or<E, F: FnOnce() -> Result<T, E>>(f: F, _err: E) -> Result<Self, E> {
+            f()
+        }
+    }
+
+    impl<T> With<T> for Infallible {
+        fn with<O, F: FnOnce(T) -> O>(self, _f: F) -> O {
+            match self {}
+        }
+
+        fn try_with_or<E, F: FnOnce() -> Result<T, E>>(_f: F, err: E) -> Result<Self, E> {
+            Err(err)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    impl<T> From<T> for Spanned<T> {
+        fn from(t: T) -> Spanned<T> {
+            Spanned::new(t, Span::call_site())
+        }
+    }
+
+    // We ignore spans for equality in testing since real spans are hard to
+    // synthesize and don't implement `PartialEq`.
+    impl<T: PartialEq> PartialEq for Spanned<T> {
+        fn eq(&self, other: &Spanned<T>) -> bool {
+            self.t.eq(&other.t)
+        }
+    }
+
+    impl<T: Eq> Eq for Spanned<T> {}
+
+    impl<Prim: PartialEq, Packed: PartialEq> PartialEq for Repr<Prim, Packed> {
+        fn eq(&self, other: &Repr<Prim, Packed>) -> bool {
+            match (self, other) {
+                (Repr::Transparent(_), Repr::Transparent(_)) => true,
+                (Repr::Compound(sc, sa), Repr::Compound(oc, oa)) => (sc, sa) == (oc, oa),
+                _ => false,
+            }
+        }
+    }
+
+    fn s() -> Span {
+        Span::call_site()
+    }
+
+    #[test]
+    fn test() {
+        // Test that a given `#[repr(...)]` attribute parses and returns the
+        // given `Repr` or error.
+        macro_rules! test {
+            ($(#[$attr:meta])* => $repr:expr) => {
+                test!(@inner $(#[$attr])* => Repr => Ok($repr));
+            };
+            // In the error case, the caller must explicitly provide the name of
+            // the `Repr` type to assist in type inference.
+            (@error $(#[$attr:meta])* => $typ:ident => $repr:expr) => {
+                test!(@inner $(#[$attr])* => $typ => Err($repr));
+            };
+            (@inner $(#[$attr:meta])* => $typ:ident => $repr:expr) => {
+                let attr: Attribute = parse_quote!($(#[$attr])*);
+                let mut got = $typ::from_attrs_inner(&[attr]);
+                let expect: Result<Repr<_, _>, _> = $repr;
+                if false {
+                    // Force Rust to infer `got` as having the same type as
+                    // `expect`.
+                    got = expect;
+                }
+                assert_eq!(got, expect, stringify!($(#[$attr])*));
+            };
+        }
+
+        use {AlignRepr::*, CompoundRepr::*, PrimitiveRepr::*};
+        let nz = |n: u32| NonZeroU32::new(n).unwrap();
+
+        test!(#[repr(transparent)] => StructUnionRepr::Transparent(s()));
+        test!(#[repr()] => StructUnionRepr::Compound(Rust.into(), None));
+        test!(#[repr(packed)] => StructUnionRepr::Compound(Rust.into(), Some(Packed(nz(1)).into())));
+        test!(#[repr(packed(2))] => StructUnionRepr::Compound(Rust.into(), Some(Packed(nz(2)).into())));
+        test!(#[repr(align(1))] => StructUnionRepr::Compound(Rust.into(), Some(Align(nz(1)).into())));
+        test!(#[repr(align(2))] => StructUnionRepr::Compound(Rust.into(), Some(Align(nz(2)).into())));
+        test!(#[repr(C)] => StructUnionRepr::Compound(C.into(), None));
+        test!(#[repr(C, packed)] => StructUnionRepr::Compound(C.into(), Some(Packed(nz(1)).into())));
+        test!(#[repr(C, packed(2))] => StructUnionRepr::Compound(C.into(), Some(Packed(nz(2)).into())));
+        test!(#[repr(C, align(1))] => StructUnionRepr::Compound(C.into(), Some(Align(nz(1)).into())));
+        test!(#[repr(C, align(2))] => StructUnionRepr::Compound(C.into(), Some(Align(nz(2)).into())));
+
+        test!(#[repr(transparent)] => EnumRepr::Transparent(s()));
+        test!(#[repr()] => EnumRepr::Compound(Rust.into(), None));
+        test!(#[repr(align(1))] => EnumRepr::Compound(Rust.into(), Some(Align(nz(1)).into())));
+        test!(#[repr(align(2))] => EnumRepr::Compound(Rust.into(), Some(Align(nz(2)).into())));
+
+        macro_rules! for_each_compound_repr {
+            ($($r:tt => $var:expr),*) => {
+                $(
+                    test!(#[repr($r)] => EnumRepr::Compound($var.into(), None));
+                    test!(#[repr($r, align(1))] => EnumRepr::Compound($var.into(), Some(Align(nz(1)).into())));
+                    test!(#[repr($r, align(2))] => EnumRepr::Compound($var.into(), Some(Align(nz(2)).into())));
+                )*
+            }
+        }
+
+        for_each_compound_repr!(
+            C => C,
+            u8 => Primitive(U8),
+            u16 => Primitive(U16),
+            u32 => Primitive(U32),
+            u64 => Primitive(U64),
+            usize => Primitive(Usize),
+            i8 => Primitive(I8),
+            i16 => Primitive(I16),
+            i32 => Primitive(I32),
+            i64 => Primitive(I64),
+            isize => Primitive(Isize)
+        );
+
+        use {FromAttrsError::*, FromRawReprsError::*};
+
+        // Run failure tests which are valid for both `StructUnionRepr` and
+        // `EnumRepr`.
+        macro_rules! for_each_repr_type {
+            ($($repr:ident),*) => {
+                $(
+                    // Invalid packed or align attributes
+                    test!(@error #[repr(packed(0))] => $repr => Unrecognized.into());
+                    test!(@error #[repr(packed(3))] => $repr => Unrecognized.into());
+                    test!(@error #[repr(align(0))] => $repr => Unrecognized.into());
+                    test!(@error #[repr(align(3))] => $repr => Unrecognized.into());
+
+                    // Conflicts
+                    test!(@error #[repr(transparent, transparent)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(transparent, C)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(transparent, Rust)] => $repr => FromRawReprs(Conflict).into());
+
+                    test!(@error #[repr(C, transparent)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(C, C)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(C, Rust)] => $repr => FromRawReprs(Conflict).into());
+
+                    test!(@error #[repr(Rust, transparent)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(Rust, C)] => $repr => FromRawReprs(Conflict).into());
+                    test!(@error #[repr(Rust, Rust)] => $repr => FromRawReprs(Conflict).into());
+                )*
+            }
+        }
+
+        for_each_repr_type!(StructUnionRepr, EnumRepr);
+
+        // Enum-specific conflicts.
+        //
+        // We don't bother to test every combination since that would be a huge
+        // number (enums can have primitive reprs u8, u16, u32, u64, usize, i8,
+        // i16, i32, i64, and isize). Instead, since the conflict logic doesn't
+        // care what specific value of `PrimitiveRepr` is present, we assume
+        // that testing against u8 alone is fine.
+        test!(@error #[repr(transparent, u8)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(u8, transparent)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(C, u8)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(u8, C)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(Rust, u8)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(u8, Rust)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(u8, u8)] => EnumRepr => FromRawReprs(Conflict).into());
+
+        // Illegal struct/union reprs
+        test!(@error #[repr(u8)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(u16)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(u32)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(u64)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(usize)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(i8)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(i16)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(i32)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(i64)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(isize)] => StructUnionRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+
+        // Illegal enum reprs
+        test!(@error #[repr(packed)] => EnumRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(packed(1))] => EnumRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+        test!(@error #[repr(packed(2))] => EnumRepr => FromRawReprs(Single(UnsupportedReprError)).into());
+    }
 }

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -10,19 +10,21 @@ error: unrecognized representation hint
 25 | #[repr(foo)]
    |        ^^^
 
-error: unsupported representation for deriving zerocopy trait(s) on an enum
-  --> tests/ui-msrv/enum.rs:31:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-msrv/enum.rs:30:10
    |
-31 | #[repr(transparent)]
-   |        ^^^^^^^^^^^
+30 | #[derive(FromBytes)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: conflicting representation hints
-  --> tests/ui-msrv/enum.rs:37:1
+error: this conflicts with another representation hint
+  --> tests/ui-msrv/enum.rs:37:12
    |
 37 | #[repr(u8, u16)]
-   | ^
+   |            ^^^
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:42:10
    |
 42 | #[derive(FromBytes)]
@@ -30,7 +32,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:69:10
    |
 69 | #[derive(TryFromBytes)]
@@ -38,7 +40,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:74:10
    |
 74 | #[derive(TryFromBytes)]
@@ -46,7 +48,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:92:10
    |
 92 | #[derive(FromZeros)]
@@ -54,7 +56,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-msrv/enum.rs:97:10
    |
 97 | #[derive(FromZeros)]
@@ -62,7 +64,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> tests/ui-msrv/enum.rs:103:10
     |
 103 | #[derive(FromZeros)]
@@ -101,125 +103,167 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
 138 | | }
     | |_^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:145:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-msrv/enum.rs:144:10
     |
-145 | #[repr(C)]
+144 | #[derive(FromBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:150:8
+    |
+150 | #[repr(C)]
     |        ^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:151:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:156:8
     |
-151 | #[repr(usize)]
+156 | #[repr(usize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:157:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:162:8
     |
-157 | #[repr(isize)]
+162 | #[repr(isize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:163:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:168:8
     |
-163 | #[repr(u32)]
+168 | #[repr(u32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:169:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:174:8
     |
-169 | #[repr(i32)]
+174 | #[repr(i32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:175:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:180:8
     |
-175 | #[repr(u64)]
+180 | #[repr(u64)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-msrv/enum.rs:181:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-msrv/enum.rs:186:8
     |
-181 | #[repr(i64)]
+186 | #[repr(i64)]
     |        ^^^
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:452:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:456:10
     |
-452 | #[repr(C)]
-    |        ^
+456 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:458:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:462:10
     |
-458 | #[repr(u16)]
-    |        ^^^
+462 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:464:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:468:10
     |
-464 | #[repr(i16)]
-    |        ^^^
+468 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:470:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:474:10
     |
-470 | #[repr(u32)]
-    |        ^^^
+474 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:476:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:480:10
     |
-476 | #[repr(i32)]
-    |        ^^^
+480 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:482:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:486:10
     |
-482 | #[repr(u64)]
-    |        ^^^
+486 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:488:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:492:10
     |
-488 | #[repr(i64)]
-    |        ^^^
+492 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:494:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:498:10
     |
-494 | #[repr(usize)]
-    |        ^^^^^
+498 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-msrv/enum.rs:500:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/enum.rs:504:10
     |
-500 | #[repr(isize)]
-    |        ^^^^^
+504 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:506:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-msrv/enum.rs:511:12
     |
-506 | #[repr(u8, align(2))]
-    |            ^^^^^^^^
+511 | #[repr(u8, align(2))]
+    |            ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:512:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-msrv/enum.rs:517:12
     |
-512 | #[repr(i8, align(2))]
-    |            ^^^^^^^^
+517 | #[repr(i8, align(2))]
+    |            ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:518:18
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/enum.rs:523:18
     |
-518 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+523 | #[repr(align(1), align(2))]
+    |                  ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/enum.rs:524:8
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/enum.rs:529:18
     |
-524 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+529 | #[repr(align(2), align(4))]
+    |                  ^^^^^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-msrv/enum.rs:562:10
+    |
+562 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-msrv/enum.rs:568:10
+    |
+568 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
    --> tests/ui-msrv/enum.rs:136:9
@@ -298,28 +342,19 @@ error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> tests/ui-msrv/enum.rs:133:10
-    |
-133 | #[derive(FromZeros)]
-    |          ^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotFromZeros`
-    |
-    = help: see issue #48214
-    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> tests/ui-msrv/enum.rs:186:10
+   --> tests/ui-msrv/enum.rs:191:10
     |
-186 | #[derive(FromBytes)]
+191 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, true>` is not satisfied
-   --> tests/ui-msrv/enum.rs:533:10
+   --> tests/ui-msrv/enum.rs:538:10
     |
-533 | #[derive(IntoBytes)]
+538 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -328,9 +363,9 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, true>` is not satisfi
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
-   --> tests/ui-msrv/enum.rs:544:10
+   --> tests/ui-msrv/enum.rs:549:10
     |
-544 | #[derive(IntoBytes)]
+549 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -339,9 +374,9 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfi
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfied
-   --> tests/ui-msrv/enum.rs:550:10
+   --> tests/ui-msrv/enum.rs:555:10
     |
-550 | #[derive(IntoBytes)]
+555 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
     |
     = help: the following implementations were found:

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -1,37 +1,81 @@
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/struct.rs:137:11
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:133:11
     |
-137 | #[repr(C, align(2))]
-    |           ^^^^^^^^
+133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+    |           ^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/struct.rs:141:21
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-msrv/struct.rs:151:10
     |
-141 | #[repr(transparent, align(2))]
-    |                     ^^^^^^^^
+151 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/struct.rs:147:16
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-msrv/struct.rs:156:10
     |
-147 | #[repr(packed, align(2))]
-    |                ^^^^^^^^
+156 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/struct.rs:151:18
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-msrv/struct.rs:167:11
     |
-151 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+167 | #[repr(C, align(2))]
+    |           ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-msrv/struct.rs:155:8
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:171:8
     |
-155 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+171 | #[repr(transparent, align(2))]
+    |        ^^^^^^^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:177:16
+    |
+177 | #[repr(packed, align(2))]
+    |                ^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:181:18
+    |
+181 | #[repr(align(1), align(2))]
+    |                  ^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:185:18
+    |
+185 | #[repr(align(2), align(4))]
+    |                  ^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/struct.rs:188:10
+    |
+188 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-msrv/struct.rs:191:10
+    |
+191 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: this conflicts with another representation hint
+   --> tests/ui-msrv/struct.rs:201:8
+    |
+201 | #[repr(C, packed(2))]
+    |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-msrv/struct.rs:141:8
+   --> tests/ui-msrv/struct.rs:171:8
     |
-141 | #[repr(transparent, align(2))]
+171 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -6,29 +6,45 @@ error: unsupported on types with type parameters
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: cannot derive `Unaligned` on type with alignment greater than 1
   --> tests/ui-msrv/union.rs:51:11
    |
 51 | #[repr(C, align(2))]
-   |           ^^^^^^^^
+   |           ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: this conflicts with another representation hint
   --> tests/ui-msrv/union.rs:67:16
    |
 67 | #[repr(packed, align(2))]
-   |                ^^^^^^^^
+   |                ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: this conflicts with another representation hint
   --> tests/ui-msrv/union.rs:73:18
    |
 73 | #[repr(align(1), align(2))]
-   |                  ^^^^^^^^
+   |                  ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-msrv/union.rs:79:8
+error: this conflicts with another representation hint
+  --> tests/ui-msrv/union.rs:79:18
    |
 79 | #[repr(align(2), align(4))]
-   |        ^^^^^^^^
+   |                  ^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-msrv/union.rs:84:10
+   |
+84 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-msrv/union.rs:90:10
+   |
+90 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/union.rs:24:10

--- a/zerocopy-derive/tests/ui-nightly/enum.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum.rs
@@ -142,44 +142,49 @@ enum FromZeros7 {
 //
 
 #[derive(FromBytes)]
-#[repr(C)]
 enum FromBytes1 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(usize)]
+#[repr(C)]
 enum FromBytes2 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(isize)]
+#[repr(usize)]
 enum FromBytes3 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(u32)]
+#[repr(isize)]
 enum FromBytes4 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(i32)]
+#[repr(u32)]
 enum FromBytes5 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(u64)]
+#[repr(i32)]
 enum FromBytes6 {
     A,
 }
 
 #[derive(FromBytes)]
-#[repr(i64)]
+#[repr(u64)]
 enum FromBytes7 {
+    A,
+}
+
+#[derive(FromBytes)]
+#[repr(i64)]
+enum FromBytes8 {
     A,
 }
 
@@ -552,4 +557,15 @@ enum IntoBytes2 {
 enum IntoBytes3 {
     A(u32),
     B(u16),
+}
+
+#[derive(IntoBytes)]
+enum IntoBytes4 {
+    A(u32),
+    B(u16),
+}
+
+#[derive(IntoBytes)]
+enum IntoBytes5 {
+    A(u32),
 }

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -10,19 +10,21 @@ error: unrecognized representation hint
 25 | #[repr(foo)]
    |        ^^^
 
-error: unsupported representation for deriving zerocopy trait(s) on an enum
-  --> tests/ui-nightly/enum.rs:31:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-nightly/enum.rs:30:10
    |
-31 | #[repr(transparent)]
-   |        ^^^^^^^^^^^
+30 | #[derive(FromBytes)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: conflicting representation hints
+error: this conflicts with another representation hint
   --> tests/ui-nightly/enum.rs:37:8
    |
 37 | #[repr(u8, u16)]
    |        ^^^^^^^
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:42:10
    |
 42 | #[derive(FromBytes)]
@@ -30,7 +32,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:69:10
    |
 69 | #[derive(TryFromBytes)]
@@ -38,7 +40,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:74:10
    |
 74 | #[derive(TryFromBytes)]
@@ -46,7 +48,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:92:10
    |
 92 | #[derive(FromZeros)]
@@ -54,7 +56,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-nightly/enum.rs:97:10
    |
 97 | #[derive(FromZeros)]
@@ -62,7 +64,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> tests/ui-nightly/enum.rs:103:10
     |
 103 | #[derive(FromZeros)]
@@ -101,125 +103,167 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
 138 | | }
     | |_^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:145:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-nightly/enum.rs:144:10
     |
-145 | #[repr(C)]
+144 | #[derive(FromBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:150:8
+    |
+150 | #[repr(C)]
     |        ^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:151:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:156:8
     |
-151 | #[repr(usize)]
+156 | #[repr(usize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:157:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:162:8
     |
-157 | #[repr(isize)]
+162 | #[repr(isize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:163:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:168:8
     |
-163 | #[repr(u32)]
+168 | #[repr(u32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:169:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:174:8
     |
-169 | #[repr(i32)]
+174 | #[repr(i32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:175:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:180:8
     |
-175 | #[repr(u64)]
+180 | #[repr(u64)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-nightly/enum.rs:181:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-nightly/enum.rs:186:8
     |
-181 | #[repr(i64)]
+186 | #[repr(i64)]
     |        ^^^
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:452:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:456:10
     |
-452 | #[repr(C)]
-    |        ^
+456 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:458:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:462:10
     |
-458 | #[repr(u16)]
-    |        ^^^
+462 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:464:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:468:10
     |
-464 | #[repr(i16)]
-    |        ^^^
+468 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:470:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:474:10
     |
-470 | #[repr(u32)]
-    |        ^^^
+474 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:476:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:480:10
     |
-476 | #[repr(i32)]
-    |        ^^^
+480 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:482:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:486:10
     |
-482 | #[repr(u64)]
-    |        ^^^
+486 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:488:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:492:10
     |
-488 | #[repr(i64)]
-    |        ^^^
+492 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:494:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:498:10
     |
-494 | #[repr(usize)]
-    |        ^^^^^
+498 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-nightly/enum.rs:500:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/enum.rs:504:10
     |
-500 | #[repr(isize)]
-    |        ^^^^^
+504 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:506:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-nightly/enum.rs:511:12
     |
-506 | #[repr(u8, align(2))]
+511 | #[repr(u8, align(2))]
     |            ^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:512:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-nightly/enum.rs:517:12
     |
-512 | #[repr(i8, align(2))]
+517 | #[repr(i8, align(2))]
     |            ^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:518:18
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/enum.rs:523:8
     |
-518 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+523 | #[repr(align(1), align(2))]
+    |        ^^^^^^^^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/enum.rs:524:8
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/enum.rs:529:8
     |
-524 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+529 | #[repr(align(2), align(4))]
+    |        ^^^^^^^^^^^^^^^^^^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-nightly/enum.rs:562:10
+    |
+562 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-nightly/enum.rs:568:10
+    |
+568 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0565]: meta item in `repr` must be an identifier
   --> tests/ui-nightly/enum.rs:19:8
@@ -365,34 +409,10 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9   + #![feature(trivial_bounds)]
     |
 
-error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> tests/ui-nightly/enum.rs:133:10
-    |
-133 | #[derive(FromZeros)]
-    |          ^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotFromZeros`
-    |
-    = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
-    = help: the following other types implement trait `TryFromBytes`:
-              ()
-              *const T
-              *mut T
-              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              AtomicBool
-              AtomicI16
-              AtomicI32
-            and $N others
-    = help: see issue #48214
-    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-    |
-9   + #![feature(trivial_bounds)]
-    |
-
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> tests/ui-nightly/enum.rs:186:10
+   --> tests/ui-nightly/enum.rs:191:10
     |
-186 | #[derive(FromBytes)]
+191 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -414,9 +434,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes1` has inter-field padding
-   --> tests/ui-nightly/enum.rs:533:10
+   --> tests/ui-nightly/enum.rs:538:10
     |
-533 | #[derive(IntoBytes)]
+538 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
@@ -432,9 +452,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes2` has inter-field padding
-   --> tests/ui-nightly/enum.rs:544:10
+   --> tests/ui-nightly/enum.rs:549:10
     |
-544 | #[derive(IntoBytes)]
+549 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
@@ -450,9 +470,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes3` has inter-field padding
-   --> tests/ui-nightly/enum.rs:550:10
+   --> tests/ui-nightly/enum.rs:555:10
     |
-550 | #[derive(IntoBytes)]
+555 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -129,6 +129,36 @@ struct IntoBytes4 {
     b: [u8],
 }
 
+#[derive(IntoBytes)]
+#[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+struct IntoBytes5 {
+    a: u8,
+}
+
+// TODO(#1764): This currently compiles, but maybe it shouldn't.
+#[derive(IntoBytes)]
+struct IntoBytes6 {
+    a: u8,
+}
+
+// TODO(#1764): This currently compiles, but maybe it shouldn't.
+#[derive(IntoBytes)]
+#[repr(packed(2))]
+struct IntoBytes7 {
+    a: u8,
+}
+
+#[derive(IntoBytes)]
+struct IntoBytes8<T> {
+    t: T,
+}
+
+#[derive(IntoBytes)]
+#[repr(packed(2))]
+struct IntoBytes9<T> {
+    t: T,
+}
+
 //
 // Unaligned errors
 //
@@ -154,3 +184,19 @@ struct Unaligned4;
 #[derive(Unaligned)]
 #[repr(align(2), align(4))]
 struct Unaligned5;
+
+#[derive(Unaligned)]
+struct Unaligned6;
+
+#[derive(Unaligned)]
+#[repr(packed(2))]
+struct Unaligned7;
+
+// Test the error message emitted when conflicting reprs appear on different
+// lines. On the nightly compiler, this emits a "joint span" that spans both
+// problematic repr token trees and everything in between.
+#[derive(Copy, Clone)]
+#[repr(packed(2), C)]
+#[derive(Unaligned)]
+#[repr(C, packed(2))]
+struct WeirdReprSpan;

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -1,37 +1,84 @@
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/struct.rs:137:11
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:133:8
     |
-137 | #[repr(C, align(2))]
+133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+    |        ^^^^
+
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-nightly/struct.rs:151:10
+    |
+151 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-nightly/struct.rs:156:10
+    |
+156 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-nightly/struct.rs:167:11
+    |
+167 | #[repr(C, align(2))]
     |           ^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/struct.rs:141:21
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:171:8
     |
-141 | #[repr(transparent, align(2))]
-    |                     ^^^^^^^^
+171 | #[repr(transparent, align(2))]
+    |        ^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/struct.rs:147:16
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:177:8
     |
-147 | #[repr(packed, align(2))]
-    |                ^^^^^^^^
+177 | #[repr(packed, align(2))]
+    |        ^^^^^^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/struct.rs:151:18
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:181:8
     |
-151 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+181 | #[repr(align(1), align(2))]
+    |        ^^^^^^^^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-nightly/struct.rs:155:8
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:185:8
     |
-155 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+185 | #[repr(align(2), align(4))]
+    |        ^^^^^^^^^^^^^^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/struct.rs:188:10
+    |
+188 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-nightly/struct.rs:191:10
+    |
+191 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: this conflicts with another representation hint
+   --> tests/ui-nightly/struct.rs:199:19
+    |
+199 |   #[repr(packed(2), C)]
+    |  ___________________^
+200 | | #[derive(Unaligned)]
+201 | | #[repr(C, packed(2))]
+    | |________^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-nightly/struct.rs:141:8
+   --> tests/ui-nightly/struct.rs:171:8
     |
-141 | #[repr(transparent, align(2))]
+171 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -313,7 +360,7 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |                             ^^^^^ required by this bound in `size_of`
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> tests/ui-nightly/struct.rs:148:1
+   --> tests/ui-nightly/struct.rs:178:1
     |
-148 | struct Unaligned3;
+178 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^

--- a/zerocopy-derive/tests/ui-nightly/union.rs
+++ b/zerocopy-derive/tests/ui-nightly/union.rs
@@ -80,3 +80,16 @@ struct Unaligned4 {
 struct Unaligned5 {
     foo: u8,
 }
+
+#[derive(Unaligned)]
+union Unaligned6 {
+    foo: i16,
+    bar: AU16,
+}
+
+#[derive(Unaligned)]
+#[repr(packed(2))]
+union Unaligned7 {
+    foo: i16,
+    bar: AU16,
+}

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -6,29 +6,45 @@ error: unsupported on types with type parameters
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: cannot derive `Unaligned` on type with alignment greater than 1
   --> tests/ui-nightly/union.rs:51:11
    |
 51 | #[repr(C, align(2))]
    |           ^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:67:16
+error: this conflicts with another representation hint
+  --> tests/ui-nightly/union.rs:67:8
    |
 67 | #[repr(packed, align(2))]
-   |                ^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-nightly/union.rs:73:18
+error: this conflicts with another representation hint
+  --> tests/ui-nightly/union.rs:73:8
    |
 73 | #[repr(align(1), align(2))]
-   |                  ^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: this conflicts with another representation hint
   --> tests/ui-nightly/union.rs:79:8
    |
 79 | #[repr(align(2), align(4))]
-   |        ^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-nightly/union.rs:84:10
+   |
+84 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-nightly/union.rs:90:10
+   |
+90 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-nightly/union.rs:24:10
@@ -78,3 +94,15 @@ error[E0587]: type has conflicting packed and align representation hints
    |
 68 | union Unaligned3 {
    | ^^^^^^^^^^^^^^^^
+
+error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
+  --> tests/ui-nightly/union.rs:92:1
+   |
+92 | union Unaligned7 {
+   | ^^^^^^^^^^^^^^^^
+   |
+note: `AU16` has a `#[repr(align)]` attribute
+  --> tests/ui-nightly/../include.rs
+   |
+   |     pub struct AU16(pub u16);
+   |     ^^^^^^^^^^^^^^^

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -10,19 +10,21 @@ error: unrecognized representation hint
 25 | #[repr(foo)]
    |        ^^^
 
-error: unsupported representation for deriving zerocopy trait(s) on an enum
-  --> tests/ui-stable/enum.rs:31:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+  --> tests/ui-stable/enum.rs:30:10
    |
-31 | #[repr(transparent)]
-   |        ^^^^^^^^^^^
+30 | #[derive(FromBytes)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: conflicting representation hints
-  --> tests/ui-stable/enum.rs:37:1
+error: this conflicts with another representation hint
+  --> tests/ui-stable/enum.rs:37:12
    |
 37 | #[repr(u8, u16)]
-   | ^
+   |            ^^^
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:42:10
    |
 42 | #[derive(FromBytes)]
@@ -30,7 +32,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:69:10
    |
 69 | #[derive(TryFromBytes)]
@@ -38,7 +40,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:74:10
    |
 74 | #[derive(TryFromBytes)]
@@ -46,7 +48,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:92:10
    |
 92 | #[derive(FromZeros)]
@@ -54,7 +56,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
   --> tests/ui-stable/enum.rs:97:10
    |
 97 | #[derive(FromZeros)]
@@ -62,7 +64,7 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
    |
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> tests/ui-stable/enum.rs:103:10
     |
 103 | #[derive(FromZeros)]
@@ -101,125 +103,167 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
 138 | | }
     | |_^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:145:8
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-stable/enum.rs:144:10
     |
-145 | #[repr(C)]
+144 | #[derive(FromBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:150:8
+    |
+150 | #[repr(C)]
     |        ^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:151:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:156:8
     |
-151 | #[repr(usize)]
+156 | #[repr(usize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:157:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:162:8
     |
-157 | #[repr(isize)]
+162 | #[repr(isize)]
     |        ^^^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:163:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:168:8
     |
-163 | #[repr(u32)]
+168 | #[repr(u32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:169:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:174:8
     |
-169 | #[repr(i32)]
+174 | #[repr(i32)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:175:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:180:8
     |
-175 | #[repr(u64)]
+180 | #[repr(u64)]
     |        ^^^
 
-error: FromBytes requires repr of "u8", "u16", "i8", or "i16"
-   --> tests/ui-stable/enum.rs:181:8
+error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
+   --> tests/ui-stable/enum.rs:186:8
     |
-181 | #[repr(i64)]
+186 | #[repr(i64)]
     |        ^^^
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:452:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:456:10
     |
-452 | #[repr(C)]
-    |        ^
+456 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:458:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:462:10
     |
-458 | #[repr(u16)]
-    |        ^^^
+462 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:464:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:468:10
     |
-464 | #[repr(i16)]
-    |        ^^^
+468 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:470:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:474:10
     |
-470 | #[repr(u32)]
-    |        ^^^
+474 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:476:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:480:10
     |
-476 | #[repr(i32)]
-    |        ^^^
+480 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:482:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:486:10
     |
-482 | #[repr(u64)]
-    |        ^^^
+486 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:488:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:492:10
     |
-488 | #[repr(i64)]
-    |        ^^^
+492 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:494:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:498:10
     |
-494 | #[repr(usize)]
-    |        ^^^^^
+498 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unaligned requires repr of "u8" or "i8", and no alignment (i.e., repr(align(N > 1)))
-   --> tests/ui-stable/enum.rs:500:8
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/enum.rs:504:10
     |
-500 | #[repr(isize)]
-    |        ^^^^^
+504 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/enum.rs:506:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-stable/enum.rs:511:12
     |
-506 | #[repr(u8, align(2))]
-    |            ^^^^^^^^
+511 | #[repr(u8, align(2))]
+    |            ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/enum.rs:512:12
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-stable/enum.rs:517:12
     |
-512 | #[repr(i8, align(2))]
-    |            ^^^^^^^^
+517 | #[repr(i8, align(2))]
+    |            ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/enum.rs:518:18
+error: this conflicts with another representation hint
+   --> tests/ui-stable/enum.rs:523:18
     |
-518 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+523 | #[repr(align(1), align(2))]
+    |                  ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/enum.rs:524:8
+error: this conflicts with another representation hint
+   --> tests/ui-stable/enum.rs:529:18
     |
-524 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+529 | #[repr(align(2), align(4))]
+    |                  ^^^^^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-stable/enum.rs:562:10
+    |
+562 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> tests/ui-stable/enum.rs:568:10
+    |
+568 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0565]: meta item in `repr` must be an identifier
   --> tests/ui-stable/enum.rs:19:8
@@ -345,30 +389,10 @@ error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> tests/ui-stable/enum.rs:133:10
-    |
-133 | #[derive(FromZeros)]
-    |          ^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotFromZeros`
-    |
-    = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
-    = help: the following other types implement trait `TryFromBytes`:
-              ()
-              *const T
-              *mut T
-              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              AtomicBool
-              AtomicI16
-              AtomicI32
-            and $N others
-    = help: see issue #48214
-    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> tests/ui-stable/enum.rs:186:10
+   --> tests/ui-stable/enum.rs:191:10
     |
-186 | #[derive(FromBytes)]
+191 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -386,9 +410,9 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes1` has inter-field padding
-   --> tests/ui-stable/enum.rs:533:10
+   --> tests/ui-stable/enum.rs:538:10
     |
-533 | #[derive(IntoBytes)]
+538 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
@@ -400,9 +424,9 @@ error[E0277]: `IntoBytes1` has inter-field padding
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes2` has inter-field padding
-   --> tests/ui-stable/enum.rs:544:10
+   --> tests/ui-stable/enum.rs:549:10
     |
-544 | #[derive(IntoBytes)]
+549 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
@@ -414,9 +438,9 @@ error[E0277]: `IntoBytes2` has inter-field padding
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes3` has inter-field padding
-   --> tests/ui-stable/enum.rs:550:10
+   --> tests/ui-stable/enum.rs:555:10
     |
-550 | #[derive(IntoBytes)]
+555 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -1,37 +1,81 @@
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/struct.rs:137:11
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:133:11
     |
-137 | #[repr(C, align(2))]
-    |           ^^^^^^^^
+133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+    |           ^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/struct.rs:141:21
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-stable/struct.rs:151:10
     |
-141 | #[repr(transparent, align(2))]
-    |                     ^^^^^^^^
+151 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/struct.rs:147:16
+error: must have a non-align #[repr(...)] attribute or #[repr(packed)] in order to guarantee this type's memory layout
+   --> tests/ui-stable/struct.rs:156:10
     |
-147 | #[repr(packed, align(2))]
-    |                ^^^^^^^^
+156 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/struct.rs:151:18
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> tests/ui-stable/struct.rs:167:11
     |
-151 | #[repr(align(1), align(2))]
-    |                  ^^^^^^^^
+167 | #[repr(C, align(2))]
+    |           ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-   --> tests/ui-stable/struct.rs:155:8
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:171:8
     |
-155 | #[repr(align(2), align(4))]
-    |        ^^^^^^^^
+171 | #[repr(transparent, align(2))]
+    |        ^^^^^^^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:177:16
+    |
+177 | #[repr(packed, align(2))]
+    |                ^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:181:18
+    |
+181 | #[repr(align(1), align(2))]
+    |                  ^^^^^
+
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:185:18
+    |
+185 | #[repr(align(2), align(4))]
+    |                  ^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/struct.rs:188:10
+    |
+188 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+   --> tests/ui-stable/struct.rs:191:10
+    |
+191 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: this conflicts with another representation hint
+   --> tests/ui-stable/struct.rs:201:8
+    |
+201 | #[repr(C, packed(2))]
+    |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-stable/struct.rs:141:8
+   --> tests/ui-stable/struct.rs:171:8
     |
-141 | #[repr(transparent, align(2))]
+171 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -277,7 +321,7 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |                             ^^^^^ required by this bound in `size_of`
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> tests/ui-stable/struct.rs:148:1
+   --> tests/ui-stable/struct.rs:178:1
     |
-148 | struct Unaligned3;
+178 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^

--- a/zerocopy-derive/tests/ui-stable/union.stderr
+++ b/zerocopy-derive/tests/ui-stable/union.stderr
@@ -6,29 +6,45 @@ error: unsupported on types with type parameters
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: cannot derive `Unaligned` on type with alignment greater than 1
   --> tests/ui-stable/union.rs:51:11
    |
 51 | #[repr(C, align(2))]
-   |           ^^^^^^^^
+   |           ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: this conflicts with another representation hint
   --> tests/ui-stable/union.rs:67:16
    |
 67 | #[repr(packed, align(2))]
-   |                ^^^^^^^^
+   |                ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
+error: this conflicts with another representation hint
   --> tests/ui-stable/union.rs:73:18
    |
 73 | #[repr(align(1), align(2))]
-   |                  ^^^^^^^^
+   |                  ^^^^^
 
-error: cannot derive Unaligned with repr(align(N > 1))
-  --> tests/ui-stable/union.rs:79:8
+error: this conflicts with another representation hint
+  --> tests/ui-stable/union.rs:79:18
    |
 79 | #[repr(align(2), align(4))]
-   |        ^^^^^^^^
+   |                  ^^^^^
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-stable/union.rs:84:10
+   |
+84 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
+  --> tests/ui-stable/union.rs:90:10
+   |
+90 | #[derive(Unaligned)]
+   |          ^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satisfied
   --> tests/ui-stable/union.rs:24:10
@@ -70,3 +86,15 @@ error[E0587]: type has conflicting packed and align representation hints
    |
 68 | union Unaligned3 {
    | ^^^^^^^^^^^^^^^^
+
+error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
+  --> tests/ui-stable/union.rs:92:1
+   |
+92 | union Unaligned7 {
+   | ^^^^^^^^^^^^^^^^
+   |
+note: `AU16` has a `#[repr(align)]` attribute
+  --> tests/ui-stable/../include.rs
+   |
+   |     pub struct AU16(pub u16);
+   |     ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Represent the result of parsing all `#[repr(...)]` attributes on a type as a high-level type which is only capable of representing valid combinations of `#[repr(...)]` attributes and processes them into a concise representation that's easier for high-level code to work with.

This prepares us to more easily fix https://github.com/google/zerocopy/issues/1748.

While we're here, we make a number of other improvements.

1) Errors are now converted to `TokenStream`s as late as possible rather than as early as possible, which was the previous behavior. This allows us to bail early when deriving an implied trait fails (e.g., deriving `TryFromBytes` when the user wrote `#[derive(FromZeros)]`).
2) Avoid re-computing some repr information in `TryFromBytes` enum support.