### PR TITLE
[derive] Implement a IntoBytes-based Hash derive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5432,6 +5432,22 @@ pub unsafe trait Unaligned {
         Self: Sized;
 }
 
+/// Derives an optimized implementation of [`Hash`] for types that implement
+/// [`IntoBytes`] and [`Immutable`].
+///
+/// The standard library's derive for `Hash` generates a recursive descent
+/// into the fields of the type it is applied to. Instead, the implementation
+/// derived by this macro makes a single call to [`Hasher::write()`] for both
+/// [`Hash::hash()`] and [`Hash::hash_slice()`], feeding the hasher the bytes
+/// of the type or slice all at once.
+///
+/// [`Hash`]: core::hash::Hash
+/// [`Hash::hash()`]: core::hash::Hash::hash()
+/// [`Hash::hash_slice()`]: core::hash::Hash::hash_slice()
+#[cfg(any(feature = "derive", test))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
+pub use zerocopy_derive::ByteHash;
+
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -26,6 +26,7 @@ use_as_trait_name!(
     FromBytes => derive_from_bytes_inner,
     IntoBytes => derive_into_bytes_inner,
     Unaligned => derive_unaligned_inner,
+    ByteHash => derive_hash_inner,
 );
 
 /// Test that the given derive input expands to the expected output.
@@ -1976,6 +1977,43 @@ fn test_try_from_bytes_trivial_is_bit_valid_enum() {
                         + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
                 {
                     true
+                }
+            }
+        } no_build
+    }
+}
+
+#[test]
+fn test_hash() {
+    test! {
+        ByteHash {
+            struct Foo<T: Clone>(T) where Self: Sized;
+        } expands to {
+            #[allow(deprecated)]
+            #[automatically_derived]
+            impl<T: Clone> ::zerocopy::util::macro_util::core_reexport::hash::Hash for Foo<T>
+            where
+                Self: ::zerocopy::IntoBytes + ::zerocopy::Immutable,
+                Self: Sized,
+            {
+                fn hash<H>(&self, state: &mut H)
+                where
+                    H: ::zerocopy::util::macro_util::core_reexport::hash::Hasher,
+                {
+                    ::zerocopy::util::macro_util::core_reexport::hash::Hasher::write(
+                        state,
+                        ::zerocopy::IntoBytes::as_bytes(self)
+                    )
+                }
+
+                fn hash_slice<H>(data: &[Self], state: &mut H)
+                where
+                    H: ::zerocopy::util::macro_util::core_reexport::hash::Hasher,
+                {
+                    ::zerocopy::util::macro_util::core_reexport::hash::Hasher::write(
+                        state,
+                        ::zerocopy::IntoBytes::as_bytes(data)
+                    )
                 }
             }
         } no_build

--- a/zerocopy-derive/tests/hash.rs
+++ b/zerocopy-derive/tests/hash.rs
@@ -1,0 +1,38 @@
+// Copyright 2024 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+#[derive(imp::IntoBytes, imp::Immutable, imp::ByteHash)]
+#[repr(C)]
+struct Struct {
+    a: u64,
+    b: u32,
+    c: u32,
+}
+
+util_assert_impl_all!(Struct: imp::IntoBytes, imp::hash::Hash);
+
+#[test]
+fn test_hash() {
+    use imp::{
+        hash::{Hash, Hasher},
+        DefaultHasher,
+    };
+    fn hash(val: impl Hash) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        val.hash(&mut hasher);
+        hasher.finish()
+    }
+    hash(Struct { a: 10, b: 15, c: 20 });
+    hash(&[Struct { a: 10, b: 15, c: 20 }, Struct { a: 5, b: 4, c: 3 }]);
+}

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -29,13 +29,14 @@ mod imp {
             assert_eq,
             cell::UnsafeCell,
             convert::TryFrom,
+            hash,
             marker::PhantomData,
             mem::{ManuallyDrop, MaybeUninit},
             option::IntoIter,
             prelude::v1::*,
             primitive::*,
         },
-        ::std::prelude::v1::*,
+        ::std::{collections::hash_map::DefaultHasher, prelude::v1::*},
         ::zerocopy::*,
     };
 }


### PR DESCRIPTION
The standard library's derive for `Hash` generates a recursive descent into the fields of the type it is applied to. This commit adds an alternative derive that generates an optimized, byte-oriented `Hash` implementation for types that implement `IntoBytes`. Instead of a recursive descent, the generated implementation makes a single call to `Hasher::write()` in both `Hash::hash()` and `Hash::hash_slice()`, feeding the hasher the bytes of the type or slice all at once.

Resolves #2075

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
