### PR TITLE
Relax `pointer_to_metadata` preconditions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -758,7 +758,7 @@ pub unsafe trait KnownLayout {
     /// `pointer_to_metadata` always returns the correct metadata stored in
     /// `ptr`.
     #[doc(hidden)]
-    fn pointer_to_metadata(ptr: NonNull<Self>) -> Self::PointerMetadata;
+    fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata;
 
     /// Computes the length of the byte range addressed by `ptr`.
     ///
@@ -775,7 +775,7 @@ pub unsafe trait KnownLayout {
     #[must_use]
     #[inline(always)]
     fn size_of_val_raw(ptr: NonNull<Self>) -> Option<usize> {
-        let meta = Self::pointer_to_metadata(ptr);
+        let meta = Self::pointer_to_metadata(ptr.as_ptr());
         // SAFETY: `size_for_metadata` promises to only return `None` if the
         // resulting size would not fit in a `usize`.
         meta.size_for_metadata(Self::LAYOUT)
@@ -868,9 +868,9 @@ unsafe impl<T> KnownLayout for [T] {
     }
 
     #[inline(always)]
-    fn pointer_to_metadata(ptr: NonNull<[T]>) -> usize {
+    fn pointer_to_metadata(ptr: *mut [T]) -> usize {
         #[allow(clippy::as_conversions)]
-        let slc = ptr.as_ptr() as *const [()];
+        let slc = ptr as *const [()];
 
         // SAFETY:
         // - `()` has alignment 1, so `slc` is trivially aligned.

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1431,7 +1431,7 @@ mod _project {
         /// Unsafe code my rely on `trailing_slice_len` satisfying the above
         /// contract.
         pub(super) fn trailing_slice_len(&self) -> usize {
-            T::pointer_to_metadata(self.as_non_null())
+            T::pointer_to_metadata(self.as_non_null().as_ptr())
         }
     }
 
@@ -1760,7 +1760,9 @@ mod tests {
                                 }
 
                                 if let Some(want) = meta {
-                                    let got = KnownLayout::pointer_to_metadata(slf.as_non_null());
+                                    let got = KnownLayout::pointer_to_metadata(
+                                        slf.as_non_null().as_ptr(),
+                                    );
                                     assert_eq!(got, want);
                                 }
                             }
@@ -1775,7 +1777,8 @@ mod tests {
                             assert_eq!(len, bytes.len());
 
                             if let Some(want) = meta {
-                                let got = KnownLayout::pointer_to_metadata(slf.as_non_null());
+                                let got =
+                                    KnownLayout::pointer_to_metadata(slf.as_non_null().as_ptr());
                                 assert_eq!(got, want);
                             }
                         }
@@ -1859,7 +1862,10 @@ mod tests {
                     ptr.try_cast_into::<$ty, BecauseImmutable>(CastType::Prefix, Some($elems));
                 if let Some(expect) = $expect {
                     let (ptr, _) = res.unwrap();
-                    assert_eq!(KnownLayout::pointer_to_metadata(ptr.as_non_null()), expect);
+                    assert_eq!(
+                        KnownLayout::pointer_to_metadata(ptr.as_non_null().as_ptr()),
+                        expect
+                    );
                 } else {
                     let _ = res.unwrap_err();
                 }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -542,7 +542,7 @@ macro_rules! impl_known_layout {
                 }
 
                 #[inline(always)]
-                fn pointer_to_metadata(_ptr: NonNull<Self>) -> () {
+                fn pointer_to_metadata(_ptr: *mut Self) -> () {
                 }
             }
         };
@@ -589,10 +589,9 @@ macro_rules! unsafe_impl_known_layout {
                 }
 
                 #[inline(always)]
-                fn pointer_to_metadata(ptr: NonNull<Self>) -> Self::PointerMetadata {
-                    // SAFETY: `ptr` is non-null.
+                fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
                     #[allow(clippy::as_conversions)]
-                    let ptr = unsafe { NonNull::new_unchecked(ptr.as_ptr() as *mut $repr) };
+                    let ptr = ptr as *mut $repr;
                     <$repr>::pointer_to_metadata(ptr)
                 }
             }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -235,10 +235,8 @@ fn derive_known_layout_inner(ast: &DeriveInput, _top_level: Trait) -> Result<Tok
                 }
 
                 #[inline(always)]
-                fn pointer_to_metadata(ptr: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self>) -> Self::PointerMetadata {
-                    // SAFETY: `ptr` is non-null.
-                    let ptr = unsafe { ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(ptr.as_ptr() as *mut _) };
-                    <#trailing_field_ty>::pointer_to_metadata(ptr)
+                fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+                    <#trailing_field_ty>::pointer_to_metadata(ptr as *mut _)
                 }
             ),
         )
@@ -270,10 +268,7 @@ fn derive_known_layout_inner(ast: &DeriveInput, _top_level: Trait) -> Result<Tok
                 }
 
                 #[inline(always)]
-                fn pointer_to_metadata(
-                    _ptr: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self>,
-                ) -> () {
-                }
+                fn pointer_to_metadata(_ptr: *mut Self) -> () {}
             ),
         )
     };

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -121,10 +121,7 @@ fn test_known_layout() {
                 }
 
                 #[inline(always)]
-                fn pointer_to_metadata(
-                    _ptr: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self>,
-                ) -> () {
-                }
+                fn pointer_to_metadata(_ptr: *mut Self) -> () {}
             }
         } no_build
     }


### PR DESCRIPTION
Change argument type of `pointer_to_metadata` from `NonNull<Self>` to `*mut Self`, since the implementations of `pointer_to_metadata` do not actually require the argument to be non-null.

I anticipate this change will make future code less verbose, as many standard library APIs return raw pointers, not  `NonNull`; for example, `Box::into_raw`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
