### PR TITLE
Upgrade some code for MSRV 1.65

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -474,12 +474,8 @@ impl DstLayout {
         // invalid type) instead of allowing this panic to be hidden if the cast
         // would have failed anyway for runtime reasons (such as a too-small
         // memory region).
-        //
-        // TODO(#67): Once our MSRV is 1.65, use let-else:
-        // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-        let size_info = match self.size_info.try_to_nonzero_elem_size() {
-            Some(size_info) => size_info,
-            None => panic!("attempted to cast to slice type with zero-sized element"),
+        let Some(size_info) = self.size_info.try_to_nonzero_elem_size() else {
+            panic!("attempted to cast to slice type with zero-sized element");
         };
 
         // Precondition
@@ -531,13 +527,9 @@ impl DstLayout {
                     util::round_down_to_next_multiple_of_alignment(bytes_len, self.align);
                 // Calculate the maximum number of bytes that could be consumed
                 // by the trailing slice.
-                //
-                // TODO(#67): Once our MSRV is 1.65, use let-else:
-                // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
-                let max_slice_and_padding_bytes = match max_total_bytes.checked_sub(offset) {
-                    Some(max) => max,
+                let Some(max_slice_and_padding_bytes) = max_total_bytes.checked_sub(offset) else {
                     // `bytes_len` too small even for 0 trailing slice elements.
-                    None => return Err(MetadataCastError::Size),
+                    return Err(MetadataCastError::Size);
                 };
 
                 // Calculate the number of elements that fit in
@@ -596,11 +588,6 @@ impl DstLayout {
     }
 }
 
-// TODO(#67): For some reason, on our MSRV toolchain, this `allow` isn't
-// enforced despite having `#![allow(unknown_lints)]` at the crate root, but
-// putting it here works. Once our MSRV is high enough that this bug has been
-// fixed, remove this `allow`.
-#[allow(unknown_lints)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1296,9 +1296,6 @@ mod _casts {
             U: 'a + ?Sized + KnownLayout + AliasingSafe<[u8], I::Aliasing, R>,
             R: AliasingSafeReason,
         {
-            // TODO(#67): Remove this allow. See NonNulSlicelExt for more
-            // details.
-            #[allow(unstable_name_collisions)]
             match self.try_cast_into(CastType::Prefix, meta) {
                 Ok((slf, remainder)) => {
                     if remainder.len() == 0 {

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -469,12 +469,7 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     // - The caller has guaranteed that alignment is not increased.
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.
-    //
-    // TODO(#67): Once our MSRV is 1.58, replace this `transmute` with `&*dst`.
-    #[allow(clippy::transmute_ptr_to_ref)]
-    unsafe {
-        mem::transmute(dst)
-    }
+    unsafe { &*dst }
 }
 
 /// Transmutes a mutable reference of one type to a mutable reference of another

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -725,7 +725,7 @@ pub(crate) mod polyfills {
     // toolchain versions, `ptr.slice_from_raw_parts()` resolves to the inherent
     // method rather than to this trait, and so this trait is considered unused.
     //
-    // TODO(#67): Once our MSRV is high enough, remove this.
+    // TODO(#67): Once our MSRV is >= 1.79, remove this.
     #[allow(unused)]
     pub(crate) trait NumExt {
         /// Subtract without checking for underflow.

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -1349,25 +1349,3 @@ fn impl_block<D: DataExt>(
         }
     }
 }
-
-// A polyfill for `Option::then_some`, which was added after our MSRV.
-//
-// The `#[allow(unused)]` is necessary because, on sufficiently recent toolchain
-// versions, `b.then_some(...)` resolves to the inherent method rather than to
-// this trait, and so this trait is considered unused.
-//
-// TODO(#67): Remove this once our MSRV is >= 1.62.
-#[allow(unused)]
-trait BoolExt {
-    fn then_some<T>(self, t: T) -> Option<T>;
-}
-
-impl BoolExt for bool {
-    fn then_some<T>(self, t: T) -> Option<T> {
-        if self {
-            Some(t)
-        } else {
-            None
-        }
-    }
-}


### PR DESCRIPTION
Now that our MSRV is 1.65, we can clean up some code.

Makes progress on #67

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
