### PR TITLE
[ci] Don't run on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ name: Build & Tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - v0.6.x
   merge_group:
 
 permissions: read-all


### PR DESCRIPTION
We already have the merge queue; running on push is redundant.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
