### PR TITLE
[pointer] Rename `Any` -> `Unknown`/`Inaccessible`

### DIFF
--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -24,14 +24,14 @@ use crate::Unaligned;
 /// to [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Any> =
+pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
 
 /// A semi-user-facing wrapper type representing a maybe-aligned reference, for
 /// use in [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Any> =
+pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Valid)>;
 
 // These methods are defined on the type alias, `MaybeAligned`, so as to bring

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -676,8 +676,8 @@ mod _transitions {
         #[doc(hidden)]
         #[must_use]
         #[inline]
-        pub const fn forget_aligned(self) -> Ptr<'a, T, I::WithAlignment<Any>> {
-            // SAFETY: `Any` is less restrictive than `Aligned`.
+        pub const fn forget_aligned(self) -> Ptr<'a, T, I::WithAlignment<Unknown>> {
+            // SAFETY: `Unknown` is less restrictive than `Aligned`.
             unsafe { self.assume_invariants() }
         }
     }
@@ -706,15 +706,14 @@ mod _casts {
         /// following properties:
         /// - `u` addresses a subset of the bytes addressed by `p`
         /// - `u` has the same provenance as `p`
-        /// - If `I::Aliasing` is [`Any`] or [`Shared`], `UnsafeCell`s in `*u`
-        ///   must exist at ranges identical to those at which `UnsafeCell`s
-        ///   exist in `*p`
+        /// - If `I::Aliasing` is [`Shared`], `UnsafeCell`s in `*u` must exist
+        ///   at ranges identical to those at which `UnsafeCell`s exist in `*p`
         #[doc(hidden)]
         #[inline]
         pub unsafe fn cast_unsized_unchecked<U: 'a + ?Sized, F: FnOnce(*mut T) -> *mut U>(
             self,
             cast: F,
-        ) -> Ptr<'a, U, (I::Aliasing, Any, Any)> {
+        ) -> Ptr<'a, U, (I::Aliasing, Unknown, Unknown)> {
             let ptr = cast(self.as_inner().as_non_null().as_ptr());
 
             // SAFETY: Caller promises that `cast` returns a pointer whose
@@ -768,9 +767,11 @@ mod _casts {
             //        pointer will permit mutation of this byte during `'a`, by
             //        invariant on `self`, no other code assumes that this will
             //        not happen.
+            //    - `Inaccessible`: There are no restrictions we need to uphold.
             // 7. `ptr`, trivially, conforms to the alignment invariant of
-            //    `Any`.
-            // 8. `ptr`, trivially, conforms to the validity invariant of `Any`.
+            //    `Unknown`.
+            // 8. `ptr`, trivially, conforms to the validity invariant of
+            //    `Unknown`.
             unsafe { Ptr::new(ptr) }
         }
 
@@ -784,7 +785,10 @@ mod _casts {
         /// - `u` has the same provenance as `p`
         #[doc(hidden)]
         #[inline]
-        pub unsafe fn cast_unsized<U, F, R, S>(self, cast: F) -> Ptr<'a, U, (I::Aliasing, Any, Any)>
+        pub unsafe fn cast_unsized<U, F, R, S>(
+            self,
+            cast: F,
+        ) -> Ptr<'a, U, (I::Aliasing, Unknown, Unknown)>
         where
             T: Read<I::Aliasing, R>,
             U: 'a + ?Sized + Read<I::Aliasing, S>,
@@ -927,10 +931,11 @@ mod _casts {
             // 0. Since `U: Read<I::Aliasing, _>`, either:
             //    - `I::Aliasing` is `Exclusive`, in which case both `src` and
             //      `ptr` conform to `Exclusive`
-            //    - `I::Aliasing` is `Shared` or `Any` and `U` is `Immutable`
-            //      (we already know that `[u8]: Immutable`). In this case,
-            //      neither `U` nor `[u8]` permit mutation, and so `Shared`
-            //      aliasing is satisfied.
+            //    - `I::Aliasing` is `Shared` or `Inaccessible` and `U` is
+            //      `Immutable` (we already know that `[u8]: Immutable`). In
+            //      this case, neither `U` nor `[u8]` permit mutation, and so
+            //      `Shared` aliasing is satisfied. `Inaccessible` is trivially
+            //      satisfied since it imposes no requirements.
             // 1. `ptr` conforms to the alignment invariant of `Aligned` because
             //    it is derived from `try_cast_into`, which promises that the
             //    object described by `target` is validly aligned for `U`.
@@ -1070,7 +1075,7 @@ mod _project {
         pub unsafe fn project<U: 'a + ?Sized>(
             self,
             projector: impl FnOnce(*mut T) -> *mut U,
-        ) -> Ptr<'a, U, (I::Aliasing, Any, Initialized)> {
+        ) -> Ptr<'a, U, (I::Aliasing, Unknown, Initialized)> {
             // TODO(#1122): If `cast_unsized` were able to reason that, when
             // casting from an `Initialized` pointer, the result is another
             // `Initialized` pointer, we could remove this method entirely.

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -520,7 +520,7 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 fn try_cast_or_pme<Src, Dst, I, R>(
     src: Ptr<'_, Src, I>,
 ) -> Result<
-    Ptr<'_, Dst, (I::Aliasing, invariant::Any, invariant::Valid)>,
+    Ptr<'_, Dst, (I::Aliasing, invariant::Unknown, invariant::Valid)>,
     ValidityError<Ptr<'_, Src, I>, Dst>,
 >
 where

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -99,11 +99,11 @@ impl<I: invariant::Validity> ValidityVariance<I> for Covariant {
 pub enum Invariant {}
 
 impl<I: invariant::Alignment> AlignmentVariance<I> for Invariant {
-    type Applied = invariant::Any;
+    type Applied = invariant::Unknown;
 }
 
 impl<I: invariant::Validity> ValidityVariance<I> for Invariant {
-    type Applied = invariant::Any;
+    type Applied = invariant::Unknown;
 }
 
 // SAFETY:


### PR DESCRIPTION
For aliasing, use `Inaccessible`. For alignment and validity, use `Unknown`.