### PR TITLE
[pointer] Support generic invariant mapping

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -290,15 +290,6 @@ safety_comment! {
     ///     because `NonZeroXxx` and `xxx` have the same size. [1] Neither `r`
     ///     nor `t` refer to any `UnsafeCell`s because neither `NonZeroXxx` [2]
     ///     nor `xxx` do.
-    ///   - Since the closure takes a `&xxx` argument, given a `Maybe<'a,
-    ///     NonZeroXxx>` which satisfies the preconditions of
-    ///     `TryFromBytes::<NonZeroXxx>::is_bit_valid`, it must be guaranteed
-    ///     that the memory referenced by that `MabyeValid` always contains a
-    ///     valid `xxx`. Since `NonZeroXxx`'s bytes are always initialized [1],
-    ///     `is_bit_valid`'s precondition requires that the same is true of its
-    ///     argument. Since `xxx`'s only bit validity invariant is that its
-    ///     bytes must be initialized, this memory is guaranteed to contain a
-    ///     valid `xxx`.
     ///   - The impl must only return `true` for its argument if the original
     ///     `Maybe<NonZeroXxx>` refers to a valid `NonZeroXxx`. The only
     ///     `xxx` which is not also a valid `NonZeroXxx` is 0. [1]

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -421,7 +421,7 @@ macro_rules! assert_align_gt_eq {
 #[doc(hidden)] // `#[macro_export]` bypasses this module's `#[doc(hidden)]`.
 #[macro_export]
 macro_rules! assert_size_eq {
-    ($t:ident, $u: ident) => {{
+    ($t:ident, $u:ident) => {{
         // The comments here should be read in the context of this macro's
         // invocations in `transmute_ref!` and `transmute_mut!`.
         if false {

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -265,10 +265,6 @@ pub(crate) fn derive_is_bit_valid(
                             }
                         )
                     };
-                    // SAFETY: `cast_unsized_unchecked` removes the
-                    // initialization invariant from `p`, so we re-assert that
-                    // all of the bytes are initialized.
-                    let variant = unsafe { variant.assume_initialized() };
                     <
                         #variant_struct_ident #ty_generics as #trait_path
                     >::is_bit_valid(variant)
@@ -325,10 +321,6 @@ pub(crate) fn derive_is_bit_valid(
                         p as *mut ___ZerocopyTagPrimitive
                     })
                 };
-                // SAFETY: `tag_ptr` is casted from `candidate`, whose referent
-                // is `Initialized`. Since we have not written uninitialized
-                // bytes into the referent, `tag_ptr` is also `Initialized`.
-                let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                 tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
             };
 
@@ -347,10 +339,6 @@ pub(crate) fn derive_is_bit_valid(
                     p as *mut ___ZerocopyRawEnum #ty_generics
                 })
             };
-            // SAFETY: `cast_unsized_unchecked` removes the initialization
-            // invariant from `p`, so we re-assert that all of the bytes are
-            // initialized.
-            let raw_enum = unsafe { raw_enum.assume_initialized() };
             // SAFETY:
             // - This projection returns a subfield of `this` using
             //   `addr_of_mut!`.

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -591,13 +591,11 @@ fn test_try_from_bytes_enum() {
                         let tag_ptr = unsafe {
                             candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
                         raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
@@ -612,7 +610,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_StructLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }
@@ -622,7 +619,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_TupleLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }
@@ -882,13 +878,11 @@ fn test_try_from_bytes_enum() {
                         let tag_ptr = unsafe {
                             candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
                         raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
@@ -903,7 +897,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_StructLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }
@@ -913,7 +906,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_TupleLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }
@@ -1173,13 +1165,11 @@ fn test_try_from_bytes_enum() {
                         let tag_ptr = unsafe {
                             candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
                         raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
@@ -1194,7 +1184,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_StructLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }
@@ -1204,7 +1193,6 @@ fn test_try_from_bytes_enum() {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };
-                            let variant = unsafe { variant.assume_initialized() };
                            <___ZerocopyVariantStruct_TupleLike<'a, N, X, Y> as ::zerocopy ::TryFromBytes>::is_bit_valid (
                                             variant)
                         }


### PR DESCRIPTION
This commit adds a framework which supports encoding in the type system any `I -> I` mapping where `I` is any `Invariant` type. This permits us to make `cast_unsized`'s return value smarter, and as a result, allows us to remove a lot of `unsafe` code.

Makes progress on #1122

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
