### PR TITLE
[pointer] Clarify semantics of aliasing invariants

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -657,9 +657,7 @@ unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
     }
 
     #[inline]
-    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
-        candidate: Maybe<'_, Self, A>,
-    ) -> bool {
+    fn is_bit_valid<A: invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
         // The only way to implement this function is using an exclusive-aliased
         // pointer. `UnsafeCell`s cannot be read via shared-aliased pointers
         // (other than by using `unsafe` code, which we can't use since we can't
@@ -1134,10 +1132,7 @@ mod tests {
 
             pub(super) trait TestIsBitValidShared<T: ?Sized> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<
-                    'ptr,
-                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
-                >(
+                fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool>;
@@ -1145,10 +1140,7 @@ mod tests {
 
             impl<T: TryFromBytes + Immutable + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<
-                    'ptr,
-                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
-                >(
+                fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool> {
@@ -1238,7 +1230,7 @@ mod tests {
                 #[allow(unused, non_local_definitions)]
                 impl AutorefWrapper<$ty> {
                     #[allow(clippy::needless_lifetimes)]
-                    fn test_is_bit_valid_shared<'ptr, A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
+                    fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                         &mut self,
                         candidate: Maybe<'ptr, $ty, A>,
                     ) -> Option<bool> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1321,9 +1321,7 @@ pub unsafe trait TryFromBytes {
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
-        candidate: Maybe<'_, Self, A>,
-    ) -> bool;
+    fn is_bit_valid<A: invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool;
 
     /// Attempts to interpret the given `source` as a `&Self`.
     ///

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -35,7 +35,7 @@ pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant
 impl<'a, T, Aliasing, Alignment> MaybeAligned<'a, T, Aliasing, Alignment>
 where
     T: 'a + ?Sized,
-    Aliasing: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
+    Aliasing: invariant::Reference,
     Alignment: invariant::Alignment,
 {
     /// Reads the value from `MaybeAligned`.
@@ -47,11 +47,20 @@ where
     {
         let raw = self.as_non_null().as_ptr();
         // SAFETY: By invariant on `MaybeAligned`, `raw` contains
-        // validly-initialized data for `T`. The value is safe to read and
-        // return, because `T` is copy.
+        // validly-initialized data for `T`. By `Aliasing: Reference`,
+        // `Aliasing` is either `Shared` or `Exclusive`, both of which ensure
+        // that it is sound to perform this read. By `T: Copy`, the value is
+        // safe to return.
         unsafe { core::ptr::read_unaligned(raw) }
     }
+}
 
+impl<'a, T, Aliasing, Alignment> MaybeAligned<'a, T, Aliasing, Alignment>
+where
+    T: 'a + ?Sized,
+    Aliasing: invariant::Reference,
+    Alignment: invariant::Alignment,
+{
     /// Views the value as an aligned reference.
     ///
     /// This is only available if `T` is [`Unaligned`].
@@ -70,7 +79,7 @@ pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
 where
     T: crate::Immutable + crate::KnownLayout,
     I: invariant::Invariants<Validity = invariant::Initialized>,
-    I::Aliasing: invariant::AtLeast<invariant::Shared>,
+    I::Aliasing: invariant::Reference,
 {
     ptr.as_bytes::<BecauseImmutable>().as_ref().iter().all(|&byte| byte == 0)
 }

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -26,7 +26,7 @@ use core::ptr::{self, NonNull};
 
 use crate::{
     pointer::{
-        invariant::{self, AtLeast, Invariants},
+        invariant::{self, Invariants},
         AliasingSafe, AliasingSafeReason, BecauseExclusive, BecauseImmutable,
     },
     Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
@@ -530,7 +530,7 @@ where
     Src: IntoBytes,
     Dst: TryFromBytes + AliasingSafe<Src, I::Aliasing, R>,
     I: Invariants<Validity = invariant::Valid>,
-    I::Aliasing: AtLeast<invariant::Shared>,
+    I::Aliasing: invariant::Reference,
     R: AliasingSafeReason,
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -141,7 +141,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The cast preserves address. The caller has promised that the
             //   cast results in an object of equal or lesser size, and so the
@@ -165,7 +165,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The cast preserves address. The caller has promised that the
             //   cast results in an object of equal or lesser size, and so the
@@ -189,7 +189,7 @@ macro_rules! unsafe_impl {
         #[allow(clippy::missing_inline_in_public_items)]
         #[cfg_attr(coverage_nightly, coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        #[inline(always)] fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(_: Maybe<'_, Self, A>) -> bool { true }
+        #[inline(always)] fn is_bit_valid<AA: crate::pointer::invariant::Reference>(_: Maybe<'_, Self, AA>) -> bool { true }
     };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items)]
@@ -341,7 +341,7 @@ macro_rules! impl_for_transparent_wrapper {
         // TryFromBytes)` macro arm for an explanation of why this is a sound
         // implementation of `is_bit_valid`.
         #[inline]
-        fn is_bit_valid<A: crate::pointer::invariant::Aliasing + crate::pointer::invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, A>) -> bool {
+        fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
             TryFromBytes::is_bit_valid(candidate.transparent_wrapper_into_inner())
         }
     };

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -286,8 +286,7 @@ pub(crate) fn derive_is_bit_valid(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
-            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
         {
             use ::zerocopy::util::macro_util::core_reexport;
 

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -422,8 +422,7 @@ fn derive_try_from_bytes_struct(
                 mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 true #(&& {
                     // SAFETY:
@@ -480,8 +479,7 @@ fn derive_try_from_bytes_union(
                 mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 false #(|| {
                     // SAFETY:
@@ -574,8 +572,7 @@ fn try_gen_trivial_is_bit_valid(
                 _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 if false {
                     fn assert_is_from_bytes<T>()
@@ -618,8 +615,7 @@ unsafe fn gen_trivial_is_bit_valid_unchecked() -> proc_macro2::TokenStream {
             _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
-            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
         {
             true
         }

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -155,8 +155,7 @@ fn test_try_from_bytes() {
                     mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }
@@ -179,8 +178,7 @@ fn test_from_zeros() {
                     mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }
@@ -208,8 +206,7 @@ fn test_from_bytes_struct() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -256,8 +253,7 @@ fn test_from_bytes_union() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -377,8 +373,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(u8)]
@@ -434,8 +429,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -528,8 +522,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -671,8 +664,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(u32)]
@@ -728,8 +720,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -822,8 +813,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -965,8 +955,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(C)]
@@ -1022,8 +1011,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -1116,8 +1104,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -1503,8 +1490,7 @@ fn test_from_bytes_enum() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -1808,8 +1794,7 @@ fn test_try_from_bytes_trivial_is_bit_valid_enum() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }


### PR DESCRIPTION
Previously, we supported the `AtLeast` bound, which was used to describe a subset relationship in which `I: AtLeast<J>` implied that `I` as at least as restrictive as `J`. However, as described in #1866, this incorrectly models invariants as monotonic. In reality, invariants both provide guarantees but also *require* guarantees.

This commit takes a step in the direction of resolving #1866 by removing `AtLeast`. Uses of `AtLeast<Shared>` are replaced by a new `Reference` trait, which is implemented for `Shared` and `Exclusive`. This serves two purposes: First, it makes it explicit what this bound means. Previously, `AtLeast<Shared>` had an ambiguous meaning, while `Reference` means precisely that an invariant is either `Shared` or `Exclusive` and nothing else. Second, it paves the way for #1183, in which we may add new aliasing invariants which convey ownership. In that case, it will be important for existing methods to add `Reference` bounds when those methods would not be sound in the face of ownership semantics.

We also inline the items in the `invariant` module, which were previously generated by macro. The addition of the `Reference` trait did not play nicely with that macro, and we will likely need to go further from the macro in order to fix #1839 – this fix will likely require making aliasing invariants meaningfully different than other invariants, for example by adding an associated type.

Makes progress on #1866

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
