### PR TITLE
Teach transmute_{ref,mut}! to handle slice DSTs

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -680,6 +680,7 @@ mod atomics {
         // TODO(#170): Implement `FromBytes` and `IntoBytes` once we implement
         // those traits for `*mut T`.
         impl_for_transmute_from!(T => TryFromBytes for AtomicPtr<T> [UnsafeCell<*mut T>]);
+        impl_for_transmute_from!(T => FromZeros for AtomicPtr<T> [UnsafeCell<*mut T>]);
 
         safety_comment! {
             /// SAFETY:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,17 +805,6 @@ pub unsafe trait KnownLayout {
         // resulting size would not fit in a `usize`.
         meta.size_for_metadata(Self::LAYOUT)
     }
-
-    #[doc(hidden)]
-    #[must_use]
-    #[inline(always)]
-    fn cast_from_raw<P: KnownLayout<PointerMetadata = Self::PointerMetadata> + ?Sized>(
-        ptr: NonNull<P>,
-    ) -> NonNull<Self> {
-        let data = ptr.cast::<u8>();
-        let meta = P::pointer_to_metadata(ptr.as_ptr());
-        Self::raw_from_ptr_len(data, meta)
-    }
 }
 
 /// The metadata associated with a [`KnownLayout`] type.

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -393,12 +393,8 @@ mod _conversions {
     {
         pub(crate) fn transmute<U, V, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
-            T: KnownLayout,
             V: Validity,
-            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R>
-                + KnownLayout<PointerMetadata = T::PointerMetadata>
-                + SizeEq<T>
-                + ?Sized,
+            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeEq<T> + ?Sized,
         {
             // SAFETY:
             // - This cast preserves address and provenance
@@ -414,28 +410,6 @@ mod _conversions {
             // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
             unsafe { self.transmute_unchecked(|t: NonNull<T>| U::cast_from_raw(t)) }
-        }
-
-        pub(crate) fn transmute_sized<U, V, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
-        where
-            T: Sized,
-            V: Validity,
-            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeEq<T>,
-        {
-            // SAFETY:
-            // - This cast preserves address and provenance
-            // - `U: SizeEq<T>` guarantees that this cast preserves the number
-            //   of bytes in the referent
-            // - If aliasing is `Shared`, then by `U: TransmuteFromPtr<T>`, at
-            //   least one of the following holds:
-            //   - `T: Immutable` and `U: Immutable`, in which case it is
-            //     trivially sound for shared code to operate on a `&T` and `&U`
-            //     at the same time, as neither can perform interior mutation
-            //   - It is directly guaranteed that it is sound for shared code to
-            //     operate on these references simultaneously
-            // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
-            //   sound to perform this transmute.
-            unsafe { self.transmute_unchecked(cast!()) }
         }
 
         #[doc(hidden)]

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -250,7 +250,7 @@ macro_rules! impl_for_transmute_from {
         TryFromBytes for $ty:ty [<$repr:ty>]
     ) => {
         #[inline]
-        fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
+        fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: $crate::Maybe<'_, Self, A>) -> bool {
             // SAFETY: This macro ensures that `$repr` and `Self` have the same
             // size and bit validity. Thus, a bit-valid instance of `$repr` is
             // also a bit-valid instance of `Self`.
@@ -664,14 +664,15 @@ macro_rules! static_assert {
             const ASSERT: bool;
         }
 
-        impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?,)*> StaticAssert for ($($tyvar,)*) {
+        // NOTE: We use `PhantomData` so we can support unsized types.
+        impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?,)*> StaticAssert for ($(core::marker::PhantomData<$tyvar>,)*) {
             const ASSERT: bool = {
                 const_assert!($condition $(, $args)*);
                 $condition
             };
         }
 
-        const_assert!(<($($tyvar,)*) as StaticAssert>::ASSERT);
+        const_assert!(<($(core::marker::PhantomData<$tyvar>,)*) as StaticAssert>::ASSERT);
     }};
 }
 

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -139,7 +139,7 @@ safety_comment! {
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
         T: TryFromBytes => TryFromBytes for Unalign<T>;
-        |c| T::is_bit_valid(c.transmute_sized())
+        |c| T::is_bit_valid(c.transmute())
     );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
@@ -188,7 +188,7 @@ impl<T> Unalign<T> {
     /// may prefer [`Deref::deref`], which is infallible.
     #[inline(always)]
     pub fn try_deref(&self) -> Result<&T, AlignmentError<&Self, T>> {
-        let inner = Ptr::from_ref(self).transmute_sized();
+        let inner = Ptr::from_ref(self).transmute();
         match inner.bikeshed_try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_ref()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_ref())),
@@ -205,7 +205,7 @@ impl<T> Unalign<T> {
     /// callers may prefer [`DerefMut::deref_mut`], which is infallible.
     #[inline(always)]
     pub fn try_deref_mut(&mut self) -> Result<&mut T, AlignmentError<&mut Self, T>> {
-        let inner = Ptr::from_mut(self).transmute_sized::<_, _, (_, (_, _))>();
+        let inner = Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>();
         match inner.bikeshed_try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_mut()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_mut())),
@@ -394,17 +394,14 @@ impl<T: Unaligned> Deref for Unalign<T> {
 
     #[inline(always)]
     fn deref(&self) -> &T {
-        Ptr::from_ref(self).transmute_sized().bikeshed_recall_aligned().as_ref()
+        Ptr::from_ref(self).transmute().bikeshed_recall_aligned().as_ref()
     }
 }
 
 impl<T: Unaligned> DerefMut for Unalign<T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
-        Ptr::from_mut(self)
-            .transmute_sized::<_, _, (_, (_, _))>()
-            .bikeshed_recall_aligned()
-            .as_mut()
+        Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>().bikeshed_recall_aligned().as_mut()
     }
 }
 


### PR DESCRIPTION
TODO:
- Figure out how to make this backwards-compatible (since current macros work with `T: Sized`, but `T: Sized` does not imply `T: KnownLayout`)
- Make it so that `Sized` bounds are still enforced on older toolchains that don't support slice DST transmutes
- Write safety comments
- Get rid of now-unused macros and functions in util::macro_util

Makes progress on #1817

gherrit-pr-id: Ib4bc62202e0b3b09d155333b525087f7aa8f02c2

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
