### PR TITLE
Use #[marker] on nightly in CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(
     __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS,
-    feature(layout_for_ptr, strict_provenance, coverage_attribute)
+    feature(layout_for_ptr, strict_provenance, coverage_attribute, marker_trait_attr)
 )]
 
 // This is a hack to allow zerocopy-derive derives to work in this crate. They

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -14,7 +14,7 @@ pub mod invariant;
 mod ptr;
 
 #[doc(hidden)]
-pub use invariant::{BecauseExclusive, BecauseImmutable, Read, ReadReason};
+pub use invariant::{BecauseExclusive, BecauseImmutable, Read};
 #[doc(hidden)]
 pub use ptr::Ptr;
 
@@ -48,7 +48,6 @@ where
     pub fn read_unaligned<R>(self) -> T
     where
         T: Copy,
-        R: invariant::ReadReason,
         T: invariant::Read<Aliasing, R>,
     {
         // SAFETY: By invariant on `MaybeAligned`, `raw` contains

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -658,7 +658,6 @@ mod _transitions {
             T: TryFromBytes + Read<I::Aliasing, R>,
             I::Aliasing: Reference,
             I: Invariants<Validity = Initialized>,
-            R: crate::pointer::ReadReason,
         {
             // This call may panic. If that happens, it doesn't cause any soundness
             // issues, as we have not generated any invalid state which we need to
@@ -805,8 +804,6 @@ mod _casts {
         where
             T: Read<I::Aliasing, R>,
             U: 'a + ?Sized + Read<I::Aliasing, S>,
-            R: ReadReason,
-            S: ReadReason,
             F: FnOnce(*mut T) -> *mut U,
         {
             // SAFETY: Because `T` and `U` both implement `Read<I::Aliasing, _>`,
@@ -829,7 +826,6 @@ mod _casts {
         #[allow(clippy::wrong_self_convention)]
         pub(crate) fn as_bytes<R>(self) -> Ptr<'a, [u8], (I::Aliasing, Aligned, Valid)>
         where
-            R: ReadReason,
             T: Read<I::Aliasing, R>,
             I::Aliasing: Reference,
         {
@@ -919,7 +915,6 @@ mod _casts {
             CastError<Self, U>,
         >
         where
-            R: ReadReason,
             I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
         {
@@ -983,7 +978,6 @@ mod _casts {
         where
             I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
-            R: ReadReason,
         {
             match self.try_cast_into(CastType::Prefix, meta) {
                 Ok((slf, remainder)) => {

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -25,7 +25,7 @@ use core::mem::{self, ManuallyDrop};
 use core::ptr::{self, NonNull};
 
 use crate::{
-    pointer::invariant::{self, BecauseExclusive, BecauseImmutable, Invariants, ReadReason},
+    pointer::invariant::{self, BecauseExclusive, BecauseImmutable, Invariants},
     Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
 };
 
@@ -528,7 +528,6 @@ where
     Dst: TryFromBytes + invariant::Read<I::Aliasing, R>,
     I: Invariants<Validity = invariant::Valid>,
     I::Aliasing: invariant::Reference,
-    R: ReadReason,
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());
 

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -655,3 +655,14 @@ macro_rules! static_assert_dst_is_not_zst {
         }, "cannot call this method on a dynamically-sized type whose trailing slice element is zero-sized");
     }}
 }
+
+macro_rules! define_because {
+    ($(#[$attr:meta])* $vis:vis $name:ident) => {
+        #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
+        $(#[$attr])*
+        $vis type $name = ();
+        #[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS))]
+        $(#[$attr])*
+        $vis enum $name {}
+    };
+}


### PR DESCRIPTION
We eventually hope to make use of `#[marker]` traits once they're
stable. This permits us to test to make sure the feature is as we expect
and that our intended usage works.




---

This PR is on branch [ptr-overhaul](../tree/ptr-overhaul).

- #1913
- #1910
- #1911
- #1925