### PR TITLE
Implement `Ref::{try_as_ref,try_into_ref,try_into_mut}`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -569,6 +569,13 @@ impl<Src, Dst: ?Sized + TryFromBytes> ValidityError<Src, Dst> {
         self.src
     }
 
+    pub(crate) fn with_src<NewSrc>(self, new_src: NewSrc) -> ValidityError<NewSrc, Dst> {
+        // INVARIANT: `with_src` doesn't change the type of `Dst`, so the
+        // invariant that `Dst`'s alignment requirement is greater than one is
+        // preserved.
+        ValidityError { src: new_src, dst: SendSyncPhantomData::default() }
+    }
+
     /// Maps the source value associated with the conversion error.
     ///
     /// This can help mitigate [issues with `Send`, `Sync` and `'static`


### PR DESCRIPTION
Only `Ref::try_as_mut` remains missing, probably pending polonius landing in rustc.

Partially fixes #1865
Supersedes #1184

A restricted form of `Ref::try_as_mut` can be implemented now as:
```rust
impl<B, T> Ref<B, T>
where
    B: ByteSlice,
    T: KnownLayout + ?Sized,
{
    #[must_use = "has no side effects"]
    #[inline(always)]
    pub fn try_as_mut(r: &mut Self) -> Result<&mut T, ValidityError<&mut Self, T>>
    where
        T: TryFromBytes + Immutable,
        B: ByteSliceMut + CloneableByteSlice,
    {
        // Presumably unreachable, since we've guarded each constructor of `Ref`.
        static_assert_dst_is_not_zst!(T);

        // Due to a false-positive in Rust's current borrow checker, the same
        // `r` can't be used for both validation *and* be returned upon
        // validation failure. We use `r_tmp` for validation, and `r` as the
        // value returned upon failure.
        let mut r_tmp = r.clone();

        // SAFETY: We don't call any methods on `t` other than those provided by
        // `ByteSlice`.
        let b = unsafe { r_tmp.as_byte_slice_mut() };

        match Ptr::from_mut(b.deref_mut()).try_cast_into_no_leftover::<T, BecauseExclusive>(None) {
            Ok(candidate) => match candidate.try_into_valid() {
                Ok(valid) => {
                    // SAFETY: `valid` inherits the local lifetime of `r_tmp`,
                    // but its value is derived from `r_tmp`'s underlying bytes.
                    // By contract on `CloneableByteSlice`, `r_temp.deref()
                    // produces a byte slice whose address (and thus lifetime)
                    // is identicial to that produced by `r.deref()`. We can
                    // therefor soundly extend the lifetime of `valid` to that
                    // of `r`.
                    Ok(unsafe { valid.assume_lifetime() }.as_mut())
                },
                Err(e) => Err(e.with_src(r)),
            },
            Err(CastError::Validity(i)) => match i {},
            Err(CastError::Alignment(_) | CastError::Size(_)) => {
                // SAFETY: By invariant on `Ref::0`, the referenced byte slice
                // is aligned to `T`'s alignment and its size corresponds to a
                // valid size for `T`. Since properties are checked upon
                // constructing `Ref`, these failures are unreachable.
                unsafe { core::hint::unreachable_unchecked() }
            }
        }
    }
}
```
...but we don't yet implement `ClonableByteSlice` for anything except `&[u8]`, so the method is effectively untestable. 