### PR TITLE
Fix roll-pinned-toolchain-versions

### DIFF
--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -92,6 +92,9 @@ jobs:
 
             # Confirm that the update didn't bork `Cargo.toml`.
             validate-file "$REGEX" Cargo.toml
+
+            export RUSTFLAGS='--cfg zerocopy_derive_union_into_bytes'
+
             # Run `cargo fix` in case there are any warnings or errors
             # introduced on this new toolchain that we can fix automatically.
             # This is best-effort, so we don't let failure cause the whole job


### PR DESCRIPTION
Pass `RUSTFLAGS='--cfg=zerocopy_derive_union_into_bytes'`

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
