### PR TITLE
Pin `libc` version to 0.2.163 (#2085)

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -36,6 +36,9 @@ syn = { version = "2.0.79", features = ["full"] }
 
 [dev-dependencies]
 dissimilar = "1.0.9"
+# We don't use this directly, but we depend on it indirectly. More recent
+# versions have an MSRV which is higher than our MSRV.
+libc = "=0.2.163"
 prettyplease = "0.2.22"
 rustversion = "1.0.17"
 static_assertions = "1.1.0"


### PR DESCRIPTION
0.2.164 bumps the MSRV of libc beyond our crate's. By pinning libc to the last compatible version, we ensure that our CI can run without issue.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
