### PR TITLE
Inline layout validation and pointer cast code to optimize out panic

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -451,6 +451,7 @@ impl DstLayout {
     /// rely on `validate_cast_and_convert_metadata` panicking in any particular
     /// condition, even if `debug_assertions` are enabled.
     #[allow(unused)]
+    #[inline(always)]
     pub(crate) const fn validate_cast_and_convert_metadata(
         &self,
         addr: usize,

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1165,6 +1165,7 @@ mod _casts {
         /// - If this is a prefix cast, `ptr` has the same address as `self`.
         /// - If this is a suffix cast, `remainder` has the same address as
         ///   `self`.
+        #[inline(always)]
         pub(crate) fn try_cast_into<U, R>(
             self,
             cast_type: CastType,


### PR DESCRIPTION
If `try_cast_into` and `validate_cast_and_convert_metadata` are not inlined, then the compiler will include a panic in `validate_cast_and_convert_metadata`.

If these functions are inlined, then the panic can be optimized out.

Additional context can be found at https://github.com/google/zerocopy/issues/1661#issuecomment-2447948912

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
