### PR TITLE
src/impls.rs: don't attempt use of neon / SIMD on big-endian aarch64.

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -934,7 +934,7 @@ mod simd {
         );
         #[cfg(zerocopy_aarch64_simd)]
         simd_arch_mod!(
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
             aarch64, aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,
             int8x8x3_t, int8x8x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int16x4_t,
             int16x8_t, int32x2_t, int32x4_t, int64x1_t, int64x2_t, poly8x8_t, poly8x8x2_t, poly8x8x3_t,
@@ -1879,7 +1879,7 @@ mod tests {
                 vector_signed_long,
                 vector_unsigned_long
             );
-            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd))]
+            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd, target_endian = "little"))]
             #[rustfmt::skip]
             test_simd_arch_mod!(
                 aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,


### PR DESCRIPTION
Neon / SIMD is known to be problematical in rust, ref. https://github.com/rust-lang/stdarch/issues/1484, even though the CPU itself supports it.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
