### PR TITLE
Pin `libc` version to 0.2.163

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -40,6 +40,8 @@ dissimilar = "1.0.9"
 # version resolver fails to select any version for once_cell unless we
 # depend on it directly.
 once_cell = "=1.9"
+# Same MSRV issue as above.
+libc = "=0.2.163"
 # This is the latest version which is compatible with `syn` 2.0.46, which we pin
 # to in CI for MSRV compatibility reasons.
 prettyplease = "=0.2.17"


### PR DESCRIPTION
0.2.164 bumps the MSRV of libc beyond our crate's. By pinning libc to the last compatible version, we ensure that our CI can run without issue. Probably.
