### PR TITLE
Practice good `Self` hygiene

### DIFF
--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -32,6 +32,20 @@ use crate::{
     Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
 };
 
+/// Projects the type of the field at `Index` in `Self`.
+///
+/// The `Index` parameter is any sort of handle that identifies the field; its
+/// definition is the obligation of the implementer.
+///
+/// # Safety
+///
+/// Unsafe code may assume that this accurately reflects the definition of
+/// `Self`.
+pub unsafe trait Field<Index> {
+    /// The type of the field at `Index`.
+    type Type: ?Sized;
+}
+
 #[cfg_attr(
     zerocopy_diagnostic_on_unimplemented_1_78_0,
     diagnostic::on_unimplemented(

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -176,20 +176,47 @@ fn test_known_layout() {
                         <U>::pointer_to_metadata(ptr as *mut _)
                     }
                 }
+                #[allow(non_camel_case_types)]
+                struct __Zerocopy_Field_0;
+                #[allow(non_camel_case_types)]
+                struct __Zerocopy_Field_1;
+                unsafe impl<T, U> ::zerocopy::util::macro_util::Field<__Zerocopy_Field_0>
+                for Foo<T, U> {
+                    type Type = T;
+                }
+                unsafe impl<T, U> ::zerocopy::util::macro_util::Field<__Zerocopy_Field_1>
+                for Foo<T, U> {
+                    type Type = U;
+                }
                 #[repr(C)]
                 #[repr(align(2))]
                 #[doc(hidden)]
                 struct __ZerocopyKnownLayoutMaybeUninit<T, U>(
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<T>,
-                    <U as ::zerocopy::KnownLayout>::MaybeUninit,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        <Foo<T, U> as ::zerocopy::util::macro_util::Field<__Zerocopy_Field_0>>::Type,
+                    >,
+                    <<Foo<
+                        T,
+                        U,
+                    > as ::zerocopy::util::macro_util::Field<
+                        __Zerocopy_Field_1,
+                    >>::Type as ::zerocopy::KnownLayout>::MaybeUninit,
                 )
                 where
-                    U: ::zerocopy::KnownLayout;
-                unsafe impl<T, U> ::zerocopy::KnownLayout
-                for __ZerocopyKnownLayoutMaybeUninit<T, U>
+                    <Foo<
+                        T,
+                        U,
+                    > as ::zerocopy::util::macro_util::Field<
+                        __Zerocopy_Field_1,
+                    >>::Type: ::zerocopy::KnownLayout;
+                unsafe impl<T, U> ::zerocopy::KnownLayout for __ZerocopyKnownLayoutMaybeUninit<T, U>
                 where
-                    U: ::zerocopy::KnownLayout,
-                    <U as ::zerocopy::KnownLayout>::MaybeUninit: ::zerocopy::KnownLayout,
+                    <Foo<
+                        T,
+                        U,
+                    > as ::zerocopy::util::macro_util::Field<
+                        __Zerocopy_Field_1,
+                    >>::Type: ::zerocopy::KnownLayout,
                 {
                     #[allow(clippy::missing_inline_in_public_items)]
                     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -206,7 +233,12 @@ fn test_known_layout() {
                         meta: Self::PointerMetadata,
                     ) -> ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self> {
                         use ::zerocopy::KnownLayout;
-                        let trailing = <<U as ::zerocopy::KnownLayout>::MaybeUninit as KnownLayout>::raw_from_ptr_len(
+                        let trailing = <<<Foo<
+                            T,
+                            U,
+                        > as ::zerocopy::util::macro_util::Field<
+                            __Zerocopy_Field_1,
+                        >>::Type as ::zerocopy::KnownLayout>::MaybeUninit as KnownLayout>::raw_from_ptr_len(
                             bytes,
                             meta,
                         );
@@ -219,7 +251,12 @@ fn test_known_layout() {
                     }
                     #[inline(always)]
                     fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
-                        <<U as ::zerocopy::KnownLayout>::MaybeUninit>::pointer_to_metadata(
+                        <<<Foo<
+                            T,
+                            U,
+                        > as ::zerocopy::util::macro_util::Field<
+                            __Zerocopy_Field_1,
+                        >>::Type as ::zerocopy::KnownLayout>::MaybeUninit>::pointer_to_metadata(
                             ptr as *mut _,
                         )
                     }


### PR DESCRIPTION
This commit revises the `KnownLayout` derive on `repr(C)` target structs to preserve the correct resolution of `Self` when constructing `__ZerocopyKnownLayoutMaybeUninit`. This type contains a `MaybeUninit` version of each of the target struct's field types. Previously, it achieved this by simply copying the tokens corresponding to field types from the definition of the target struct into the definition of `__ZerocopyKnownLayoutMaybeUninit`

However, on types like this:

```rust
#[repr(C)]
struct Struct([u8; Self::N]);
```

…this approach is insufficient. Pasted into `__ZerocopyKnownLayoutMaybeUninit`, `Self` ceases to refer to the target struct and instead refers to `__ZerocopyKnownLayoutMaybeUninit`.

To preserve `Self` hygiene, this commit defines a struct for projecting the field types of the target struct based on their index:

```rust
pub unsafe trait Field<const N: usize> {
    type Type: ?Sized;
}
```

…then implements it for each of the field types of the target struct; e.g.:

```rust
impl Field<0> for Struct {
    type Type = [u8; Self::N];
}
```

With this, the fields of `__ZerocopyKnownLayoutMaybeUninit` can be defined hygienically; e.g., as `<Struct as Field<0>>::Type`.

Fixes #2116