### PR TITLE
[derive] Document trivial_is_bit_valid

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -553,6 +553,22 @@ fn derive_try_from_bytes_enum(
 /// Attempts to generate a `TryFromBytes::is_bit_valid` instance that
 /// unconditionally returns true.
 ///
+/// This is possible when the `top_level` trait is `FromBytes` and there are no
+/// generic type parameters. In this case, we know that compilation will succeed
+/// only if the type is unconditionally `FromBytes`. Type parameters are not
+/// supported because a type with type parameters could be `TryFromBytes` but
+/// not `FromBytes` depending on its type parameters, and so deriving a trivial
+/// `is_bit_valid` would be either unsound or, assuming we add a defensive
+/// `Self: FromBytes` bound (as we currently do), overly restrictive. Consider,
+/// for example, that `Foo<bool>` ought to be `TryFromBytes` but not `FromBytes`
+/// in this example:
+///
+/// ```rust,ignore
+/// #[derive(FromBytes)]
+/// #[repr(transparent)]
+/// struct Foo<T>(T);
+/// ```
+///
 /// This should be used where possible. Using this impl is faster to codegen,
 /// faster to compile, and is friendlier on the optimizer.
 fn try_gen_trivial_is_bit_valid(


### PR DESCRIPTION
Explain why we only support concrete types so that future authors won't spuriously add support for them.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
