### PR TITLE
[derive] Don't emit #[cfg(coverage_nightly)] (#2123)

### DIFF
--- a/zerocopy-derive/tests/issue_2117.rs
+++ b/zerocopy-derive/tests/issue_2117.rs
@@ -1,0 +1,20 @@
+// Copyright 2024 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+#![forbid(unexpected_cfgs)]
+
+include!("include.rs");
+
+// Make sure no unexpected `cfg`s are emitted by our derives (see #2117).
+
+#[derive(imp::KnownLayout)]
+#[repr(C)]
+pub struct Test(pub [u8; 32]);


### PR DESCRIPTION
As of nightly-2024-11-20 - specifically [1] - this triggers an `unexpected_cfgs` lint even when emitted in derive-generated code.

[1] https://github.com/rust-lang/rust/pull/132577

Fixes #2117

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
