### PR TITLE
[derive] Don't emit #[cfg(coverage_nightly)]

### DIFF
--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -301,7 +301,6 @@ fn derive_known_layout_inner(ast: &DeriveInput, _top_level: Trait) -> Result<Tok
                     #predicates
                 {
                     #[allow(clippy::missing_inline_in_public_items)]
-                    #[cfg_attr(coverage_nightly, coverage(off))]
                     fn only_derive_is_allowed_to_implement_this_trait() {}
 
                     type PointerMetadata = <#ident #ty_generics as ::zerocopy::KnownLayout>::PointerMetadata;

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -192,7 +192,6 @@ fn test_known_layout() {
                     <U as ::zerocopy::KnownLayout>::MaybeUninit: ::zerocopy::KnownLayout,
                 {
                     #[allow(clippy::missing_inline_in_public_items)]
-                    #[cfg_attr(coverage_nightly, coverage(off))]
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type PointerMetadata = <Foo<T, U> as ::zerocopy::KnownLayout>::PointerMetadata;
                     type MaybeUninit = Self;

--- a/zerocopy-derive/tests/issue_2117.rs
+++ b/zerocopy-derive/tests/issue_2117.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+#![forbid(unexpected_cfgs)]
+
+include!("include.rs");
+
+// Make sure no unexpected `cfg`s are emitted by our derives (see #2117).
+
+#[derive(imp::KnownLayout)]
+#[repr(C)]
+pub struct Test(pub [u8; 32]);


### PR DESCRIPTION
As of nightly-2024-11-20 - specifically [1] - this triggers an `unexpected_cfgs` lint even when emitted in derive-generated code.

[1] https://github.com/rust-lang/rust/pull/132577

Fixes #2117