### PR TITLE
[doc] Render toolchain version detection in rustdoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
           # These are the names of specific Rust versions detected in
           # `build.rs`. Each of these represents the minimum Rust version for
           # which a particular feature is supported.
-          "zerocopy-core-error",
-          "zerocopy-diagnostic-on-unimplemented",
-          "zerocopy-generic-bounds-in-const-fn",
-          "zerocopy-target-has-atomics",
-          "zerocopy-aarch64-simd",
-          "zerocopy-panic-in-const-and-vec-try-reserve"
+          "zerocopy-core-error-1-81-0",
+          "zerocopy-diagnostic-on-unimplemented-1-78-0",
+          "zerocopy-generic-bounds-in-const-fn-1-61-0",
+          "zerocopy-target-has-atomics-1-60-0",
+          "zerocopy-aarch64-simd-1-59-0",
+          "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
         ]
         target: [
           "i686-unknown-linux-gnu",
@@ -89,17 +89,17 @@ jobs:
             features: "--all-features"
           - toolchain: "stable"
             features: "--all-features"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             features: "--all-features"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             features: "--all-features"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
             features: "--all-features"
-          - toolchain: "zerocopy-target-has-atomics"
+          - toolchain: "zerocopy-target-has-atomics-1-60-0"
             features: "--all-features"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             features: "--all-features"
-          - toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
+          - toolchain: "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
             features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
@@ -114,103 +114,103 @@ jobs:
           # exist to exercise zerocopy behavior which differs by toolchain;
           # zerocopy-derive doesn't behave different on these toolchains.
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-core-error"
+            toolchain: "zerocopy-core-error-1-81-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-diagnostic-on-unimplemented"
+            toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-generic-bounds-in-const-fn"
+            toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-target-has-atomics"
+            toolchain: "zerocopy-target-has-atomics-1-60-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-aarch64-simd"
+            toolchain: "zerocopy-aarch64-simd-1-59-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-panic-in-const-and-vec-try-reserve"
-          # Exclude non-aarch64 targets from the `zerocopy-aarch64-simd`
+            toolchain: "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
+          # Exclude non-aarch64 targets from the `zerocopy-aarch64-simd-1-59-0`
           # toolchain.
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "i686-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "x86_64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-aarch64-simd"
+          - toolchain: "zerocopy-aarch64-simd-1-59-0"
             target: "wasm32-wasi"
-          # Exclude most targets targets from the `zerocopy-core-error`
-          # toolchain since the `zerocopy-core-error` feature is unrelated to
+          # Exclude most targets targets from the `zerocopy-core-error-1-81-0`
+          # toolchain since the `zerocopy-core-error-1-81-0` feature is unrelated to
           # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-core-error"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-core-error"
-            target: "wasm32-wasi"
-          # Exclude most targets targets from the
-          # `zerocopy-diagnostic-on-unimplemented` toolchain since the
-          # `zerocopy-diagnostic-on-unimplemented` feature is unrelated to
-          # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
-            target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented"
+          - toolchain: "zerocopy-core-error-1-81-0"
             target: "wasm32-wasi"
           # Exclude most targets targets from the
-          # `zerocopy-generic-bounds-in-const-fn` toolchain since the
-          # `zerocopy-generic-bounds-in-const-fn` feature is unrelated to
+          # `zerocopy-diagnostic-on-unimplemented-1-78-0` toolchain since the
+          # `zerocopy-diagnostic-on-unimplemented-1-78-0` feature is unrelated to
           # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn"
+          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
+            target: "wasm32-wasi"
+          # Exclude most targets targets from the
+          # `zerocopy-generic-bounds-in-const-fn-1-61-0` toolchain since the
+          # `zerocopy-generic-bounds-in-const-fn-1-61-0` feature is unrelated to
+          # compilation target. This only leaves i686 and x86_64 targets.
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "arm-unknown-linux-gnueabi"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "aarch64-unknown-linux-gnu"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "powerpc-unknown-linux-gnu"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "powerpc64-unknown-linux-gnu"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "riscv64gc-unknown-linux-gnu"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "s390x-unknown-linux-gnu"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "x86_64-pc-windows-msvc"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "thumbv6m-none-eabi"
+          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
             target: "wasm32-wasi"
           # Exclude `thumbv6m-none-eabi` combined with any feature that implies
           # the `std` feature since `thumbv6m-none-eabi` does not include a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
@@ -31,27 +31,31 @@ exclude = [".*"]
 # which will be emitted if zerocopy is built with a toolchain version at least
 # as high as the specified version. In the emitted `--cfg`, dashes are replaced
 # by underscores.
+#
+# Each name is suffixed with the version it corresponds to. This is a convention
+# used in the codebase to make it less likely for us to make mistakes when
+# writing `doc_cfg` attributes.
 
 # From 1.81.0, Rust supports the `core::error::Error` trait.
-zerocopy-core-error = "1.81.0"
+zerocopy-core-error-1-81-0 = "1.81.0"
 
 # From 1.78.0, Rust supports the `#[diagnostic::on_unimplemented]` attribute.
-zerocopy-diagnostic-on-unimplemented = "1.78.0"
+zerocopy-diagnostic-on-unimplemented-1-78-0 = "1.78.0"
 
 # From 1.61.0, Rust supports generic types with trait bounds in `const fn`.
-zerocopy-generic-bounds-in-const-fn = "1.61.0"
+zerocopy-generic-bounds-in-const-fn-1-61-0 = "1.61.0"
 
 # From 1.60.0, Rust supports `cfg(target_has_atomics)`, which allows us to
 # detect whether a target supports particular sets of atomics.
-zerocopy-target-has-atomics = "1.60.0"
+zerocopy-target-has-atomics-1-60-0 = "1.60.0"
 
 # When the "simd" feature is enabled, include SIMD types from the
 # `core::arch::aarch64` module, which was stabilized in 1.59.0. On earlier Rust
 # versions, these types require the "simd-nightly" feature.
-zerocopy-aarch64-simd = "1.59.0"
+zerocopy-aarch64-simd-1-59-0 = "1.59.0"
 
 # Permit panicking in `const fn`s and calling `Vec::try_reserve`.
-zerocopy-panic-in-const-and-vec-try-reserve = "1.57.0"
+zerocopy-panic-in-const-and-vec-try-reserve-1-57-0 = "1.57.0"
 
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
@@ -77,13 +81,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.7", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.7", path = "zerocopy-derive" }
 
 [dev-dependencies]
 itertools = "0.11"
@@ -97,6 +101,6 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.6", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.7", path = "zerocopy-derive" }
 # TODO(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,9 +121,9 @@ use core::{
     ops::Deref,
 };
 
-#[cfg(zerocopy_core_error)]
+#[cfg(zerocopy_core_error_1_81_0)]
 use core::error::Error;
-#[cfg(all(not(zerocopy_core_error), any(feature = "std", test)))]
+#[cfg(all(not(zerocopy_core_error_1_81_0), any(feature = "std", test)))]
 use std::error::Error;
 
 use crate::{util::SendSyncPhantomData, KnownLayout, TryFromBytes, Unaligned};
@@ -232,7 +232,8 @@ impl<A: fmt::Display, S: fmt::Display, V: fmt::Display> fmt::Display for Convert
     }
 }
 
-#[cfg(any(zerocopy_core_error, feature = "std", test))]
+#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<A, S, V> Error for ConvertError<A, S, V>
 where
     A: fmt::Display + fmt::Debug,
@@ -389,7 +390,8 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error, feature = "std", test))]
+#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for AlignmentError<Src, Dst>
 where
     Src: Deref,
@@ -534,7 +536,8 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error, feature = "std", test))]
+#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for SizeError<Src, Dst>
 where
     Src: Deref,
@@ -641,7 +644,8 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error, feature = "std", test))]
+#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for ValidityError<Src, Dst>
 where
     Src: Deref,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -442,7 +442,7 @@ safety_comment! {
 }
 
 #[cfg(all(
-    zerocopy_target_has_atomics,
+    zerocopy_target_has_atomics_1_60_0,
     any(
         target_has_atomic = "8",
         target_has_atomic = "16",
@@ -451,6 +451,7 @@ safety_comment! {
         target_has_atomic = "ptr"
     )
 ))]
+#[cfg_attr(doc_cfg, doc(cfg(rust = "1.60.0")))]
 mod atomics {
     use super::*;
 
@@ -933,7 +934,8 @@ mod simd {
             #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
             powerpc64, powerpc64, vector_bool_long, vector_double, vector_signed_long, vector_unsigned_long
         );
-        #[cfg(zerocopy_aarch64_simd)]
+        #[cfg(zerocopy_aarch64_simd_1_59_0)]
+        #[cfg_attr(doc_cfg, doc(cfg(rust = "1.59.0")))]
         simd_arch_mod!(
             // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
             // broken on big-endian platforms.
@@ -1882,7 +1884,7 @@ mod tests {
                 vector_signed_long,
                 vector_unsigned_long
             );
-            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd))]
+            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd_1_59_0))]
             #[rustfmt::skip]
             test_simd_arch_mod!(
                 aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -880,7 +880,7 @@ mod tests {
                             layout(size_info, align).validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
                         }).map_err(|d| {
                             let msg = d.downcast::<&'static str>().ok().map(|s| *s.as_ref());
-                            assert!(msg.is_some() || cfg!(not(zerocopy_panic_in_const_and_vec_try_reserve)), "non-string panic messages are not permitted when `--cfg zerocopy_panic_in_const_and_vec_try_reserve` is set");
+                            assert!(msg.is_some() || cfg!(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)), "non-string panic messages are not permitted when `--cfg zerocopy_panic_in_const_and_vec_try_reserve` is set");
                             msg
                         });
                         std::panic::set_hook(previous_hook);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -706,7 +706,7 @@ pub use zerocopy_derive::KnownLayout;
     doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.KnownLayout.html"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(KnownLayout)]` to `{Self}`")
 )]
 pub unsafe trait KnownLayout {
@@ -1158,7 +1158,7 @@ pub use zerocopy_derive::Immutable;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Immutable.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(Immutable)]` to `{Self}`")
 )]
 pub unsafe trait Immutable {
@@ -1308,7 +1308,7 @@ pub use zerocopy_derive::TryFromBytes;
     doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.TryFromBytes.html"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(TryFromBytes)]` to `{Self}`")
 )]
 pub unsafe trait TryFromBytes {
@@ -2838,7 +2838,7 @@ unsafe fn try_read_from<S, T: TryFromBytes>(
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.FromZeros.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(FromZeros)]` to `{Self}`")
 )]
 pub unsafe trait FromZeros: TryFromBytes {
@@ -3141,9 +3141,9 @@ pub unsafe trait FromZeros: TryFromBytes {
 
     /// Extends a `Vec<Self>` by pushing `additional` new items onto the end of
     /// the vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+    #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.57.0", feature = "alloc"))))]
     #[inline(always)]
     fn extend_vec_zeroed(v: &mut Vec<Self>, additional: usize) -> Result<(), AllocError>
     where
@@ -3160,9 +3160,9 @@ pub unsafe trait FromZeros: TryFromBytes {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+    #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.57.0", feature = "alloc"))))]
     #[inline]
     fn insert_vec_zeroed(
         v: &mut Vec<Self>,
@@ -3420,7 +3420,7 @@ pub use zerocopy_derive::FromBytes;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.FromBytes.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(FromBytes)]` to `{Self}`")
 )]
 pub unsafe trait FromBytes: FromZeros {
@@ -4816,7 +4816,7 @@ pub use zerocopy_derive::IntoBytes;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.IntoBytes.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(IntoBytes)]` to `{Self}`")
 )]
 pub unsafe trait IntoBytes {
@@ -5326,7 +5326,7 @@ pub use zerocopy_derive::Unaligned;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Unaligned.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(Unaligned)]` to `{Self}`")
 )]
 pub unsafe trait Unaligned {
@@ -5340,13 +5340,13 @@ pub unsafe trait Unaligned {
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+#[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
 mod alloc_support {
     use super::*;
 
     /// Extends a `Vec<T>` by pushing `additional` new items onto the end of the
     /// vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5363,7 +5363,7 @@ mod alloc_support {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5377,7 +5377,7 @@ mod alloc_support {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+#[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
 #[doc(hidden)]
 pub use alloc_support::*;
 
@@ -6240,7 +6240,7 @@ mod tests {
     mod alloc {
         use super::*;
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         #[test]
         fn test_extend_vec_zeroed() {
             // Test extending when there is an existing allocation.
@@ -6258,7 +6258,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         #[test]
         fn test_extend_vec_zeroed_zst() {
             // Test extending when there is an existing (fake) allocation.
@@ -6275,7 +6275,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         #[test]
         fn test_insert_vec_zeroed() {
             // Insert at start (no existing allocation).
@@ -6307,7 +6307,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         #[test]
         fn test_insert_vec_zeroed_zst() {
             // Insert at start (no existing fake allocation).

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented,
+    zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(
         message = "`{T}` has inter-field padding",
         label = "types with padding cannot implement `IntoBytes`",
@@ -289,7 +289,7 @@ pub type SizeToTag<const SIZE: usize> = <() as size_to_tag::SizeToTag<SIZE>>::Ta
 
 // We put `Sized` in its own module so it can have the same name as the standard
 // library `Sized` without shadowing it in the parent module.
-#[cfg(zerocopy_diagnostic_on_unimplemented)]
+#[cfg(zerocopy_diagnostic_on_unimplemented_1_78_0)]
 mod __size_of {
     #[diagnostic::on_unimplemented(
         message = "`{Self}` is unsized",
@@ -308,9 +308,9 @@ mod __size_of {
     }
 }
 
-#[cfg(zerocopy_diagnostic_on_unimplemented)]
+#[cfg(zerocopy_diagnostic_on_unimplemented_1_78_0)]
 pub use __size_of::size_of;
-#[cfg(not(zerocopy_diagnostic_on_unimplemented))]
+#[cfg(not(zerocopy_diagnostic_on_unimplemented_1_78_0))]
 pub use core::mem::size_of;
 
 /// Does the struct type `$t` have padding?

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -623,10 +623,10 @@ macro_rules! maybe_const_trait_bounded_fn {
     // non-method functions. Each `$args` may optionally be followed by `:
     // $arg_tys:ty`, which can be omitted for `self`.
     ($(#[$attr:meta])* $vis:vis const fn $name:ident($($args:ident $(: $arg_tys:ty)?),* $(,)?) $(-> $ret_ty:ty)? $body:block) => {
-        #[cfg(zerocopy_generic_bounds_in_const_fn)]
+        #[cfg(zerocopy_generic_bounds_in_const_fn_1_61_0)]
         $(#[$attr])* $vis const fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
 
-        #[cfg(not(zerocopy_generic_bounds_in_const_fn))]
+        #[cfg(not(zerocopy_generic_bounds_in_const_fn_1_61_0))]
         $(#[$attr])* $vis fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
     };
 }
@@ -647,9 +647,9 @@ macro_rules! const_panic {
         panic[0]
     }};
     ($($arg:tt)+) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         panic!($($arg)+);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         const_panic!(@non_panic $($arg)+)
     }};
 }
@@ -660,9 +660,9 @@ macro_rules! const_panic {
 /// accommodate old toolchains.
 macro_rules! const_assert {
     ($e:expr) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         assert!($e);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         {
             let e = $e;
             if !e {
@@ -671,9 +671,9 @@ macro_rules! const_assert {
         }
     }};
     ($e:expr, $($args:tt)+) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         assert!($e, $($args)+);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         {
             let e = $e;
             if !e {
@@ -686,9 +686,9 @@ macro_rules! const_assert {
 /// Like `const_assert!`, but relative to `debug_assert!`.
 macro_rules! const_debug_assert {
     ($e:expr $(, $msg:expr)?) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         debug_assert!($e $(, $msg)?);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         {
             // Use this (rather than `#[cfg(debug_assertions)]`) to ensure that
             // `$e` is always compiled even if it will never be evaluated at
@@ -707,10 +707,10 @@ macro_rules! const_debug_assert {
 /// toolchain supports panicking in `const fn`.
 macro_rules! const_unreachable {
     () => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         unreachable!();
 
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve))]
+        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         loop {}
     }};
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -374,7 +374,7 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for Unalign<T> {
 /// The caller promises that `$atomic` is an atomic type whose natie equivalent
 /// is `$native`.
 #[cfg(all(
-    zerocopy_target_has_atomics,
+    zerocopy_target_has_atomics_1_60_0,
     any(
         target_has_atomic = "8",
         target_has_atomic = "16",
@@ -635,7 +635,7 @@ pub(crate) const fn round_down_to_next_multiple_of_alignment(
     align: NonZeroUsize,
 ) -> usize {
     let align = align.get();
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve)]
+    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
     debug_assert!(align.is_power_of_two());
 
     // Subtraction can't underflow because `align.get() >= 1`.

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
Previously, we had avoided doing this because there wasn't any way to guarantee that we didn't make mistakes and render the wrong version for a particular named toolchain version.

In this commit, we take the pragmatic approach of renaming the named toolchain versions - in particular, we add a suffix which includes the toolchain version. This is fairly error-resistant for two reasons:
- At the definition site (in `Cargo.toml`), the name appears on the same line as the version, so mistakes should be obvious
- At the use site (in various `.rs` files), the name appears within a few lines of any `#[cfg_attr(doc_cfg, doc(cfg(...)))]` attribute, so mistakes should similarly be obvious

Release 0.8.7.

Closes #894

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
