### PR TITLE
Fix type arity error in padding check

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -1286,10 +1286,10 @@ fn impl_block<D: DataExt>(
             let t = tag.iter();
             parse_quote! {
                 (): ::zerocopy::util::macro_util::PaddingFree<
-                    #type_ident,
+                    Self,
                     {
                         #validator_context
-                        ::zerocopy::#validator_macro!(#type_ident, #(#t,)* #(#variant_types),*)
+                        ::zerocopy::#validator_macro!(Self, #(#t,)* #(#variant_types),*)
                     }
                 >
             }

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -322,8 +322,8 @@ fn test_into_bytes() {
                 u8: ::zerocopy::IntoBytes,
                 u8: ::zerocopy::IntoBytes,
                 (): ::zerocopy::util::macro_util::PaddingFree<
-                    Foo,
-                    { ::zerocopy::struct_has_padding!(Foo, [u8, u8]) },
+                    Self,
+                    { ::zerocopy::struct_has_padding!(Self, [u8, u8]) },
                 >,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -265,6 +265,14 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: generic parameters may not be used in const operations
+   --> tests/ui-msrv/enum.rs:576:7
+    |
+576 |     A(T),
+    |       ^ cannot perform const operation using `T`
+    |
+    = note: type parameters may not be used in const expressions
+
 error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
    --> tests/ui-msrv/enum.rs:136:9
     |
@@ -382,4 +390,17 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfi
     = help: the following implementations were found:
               <() as PaddingFree<T, false>>
     = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: generic `Self` types are currently not permitted in anonymous constants
+   --> tests/ui-msrv/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+note: not a concrete type
+   --> tests/ui-msrv/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/enum.rs
+++ b/zerocopy-derive/tests/ui-nightly/enum.rs
@@ -569,3 +569,9 @@ enum IntoBytes4 {
 enum IntoBytes5 {
     A(u32),
 }
+
+#[derive(IntoBytes)]
+#[repr(u8)]
+enum IntoBytes6<T> {
+    A(T),
+}

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -265,6 +265,15 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: generic parameters may not be used in const operations
+   --> tests/ui-nightly/enum.rs:576:7
+    |
+576 |     A(T),
+    |       ^ cannot perform const operation using `T`
+    |
+    = note: type parameters may not be used in const expressions
+    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
 error[E0565]: meta item in `repr` must be an identifier
   --> tests/ui-nightly/enum.rs:19:8
    |
@@ -486,6 +495,19 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 9   + #![feature(trivial_bounds)]
     |
+
+error: generic `Self` types are currently not permitted in anonymous constants
+   --> tests/ui-nightly/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+note: not a concrete type
+   --> tests/ui-nightly/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
    --> tests/ui-nightly/enum.rs:191:10

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -333,10 +333,10 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-nightly/struct.rs:127:8
+   --> tests/ui-nightly/struct.rs:125:10
     |
-127 | struct IntoBytes4 {
-    |        ^^^^^^^^^^ doesn't have a size known at compile-time
+125 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`, which is required by `IntoBytes4: macro_util::__size_of::Sized`
 note: required because it appears within the type `IntoBytes4`
@@ -350,6 +350,7 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |
     |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
    --> tests/ui-nightly/struct.rs:129:8

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -265,6 +265,14 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: generic parameters may not be used in const operations
+   --> tests/ui-stable/enum.rs:576:7
+    |
+576 |     A(T),
+    |       ^ cannot perform const operation using `T`
+    |
+    = note: type parameters may not be used in const expressions
+
 error[E0565]: meta item in `repr` must be an identifier
   --> tests/ui-stable/enum.rs:19:8
    |
@@ -449,6 +457,19 @@ error[E0277]: `IntoBytes3` has inter-field padding
     = note: consider using `#[repr(packed)]` to remove inter-field padding
     = help: the trait `PaddingFree<IntoBytes3, false>` is implemented for `()`
     = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: generic `Self` types are currently not permitted in anonymous constants
+   --> tests/ui-stable/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+note: not a concrete type
+   --> tests/ui-stable/enum.rs:573:10
+    |
+573 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -294,10 +294,10 @@ error[E0277]: `IntoBytes3` has inter-field padding
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-stable/struct.rs:127:8
+   --> tests/ui-stable/struct.rs:125:10
     |
-127 | struct IntoBytes4 {
-    |        ^^^^^^^^^^ doesn't have a size known at compile-time
+125 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`, which is required by `IntoBytes4: macro_util::__size_of::Sized`
 note: required because it appears within the type `IntoBytes4`
@@ -311,6 +311,7 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |
     |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
    --> tests/ui-stable/struct.rs:129:8


### PR DESCRIPTION
Use `Self` in padding check instead of type name.

Fixes #1642

Makes progress towards #671

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
