### PR TITLE
Implement `Hash` for `ByteOrder` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
@@ -77,13 +77,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.4", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.4", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
 
 [dev-dependencies]
 itertools = "0.11"
@@ -97,6 +97,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.4", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -63,6 +63,7 @@
 use core::{
     convert::{TryFrom, TryInto},
     fmt::{Binary, Debug, LowerHex, Octal, UpperHex},
+    hash::Hash,
     num::TryFromIntError,
 };
 
@@ -81,7 +82,7 @@ use super::*;
 ///
 /// [`U32<BigEndian>`]: U32
 pub trait ByteOrder:
-    Copy + Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd + private::Sealed
+    Copy + Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd + Hash + private::Sealed
 {
     #[doc(hidden)]
     const ORDER: Order;
@@ -104,7 +105,7 @@ pub enum Order {
 /// Big-endian byte order.
 ///
 /// See [`ByteOrder`] for more details.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum BigEndian {}
 
 impl ByteOrder for BigEndian {
@@ -121,7 +122,7 @@ impl Display for BigEndian {
 /// Little-endian byte order.
 ///
 /// See [`ByteOrder`] for more details.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum LittleEndian {}
 
 impl ByteOrder for LittleEndian {
@@ -1070,7 +1071,7 @@ mod tests {
     }
 
     trait ByteOrderType:
-        FromBytes + IntoBytes + Unaligned + Copy + Eq + Debug + From<Self::Native>
+        FromBytes + IntoBytes + Unaligned + Copy + Eq + Debug + Hash + From<Self::Native>
     {
         type Native: Native;
         type ByteArray: ByteArray;

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
The absence of these impls lead to the absence of `Hash` for the byteorder-aware numeric types.

Fixes #1871

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
