### PR TITLE
Enable clippy::missing_const_for_fn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,6 @@ jobs:
           # which a particular feature is supported.
           "zerocopy-core-error",
           "zerocopy-diagnostic-on-unimplemented",
-          "zerocopy-generic-bounds-in-const-fn",
-          "zerocopy-target-has-atomics",
-          "zerocopy-aarch64-simd",
-          "zerocopy-panic-in-const-and-vec-try-reserve"
         ]
         target: [
           "i686-unknown-linux-gnu",
@@ -93,14 +89,6 @@ jobs:
             features: "--all-features"
           - toolchain: "zerocopy-diagnostic-on-unimplemented"
             features: "--all-features"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            features: "--all-features"
-          - toolchain: "zerocopy-target-has-atomics"
-            features: "--all-features"
-          - toolchain: "zerocopy-aarch64-simd"
-            features: "--all-features"
-          - toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
-            features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
           - crate: "zerocopy-derive"
@@ -117,36 +105,6 @@ jobs:
             toolchain: "zerocopy-core-error"
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-diagnostic-on-unimplemented"
-          - crate: "zerocopy-derive"
-            toolchain: "zerocopy-generic-bounds-in-const-fn"
-          - crate: "zerocopy-derive"
-            toolchain: "zerocopy-target-has-atomics"
-          - crate: "zerocopy-derive"
-            toolchain: "zerocopy-aarch64-simd"
-          - crate: "zerocopy-derive"
-            toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
-          # Exclude non-aarch64 targets from the `zerocopy-aarch64-simd`
-          # toolchain.
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "i686-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "x86_64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-aarch64-simd"
-            target: "wasm32-wasi"
           # Exclude most targets targets from the `zerocopy-core-error`
           # toolchain since the `zerocopy-core-error` feature is unrelated to
           # compilation target. This only leaves i686 and x86_64 targets.
@@ -189,28 +147,6 @@ jobs:
           - toolchain: "zerocopy-diagnostic-on-unimplemented"
             target: "thumbv6m-none-eabi"
           - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "wasm32-wasi"
-          # Exclude most targets targets from the
-          # `zerocopy-generic-bounds-in-const-fn` toolchain since the
-          # `zerocopy-generic-bounds-in-const-fn` feature is unrelated to
-          # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
-            target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
             target: "wasm32-wasi"
           # Exclude `thumbv6m-none-eabi` combined with any feature that implies
           # the `std` feature since `thumbv6m-none-eabi` does not include a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.5"
+version = "0.9.0-alpha.0"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
 keywords = ["cast", "convert", "transmute", "transmutation", "type-punning"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
-rust-version = "1.56.0"
+rust-version = "1.65.0"
 
 exclude = [".*"]
 
@@ -37,21 +37,6 @@ zerocopy-core-error = "1.81.0"
 
 # From 1.78.0, Rust supports the `#[diagnostic::on_unimplemented]` attribute.
 zerocopy-diagnostic-on-unimplemented = "1.78.0"
-
-# From 1.61.0, Rust supports generic types with trait bounds in `const fn`.
-zerocopy-generic-bounds-in-const-fn = "1.61.0"
-
-# From 1.60.0, Rust supports `cfg(target_has_atomics)`, which allows us to
-# detect whether a target supports particular sets of atomics.
-zerocopy-target-has-atomics = "1.60.0"
-
-# When the "simd" feature is enabled, include SIMD types from the
-# `core::arch::aarch64` module, which was stabilized in 1.59.0. On earlier Rust
-# versions, these types require the "simd-nightly" feature.
-zerocopy-aarch64-simd = "1.59.0"
-
-# Permit panicking in `const fn`s and calling `Vec::try_reserve`.
-zerocopy-panic-in-const-and-vec-try-reserve = "1.57.0"
 
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
@@ -77,13 +62,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.9.0-alpha.0", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.9.0-alpha.0", path = "zerocopy-derive" }
 
 [dev-dependencies]
 itertools = "0.11"
@@ -97,6 +82,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.9.0-alpha.0", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -967,6 +967,7 @@ module!(network_endian, NetworkEndian, "network-endian");
 module!(native_endian, NativeEndian, "native-endian");
 
 #[cfg(any(test, kani))]
+#[allow(clippy::missing_const_for_fn)]
 mod tests {
     use super::*;
 

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -539,33 +539,29 @@ example of how it can be used for parsing UDP packets.
         }
 
         impl<O: ByteOrder> $name<O> {
-            maybe_const_trait_bounded_fn! {
-                /// Constructs a new value, possibly performing an endianness
-                /// swap to guarantee that the returned value has endianness
-                /// `O`.
-                #[must_use = "has no side effects"]
-                #[inline(always)]
-                pub const fn new(n: $native) -> $name<O> {
-                    let bytes = match O::ORDER {
-                        Order::BigEndian => $to_be_fn(n),
-                        Order::LittleEndian => $to_le_fn(n),
-                    };
+            /// Constructs a new value, possibly performing an endianness
+            /// swap to guarantee that the returned value has endianness
+            /// `O`.
+            #[must_use = "has no side effects"]
+            #[inline(always)]
+            pub const fn new(n: $native) -> $name<O> {
+                let bytes = match O::ORDER {
+                    Order::BigEndian => $to_be_fn(n),
+                    Order::LittleEndian => $to_le_fn(n),
+                };
 
-                    $name(bytes, PhantomData)
-                }
+                $name(bytes, PhantomData)
             }
 
-            maybe_const_trait_bounded_fn! {
-                /// Returns the value as a primitive type, possibly performing
-                /// an endianness swap to guarantee that the return value has
-                /// the endianness of the native platform.
-                #[must_use = "has no side effects"]
-                #[inline(always)]
-                pub const fn get(self) -> $native {
-                    match O::ORDER {
-                        Order::BigEndian => $from_be_fn(self.0),
-                        Order::LittleEndian => $from_le_fn(self.0),
-                    }
+            /// Returns the value as a primitive type, possibly performing
+            /// an endianness swap to guarantee that the return value has
+            /// the endianness of the native platform.
+            #[must_use = "has no side effects"]
+            #[inline(always)]
+            pub const fn get(self) -> $native {
+                match O::ORDER {
+                    Order::BigEndian => $from_be_fn(self.0),
+                    Order::LittleEndian => $from_le_fn(self.0),
                 }
             }
 
@@ -1057,8 +1053,8 @@ mod tests {
         /// themselves. This method is like `assert_eq!`, but it treats NaN
         /// values as equal.
         fn assert_eq_or_nan(self, other: Self) {
-            let slf = (!self.is_nan()).then(|| self);
-            let other = (!other.is_nan()).then(|| other);
+            let slf = (!self.is_nan()).then_some(self);
+            let other = (!other.is_nan()).then_some(other);
             assert_eq!(slf, other);
         }
     }
@@ -1088,8 +1084,8 @@ mod tests {
         /// themselves. This method is like `assert_eq!`, but it treats NaN
         /// values as equal.
         fn assert_eq_or_nan(self, other: Self) {
-            let slf = (!self.get().is_nan()).then(|| self);
-            let other = (!other.get().is_nan()).then(|| other);
+            let slf = (!self.get().is_nan()).then_some(self);
+            let other = (!other.get().is_nan()).then_some(other);
             assert_eq!(slf, other);
         }
     }
@@ -1396,11 +1392,11 @@ mod tests {
                 // For `f32` and `f64`, NaN values are not considered equal to
                 // themselves. We store `Option<f32>`/`Option<f64>` and store
                 // NaN as `None` so they can still be compared.
-                let val_or_none = |t: T| (!T::Native::is_nan(t.get())).then(|| t.get());
+                let val_or_none = |t: T| (!T::Native::is_nan(t.get())).then_some(t.get());
                 let t_t_res = val_or_none(t_t_res);
                 let t_n_res = val_or_none(t_n_res);
                 let n_t_res = val_or_none(n_t_res);
-                let n_n_res = (!T::Native::is_nan(n_n_res)).then(|| n_n_res);
+                let n_n_res = (!T::Native::is_nan(n_n_res)).then_some(n_n_res);
                 assert_eq!(t_t_res, n_n_res);
                 assert_eq!(t_n_res, n_n_res);
                 assert_eq!(n_t_res, n_n_res);
@@ -1418,7 +1414,7 @@ mod tests {
                     // NaN as `None` so they can still be compared.
                     let t_t_res = val_or_none(t_t_res);
                     let t_n_res = val_or_none(t_n_res);
-                    let n_t_res = (!T::Native::is_nan(n_t_res)).then(|| n_t_res);
+                    let n_t_res = (!T::Native::is_nan(n_t_res)).then_some(n_t_res);
                     assert_eq!(t_t_res, n_n_res);
                     assert_eq!(t_n_res, n_n_res);
                     assert_eq!(n_t_res, n_n_res);

--- a/src/error.rs
+++ b/src/error.rs
@@ -302,7 +302,7 @@ impl<Src, Dst: ?Sized> AlignmentError<Src, Dst> {
         AlignmentError { src: f(self.src), dst: SendSyncPhantomData::default() }
     }
 
-    pub(crate) fn into<S, V>(self) -> ConvertError<Self, S, V> {
+    pub(crate) const fn into<S, V>(self) -> ConvertError<Self, S, V> {
         ConvertError::Alignment(self)
     }
 
@@ -463,7 +463,7 @@ impl<Src, Dst: ?Sized> SizeError<Src, Dst> {
     }
 
     /// Converts the error into a general [`ConvertError`].
-    pub(crate) fn into<A, V>(self) -> ConvertError<A, Self, V> {
+    pub(crate) const fn into<A, V>(self) -> ConvertError<A, Self, V> {
         ConvertError::Size(self)
     }
 
@@ -595,7 +595,7 @@ impl<Src, Dst: ?Sized + TryFromBytes> ValidityError<Src, Dst> {
     }
 
     /// Converts the error into a general [`ConvertError`].
-    pub(crate) fn into<A, S>(self) -> ConvertError<A, S, Self> {
+    pub(crate) const fn into<A, S>(self) -> ConvertError<A, S, Self> {
         ConvertError::Validity(self)
     }
 
@@ -957,6 +957,7 @@ pub type AlignedTryCastError<Src, Dst: ?Sized + TryFromBytes> =
 pub struct AllocError;
 
 #[cfg(test)]
+#[allow(clippy::missing_const_for_fn)]
 mod tests {
     use super::*;
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -441,15 +441,12 @@ safety_comment! {
     unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => Immutable for opt_extern_c_fn!(...));
 }
 
-#[cfg(all(
-    zerocopy_target_has_atomics,
-    any(
-        target_has_atomic = "8",
-        target_has_atomic = "16",
-        target_has_atomic = "32",
-        target_has_atomic = "64",
-        target_has_atomic = "ptr"
-    )
+#[cfg(any(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
 ))]
 mod atomics {
     use super::*;
@@ -933,7 +930,6 @@ mod simd {
             #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
             powerpc64, powerpc64, vector_bool_long, vector_double, vector_signed_long, vector_unsigned_long
         );
-        #[cfg(zerocopy_aarch64_simd)]
         simd_arch_mod!(
             // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
             // broken on big-endian platforms.
@@ -1882,7 +1878,7 @@ mod tests {
                 vector_signed_long,
                 vector_unsigned_long
             );
-            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd))]
+            #[cfg(target_arch = "aarch64")]
             #[rustfmt::skip]
             test_simd_arch_mod!(
                 aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3141,7 +3141,6 @@ pub unsafe trait FromZeros: TryFromBytes {
 
     /// Extends a `Vec<Self>` by pushing `additional` new items onto the end of
     /// the vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     #[inline(always)]
@@ -3160,7 +3159,6 @@ pub unsafe trait FromZeros: TryFromBytes {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     #[inline]
@@ -5362,13 +5360,11 @@ pub unsafe trait Unaligned {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
 mod alloc_support {
     use super::*;
 
     /// Extends a `Vec<T>` by pushing `additional` new items onto the end of the
     /// vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5385,7 +5381,6 @@ mod alloc_support {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5399,7 +5394,6 @@ mod alloc_support {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
 #[doc(hidden)]
 pub use alloc_support::*;
 
@@ -6262,7 +6256,6 @@ mod tests {
     mod alloc {
         use super::*;
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         #[test]
         fn test_extend_vec_zeroed() {
             // Test extending when there is an existing allocation.
@@ -6280,7 +6273,6 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         #[test]
         fn test_extend_vec_zeroed_zst() {
             // Test extending when there is an existing (fake) allocation.
@@ -6297,7 +6289,6 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         #[test]
         fn test_insert_vec_zeroed() {
             // Insert at start (no existing allocation).
@@ -6329,7 +6320,6 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
         #[test]
         fn test_insert_vec_zeroed_zst() {
             // Insert at start (no existing fake allocation).

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -675,7 +675,7 @@ mod _transitions {
                 const IS_EXCLUSIVE: bool = {
                     let is_exclusive =
                         strs_are_equal(<Self as Aliasing>::NAME, <Exclusive as Aliasing>::NAME);
-                    const_assert!(is_exclusive);
+                    assert!(is_exclusive);
                     true
                 };
             }

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -75,7 +75,7 @@ mod def {
         /// [`deref`]: core::ops::Deref::deref
         /// [`deref_mut`]: core::ops::DerefMut::deref_mut
         /// [`into`]: core::convert::Into::into
-        pub(crate) unsafe fn new_unchecked(bytes: B) -> Ref<B, T> {
+        pub(crate) const unsafe fn new_unchecked(bytes: B) -> Ref<B, T> {
             // INVARIANTS: The caller has promised that `bytes`'s referent is
             // validly-aligned and has a valid size.
             Ref(bytes, PhantomData)

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -255,7 +255,7 @@ macro_rules! impl_for_transparent_wrapper {
                 impl_for_transparent_wrapper!(@define_is_transparent_wrapper $trait);
 
                 #[cfg_attr(coverage_nightly, coverage(off))]
-                fn f<I: Invariants, $($tyvar $(: $(? $optbound +)* $($bound +)*)?)?>() {
+                const fn f<I: Invariants, $($tyvar $(: $(? $optbound +)* $($bound +)*)?)?>() {
                     is_transparent_wrapper::<I, $ty>();
                 }
             }
@@ -327,7 +327,7 @@ macro_rules! impl_for_transparent_wrapper {
     };
     (@define_is_transparent_wrapper $trait:ident, $variance:ident) => {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        fn is_transparent_wrapper<I: Invariants, W: TransparentWrapper<I, $variance = Covariant> + ?Sized>()
+        const fn is_transparent_wrapper<I: Invariants, W: TransparentWrapper<I, $variance = Covariant> + ?Sized>()
         where
             W::Inner: $trait,
         {}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -756,6 +756,7 @@ pub(crate) mod polyfills {
 }
 
 #[cfg(test)]
+#[allow(clippy::missing_const_for_fn)]
 pub(crate) mod testutil {
     use crate::*;
 
@@ -845,6 +846,7 @@ pub(crate) mod testutil {
 }
 
 #[cfg(test)]
+#[allow(clippy::missing_const_for_fn)]
 mod tests {
     use super::*;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -373,15 +373,12 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for Unalign<T> {
 ///
 /// The caller promises that `$atomic` is an atomic type whose natie equivalent
 /// is `$native`.
-#[cfg(all(
-    zerocopy_target_has_atomics,
-    any(
-        target_has_atomic = "8",
-        target_has_atomic = "16",
-        target_has_atomic = "32",
-        target_has_atomic = "64",
-        target_has_atomic = "ptr"
-    )
+#[cfg(any(
+    target_has_atomic = "8",
+    target_has_atomic = "16",
+    target_has_atomic = "32",
+    target_has_atomic = "64",
+    target_has_atomic = "ptr"
 ))]
 macro_rules! unsafe_impl_transparent_wrapper_for_atomic {
     ($(#[$attr:meta])* $(,)?) => {};
@@ -635,7 +632,6 @@ pub(crate) const fn round_down_to_next_multiple_of_alignment(
     align: NonZeroUsize,
 ) -> usize {
     let align = align.get();
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
     debug_assert!(align.is_power_of_two());
 
     // Subtraction can't underflow because `align.get() >= 1`.
@@ -869,10 +865,9 @@ mod tests {
         }
     }
 
-    #[rustversion::since(1.57.0)]
     #[test]
     #[should_panic]
-    fn test_round_down_to_next_multiple_of_alignment_zerocopy_panic_in_const_and_vec_try_reserve() {
+    fn test_round_down_to_next_multiple_of_alignment_panics() {
         round_down_to_next_multiple_of_alignment(0, NonZeroUsize::new(3).unwrap());
     }
 }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -525,7 +525,7 @@ mod tests {
             let au64 = unsafe { x.t.deref_unchecked() };
             match au64 {
                 AU64(123) => {}
-                _ => const_unreachable!(),
+                _ => unreachable!(),
             }
         };
     }

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -393,9 +393,8 @@ impl<T> Unalign<T> {
 
 impl<T: Copy> Unalign<T> {
     /// Gets a copy of the inner `T`.
-    // TODO(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
     #[inline(always)]
-    pub fn get(&self) -> T {
+    pub const fn get(&self) -> T {
         let Unalign(val) = *self;
         val
     }

--- a/tests/ui-msrv/diagnostic-not-implemented-from-bytes.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-from-bytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
 18 |     takes_from_bytes::<NotZerocopy>();
    |                        ^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
 note: required by a bound in `takes_from_bytes`
   --> tests/ui-msrv/diagnostic-not-implemented-from-bytes.rs:21:24
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-from-zeros.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-from-zeros.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
 18 |     takes_from_zeros::<NotZerocopy>();
    |                        ^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `FromZeros`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `takes_from_zeros`
   --> tests/ui-msrv/diagnostic-not-implemented-from-zeros.rs:21:24
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-immutable.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-immutable.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Immutable` is not satisfie
 18 |     takes_immutable::<NotZerocopy>();
    |                       ^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
 note: required by a bound in `takes_immutable`
   --> tests/ui-msrv/diagnostic-not-implemented-immutable.rs:21:23
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-into-bytes.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-into-bytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
 18 |     takes_into_bytes::<NotZerocopy>();
    |                        ^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `takes_into_bytes`
   --> tests/ui-msrv/diagnostic-not-implemented-into-bytes.rs:21:24
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-issue-1296.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-issue-1296.stderr
@@ -2,10 +2,42 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Immutable` is not satisfie
   --> tests/ui-msrv/diagnostic-not-implemented-issue-1296.rs:52:19
    |
 52 |     Foo.write_obj(NotZerocopy(()));
-   |                   ^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
+   |         --------- ^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `Foo::write_obj`
+  --> tests/ui-msrv/diagnostic-not-implemented-issue-1296.rs:58:21
+   |
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+   |                     ^^^^^^^^^ required by this bound in `Foo::write_obj`
+help: consider borrowing here
+   |
+52 |     Foo.write_obj(&NotZerocopy(()));
+   |                   +
+52 |     Foo.write_obj(&mut NotZerocopy(()));
+   |                   ++++
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/diagnostic-not-implemented-issue-1296.rs:52:19
    |
 52 |     Foo.write_obj(NotZerocopy(()));
-   |                   ^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
+   |         --------- ^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
+   |         |
+   |         required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
+note: required by a bound in `Foo::write_obj`
+  --> tests/ui-msrv/diagnostic-not-implemented-issue-1296.rs:58:33
+   |
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+   |                                 ^^^^^^^^^ required by this bound in `Foo::write_obj`

--- a/tests/ui-msrv/diagnostic-not-implemented-known-layout.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-known-layout.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::KnownLayout` is not satisf
 18 |     takes_known_layout::<NotZerocopy>();
    |                          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::KnownLayout`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `takes_known_layout`
   --> tests/ui-msrv/diagnostic-not-implemented-known-layout.rs:21:26
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-try-from-bytes.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-try-from-bytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 18 |     takes_try_from_bytes::<NotZerocopy>();
    |                            ^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `takes_try_from_bytes`
   --> tests/ui-msrv/diagnostic-not-implemented-try-from-bytes.rs:21:28
    |

--- a/tests/ui-msrv/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-unaligned.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
 18 |     takes_unaligned::<NotZerocopy>();
    |                       ^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
 note: required by a bound in `takes_unaligned`
   --> tests/ui-msrv/diagnostic-not-implemented-unaligned.rs:21:23
    |

--- a/tests/ui-msrv/include_value_not_from_bytes.stderr
+++ b/tests/ui-msrv/include_value_not_from_bytes.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
   --> tests/ui-msrv/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
+   |                                          required by a bound introduced by this call
    |
-note: required by `AssertIsFromBytes`
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
+   = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/include_value_wrong_size.stderr
+++ b/tests/ui-msrv/include_value_wrong_size.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 4]` (32 bits)
    = note: target type: `u64` (64 bits)
-   = note: this error originates in the macro `$crate::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -7,9 +7,9 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
    |
 26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | ---------------------------------------------- in this macro invocation
+   | --------------------------------------------- in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::TryFromBytes` for `Foo<T>`
+note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -23,11 +23,12 @@ note: required by a bound in `_::Subtrait`
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
    |
 26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | ---------------------------------------------- in this macro invocation
+   | --------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
+  --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
    |
-26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
+   | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
    |                  ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
@@ -39,9 +40,9 @@ error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:1
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::FromZeros` for `Foo<T>`
+note: required for `Foo<T>` to implement `zerocopy::FromZeros`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -55,11 +56,12 @@ note: required by a bound in `_::Subtrait`
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:1
    |
 27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
+  --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
    |
-27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
    |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
@@ -71,9 +73,9 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:1
    |
 28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::FromBytes` for `Foo<T>`
+note: required for `Foo<T>` to implement `zerocopy::FromBytes`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -87,11 +89,12 @@ note: required by a bound in `_::Subtrait`
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:1
    |
 28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
+  --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
    |
-28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+   | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
    |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
@@ -103,9 +106,9 @@ error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:1
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `Foo<T>`
+note: required for `Foo<T>` to implement `zerocopy::IntoBytes`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:21
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -119,11 +122,12 @@ note: required by a bound in `_::Subtrait`
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:1
    |
 29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
+  --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
    |
-29 | impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
+   | impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
    |                  +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
@@ -135,9 +139,9 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:1
    |
 30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    |
-note: required because of the requirements on the impl of `zerocopy::Unaligned` for `Foo<T>`
+note: required for `Foo<T>` to implement `zerocopy::Unaligned`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:32
    |
 22 | #[derive(FromBytes, IntoBytes, Unaligned)]
@@ -151,9 +155,10 @@ note: required by a bound in `_::Subtrait`
   ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:1
    |
 30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+   | ------------------------------------------ in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
+  --> |$DIR/tests/ui-msrv/invalid-impls/invalid-impls.rs
    |
-30 | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+   | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
    |                  +++++++++++++++++++++

--- a/tests/ui-msrv/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-dst-not-frombytes.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
   --> tests/ui-msrv/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
+   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
+   |                                         required by a bound introduced by this call
    |
-note: required by `AssertIsFromBytes`
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required by a bound in `AssertIsFromBytes`
   --> tests/ui-msrv/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-alignment-increase.stderr
@@ -6,30 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0658]: mutable references are not allowed in constants
-  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:20:54
-   |
-20 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
-   |                                                      ^^^^^^^^^^^^^
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:20:39
-   |
-20 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0716]: temporary value dropped while borrowed
-  --> tests/ui-msrv/transmute-mut-alignment-increase.rs:20:59
-   |
-20 | const INCREASE_ALIGNMENT: &mut AU16 = transmute_mut!(&mut [0u8; 2]);
-   |                                       --------------------^^^^^^^^-
-   |                                       |                   |
-   |                                       |                   creates a temporary which is freed while still in use
-   |                                       temporary value is freed at the end of this statement
-   |                                       using this value as a constant requires that borrow lasts for `'static`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-const.stderr
+++ b/tests/ui-msrv/transmute-mut-const.stderr
@@ -11,7 +11,7 @@ note: `const` item defined here
   --> tests/ui-msrv/transmute-mut-const.rs:17:1
    |
 17 | const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: mutable references are not allowed in constants
   --> tests/ui-msrv/transmute-mut-const.rs:20:52
@@ -21,12 +21,13 @@ error[E0658]: mutable references are not allowed in constants
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `transmute_mut::<[u8; 2], [u8; 2]>` in constants
   --> tests/ui-msrv/transmute-mut-const.rs:20:37
    |
 20 | const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0716]: temporary value dropped while borrowed

--- a/tests/ui-msrv/transmute-mut-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `T` (this type does not have a fixed size)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-mut-dst-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<u8>` (8 bits)
    = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-a-reference.stderr
@@ -42,8 +42,16 @@ error[E0308]: mismatched types
   --> tests/ui-msrv/transmute-mut-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `&mut _`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found `&mut _`
+   |                                    arguments to this function are incorrect
    |
    = note:           expected type `usize`
            found mutable reference `&mut _`
+note: function defined here
+  --> src/util/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-frombytes.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `Dst: FromBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Dst`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Dst`
+   |                                      required by a bound introduced by this call
    |
-note: required by `AssertDstIsFromBytes`
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+             AtomicU32
+           and $N others
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-msrv/transmute-mut-dst-not-frombytes.rs:24:38
    |
 24 | const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-not-intobytes.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `Dst: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-dst-not-intobytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Dst`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `IntoBytes` is not implemented for `Dst`
+   |                                    required by a bound introduced by this call
    |
-note: required by `AssertDstIsIntoBytes`
+   = help: the following other types implement trait `IntoBytes`:
+             ()
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required by a bound in `AssertDstIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-dst-not-intobytes.rs:24:36
    |
 24 | const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsIntoBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertDstIsSized`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -35,7 +38,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
@@ -49,35 +52,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                         ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
    |
 17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32
-   |
-17 | const DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8; 1]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-dst-unsized.rs:17:32

--- a/tests/ui-msrv/transmute-mut-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-mut-size-decrease.stderr
@@ -6,30 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 2]` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0658]: mutable references are not allowed in constants
-  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:47
-   |
-17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
-   |                                               ^^^^^^^^^^^^^
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:32
-   |
-17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0716]: temporary value dropped while borrowed
-  --> tests/ui-msrv/transmute-mut-size-decrease.rs:17:52
-   |
-17 | const DECREASE_SIZE: &mut u8 = transmute_mut!(&mut [0u8; 2]);
-   |                                --------------------^^^^^^^^-
-   |                                |                   |
-   |                                |                   creates a temporary which is freed while still in use
-   |                                temporary value is freed at the end of this statement
-   |                                using this value as a constant requires that borrow lasts for `'static`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-size-increase.stderr
+++ b/tests/ui-msrv/transmute-mut-size-increase.stderr
@@ -6,30 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0658]: mutable references are not allowed in constants
-  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:52
-   |
-17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
-   |                                                    ^^^^^^^^
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:37
-   |
-17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0716]: temporary value dropped while borrowed
-  --> tests/ui-msrv/transmute-mut-size-increase.rs:17:57
-   |
-17 | const INCREASE_SIZE: &mut [u8; 2] = transmute_mut!(&mut 0u8);
-   |                                     --------------------^^^-
-   |                                     |                   |
-   |                                     |                   creates a temporary which is freed while still in use
-   |                                     temporary value is freed at the end of this statement
-   |                                     using this value as a constant requires that borrow lasts for `'static`
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `U` (this type does not have a fixed size)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-mut-src-dst-generic.rs:20:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertSrcIsSized`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,14 +33,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertDstIsSized`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -55,7 +61,10 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute`
@@ -63,16 +72,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/util/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
@@ -82,7 +99,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
@@ -96,35 +113,24 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
@@ -138,7 +144,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
@@ -152,21 +158,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
-   |
-17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
@@ -191,13 +183,33 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                         ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
    |
 17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/util/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-mut-src-dst-unsized.rs:17:36
+   |
+17 | const SRC_DST_UNSIZED: &mut [u8] = transmute_mut!(&mut [0u8][..]);
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    doesn't have a size known at compile-time
+   |                                    required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute_mut`

--- a/tests/ui-msrv/transmute-mut-src-generic.stderr
+++ b/tests/ui-msrv/transmute-mut-src-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-mut-src-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-frombytes.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
    |
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      |
+   |                                      the trait `FromBytes` is not implemented for `Src`
+   |                                      required by a bound introduced by this call
    |
-note: required by `AssertSrcIsFromBytes`
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+             AtomicU32
+           and $N others
+note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
    |
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsFromBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Src: FromBytes` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `Src: FromBytes` is not satisfied
 24 | const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromBytes` is not implemented for `Src`
    |
+   = help: the following other types implement trait `FromBytes`:
+             ()
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+             AtomicU32
+           and $N others
 note: required by a bound in `AssertSrcIsFromBytes`
   --> tests/ui-msrv/transmute-mut-src-not-frombytes.rs:24:38
    |

--- a/tests/ui-msrv/transmute-mut-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-mut-src-not-intobytes.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    the trait `IntoBytes` is not implemented for `Src`
+   |                                    required by a bound introduced by this call
    |
-note: required by `AssertSrcIsIntoBytes`
+   = help: the following other types implement trait `IntoBytes`:
+             ()
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
    |
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `Src: IntoBytes` is not satisfied
 24 | const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `Src`
    |
+   = help: the following other types implement trait `IntoBytes`:
+             ()
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-mut-src-not-intobytes.rs:24:36
    |

--- a/tests/ui-msrv/transmute-mut-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-mut-src-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertSrcIsSized`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -41,7 +44,10 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute`
@@ -49,16 +55,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/util/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
@@ -68,7 +82,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
@@ -82,35 +96,24 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
@@ -124,7 +127,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
@@ -138,27 +141,16 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
    |
 16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   |
+   |                                   doesn't have a size known at compile-time
+   |                                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute_mut`
@@ -167,13 +159,3 @@ note: required by a bound in `transmute_mut`
    | pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
    |                                               ^^^ required by this bound in `transmute_mut`
    = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-mut-src-unsized.rs:16:35
-   |
-16 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ptr-to-usize.stderr
+++ b/tests/ui-msrv/transmute-ptr-to-usize.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              the trait `IntoBytes` is not implemented for `*const usize`
+   |                              required by a bound introduced by this call
    |
-note: required by `AssertIsIntoBytes`
+   = help: the following other types implement trait `IntoBytes`:
+             f32
+             f64
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+           and $N others
+note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
+   = help: the following other types implement trait `IntoBytes`:
+             f32
+             f64
+             i128
+             i16
+             i32
+             i64
+             i8
+             isize
+           and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |

--- a/tests/ui-msrv/transmute-ref-alignment-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-alignment-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `T` (this type does not have a fixed size)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-dst-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<u8>` (8 bits)
    = note: target type: `MaxAlignsOf<u8, T>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-mutable.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-mutable.stderr
@@ -42,8 +42,16 @@ error[E0308]: mismatched types
   --> tests/ui-msrv/transmute-ref-dst-mutable.rs:18:22
    |
 18 |     let _: &mut u8 = transmute_ref!(&0u8);
-   |                      ^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      types differ in mutability
+   |                      arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
+note: function defined here
+  --> src/util/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-a-reference.stderr
@@ -42,8 +42,16 @@ error[E0308]: mismatched types
   --> tests/ui-msrv/transmute-ref-dst-not-a-reference.rs:17:36
    |
 17 | const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
-   |                                    ^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |                                    ^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    expected `usize`, found reference
+   |                                    arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+note: function defined here
+  --> src/util/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-frombytes.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `Dst: zerocopy::FromBytes` is not satisfied
   --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:23:34
    |
 23 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `Dst`
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `zerocopy::FromBytes` is not implemented for `Dst`
+   |                                  required by a bound introduced by this call
    |
-note: required by `AssertDstIsFromBytes`
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-msrv/transmute-ref-dst-not-frombytes.rs:23:34
    |
 23 | const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-not-nocell.stderr
@@ -2,11 +2,24 @@ error[E0277]: the trait bound `Dst: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:33
    |
 23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Dst`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `zerocopy::Immutable` is not implemented for `Dst`
+   |                                 required by a bound introduced by this call
    |
-note: required by `AssertDstIsImmutable`
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
+note: required by a bound in `AssertDstIsImmutable`
   --> tests/ui-msrv/transmute-ref-dst-not-nocell.rs:23:33
    |
 23 | const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertDstIsSized`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -35,7 +38,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
@@ -49,35 +52,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                         ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
    |
 17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            doesn't have a size known at compile-time
+   |                            required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28
-   |
-17 | const DST_UNSIZED: &[u8] = transmute_ref!(&[0u8; 1]);
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                          ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-dst-unsized.rs:17:28

--- a/tests/ui-msrv/transmute-ref-size-decrease.stderr
+++ b/tests/ui-msrv/transmute-ref-size-decrease.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `[u8; 2]` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-size-increase.stderr
+++ b/tests/ui-msrv/transmute-ref-size-increase.stderr
@@ -6,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `U` (this type does not have a fixed size)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-src-dst-generic.rs:18:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, U>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-not-references.stderr
@@ -55,8 +55,16 @@ error[E0308]: mismatched types
   --> tests/ui-msrv/transmute-ref-src-dst-not-references.rs:17:39
    |
 17 | const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found reference
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^
+   |                                       |
+   |                                       expected `usize`, found reference
+   |                                       arguments to this function are incorrect
    |
    = note:   expected type `usize`
            found reference `&_`
+note: function defined here
+  --> src/util/macro_util.rs
+   |
+   | pub const fn must_use<T>(t: T) -> T {
+   |              ^^^^^^^^
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-dst-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertSrcIsSized`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -30,14 +33,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertDstIsSized`
+note: required by a bound in `AssertDstIsSized`
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -55,7 +61,10 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute`
@@ -63,16 +72,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/util/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -82,7 +99,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -96,35 +113,24 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -138,7 +144,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -152,21 +158,7 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
-   |
-17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
@@ -191,13 +183,33 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                         ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
    |
 17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
+  --> src/util/macro_util.rs
+   |
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |         ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> tests/ui-msrv/transmute-ref-src-dst-unsized.rs:17:32
+   |
+17 | const SRC_DST_UNSIZED: &[u8] = transmute_ref!(&[0u8][..]);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                doesn't have a size known at compile-time
+   |                                required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute_ref`

--- a/tests/ui-msrv/transmute-ref-src-generic.stderr
+++ b/tests/ui-msrv/transmute-ref-src-generic.stderr
@@ -6,7 +6,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `T` (this type does not have a fixed size)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/transmute-ref-src-generic.rs:17:5
@@ -16,4 +16,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<T>` (size can vary because of T)
    = note: target type: `MaxAlignsOf<T, u8>` (size can vary because of T)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ref-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-intobytes.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 the trait `zerocopy::IntoBytes` is not implemented for `Src`
+   |                                 required by a bound introduced by this call
    |
-note: required by `AssertSrcIsIntoBytes`
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
+note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
    |
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsIntoBytes`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `Src: zerocopy::IntoBytes` is not satisfied
 23 | const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `Src`
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `AssertSrcIsIntoBytes`
   --> tests/ui-msrv/transmute-ref-src-not-intobytes.rs:23:33
    |

--- a/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-msrv/transmute-ref-src-not-nocell.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
   --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
 23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `zerocopy::Immutable`
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  the trait `zerocopy::Immutable` is not implemented for `Src`
+   |                                  required by a bound introduced by this call
    |
-note: required by `AssertSrcIsImmutable`
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
+note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |
 23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `Src: zerocopy::Immutable` is not satisfied
 23 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `Src`
    |
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
 note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-msrv/transmute-ref-src-not-nocell.rs:23:34
    |

--- a/tests/ui-msrv/transmute-ref-src-unsized.stderr
+++ b/tests/ui-msrv/transmute-ref-src-unsized.stderr
@@ -2,14 +2,17 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `AssertSrcIsSized`
+note: required by a bound in `AssertSrcIsSized`
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsSized`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -41,7 +44,10 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute`
@@ -49,16 +55,24 @@ note: required by a bound in `transmute`
    |
    |     pub fn transmute<T, U>(e: T) -> U;
    |                      ^ required by this bound in `transmute`
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `AlignOf::<T>::into_t`
+  --> src/util/macro_util.rs
+   |
+   | impl<T> AlignOf<T> {
+   |      ^ required by this bound in `AlignOf::<T>::into_t`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -68,7 +82,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: the left-hand-side of an assignment must have a statically known size
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -82,35 +96,24 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by `MaxAlignsOf::<T, U>::new`
+note: required by a bound in `MaxAlignsOf::<T, U>::new`
   --> src/util/macro_util.rs
    |
-   |     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | impl<T, U> MaxAlignsOf<T, U> {
+   |      ^ required by this bound in `MaxAlignsOf::<T, U>::new`
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -124,7 +127,7 @@ note: required by a bound in `MaxAlignsOf`
    |
    | pub union MaxAlignsOf<T, U> {
    |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
@@ -138,27 +141,16 @@ note: required by a bound in `AlignOf`
    |
    | pub struct AlignOf<T> {
    |                    ^ required by this bound in `AlignOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
    |
 16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `MaxAlignsOf`
-  --> src/util/macro_util.rs
-   |
-   | pub union MaxAlignsOf<T, U> {
-   |                       ^ required by this bound in `MaxAlignsOf`
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               |
+   |                               doesn't have a size known at compile-time
+   |                               required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `transmute_ref`
@@ -167,13 +159,3 @@ note: required by a bound in `transmute_ref`
    | pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
    |                                                     ^^^ required by this bound in `transmute_ref`
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui-msrv/transmute-ref-src-unsized.rs:16:31
-   |
-16 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: all function arguments must have a statically known size
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-src-not-intobytes.stderr
@@ -2,13 +2,26 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                required by a bound introduced by this call
    |
-note: required by `AssertIsIntoBytes`
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
+note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
@@ -17,6 +30,16 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `AssertIsIntoBytes`
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |

--- a/tests/ui-msrv/try_transmute-dst-not-tryfrombytes.stderr
+++ b/tests/ui-msrv/try_transmute-dst-not-tryfrombytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 17 |     let dst_not_try_from_bytes: Result<NotZerocopy, _> = try_transmute!(AU16(0));
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `try_transmute`
   --> src/util/macro_util.rs
    |
@@ -17,6 +27,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 17 |     let dst_not_try_from_bytes: Result<NotZerocopy, _> = try_transmute!(AU16(0));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |
@@ -29,6 +49,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 17 |     let dst_not_try_from_bytes: Result<NotZerocopy, _> = try_transmute!(AU16(0));
    |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |

--- a/tests/ui-msrv/try_transmute-size-decrease.stderr
+++ b/tests/ui-msrv/try_transmute-size-decrease.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `decrease_size`
-  --> tests/ui-msrv/try_transmute-size-decrease.rs:19:9
-   |
-19 |     let decrease_size: Result<u8, _> = try_transmute!(AU16(0));
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_decrease_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute-size-decrease.rs:19:40
    |

--- a/tests/ui-msrv/try_transmute-size-increase.stderr
+++ b/tests/ui-msrv/try_transmute-size-increase.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `increase_size`
-  --> tests/ui-msrv/try_transmute-size-increase.rs:19:9
-   |
-19 |     let increase_size: Result<AU16, _> = try_transmute!(0u8);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_increase_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute-size-increase.rs:19:42
    |

--- a/tests/ui-msrv/try_transmute-src-not-intobytes.stderr
+++ b/tests/ui-msrv/try_transmute-src-not-intobytes.stderr
@@ -2,8 +2,21 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
   --> tests/ui-msrv/try_transmute-src-not-intobytes.rs:18:47
    |
 18 |     let src_not_into_bytes: Result<AU16, _> = try_transmute!(NotZerocopy(AU16(0)));
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               |
+   |                                               the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                               required by a bound introduced by this call
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `try_transmute`
   --> src/util/macro_util.rs
    |

--- a/tests/ui-msrv/try_transmute_mut-alignment-increase.stderr
+++ b/tests/ui-msrv/try_transmute_mut-alignment-increase.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `increase_size`
-  --> tests/ui-msrv/try_transmute_mut-alignment-increase.rs:20:9
-   |
-20 |     let increase_size: Result<&mut AU16, _> = try_transmute_mut!(src);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_increase_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_mut-alignment-increase.rs:20:47
    |
@@ -14,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_mut-dst-not-tryfrombytes.stderr
+++ b/tests/ui-msrv/try_transmute_mut-dst-not-tryfrombytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 20 |     let dst_not_try_from_bytes: Result<&mut NotZerocopy, _> = try_transmute_mut!(src);
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `try_transmute_mut`
   --> src/util/macro_util.rs
    |
@@ -17,6 +27,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 20 |     let dst_not_try_from_bytes: Result<&mut NotZerocopy, _> = try_transmute_mut!(src);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |
@@ -29,6 +49,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 20 |     let dst_not_try_from_bytes: Result<&mut NotZerocopy, _> = try_transmute_mut!(src);
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |

--- a/tests/ui-msrv/try_transmute_mut-size-decrease.stderr
+++ b/tests/ui-msrv/try_transmute_mut-size-decrease.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `decrease_size`
-  --> tests/ui-msrv/try_transmute_mut-size-decrease.rs:20:9
-   |
-20 |     let decrease_size: Result<&mut u8, _> = try_transmute_mut!(src);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_decrease_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_mut-size-decrease.rs:20:45
    |
@@ -14,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AU16` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_mut-size-increase.stderr
+++ b/tests/ui-msrv/try_transmute_mut-size-increase.stderr
@@ -6,14 +6,6 @@ warning: unused import: `util::AU16`
    |
    = note: `#[warn(unused_imports)]` on by default
 
-warning: unused variable: `increase_size`
-  --> tests/ui-msrv/try_transmute_mut-size-increase.rs:20:9
-   |
-20 |     let increase_size: Result<&mut [u8; 2], _> = try_transmute_mut!(src);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_increase_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_mut-size-increase.rs:20:50
    |
@@ -22,4 +14,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `u8` (8 bits)
    = note: target type: `[u8; 2]` (16 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_mut-src-not-intobytes.stderr
+++ b/tests/ui-msrv/try_transmute_mut-src-not-intobytes.stderr
@@ -2,8 +2,21 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
   --> tests/ui-msrv/try_transmute_mut-src-not-intobytes.rs:19:52
    |
 19 |     let src_not_into_bytes: Result<&mut AU16, _> = try_transmute_mut!(src);
-   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                    |
+   |                                                    the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                                    required by a bound introduced by this call
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `try_transmute_mut`
   --> src/util/macro_util.rs
    |

--- a/tests/ui-msrv/try_transmute_ref-alignment-increase.stderr
+++ b/tests/ui-msrv/try_transmute_ref-alignment-increase.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `increase_size`
-  --> tests/ui-msrv/try_transmute_ref-alignment-increase.rs:19:9
-   |
-19 |     let increase_size: Result<&AU16, _> = try_transmute_ref!(&[0u8; 2]);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_increase_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_ref-alignment-increase.rs:19:43
    |
@@ -14,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_ref-dst-mutable.stderr
+++ b/tests/ui-msrv/try_transmute_ref-dst-mutable.stderr
@@ -2,21 +2,31 @@ error[E0308]: mismatched types
   --> tests/ui-msrv/try_transmute_ref-dst-mutable.rs:18:33
    |
 18 |     let _: Result<&mut u8, _> = try_transmute_ref!(&0u8);
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 |
+   |                                 types differ in mutability
+   |                                 arguments to this enum variant are incorrect
    |
    = note: expected mutable reference `&mut u8`
                       found reference `&_`
+note: tuple variant defined here
+  --> $RUST/core/src/result.rs
+   |
+   |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
    = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/ui-msrv/try_transmute_ref-dst-mutable.rs:18:33
    |
 18 |     let _: Result<&mut u8, _> = try_transmute_ref!(&0u8);
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                 |
-   |                                 types differ in mutability
-   |                                 help: try using a variant of the expected enum: `Err($crate::util::macro_util::try_transmute_ref::<_, _>(e))`
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^ types differ in mutability
    |
    = note: expected enum `Result<&mut u8, _>`
               found enum `Result<&_, ValidityError<&u8, _>>`
    = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try wrapping the expression in `Err`
+  --> src/macros.rs
+   |
+   |             Err($crate::util::macro_util::try_transmute_ref::<_, _>(e))
+   |             ++++                                                      +

--- a/tests/ui-msrv/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
+++ b/tests/ui-msrv/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
@@ -4,6 +4,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 19 |     let dst_not_try_from_bytes: Result<&NotZerocopy, _> = try_transmute_ref!(&AU16(0));
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `try_transmute_ref`
   --> src/util/macro_util.rs
    |
@@ -17,6 +27,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Immutable` is not satisfie
 19 |     let dst_not_try_from_bytes: Result<&NotZerocopy, _> = try_transmute_ref!(&AU16(0));
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
 note: required by a bound in `try_transmute_ref`
   --> src/util/macro_util.rs
    |
@@ -30,6 +50,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 19 |     let dst_not_try_from_bytes: Result<&NotZerocopy, _> = try_transmute_ref!(&AU16(0));
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |
@@ -42,6 +72,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 19 |     let dst_not_try_from_bytes: Result<&NotZerocopy, _> = try_transmute_ref!(&AU16(0));
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
 note: required by a bound in `ValidityError`
   --> src/error.rs
    |

--- a/tests/ui-msrv/try_transmute_ref-size-decrease.stderr
+++ b/tests/ui-msrv/try_transmute_ref-size-decrease.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `decrease_size`
-  --> tests/ui-msrv/try_transmute_ref-size-decrease.rs:19:9
-   |
-19 |     let decrease_size: Result<&u8, _> = try_transmute_ref!(&AU16(0));
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_decrease_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_ref-size-decrease.rs:19:41
    |
@@ -14,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AU16` (16 bits)
    = note: target type: `u8` (8 bits)
-   = note: this error originates in the macro `$crate::assert_size_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_size_eq` which comes from the expansion of the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_ref-size-increase.stderr
+++ b/tests/ui-msrv/try_transmute_ref-size-increase.stderr
@@ -1,11 +1,3 @@
-warning: unused variable: `increase_size`
-  --> tests/ui-msrv/try_transmute_ref-size-increase.rs:19:9
-   |
-19 |     let increase_size: Result<&AU16, _> = try_transmute_ref!(&[0u8; 2]);
-   |         ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_increase_size`
-   |
-   = note: `#[warn(unused_variables)]` on by default
-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests/ui-msrv/try_transmute_ref-size-increase.rs:19:43
    |
@@ -14,4 +6,4 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
    |
    = note: source type: `AlignOf<[u8; 2]>` (8 bits)
    = note: target type: `MaxAlignsOf<[u8; 2], AU16>` (16 bits)
-   = note: this error originates in the macro `$crate::assert_align_gt_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_align_gt_eq` which comes from the expansion of the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/try_transmute_ref-src-not-immutable-intobytes.stderr
+++ b/tests/ui-msrv/try_transmute_ref-src-not-immutable-intobytes.stderr
@@ -2,8 +2,21 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
   --> tests/ui-msrv/try_transmute_ref-src-not-immutable-intobytes.rs:19:48
    |
 19 |     let src_not_into_bytes: Result<&AU16, _> = try_transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                |
+   |                                                the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
+   |                                                required by a bound introduced by this call
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
 note: required by a bound in `try_transmute_ref`
   --> src/util/macro_util.rs
    |
@@ -15,8 +28,21 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::Immutable` is not sa
   --> tests/ui-msrv/try_transmute_ref-src-not-immutable-intobytes.rs:19:48
    |
 19 |     let src_not_into_bytes: Result<&AU16, _> = try_transmute_ref!(&NotZerocopy(AU16(0)));
-   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an implementor of trait `zerocopy::Immutable`
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                |
+   |                                                the trait `zerocopy::Immutable` is not implemented for `NotZerocopy<AU16>`
+   |                                                required by a bound introduced by this call
    |
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             Box<T>
+             F32<O>
+           and $N others
 note: required by a bound in `try_transmute_ref`
   --> src/util/macro_util.rs
    |

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.5"
+version = "0.9.0-alpha.0"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -26,7 +26,7 @@ mod imp {
     #[allow(unused)]
     pub use {
         ::core::{
-            assert_eq,
+            self, assert_eq,
             cell::UnsafeCell,
             convert::TryFrom,
             marker::PhantomData,

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -171,7 +171,7 @@ fn test_maybe_from_bytes() {
     imp::assert!(!is_bit_valid);
 }
 
-#[derive(Debug, PartialEq, Eq, imp::TryFromBytes, imp::Immutable, imp::KnownLayout)]
+#[derive(imp::TryFromBytes, imp::Immutable, imp::KnownLayout)]
 #[repr(C, packed)]
 struct CPacked {
     a: u8,
@@ -189,7 +189,9 @@ struct CPacked {
 fn c_packed() {
     let candidate = &[42u8, 0xFF, 0xFF, 0xFF, 0xFF];
     let converted = <CPacked as imp::TryFromBytes>::try_ref_from_bytes(candidate);
-    imp::assert_eq!(converted, imp::Ok(&CPacked { a: 42, b: u32::MAX }));
+    // Can't derive `Debug` or `PartialEq` on a `#[repr(packed)]` type, so we
+    // can't use `assert_eq!` or `assert!(converted == ...)`.
+    imp::assert!(imp::core::matches!(converted, imp::Ok(&CPacked { a: 42, b: u32::MAX })));
 }
 
 #[derive(imp::TryFromBytes, imp::KnownLayout, imp::Immutable)]

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -1,10 +1,20 @@
 error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:34:1
+  --> tests/ui-msrv/derive_transparent.rs:34:23
    |
 34 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `zerocopy::TryFromBytes` for `TransparentStruct<NotZerocopy>`
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-msrv/derive_transparent.rs:24:21
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -13,16 +23,26 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:34:1
    |
 34 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:35:1
+  --> tests/ui-msrv/derive_transparent.rs:35:23
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `FromZeros` for `TransparentStruct<NotZerocopy>`
+   = help: the following other types implement trait `FromZeros`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-msrv/derive_transparent.rs:24:21
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -31,16 +51,26 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:35:1
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:36:1
+  --> tests/ui-msrv/derive_transparent.rs:36:23
    |
 36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `zerocopy::FromBytes` for `TransparentStruct<NotZerocopy>`
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::FromBytes`
   --> tests/ui-msrv/derive_transparent.rs:24:21
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -49,16 +79,26 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:36:1
    |
 36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:37:1
+  --> tests/ui-msrv/derive_transparent.rs:37:23
    |
 37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `TransparentStruct<NotZerocopy>`
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::IntoBytes`
   --> tests/ui-msrv/derive_transparent.rs:24:10
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -67,16 +107,26 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:37:1
    |
 37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
-  --> tests/ui-msrv/derive_transparent.rs:38:1
+  --> tests/ui-msrv/derive_transparent.rs:38:23
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
+note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
   --> tests/ui-msrv/derive_transparent.rs:24:32
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
@@ -85,5 +135,5 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
   --> tests/ui-msrv/derive_transparent.rs:38:1
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-   = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
+   = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -83,7 +83,7 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
+       help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
    --> tests/ui-msrv/enum.rs:119:1
     |
 119 | / #[repr(i8)]
@@ -294,6 +294,8 @@ error[E0552]: unrecognized representation hint
    |
 25 | #[repr(foo)]
    |        ^^^
+   |
+   = help: valid reprs are `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
 
 error[E0566]: conflicting representation hints
   --> tests/ui-msrv/enum.rs:37:8
@@ -311,6 +313,16 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
 51 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
+   = help: the following other types implement trait `Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             F32<O>
+             F64<O>
+             I128<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -320,6 +332,16 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
 59 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
+   = help: the following other types implement trait `Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             F32<O>
+             F64<O>
+             I128<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -329,6 +351,16 @@ error[E0277]: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
 82 | #[derive(TryFromBytes)]
    |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
    |
+   = help: the following other types implement trait `TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+             AtomicBool
+             AtomicI16
+             AtomicI32
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -338,6 +370,16 @@ error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
 127 | #[derive(FromZeros)]
     |          ^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotFromZeros`
     |
+    = help: the following other types implement trait `TryFromBytes`:
+              ()
+              *const T
+              *mut T
+              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+              AtomicBool
+              AtomicI16
+              AtomicI32
+            and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -347,6 +389,16 @@ error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
 127 | #[derive(FromZeros)]
     |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotFromZeros`
     |
+    = help: the following other types implement trait `FromZeros`:
+              ()
+              *const T
+              *mut T
+              AtomicBool
+              AtomicI16
+              AtomicI32
+              AtomicI64
+              AtomicI8
+            and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -356,6 +408,16 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
 191 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
+    = help: the following other types implement trait `FromBytes`:
+              ()
+              AtomicI16
+              AtomicI32
+              AtomicI64
+              AtomicI8
+              AtomicIsize
+              AtomicU16
+              AtomicU32
+            and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -365,8 +427,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, true>` is not satisfi
 538 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
     |
-    = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+    = help: the trait `PaddingFree<T, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -376,8 +437,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfi
 549 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
     |
-    = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+    = help: the trait `PaddingFree<T, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -387,8 +447,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfi
 555 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
     |
-    = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+    = help: the trait `PaddingFree<T, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -12,6 +12,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 28 | #[derive(TryFromBytes)]
    |          ^^^^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -21,6 +31,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 37 | #[derive(FromZeros)]
    |          ^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -30,6 +50,16 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
 37 | #[derive(FromZeros)]
    |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `FromZeros`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -39,6 +69,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::TryFromBytes` is not satis
 46 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::TryFromBytes`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -48,6 +88,16 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
 46 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `FromZeros`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -57,6 +107,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
 46 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::FromBytes`:
+             ()
+             AU16
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+             AtomicU16
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,6 +126,16 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
 55 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy`
    |
+   = help: the following other types implement trait `zerocopy::IntoBytes`:
+             ()
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+             AtomicI8
+             AtomicIsize
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -75,6 +145,16 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
 65 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -84,6 +164,16 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
 73 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -93,5 +183,15 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
 80 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/mid_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/mid_compile_pass.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: KnownLayout` is not satisfied
 59 | fn test_kl13<T>(t: T) -> impl KnownLayout {
    |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`
    |
-note: required because of the requirements on the impl of `KnownLayout` for `KL13<T>`
+note: required for `KL13<T>` to implement `KnownLayout`
   --> tests/ui-msrv/mid_compile_pass.rs:55:10
    |
 55 | #[derive(KnownLayout)]
@@ -21,14 +21,16 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 30 | fn test_kl04<T: ?Sized>(kl: &KL04<T>) {
    |              - this type parameter needs to be `std::marker::Sized`
 31 |     assert_kl(kl);
-   |               ^^ doesn't have a size known at compile-time
+   |     --------- ^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because it appears within the type `KL04<T>`
   --> tests/ui-msrv/mid_compile_pass.rs:28:8
    |
 28 | struct KL04<T: ?Sized>(u8, T);
    |        ^^^^
-note: required because of the requirements on the impl of `KnownLayout` for `KL04<T>`
+note: required for `KL04<T>` to implement `KnownLayout`
   --> tests/ui-msrv/mid_compile_pass.rs:27:10
    |
 27 | #[derive(KnownLayout)]
@@ -51,14 +53,16 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
 39 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
    |              - this type parameter needs to be `std::marker::Sized`
 40 |     assert_kl(kl);
-   |               ^^ doesn't have a size known at compile-time
+   |     --------- ^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
    |
 note: required because it appears within the type `KL06<T>`
   --> tests/ui-msrv/mid_compile_pass.rs:37:8
    |
 37 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
    |        ^^^^
-note: required because of the requirements on the impl of `KnownLayout` for `KL06<T>`
+note: required for `KL06<T>` to implement `KnownLayout`
   --> tests/ui-msrv/mid_compile_pass.rs:36:10
    |
 36 | #[derive(KnownLayout)]
@@ -79,9 +83,11 @@ error[E0277]: the trait bound `T: KnownLayout` is not satisfied
   --> tests/ui-msrv/mid_compile_pass.rs:50:15
    |
 50 |     assert_kl(kl)
-   |               ^^ the trait `KnownLayout` is not implemented for `T`
+   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`
+   |     |
+   |     required by a bound introduced by this call
    |
-note: required because of the requirements on the impl of `KnownLayout` for `KL12<T>`
+note: required for `KL12<T>` to implement `KnownLayout`
   --> tests/ui-msrv/mid_compile_pass.rs:45:10
    |
 45 | #[derive(KnownLayout)]

--- a/zerocopy-derive/tests/ui-msrv/msrv_specific.stderr
+++ b/zerocopy-derive/tests/ui-msrv/msrv_specific.stderr
@@ -7,12 +7,22 @@ warning: unused `#[macro_use]` import
    = note: `#[warn(unused_imports)]` on by default
 
 error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
-  --> tests/ui-msrv/msrv_specific.rs:35:9
+  --> tests/ui-msrv/msrv_specific.rs:35:27
    |
 35 |         is_into_bytes_1::<IntoBytes1<AU16>>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |                           ^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
    |
-note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `IntoBytes1<AU16>`
+   = help: the following other types implement trait `Unaligned`:
+             ()
+             AtomicBool
+             AtomicI8
+             AtomicU8
+             F32<O>
+             F64<O>
+             I128<O>
+             I16<O>
+           and $N others
+note: required for `IntoBytes1<AU16>` to implement `zerocopy::IntoBytes`
   --> tests/ui-msrv/msrv_specific.rs:24:10
    |
 24 | #[derive(IntoBytes)]

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -122,6 +122,16 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
 41 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotKnownLayoutDst`
    |
+   = help: the following other types implement trait `zerocopy::KnownLayout`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -131,6 +141,16 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
 47 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotKnownLayout`
    |
+   = help: the following other types implement trait `zerocopy::KnownLayout`:
+             ()
+             *const T
+             *mut T
+             AU16
+             AtomicBool
+             AtomicI16
+             AtomicI32
+             AtomicI64
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -140,6 +160,16 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
 55 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             F32<O>
+             F64<O>
+           and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -149,7 +179,17 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satis
 60 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<u8>`
    |
-   = note: required because of the requirements on the impl of `zerocopy::Immutable` for `[UnsafeCell<u8>; 0]`
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             F32<O>
+             F64<O>
+           and $N others
+   = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::Immutable`
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -159,6 +199,16 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
 100 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
     |
+    = help: the following other types implement trait `Unaligned`:
+              ()
+              AtomicBool
+              AtomicI8
+              AtomicU8
+              F32<O>
+              F64<O>
+              I128<O>
+              I16<O>
+            and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -168,8 +218,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfi
 107 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
     |
-    = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+    = help: the trait `PaddingFree<T, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -179,8 +228,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfi
 114 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
     |
-    = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+    = help: the trait `PaddingFree<T, false>` is implemented for `()`
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -201,7 +249,7 @@ note: required by a bound in `std::mem::size_of`
     |
     | pub const fn size_of<T>() -> usize {
     |                      ^ required by this bound in `std::mem::size_of`
-    = note: this error originates in the macro `::zerocopy::struct_has_padding` (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
    --> tests/ui-msrv/struct.rs:129:8

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -68,7 +68,17 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
 24 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy::Immutable` is not implemented for `UnsafeCell<()>`
    |
-   = note: required because of the requirements on the impl of `zerocopy::Immutable` for `ManuallyDrop<UnsafeCell<()>>`
+   = help: the following other types implement trait `zerocopy::Immutable`:
+             &T
+             &mut T
+             ()
+             *const T
+             *mut T
+             AU16
+             F32<O>
+             F64<O>
+           and $N others
+   = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::Immutable`
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -78,7 +88,6 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfi
 39 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
    |
-   = help: the following implementations were found:
-             <() as PaddingFree<T, false>>
+   = help: the trait `PaddingFree<T, false>` is implemented for `()`
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/union_into_bytes_cfg/union_into_bytes_cfg.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union_into_bytes_cfg/union_into_bytes_cfg.stderr
@@ -1,5 +1,5 @@
 error: requires --cfg zerocopy_derive_union_into_bytes;
-please let us know you use this feature: https://github.com/google/zerocopy/discussions/1802
+       please let us know you use this feature: https://github.com/google/zerocopy/discussions/1802
   --> tests/ui-msrv/union_into_bytes_cfg/union_into_bytes_cfg.rs:20:10
    |
 20 | #[derive(IntoBytes)]


### PR DESCRIPTION
While we're here, remove defensive programming against bug in `Layout::from_size_align` which is no longer needed on our new MSRV.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
