### PR TITLE
[ci] Stop rolling toolchains on the 0.7 branch

### DIFF
--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: ["stable", "nightly"]
-        branch: ["main", "v0.7.x"]
+        branch: ["main"]
     name: Roll pinned toolchain ${{ matrix.toolchain }} version on ${{ matrix.branch }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
0.8 has been published, and 0.7 is no longer actively developed.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
