### PR TITLE
Remove deprecated `FromBytes::(mut_)slice_from` items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
@@ -77,13 +77,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive" }
 
 [dev-dependencies]
 itertools = "0.11"
@@ -97,6 +97,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.5", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4544,17 +4544,6 @@ pub unsafe trait FromBytes: FromZeros {
         Self::mut_from_bytes(source).ok()
     }
 
-    #[deprecated(since = "0.8.0", note = "`FromBytes::ref_from_bytes` now supports slices")]
-    #[doc(hidden)]
-    #[must_use = "has no side effects"]
-    #[inline(always)]
-    fn slice_from(source: &[u8]) -> Option<&[Self]>
-    where
-        Self: Sized + Immutable,
-    {
-        <[Self]>::ref_from_bytes(source).ok()
-    }
-
     #[deprecated(since = "0.8.0", note = "renamed to `FromBytes::ref_from_prefix_with_elems`")]
     #[doc(hidden)]
     #[must_use = "has no side effects"]
@@ -4575,17 +4564,6 @@ pub unsafe trait FromBytes: FromZeros {
         Self: Sized + Immutable,
     {
         <[Self]>::ref_from_suffix_with_elems(source, count).ok()
-    }
-
-    #[deprecated(since = "0.8.0", note = "`FromBytes::mut_from_bytes` now supports slices")]
-    #[must_use = "has no side effects"]
-    #[doc(hidden)]
-    #[inline(always)]
-    fn mut_slice_from(source: &mut [u8]) -> Option<&mut [Self]>
-    where
-        Self: Sized + IntoBytes,
-    {
-        <[Self]>::mut_from_bytes(source).ok()
     }
 
     #[deprecated(since = "0.8.0", note = "renamed to `FromBytes::mut_from_prefix_with_elems`")]

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
These are causing PMEs in the presence of `-C link-dead-code`, which casues them to be monomorphized for `Self = ()`, thus producing the problematic ZSTy DST `[()]`.

Ref rust-lang/rust#131793
Fixes #1867

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
