### PR TITLE
Fix flaky alignment tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1983,7 +1983,7 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &[85, 85][..];
+    /// let src = 0xCAFEu16.as_bytes();
     /// let zsty = ZSTy::try_ref_from_bytes_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
@@ -2090,7 +2090,7 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &[85, 85][..];
+    /// let src = 0xCAFEu16.as_bytes();
     /// let (zsty, _) = ZSTy::try_ref_from_prefix_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
@@ -2179,7 +2179,7 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &[85, 85][..];
+    /// let src = 0xCAFEu16.as_bytes();
     /// let (_, zsty) = ZSTy::try_ref_from_suffix_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
@@ -2269,7 +2269,8 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &mut [85, 85][..];
+    /// let mut src = 0xCAFEu16;
+    /// let src = src.as_mut_bytes();
     /// let zsty = ZSTy::try_mut_from_bytes_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
@@ -2381,7 +2382,8 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &mut [85, 85][..];
+    /// let mut src = 0xCAFEu16;
+    /// let src = src.as_mut_bytes();
     /// let (zsty, _) = ZSTy::try_mut_from_prefix_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
@@ -2475,7 +2477,8 @@ pub unsafe trait TryFromBytes {
     ///     trailing_dst: [()],
     /// }
     ///
-    /// let src = &mut [85, 85][..];
+    /// let mut src = 0xCAFEu16;
+    /// let src = src.as_mut_bytes();
     /// let (_, zsty) = ZSTy::try_mut_from_suffix_with_elems(src, 42).unwrap();
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```


### PR DESCRIPTION
These tests depend on `src` being aligned to multiples of 2. With this commit, that dependency is explicitly enforced.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
