### PR TITLE
[pointer][transmute] Support generic TransmuteFrom

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -443,13 +443,13 @@ mod atomics {
     use super::*;
 
     macro_rules! impl_traits_for_atomics {
-        ($($atomics:ident),* $(,)?) => {
+        ($($atomics:ident[$repr:ty]),* $(,)?) => {
             $(
                 impl_known_layout!($atomics);
-                impl_for_transparent_wrapper!(=> TryFromBytes for $atomics);
-                impl_for_transparent_wrapper!(=> FromZeros for $atomics);
-                impl_for_transparent_wrapper!(=> FromBytes for $atomics);
-                impl_for_transparent_wrapper!(=> IntoBytes for $atomics);
+                impl_for_transmute_from!(=> TryFromBytes for $atomics[UnsafeCell<$repr>]);
+                impl_for_transmute_from!(=> FromZeros for $atomics[UnsafeCell<$repr>]);
+                impl_for_transmute_from!(=> FromBytes for $atomics[UnsafeCell<$repr>]);
+                impl_for_transmute_from!(=> IntoBytes for $atomics[UnsafeCell<$repr>]);
             )*
         };
     }
@@ -461,13 +461,13 @@ mod atomics {
 
         use super::*;
 
-        impl_traits_for_atomics!(AtomicU8, AtomicI8);
+        impl_traits_for_atomics!(AtomicU8[u8], AtomicI8[i8]);
 
         impl_known_layout!(AtomicBool);
 
-        impl_for_transparent_wrapper!(=> TryFromBytes for AtomicBool);
-        impl_for_transparent_wrapper!(=> FromZeros for AtomicBool);
-        impl_for_transparent_wrapper!(=> IntoBytes for AtomicBool);
+        impl_for_transmute_from!(=> TryFromBytes for AtomicBool[UnsafeCell<bool>]);
+        impl_for_transmute_from!(=> FromZeros for AtomicBool[UnsafeCell<bool>]);
+        impl_for_transmute_from!(=> IntoBytes for AtomicBool[UnsafeCell<bool>]);
 
         safety_comment! {
             /// SAFETY:
@@ -497,7 +497,7 @@ mod atomics {
             /// SAFETY:
             /// All of these pass an atomic type and that type's native equivalent, as
             /// required by the macro safety preconditions.
-            unsafe_impl_transparent_wrapper_for_atomic!(AtomicU8 [u8], AtomicI8 [i8], AtomicBool [bool]);
+            unsafe_impl_transmute_from_for_atomic!(AtomicU8 [u8], AtomicI8 [i8], AtomicBool [bool]);
         }
     }
 
@@ -508,13 +508,13 @@ mod atomics {
 
         use super::*;
 
-        impl_traits_for_atomics!(AtomicU16, AtomicI16);
+        impl_traits_for_atomics!(AtomicU16[u16], AtomicI16[i16]);
 
         safety_comment! {
             /// SAFETY:
             /// All of these pass an atomic type and that type's native equivalent, as
             /// required by the macro safety preconditions.
-            unsafe_impl_transparent_wrapper_for_atomic!(AtomicU16 [u16], AtomicI16 [i16]);
+            unsafe_impl_transmute_from_for_atomic!(AtomicU16 [u16], AtomicI16 [i16]);
         }
     }
 
@@ -525,13 +525,13 @@ mod atomics {
 
         use super::*;
 
-        impl_traits_for_atomics!(AtomicU32, AtomicI32);
+        impl_traits_for_atomics!(AtomicU32[u32], AtomicI32[i32]);
 
         safety_comment! {
             /// SAFETY:
             /// All of these pass an atomic type and that type's native equivalent, as
             /// required by the macro safety preconditions.
-            unsafe_impl_transparent_wrapper_for_atomic!(AtomicU32 [u32], AtomicI32 [i32]);
+            unsafe_impl_transmute_from_for_atomic!(AtomicU32 [u32], AtomicI32 [i32]);
         }
     }
 
@@ -542,13 +542,13 @@ mod atomics {
 
         use super::*;
 
-        impl_traits_for_atomics!(AtomicU64, AtomicI64);
+        impl_traits_for_atomics!(AtomicU64[u64], AtomicI64[i64]);
 
         safety_comment! {
             /// SAFETY:
             /// All of these pass an atomic type and that type's native equivalent, as
             /// required by the macro safety preconditions.
-            unsafe_impl_transparent_wrapper_for_atomic!(AtomicU64 [u64], AtomicI64 [i64]);
+            unsafe_impl_transmute_from_for_atomic!(AtomicU64 [u64], AtomicI64 [i64]);
         }
     }
 
@@ -559,21 +559,21 @@ mod atomics {
 
         use super::*;
 
-        impl_traits_for_atomics!(AtomicUsize, AtomicIsize);
+        impl_traits_for_atomics!(AtomicUsize[usize], AtomicIsize[isize]);
 
         impl_known_layout!(T => AtomicPtr<T>);
 
         // TODO(#170): Implement `FromBytes` and `IntoBytes` once we implement
         // those traits for `*mut T`.
-        impl_for_transparent_wrapper!(T => TryFromBytes for AtomicPtr<T>);
-        impl_for_transparent_wrapper!(T => FromZeros for AtomicPtr<T>);
+        impl_for_transmute_from!(T => TryFromBytes for AtomicPtr<T>[UnsafeCell<*mut T>]);
+        impl_for_transmute_from!(T => FromZeros for AtomicPtr<T>[UnsafeCell<*mut T>]);
 
         safety_comment! {
             /// SAFETY:
             /// This passes an atomic type and that type's native equivalent, as
             /// required by the macro safety preconditions.
-            unsafe_impl_transparent_wrapper_for_atomic!(AtomicUsize [usize], AtomicIsize [isize]);
-            unsafe_impl_transparent_wrapper_for_atomic!(T => AtomicPtr<T> [*mut T]);
+            unsafe_impl_transmute_from_for_atomic!(AtomicUsize [usize], AtomicIsize [isize]);
+            unsafe_impl_transmute_from_for_atomic!(T => AtomicPtr<T> [*mut T]);
         }
     }
 }
@@ -603,12 +603,12 @@ safety_comment! {
     assert_unaligned!(PhantomData<()>, PhantomData<u8>, PhantomData<u64>);
 }
 
-impl_for_transparent_wrapper!(T: Immutable => Immutable for Wrapping<T>);
-impl_for_transparent_wrapper!(T: TryFromBytes => TryFromBytes for Wrapping<T>);
-impl_for_transparent_wrapper!(T: FromZeros => FromZeros for Wrapping<T>);
-impl_for_transparent_wrapper!(T: FromBytes => FromBytes for Wrapping<T>);
-impl_for_transparent_wrapper!(T: IntoBytes => IntoBytes for Wrapping<T>);
-impl_for_transparent_wrapper!(T: Unaligned => Unaligned for Wrapping<T>);
+impl_for_transmute_from!(T: Immutable => Immutable for Wrapping<T>[T]);
+impl_for_transmute_from!(T: TryFromBytes => TryFromBytes for Wrapping<T>[T]);
+impl_for_transmute_from!(T: FromZeros => FromZeros for Wrapping<T>[T]);
+impl_for_transmute_from!(T: FromBytes => FromBytes for Wrapping<T>[T]);
+impl_for_transmute_from!(T: IntoBytes => IntoBytes for Wrapping<T>[T]);
+impl_for_transmute_from!(T: Unaligned => Unaligned for Wrapping<T>[T]);
 assert_unaligned!(Wrapping<()>, Wrapping<u8>);
 
 safety_comment! {
@@ -620,22 +620,22 @@ safety_comment! {
     unsafe_impl!(T => FromBytes for MaybeUninit<T>);
 }
 
-impl_for_transparent_wrapper!(T: Immutable => Immutable for MaybeUninit<T>);
-impl_for_transparent_wrapper!(T: Unaligned => Unaligned for MaybeUninit<T>);
+impl_for_transmute_from!(T: Immutable => Immutable for MaybeUninit<T>[T]);
+impl_for_transmute_from!(T: Unaligned => Unaligned for MaybeUninit<T>[T]);
 assert_unaligned!(MaybeUninit<()>, MaybeUninit<u8>);
 
-impl_for_transparent_wrapper!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>);
-impl_for_transparent_wrapper!(T: ?Sized + TryFromBytes => TryFromBytes for ManuallyDrop<T>);
-impl_for_transparent_wrapper!(T: ?Sized + FromZeros => FromZeros for ManuallyDrop<T>);
-impl_for_transparent_wrapper!(T: ?Sized + FromBytes => FromBytes for ManuallyDrop<T>);
-impl_for_transparent_wrapper!(T: ?Sized + IntoBytes => IntoBytes for ManuallyDrop<T>);
-impl_for_transparent_wrapper!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>);
+impl_for_transmute_from!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>[T]);
+impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for ManuallyDrop<T>[T]);
+impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for ManuallyDrop<T>[T]);
+impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for ManuallyDrop<T>[T]);
+impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for ManuallyDrop<T>[T]);
+impl_for_transmute_from!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>[T]);
 assert_unaligned!(ManuallyDrop<()>, ManuallyDrop<u8>);
 
-impl_for_transparent_wrapper!(T: ?Sized + FromZeros => FromZeros for UnsafeCell<T>);
-impl_for_transparent_wrapper!(T: ?Sized + FromBytes => FromBytes for UnsafeCell<T>);
-impl_for_transparent_wrapper!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>);
-impl_for_transparent_wrapper!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>);
+impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for UnsafeCell<T>[T]);
+impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for UnsafeCell<T>[T]);
+impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>[T]);
+impl_for_transmute_from!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>[T]);
 assert_unaligned!(UnsafeCell<()>, UnsafeCell<u8>);
 
 // SAFETY: See safety comment in `is_bit_valid` impl.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2720,7 +2720,7 @@ unsafe fn try_read_from<S, T: TryFromBytes>(
     // We use `from_mut` despite not mutating via `c_ptr` so that we don't need
     // to add a `T: Immutable` bound.
     let c_ptr = Ptr::from_mut(&mut candidate);
-    let c_ptr = c_ptr.transparent_wrapper_into_inner();
+    let c_ptr = c_ptr.transmute::<_, pointer::transmute::BecauseBidirectional>();
     // SAFETY: `c_ptr` has no uninitialized sub-ranges because it derived from
     // `candidate`, which the caller promises is entirely initialized.
     let c_ptr = unsafe { c_ptr.assume_validity::<invariant::Initialized>() };

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -12,116 +12,197 @@ use core::{
     num::Wrapping,
 };
 
-use crate::{
-    pointer::invariant::{self, Invariants},
-    Unalign,
-};
+use crate::{pointer::invariant::*, Unalign};
 
-/// A type which has the same layout as the type it wraps.
+/// A type which supports pointer casting from another type, `T`.
 ///
 /// # Safety
 ///
-/// `T: TransparentWrapper` implies that `T` has the same size as [`T::Inner`].
-/// Further, `T: TransparentWrapper<I>` implies that:
-/// - If `T::UnsafeCellVariance = Covariant`, then `T` has `UnsafeCell`s
-///   covering the same byte ranges as `T::Inner`.
-/// - If a `T` pointer satisfies the alignment invariant `I::Alignment`, then
-///   that same pointer, cast to `T::Inner`, satisfies the alignment invariant
-///   `<T::AlignmentVariance as AlignmentVariance<I::Alignment>>::Applied`.
-/// - If a `T` pointer satisfies the validity invariant `I::Validity`, then that
-///   same pointer, cast to `T::Inner`, satisfies the validity invariant
-///   `<T::ValidityVariance as ValidityVariance<I::Validity>>::Applied`.
+/// If `U: TransmuteFromPtr<T, A, R>`, then given `t: *const T` which satisfies
+/// aliasing `A`, alignment `AA`, and validity `V`, it is sound to treat `t as
+/// *const U` as a pointer with aliasing `A`, alignment `MappedAlignment<AA, <U
+/// as TransmuteFrom<T>>::AlignmentMapping>`, and validity `MappedValidity<V, <U
+/// as TransmuteFrom<T>>::ValidityMapping>`.
 ///
-/// [`T::Inner`]: TransparentWrapper::Inner
-/// [`UnsafeCell`]: core::cell::UnsafeCell
-/// [`T::AlignmentVariance`]: TransparentWrapper::AlignmentVariance
-/// [`T::ValidityVariance`]: TransparentWrapper::ValidityVariance
-#[doc(hidden)]
-pub unsafe trait TransparentWrapper<I: Invariants> {
-    type Inner: ?Sized;
+/// If `A` is `Shared`, then this implies that, in the region referred to by
+/// both `t` and `u`, `*t` and `*u` contain `UnsafeCell`s at the same byte
+/// ranges. Thus, for `Shared` aliasing, it is not possible for `t` to perform
+/// interior mutation which violates `u`'s `Shared` aliasing invariant, or
+/// vice-versa.
+#[cfg_attr(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, marker)]
+pub(crate) unsafe trait TransmuteFromPtr<T: ?Sized, A: Aliasing, R>:
+    TransmuteFrom<T>
+{
+}
 
-    type UnsafeCellVariance;
-    type AlignmentVariance: AlignmentVariance<I::Alignment>;
-    type ValidityVariance: ValidityVariance<I::Validity>;
+// SAFETY: Let `t: *const T` satisfying `Shared` aliasing, alignment `A`, and
+// validity `V`. Let `u = t as *const U`. By safety invariant on `U:
+// TransmuteFrom<T>`, `u` satisfies alignment `MappedAlignment<A, <U as
+// TransmuteFrom<T>>::AlignmentMapping>`.
+//
+// Because `U: Immutable`, `u` with aliasing `Shared` will not be permitted to
+// write to its referent. Thus, if `t` already satisfies validity `V`, that will
+// continue to hold even though we don't require that `T: TransmuteFrom<U>`.
+//
+// By safety invariant on `U: TransmuteFrom<T>`, `u` satisfies validity
+// `MappedValidity<V, <U as TransmuteFrom<T>>::ValidityMapping>`.
+//
+// By safety invariant on `T: UnsafeCellsAgree<U>`, `t` and `u` reference
+// `UnsafeCell`s at the same byte ranges (at least within the region of memory
+// which they both address). By `U: Immutable`, that range contains no
+// `UnsafeCell`s. Thus, it is not possible for `u` to be used to perform
+// interior mutation which violate's `t`'s `Shared` aliasing invariant, and
+// vice-versa.
+//
+// NOTE: We could equivalently implement this for `T: Immutable, U: Immutable`
+// and drop the `UnsafeCellsAgree` bounds. However, this permits us to support
+// `T: !Immutable`. Perhaps we should eventually add a second impl with `T:
+// Immutable, U: Immutable` instead.
+unsafe impl<T, U> TransmuteFromPtr<T, Shared, BecauseImmutable> for U
+where
+    T: ?Sized + UnsafeCellsAgree<U>,
+    U: ?Sized + TransmuteFrom<T> + UnsafeCellsAgree<T> + crate::Immutable,
+{
+}
 
-    /// Casts a wrapper pointer to an inner pointer.
+define_because!(pub(crate) BecauseBidirectional);
+
+// SAFETY: Let `t: *const T` satisfying `Shared` aliasing, alignment `A`, and
+// validity `V`. Let `u = t as *const U`. By safety invariant on `U:
+// TransmuteFrom<T>`, `u` satisfies alignment `MappedAlignment<A, <U
+// as TransmuteFrom<T>>::AlignmentMapping>`.
+//
+// Because `T: TransmuteFrom<U, ValidityMapping = Preserved>` and `U:
+// TransmuteFrom<T, ValidityMapping = Preserved>`, `T` and `U` have identical
+// bit validity. Thus, any value written through the resulting `U` pointer will
+// satisfy whatever validity invariant is present on the original `T` pointer.
+//
+// By safety invariant on `U: TransmuteFrom<T>`, `u` satisfies validity
+// `MappedValidity<V, <U as TransmuteFrom<T>>::ValidityMapping>`.
+//
+// By safety invariant on `T: UnsafeCellsAgree<U>`, `t` and `u` reference
+// `UnsafeCell`s at the same byte ranges (at least within the region of memory
+// which they both address). Thus, if `A` is `Shared`, it is not possible for
+// `u` to be used to perform interior mutation which violate's `t` `Shared`
+// aliasing invariant, and vice-versa.
+//
+// TODO(#1945): If we permit arbitrary invariant mappings, we can relax this
+// bound and not require `ValidityMapping = Preserved`.
+unsafe impl<T, U, A> TransmuteFromPtr<T, A, BecauseBidirectional> for U
+where
+    A: Aliasing,
+    T: ?Sized + TransmuteFrom<U, ValidityMapping = Preserved> + UnsafeCellsAgree<U>,
+    U: ?Sized + TransmuteFrom<T, ValidityMapping = Preserved> + UnsafeCellsAgree<T>,
+{
+}
+
+define_because!(BecauseExclusive);
+unsafe impl<T, U> TransmuteFromPtr<T, Exclusive, BecauseExclusive> for U
+where
+    T: ?Sized + TransmuteFrom<U, ValidityMapping = Preserved>,
+    U: ?Sized + TransmuteFrom<T, ValidityMapping = Preserved>,
+{
+}
+
+/// Pairs of types which have `UnsafeCells` covering the same byte ranges.
+///
+/// # Safety
+///
+/// Let `t: &T` and `u: &U`. Let `len = min(size_of_val(t), size_of_val(u))`. If
+/// `U: UnsafeCellsAgree<T>`, then the first `len` bytes of `t` and the first
+/// `len` bytes of `u` have `UnsafeCell`s covering the same byte ranges. This
+/// condition must hold for all `t: &T` and for all `u: &U`.
+///
+/// Note that this safety invariant supports either or both of `T` and `U` being
+/// unsized.
+pub(crate) unsafe trait UnsafeCellsAgree<T: ?Sized>
+where
+    T: UnsafeCellsAgree<Self>,
+{
+}
+
+// SAFETY: `T` has `UnsafeCell`s covering the same byte ranges as itself by
+// definition.
+unsafe impl<T: ?Sized> UnsafeCellsAgree<T> for T {}
+
+/// A type which can be transmuted from another type, `T`.
+///
+/// # Safety
+///
+/// If `U: TransmuteFrom<T>`, then the following must hold:
+/// - Given `t: *const T`, `t as *const U` must produce a pointer which
+///   references the same number of bytes as `t`
+/// - If `t: *const T` satisfies the alignment invariant `A`, then `t as *const
+///   U` satisfies the alignment invariant `MappedAlignment<A,
+///   U::AlignmentMapping>`
+/// - If `t: *const T` satisfies the validity invariant `V`, then `t as *const
+///   U` satisfies the validity invariant `MappedValidity<V,
+///   U::ValidityMapping>`
+// TODO(#1940): Relax the safety invariant to support size mismatch and pairs of
+// types which require a metadata fix-up.
+//
+// TODO(#1945): Adopt an alternative encoding of invariant mappings?
+pub(crate) unsafe trait TransmuteFrom<T: ?Sized> {
+    type AlignmentMapping: AlignmentMapping;
+    type ValidityMapping: ValidityMapping;
+
+    /// Casts a `*mut T` to a `*mut Self`.
     ///
     /// # Safety
     ///
     /// The resulting pointer has the same address and provenance as `ptr`, and
     /// addresses the same number of bytes.
-    fn cast_into_inner(ptr: *mut Self) -> *mut Self::Inner;
-
-    /// Casts an inner pointer to a wrapper pointer.
-    ///
-    /// # Safety
-    ///
-    /// The resulting pointer has the same address and provenance as `ptr`, and
-    /// addresses the same number of bytes.
-    fn cast_from_inner(ptr: *mut Self::Inner) -> *mut Self;
-}
-
-#[allow(unreachable_pub)]
-#[doc(hidden)]
-pub trait AlignmentVariance<I: invariant::Alignment> {
-    type Applied: invariant::Alignment;
-}
-
-#[allow(unreachable_pub)]
-#[doc(hidden)]
-pub trait ValidityVariance<I: invariant::Validity> {
-    type Applied: invariant::Validity;
-}
-
-#[doc(hidden)]
-#[allow(missing_copy_implementations, missing_debug_implementations)]
-pub enum Covariant {}
-
-impl<I: invariant::Alignment> AlignmentVariance<I> for Covariant {
-    type Applied = I;
-}
-
-impl<I: invariant::Validity> ValidityVariance<I> for Covariant {
-    type Applied = I;
-}
-
-#[doc(hidden)]
-#[allow(missing_copy_implementations, missing_debug_implementations)]
-pub enum Invariant {}
-
-impl<I: invariant::Alignment> AlignmentVariance<I> for Invariant {
-    type Applied = invariant::Unknown;
-}
-
-impl<I: invariant::Validity> ValidityVariance<I> for Invariant {
-    type Applied = invariant::Unknown;
+    fn cast_from(ptr: *mut T) -> *mut Self;
 }
 
 // SAFETY:
+// - Given `t: *const T`, `t as *const T` is a no-op, and so trivially produces
+//   a pointer which references the same number of bytes as `t`
+// - Alignment: See inline safety comment.
+// - Validity: See inline safety comment.
+unsafe impl<T: ?Sized> TransmuteFrom<T> for T {
+    // Given a `t: *const T` with alignment `A`, `t as *const T` is a no-op, and
+    // so trivially satisfies the alignment invariant `MappedAlignment<A,
+    // Preserved> = A`.
+    type AlignmentMapping = Preserved;
+    // Given a `t: *const T` with validity `V`, `t as *const T` is a no-op, and
+    // so trivially satisfies the validity invariant `MappedValidity<V,
+    // Preserved> = V`.
+    type ValidityMapping = Preserved;
+
+    fn cast_from(ptr: *mut T) -> *mut T {
+        // SAFETY: `ptr` trivially preserves address, referent size, and
+        // provenance.
+        ptr
+    }
+}
+
+// SAFETY: `MaybeUninit<T>` has `UnsafeCell`s covering the same byte ranges as
+// `T`. This is not explicitly documented, but it can be inferred. Per [1] in
+// the following safety comment, `MaybeUninit<T>` has the same size as `T`.
+// Further, note the signature of `MaybeUninit::assume_init_ref` [1]:
+//
+//   pub unsafe fn assume_init_ref(&self) -> &T
+//
+// If the argument `&MaybeUninit<T>` and the returned `&T` had `UnsafeCell`s at
+// different offsets, this would be unsound. Its existence is proof that this is
+// not the case.
+//
+// [1] https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#method.assume_init_ref
+unsafe impl<T> UnsafeCellsAgree<T> for MaybeUninit<T> {}
+// SAFETY: See previous safety comment.
+unsafe impl<T> UnsafeCellsAgree<MaybeUninit<T>> for T {}
+
+// SAFETY:
 // - Per [1], `MaybeUninit<T>` has the same size as `T`.
-// - See inline comments for other safety justifications.
+// - Alignment: See inline safety comment.
+// - Validity: See inline safety comment.
 //
 // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
 //
 //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
 //   `T`
-unsafe impl<T, I: Invariants> TransparentWrapper<I> for MaybeUninit<T> {
-    type Inner = T;
-
-    // SAFETY: `MaybeUninit<T>` has `UnsafeCell`s covering the same byte ranges
-    // as `Inner = T`. This is not explicitly documented, but it can be
-    // inferred. Per [1] in the preceding safety comment, `MaybeUninit<T>` has
-    // the same size as `T`. Further, note the signature of
-    // `MaybeUninit::assume_init_ref` [2]:
-    //
-    //   pub unsafe fn assume_init_ref(&self) -> &T
-    //
-    // If the argument `&MaybeUninit<T>` and the returned `&T` had `UnsafeCell`s
-    // at different offsets, this would be unsound. Its existence is proof that
-    // this is not the case.
-    //
-    // [2] https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#method.assume_init_ref
-    type UnsafeCellVariance = Covariant;
+unsafe impl<T> TransmuteFrom<T> for MaybeUninit<T> {
     // SAFETY: Per [1], `MaybeUninit<T>` has the same layout as `T`, and thus
     // has the same alignment as `T`.
     //
@@ -129,27 +210,87 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for MaybeUninit<T> {
     //
     //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and
     //   ABI as `T`.
-    type AlignmentVariance = Covariant;
-    // SAFETY: `MaybeUninit` has no validity invariants. Thus, a valid
-    // `MaybeUninit<T>` is not necessarily a valid `T`.
-    type ValidityVariance = Invariant;
+    type AlignmentMapping = Preserved;
+    // SAFETY: `MaybeUninit` has no validity invariants. Thus, any `m: *const
+    // MaybeUninit<T>` always satisfies the validity invariant `Valid`.
+    type ValidityMapping = Valid;
 
-    #[inline(always)]
-    fn cast_into_inner(ptr: *mut MaybeUninit<T>) -> *mut T {
-        // SAFETY: Per [1] (from comment above), `MaybeUninit<T>` has the same
-        // layout as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<T>()
+    fn cast_from(ptr: *mut T) -> *mut MaybeUninit<T> {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `MaybeUninit<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
     }
+}
 
-    #[inline(always)]
-    fn cast_from_inner(ptr: *mut T) -> *mut MaybeUninit<T> {
-        // SAFETY: Per [1] (from comment above), `MaybeUninit<T>` has the same
-        // layout as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<MaybeUninit<T>>()
+// SAFETY:
+// - Per [1], `MaybeUninit<T>` has the same size as `T`.
+// - Alignment: See inline safety comment.
+// - Validity: See inline safety comment.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+//
+//   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
+//   `T`
+unsafe impl<T> TransmuteFrom<MaybeUninit<T>> for T {
+    // SAFETY: Per [1], `MaybeUninit<T>` has the same layout as `T`, and thus
+    // has the same alignment as `T`.
+    //
+    // [1] Per https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#layout-1:
+    //
+    //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and
+    //   ABI as `T`.
+    type AlignmentMapping = Preserved;
+    // SAFETY: Any `t: *const T` trivially conforms to the validity invariant
+    // `Unknown`.
+    type ValidityMapping = Unknown;
+
+    fn cast_from(ptr: *mut MaybeUninit<T>) -> *mut T {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `MaybeUninit<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
+    }
+}
+
+// SAFETY: Per [1], `ManuallyDrop<T>` has `UnsafeCell`s covering the same byte
+// ranges as `Inner = T`.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/mem/struct.ManuallyDrop.html:
+//
+//   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
+//   `T`, and is subject to the same layout optimizations as `T`. As a
+//   consequence, it has no effect on the assumptions that the compiler makes
+//   about its contents.
+unsafe impl<T: ?Sized> UnsafeCellsAgree<T> for ManuallyDrop<T> {}
+// SAFETY: See previous safety comment.
+unsafe impl<T: ?Sized> UnsafeCellsAgree<ManuallyDrop<T>> for T {}
+
+// SAFETY:
+// - Per [1], `ManuallyDrop<T>` has the same size as `T`.
+// - See inline comments for other safety justifications.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/mem/struct.ManuallyDrop.html:
+//
+//   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
+//   `T`
+unsafe impl<T: ?Sized> TransmuteFrom<T> for ManuallyDrop<T> {
+    // SAFETY: Per [1], `ManuallyDrop<T>` has the same layout as `T`, and thus
+    // has the same alignment as `T`.
+    //
+    // [1] Per https://doc.rust-lang.org/nightly/core/mem/struct.ManuallyDrop.html:
+    //
+    //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
+    //   validity as `T`
+    type AlignmentMapping = Preserved;
+
+    // SAFETY: Per [1] (from comment above), `ManuallyDrop<T>` has the same bit
+    // validity as `T`.
+    type ValidityMapping = Preserved;
+
+    #[allow(clippy::as_conversions)]
+    fn cast_from(ptr: *mut T) -> *mut ManuallyDrop<T> {
+        // SAFETY: An `as` cast preserves address and provenance. Since
+        // `ManuallyDrop<T>` has the same size as `T`, it also preserves size.
+        ptr as *mut ManuallyDrop<T>
     }
 }
 
@@ -161,19 +302,7 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for MaybeUninit<T> {
 //
 //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
 //   `T`
-unsafe impl<T: ?Sized, I: Invariants> TransparentWrapper<I> for ManuallyDrop<T> {
-    type Inner = T;
-
-    // SAFETY: Per [1], `ManuallyDrop<T>` has `UnsafeCell`s covering the same
-    // byte ranges as `Inner = T`.
-    //
-    // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/struct.ManuallyDrop.html:
-    //
-    //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
-    //   validity as `T`, and is subject to the same layout optimizations as
-    //   `T`. As a consequence, it has no effect on the assumptions that the
-    //   compiler makes about its contents.
-    type UnsafeCellVariance = Covariant;
+unsafe impl<T: ?Sized> TransmuteFrom<ManuallyDrop<T>> for T {
     // SAFETY: Per [1], `ManuallyDrop<T>` has the same layout as `T`, and thus
     // has the same alignment as `T`.
     //
@@ -181,32 +310,33 @@ unsafe impl<T: ?Sized, I: Invariants> TransparentWrapper<I> for ManuallyDrop<T> 
     //
     //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
     //   validity as `T`
-    type AlignmentVariance = Covariant;
+    type AlignmentMapping = Preserved;
 
     // SAFETY: Per [1] (from comment above), `ManuallyDrop<T>` has the same bit
     // validity as `T`.
-    type ValidityVariance = Covariant;
+    type ValidityMapping = Preserved;
 
-    #[inline(always)]
-    fn cast_into_inner(ptr: *mut ManuallyDrop<T>) -> *mut T {
-        // SAFETY: Per [1] (from comment above), `ManuallyDrop<T>` has the same
-        // layout as `T`. Thus, this cast preserves size even if `T` is unsized.
-        //
-        // This cast trivially preserves provenance.
-        #[allow(clippy::as_conversions)]
-        return ptr as *mut T;
-    }
-
-    #[inline(always)]
-    fn cast_from_inner(ptr: *mut T) -> *mut ManuallyDrop<T> {
-        // SAFETY: Per [1] (from comment above), `ManuallyDrop<T>` has the same
-        // layout as `T`. Thus, this cast preserves size even if `T` is unsized.
-        //
-        // This cast trivially preserves provenance.
-        #[allow(clippy::as_conversions)]
-        return ptr as *mut ManuallyDrop<T>;
+    #[allow(clippy::as_conversions)]
+    fn cast_from(ptr: *mut ManuallyDrop<T>) -> *mut T {
+        // SAFETY: An `as` cast preserves address and provenance. Since
+        // `ManuallyDrop<T>` has the same size as `T`, it also preserves size.
+        ptr as *mut T
     }
 }
+
+// SAFETY: Per [1], `Wrapping<T>` has the same layout as `T`. Since its single
+// field (of type `T`) is public, it would be a breaking change to add or remove
+// fields. Thus, we know that `Wrapping<T>` contains a `T` (as opposed to just
+// having the same size and alignment as `T`) with no pre- or post-padding.
+// Thus, `Wrapping<T>` must have `UnsafeCell`s covering the same byte ranges as
+// `Inner = T`.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
+//
+//   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
+unsafe impl<T> UnsafeCellsAgree<T> for Wrapping<T> {}
+// SAFETY: See previous safety comment.
+unsafe impl<T> UnsafeCellsAgree<Wrapping<T>> for T {}
 
 // SAFETY:
 // - Per [1], `Wrapping<T>` has the same size as `T`.
@@ -215,27 +345,14 @@ unsafe impl<T: ?Sized, I: Invariants> TransparentWrapper<I> for ManuallyDrop<T> 
 // [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
 //
 //   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
-unsafe impl<T, I: Invariants> TransparentWrapper<I> for Wrapping<T> {
-    type Inner = T;
-
-    // SAFETY: Per [1], `Wrapping<T>` has the same layout as `T`. Since its
-    // single field (of type `T`) is public, it would be a breaking change to
-    // add or remove fields. Thus, we know that `Wrapping<T>` contains a `T` (as
-    // opposed to just having the same size and alignment as `T`) with no pre-
-    // or post-padding. Thus, `Wrapping<T>` must have `UnsafeCell`s covering the
-    // same byte ranges as `Inner = T`.
-    //
-    // [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
-    //
-    //   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
-    type UnsafeCellVariance = Covariant;
+unsafe impl<T> TransmuteFrom<T> for Wrapping<T> {
     // SAFETY: Per [1], `Wrapping<T>` has the same layout as `T`, and thus has
     // the same alignment as `T`.
     //
     // [1] Per https://doc.rust-lang.org/core/num/struct.Wrapping.html#layout-1:
     //
     //   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
-    type AlignmentVariance = Covariant;
+    type AlignmentMapping = Preserved;
 
     // SAFETY: `Wrapping<T>` has only one field, which is `pub` [2]. We are also
     // guaranteed per [1] (from the comment above) that `Wrapping<T>` has the
@@ -248,25 +365,50 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for Wrapping<T> {
     // - `Wrapping` could add or change its fields, but this would be a
     //   stability-breaking change.
     //
-    // [2] https://doc.rust-lang.org/core/num/struct.Wrapping.html
-    type ValidityVariance = Covariant;
+    // [2] https://doc.rust-lang.org/1.82.0/core/num/struct.Wrapping.html
+    type ValidityMapping = Preserved;
 
-    #[inline(always)]
-    fn cast_into_inner(ptr: *mut Wrapping<T>) -> *mut T {
-        // SAFETY: Per [1] (from comment above), `Wrapping<T>` has the same
-        // layout as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<T>()
+    fn cast_from(ptr: *mut T) -> *mut Wrapping<T> {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `Wrapping<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
     }
+}
 
-    #[inline(always)]
-    fn cast_from_inner(ptr: *mut T) -> *mut Wrapping<T> {
-        // SAFETY: Per [1] (from comment above), `Wrapping<T>` has the same
-        // layout as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<Wrapping<T>>()
+// SAFETY:
+// - Per [1], `Wrapping<T>` has the same size as `T`.
+// - See inline comments for other safety justifications.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
+//
+//   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
+unsafe impl<T> TransmuteFrom<Wrapping<T>> for T {
+    // SAFETY: Per [1], `Wrapping<T>` has the same layout as `T`, and thus has
+    // the same alignment as `T`.
+    //
+    // [1] Per https://doc.rust-lang.org/core/num/struct.Wrapping.html#layout-1:
+    //
+    //   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`.
+    type AlignmentMapping = Preserved;
+
+    // SAFETY: `Wrapping<T>` has only one field, which is `pub` [2]. We are also
+    // guaranteed per [1] (from the comment above) that `Wrapping<T>` has the
+    // same layout as `T`. The only way for both of these to be true
+    // simultaneously is for `Wrapping<T>` to have the same bit validity as `T`.
+    // In particular, in order to change the bit validity, one of the following
+    // would need to happen:
+    // - `Wrapping` could change its `repr`, but this would violate the layout
+    //   guarantee.
+    // - `Wrapping` could add or change its fields, but this would be a
+    //   stability-breaking change.
+    //
+    // [2] https://doc.rust-lang.org/1.82.0/core/num/struct.Wrapping.html
+    type ValidityMapping = Preserved;
+
+    fn cast_from(ptr: *mut Wrapping<T>) -> *mut T {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `Wrapping<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
     }
 }
 
@@ -278,15 +420,10 @@ unsafe impl<T, I: Invariants> TransparentWrapper<I> for Wrapping<T> {
 //
 //   `UnsafeCell<T>` has the same in-memory representation as its inner type
 //   `T`.
-unsafe impl<T: ?Sized, I: Invariants> TransparentWrapper<I> for UnsafeCell<T> {
-    type Inner = T;
-
-    // SAFETY: Since we set this to `Invariant`, we make no safety claims.
-    type UnsafeCellVariance = Invariant;
-
+unsafe impl<T: ?Sized> TransmuteFrom<T> for UnsafeCell<T> {
     // SAFETY: Per [1] (from comment on impl), `Unalign<T>` has the same
     // representation as `T`, and thus has the same alignment as `T`.
-    type AlignmentVariance = Covariant;
+    type AlignmentMapping = Preserved;
 
     // SAFETY: Per [1], `Unalign<T>` has the same bit validity as `T`.
     // Technically the term "representation" doesn't guarantee this, but the
@@ -298,62 +435,89 @@ unsafe impl<T: ?Sized, I: Invariants> TransparentWrapper<I> for UnsafeCell<T> {
     //   `UnsafeCell<T>` has the same in-memory representation as its inner type
     //   `T`. A consequence of this guarantee is that it is possible to convert
     //   between `T` and `UnsafeCell<T>`.
-    type ValidityVariance = Covariant;
+    type ValidityMapping = Preserved;
 
-    #[inline(always)]
-    fn cast_into_inner(ptr: *mut UnsafeCell<T>) -> *mut T {
-        // SAFETY: Per [1] (from comment above), `UnsafeCell<T>` has the same
-        // representation as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        #[allow(clippy::as_conversions)]
-        return ptr as *mut T;
+    #[allow(clippy::as_conversions)]
+    fn cast_from(ptr: *mut T) -> *mut UnsafeCell<T> {
+        // SAFETY: An `as` cast preserves address and provenance. Since
+        // `UnsafeCell<T>` has the same size as `T`, it also preserves size.
+        ptr as *mut UnsafeCell<T>
     }
+}
 
-    #[inline(always)]
-    fn cast_from_inner(ptr: *mut T) -> *mut UnsafeCell<T> {
-        // SAFETY: Per [1] (from comment above), `UnsafeCell<T>` has the same
-        // representation as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        #[allow(clippy::as_conversions)]
-        return ptr as *mut UnsafeCell<T>;
+// SAFETY:
+// - Per [1], `UnsafeCell<T>` has the same size as `T`.
+// - See inline comments for other safety justifications.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.UnsafeCell.html#memory-layout:
+//
+//   `UnsafeCell<T>` has the same in-memory representation as its inner type
+//   `T`.
+unsafe impl<T: ?Sized> TransmuteFrom<UnsafeCell<T>> for T {
+    // SAFETY: Per [1] (from comment on impl), `Unalign<T>` has the same
+    // representation as `T`, and thus has the same alignment as `T`.
+    type AlignmentMapping = Preserved;
+
+    // SAFETY: Per [1], `Unalign<T>` has the same bit validity as `T`.
+    // Technically the term "representation" doesn't guarantee this, but the
+    // subsequent sentence in the documentation makes it clear that this is the
+    // intention.
+    //
+    // [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.UnsafeCell.html#memory-layout:
+    //
+    //   `UnsafeCell<T>` has the same in-memory representation as its inner type
+    //   `T`. A consequence of this guarantee is that it is possible to convert
+    //   between `T` and `UnsafeCell<T>`.
+    type ValidityMapping = Preserved;
+
+    #[allow(clippy::as_conversions)]
+    fn cast_from(ptr: *mut UnsafeCell<T>) -> *mut T {
+        // SAFETY: An `as` cast preserves address and provenance. Since
+        // `UnsafeCell<T>` has the same size as `T`, it also preserves size.
+        ptr as *mut T
+    }
+}
+
+// SAFETY: `Unalign<T>` promises to have `UnsafeCell`s covering the same byte
+// ranges as `Inner = T`.
+unsafe impl<T> UnsafeCellsAgree<T> for Unalign<T> {}
+// SAFETY: `Unalign<T>` promises to have `UnsafeCell`s covering the same byte
+// ranges as `Inner = T`.
+unsafe impl<T> UnsafeCellsAgree<Unalign<T>> for T {}
+
+// SAFETY: `Unalign<T>` promises to have the same size as `T`.
+//
+// See inline comments for other safety justifications.
+unsafe impl<T> TransmuteFrom<T> for Unalign<T> {
+    // SAFETY: `Unalign<T>` promises to have alignment 1 regardless of `T`'s
+    // alignment. Thus, any `u: *const Unalign<T>` is always aligned.
+    type AlignmentMapping = Aligned;
+
+    // SAFETY: `Unalign<T>` promises to have the same validity as `T`.
+    type ValidityMapping = Preserved;
+
+    fn cast_from(ptr: *mut T) -> *mut Unalign<T> {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `Unalign<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
     }
 }
 
 // SAFETY: `Unalign<T>` promises to have the same size as `T`.
 //
 // See inline comments for other safety justifications.
-unsafe impl<T, I: Invariants> TransparentWrapper<I> for Unalign<T> {
-    type Inner = T;
-
-    // SAFETY: `Unalign<T>` promises to have `UnsafeCell`s covering the same
-    // byte ranges as `Inner = T`.
-    type UnsafeCellVariance = Covariant;
-
-    // SAFETY: Since `Unalign<T>` promises to have alignment 1 regardless of
-    // `T`'s alignment. Thus, an aligned pointer to `Unalign<T>` is not
-    // necessarily an aligned pointer to `T`.
-    type AlignmentVariance = Invariant;
+unsafe impl<T> TransmuteFrom<Unalign<T>> for T {
+    // SAFETY: `Unalign<T>` promises to have alignment 1 regardless of `T`'s
+    // alignment. Thus, an aligned pointer to `Unalign<T>` is not necessarily an
+    // aligned pointer to `T`.
+    type AlignmentMapping = Unknown;
 
     // SAFETY: `Unalign<T>` promises to have the same validity as `T`.
-    type ValidityVariance = Covariant;
+    type ValidityMapping = Preserved;
 
-    #[inline(always)]
-    fn cast_into_inner(ptr: *mut Unalign<T>) -> *mut T {
-        // SAFETY: Per the safety comment on the impl block, `Unalign<T>` has
-        // the size as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<T>()
-    }
-
-    #[inline(always)]
-    fn cast_from_inner(ptr: *mut T) -> *mut Unalign<T> {
-        // SAFETY: Per the safety comment on the impl block, `Unalign<T>` has
-        // the size as `T`. Thus, this cast preserves size.
-        //
-        // This cast trivially preserves provenance.
-        ptr.cast::<Unalign<T>>()
+    fn cast_from(ptr: *mut Unalign<T>) -> *mut T {
+        // SAFETY: `.cast()` preserves address and provenance. Since
+        // `Unalign<T>` has the same size as `T`, it also preserves size.
+        ptr.cast()
     }
 }


### PR DESCRIPTION
This commit replaces the `TransparentWrapper` trait with a more generic,
bidirectional `TransmuteFrom<T>` trait. `U: TransmuteFrom<T>` indicates
that `T` and `U` have the same sizes and that `T` can be transmuted into
`U` given certain alignment and validity invariant mappings.

Makes progress on #1122

gherrit-pr-id: I3a6abe00c9220431e60f9beee68e472d323b5612
