### PR TITLE
Only support coverage in CI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -864,7 +864,10 @@ impl PointerMetadata for usize {
 // SAFETY: Delegates safety to `DstLayout::for_slice`.
 unsafe impl<T> KnownLayout for [T] {
     #[allow(clippy::missing_inline_in_public_items)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(
+        all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+        coverage(off)
+    )]
     fn only_derive_is_allowed_to_implement_this_trait()
     where
         Self: Sized,

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -74,7 +74,10 @@ pub struct AlignOf<T> {
 
 impl<T> AlignOf<T> {
     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(
+        all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+        coverage(off)
+    )]
     pub fn into_t(self) -> T {
         unreachable!()
     }
@@ -89,7 +92,10 @@ pub union MaxAlignsOf<T, U> {
 
 impl<T, U> MaxAlignsOf<T, U> {
     #[inline(never)] // Make `missing_inline_in_public_items` happy.
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(
+        all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+        coverage(off)
+    )]
     pub fn new(_t: T, _u: U) -> MaxAlignsOf<T, U> {
         unreachable!()
     }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -164,7 +164,7 @@ macro_rules! unsafe_impl {
 
     (@method TryFromBytes ; |$candidate:ident: MaybeAligned<$repr:ty>| $is_bit_valid:expr) => {
         #[allow(clippy::missing_inline_in_public_items)]
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
@@ -188,7 +188,7 @@ macro_rules! unsafe_impl {
     };
     (@method TryFromBytes ; |$candidate:ident: Maybe<$repr:ty>| $is_bit_valid:expr) => {
         #[allow(clippy::missing_inline_in_public_items)]
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
@@ -214,13 +214,13 @@ macro_rules! unsafe_impl {
     };
     (@method TryFromBytes) => {
         #[allow(clippy::missing_inline_in_public_items)]
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)] fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(_: Maybe<'_, Self, A>) -> bool { true }
     };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items)]
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
     };
     (@method $trait:ident; |$_candidate:ident $(: &$_ref_repr:ty)? $(: NonNull<$_ptr_repr:ty>)?| $_is_bit_valid:expr) => {
@@ -275,13 +275,13 @@ macro_rules! impl_for_transparent_wrapper {
         // slightly different for each trait.
         unsafe impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?)?> $trait for $ty {
             #[allow(dead_code, clippy::missing_inline_in_public_items)]
-            #[cfg_attr(coverage_nightly, coverage(off))]
+            #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
             fn only_derive_is_allowed_to_implement_this_trait() {
                 use crate::{pointer::invariant::Invariants, util::*};
 
                 impl_for_transparent_wrapper!(@define_is_transparent_wrapper $trait);
 
-                #[cfg_attr(coverage_nightly, coverage(off))]
+                #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
                 fn f<I: Invariants, $($tyvar $(: $(? $optbound +)* $($bound +)*)?)?>() {
                     is_transparent_wrapper::<I, $ty>();
                 }
@@ -353,7 +353,7 @@ macro_rules! impl_for_transparent_wrapper {
         impl_for_transparent_wrapper!(@define_is_transparent_wrapper TryFromBytes, ValidityVariance)
     };
     (@define_is_transparent_wrapper $trait:ident, $variance:ident) => {
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn is_transparent_wrapper<I: Invariants, W: TransparentWrapper<I, $variance = Covariant> + ?Sized>()
         where
             W::Inner: $trait,
@@ -553,7 +553,7 @@ macro_rules! impl_known_layout {
             // SAFETY: Delegates safety to `DstLayout::for_type`.
             unsafe impl<$($tyvar $(: ?$optbound)?)? $(, const $constvar : $constty)?> KnownLayout for $ty {
                 #[allow(clippy::missing_inline_in_public_items)]
-                #[cfg_attr(coverage_nightly, coverage(off))]
+                #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
                 fn only_derive_is_allowed_to_implement_this_trait() where Self: Sized {}
 
                 type PointerMetadata = ();
@@ -607,7 +607,7 @@ macro_rules! unsafe_impl_known_layout {
             #[allow(non_local_definitions)]
             unsafe impl<$($tyvar: ?Sized + KnownLayout)?> KnownLayout for $ty {
                 #[allow(clippy::missing_inline_in_public_items)]
-                #[cfg_attr(coverage_nightly, coverage(off))]
+                #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
                 fn only_derive_is_allowed_to_implement_this_trait() {}
 
                 type PointerMetadata = <$repr as KnownLayout>::PointerMetadata;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -852,7 +852,10 @@ pub(crate) mod polyfills {
         // NOTE on coverage: this will never be tested in nightly since it's a
         // polyfill for a feature which has been stabilized on our nightly
         // toolchain.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(
+            all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+            coverage(off)
+        )]
         #[inline(always)]
         fn slice_from_raw_parts(data: Self, len: usize) -> NonNull<[T]> {
             let ptr = ptr::slice_from_raw_parts_mut(data.as_ptr(), len);
@@ -883,7 +886,10 @@ pub(crate) mod polyfills {
         // NOTE on coverage: this will never be tested in nightly since it's a
         // polyfill for a feature which has been stabilized on our nightly
         // toolchain.
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(
+            all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+            coverage(off)
+        )]
         #[inline(always)]
         unsafe fn unchecked_sub(self, rhs: usize) -> usize {
             match self.checked_sub(rhs) {
@@ -973,7 +979,10 @@ pub(crate) mod testutil {
     }
 
     impl Display for AU64 {
-        #[cfg_attr(coverage_nightly, coverage(off))]
+        #[cfg_attr(
+            all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS),
+            coverage(off)
+        )]
         fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
             Display::fmt(&self.0, f)
         }


### PR DESCRIPTION
Only use the `coverage_nightly` attribute in CI (ie, when `__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS` is present).

Fixes #2286

gherrit-pr-id: I362bc7b83910e0e5112df895c559ff65d033766f

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
