### PR TITLE
aarch64 fix for big endian types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,6 +575,40 @@ jobs:
           # `roll-pinned-toolchain-versions.yml`.
           kani-version: 0.55.0
 
+  # NEON intrinsics are currently broken on big-endian platforms. [1] This test ensures
+  # that we don't accidentally attempt to compile these intrinsics on such platforms. We
+  # can't use this as part of the build matrix because rustup doesn't support the
+  # `aarch64_be-unknown-linux-gnu` target.
+  #
+  # [1] https://github.com/rust-lang/stdarch/issues/1484
+  check_be_aarch64:
+    runs-on: ubuntu-latest
+    name: Build (zerocopy / nightly / --simd / aarch64_be-unknown-linux-gnu)
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Configure environment variables
+        run: |
+          set -eo pipefail
+          ZC_TOOLCHAIN="$(./cargo.sh --version nightly)"
+          RUSTFLAGS="$RUSTFLAGS $ZC_NIGHTLY_RUSTFLAGS"
+          echo "RUSTFLAGS=$RUSTFLAGS" >> $GITHUB_ENV
+          echo "ZC_TOOLCHAIN=$ZC_TOOLCHAIN" >> $GITHUB_ENV
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+        with:
+          key: aarch64_be-unknown-linux-gnu
+      - name: Install stable Rust for use in 'cargo.sh'
+        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        with:
+          toolchain: stable
+      - name: Install Rust with nightly toolchain (${{ env.ZC_TOOLCHAIN }}) and target aarch64_be-unknown-linux-gnu
+        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        with:
+            toolchain: ${{ env.ZC_TOOLCHAIN }}
+            components: clippy, rust-src
+      - name: Check big endian for aarch64_be-unknown-linux-gnu target
+        run: ./cargo.sh +nightly build --target=aarch64_be-unknown-linux-gnu -Zbuild-std --features simd
+
   check_fmt:
     runs-on: ubuntu-latest
     name: Check Rust formatting
@@ -704,7 +738,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_fmt, check_readme, check_versions, generate_cache, check-all-toolchains-tested, check-job-dependencies, run-git-hooks]
+      needs: [build_test, kani,check_be_aarch64 , check_fmt, check_readme, check_versions, generate_cache, check-all-toolchains-tested, check-job-dependencies, run-git-hooks]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -934,7 +934,9 @@ mod simd {
         );
         #[cfg(zerocopy_aarch64_simd)]
         simd_arch_mod!(
-            #[cfg(target_arch = "aarch64")]
+            // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
+            // broken on big-endian platforms.
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
             aarch64, aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,
             int8x8x3_t, int8x8x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int16x4_t,
             int16x8_t, int32x2_t, int32x4_t, int64x1_t, int64x2_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t,


### PR DESCRIPTION
NEON intrinsics are not supported on aarch64 big endian targets. Change to use fall back types for big endian aarch64.
tested on aarch64_be-unknown-linux-gnu_ilp32 and aarch64_be-unknown-linux-gnu