### PR TITLE
Release the ownership of the src parameter in read_from_io.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4527,7 +4527,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     #[cfg(feature = "std")]
     #[inline(always)]
-    fn read_from_io<R>(mut src: R) -> io::Result<Self>
+    fn read_from_io<R>(src: &mut R) -> io::Result<Self>
     where
         Self: Sized,
         R: io::Read,


### PR DESCRIPTION
<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
