### PR TITLE
Remove misleading doc-comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2947,9 +2947,6 @@ pub unsafe trait FromZeros: TryFromBytes {
     /// pre-zeroed memory, using `new_box_zeroed` (or related functions) may
     /// have performance benefits.
     ///
-    /// Note that `Box<Self>` can be converted to `Arc<Self>` and other
-    /// container types without reallocation.
-    ///
     /// # Errors
     ///
     /// Returns an error on allocation failure. Allocation failure is guaranteed


### PR DESCRIPTION
No such guarantee exists for conversion between `Box<T>` and `Arc<T>` and the current [^1] implementation *always* creates a new allocation. I'm not aware of other container types for which the comment is correct.

[^1]: https://doc.rust-lang.org/1.81.0/src/alloc/sync.rs.html#1950-1970
