### PR TITLE
Add initial support for unsized `MaybeUninit` wrapper type (#2055)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 2
 
     - name: Populate cache
       uses: ./.github/actions/cache
@@ -427,7 +429,7 @@ jobs:
 
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           # Invoked from a PR - get the PR body directly
-          MESSAGE="${{ github.event.pull_request.body }}"
+          MESSAGE="$(git log -1 --pretty=%B ${{ github.event.pull_request.head.sha }})"
         else
           # Invoked from the merge queue - get the commit message
           MESSAGE="$(git log -1 --pretty=%B ${{ github.sha }})"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,6 +7,8 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
+use core::mem::MaybeUninit as CoreMaybeUninit;
+
 use super::*;
 
 safety_comment! {
@@ -619,14 +621,14 @@ safety_comment! {
     /// SAFETY:
     /// `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`:
     /// `MaybeUninit<T>` has no restrictions on its contents.
-    unsafe_impl!(T => TryFromBytes for MaybeUninit<T>);
-    unsafe_impl!(T => FromZeros for MaybeUninit<T>);
-    unsafe_impl!(T => FromBytes for MaybeUninit<T>);
+    unsafe_impl!(T => TryFromBytes for CoreMaybeUninit<T>);
+    unsafe_impl!(T => FromZeros for CoreMaybeUninit<T>);
+    unsafe_impl!(T => FromBytes for CoreMaybeUninit<T>);
 }
 
-impl_for_transparent_wrapper!(T: Immutable => Immutable for MaybeUninit<T>);
-impl_for_transparent_wrapper!(T: Unaligned => Unaligned for MaybeUninit<T>);
-assert_unaligned!(MaybeUninit<()>, MaybeUninit<u8>);
+impl_for_transparent_wrapper!(T: Immutable => Immutable for CoreMaybeUninit<T>);
+impl_for_transparent_wrapper!(T: Unaligned => Unaligned for CoreMaybeUninit<T>);
+assert_unaligned!(CoreMaybeUninit<()>, CoreMaybeUninit<u8>);
 
 impl_for_transparent_wrapper!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>);
 impl_for_transparent_wrapper!(T: ?Sized + TryFromBytes => TryFromBytes for ManuallyDrop<T>);
@@ -1235,8 +1237,8 @@ mod tests {
                             ManuallyDrop<UnsafeCell<()>>,
                             ManuallyDrop<[UnsafeCell<u8>]>,
                             ManuallyDrop<[UnsafeCell<bool>]>,
-                            MaybeUninit<NotZerocopy>,
-                            MaybeUninit<UnsafeCell<()>>,
+                            CoreMaybeUninit<NotZerocopy>,
+                            CoreMaybeUninit<UnsafeCell<()>>,
                             Wrapping<UnsafeCell<()>>
                         );
 
@@ -1278,9 +1280,9 @@ mod tests {
                             Option<FnManyArgs>,
                             Option<extern "C" fn()>,
                             Option<ECFnManyArgs>,
-                            MaybeUninit<u8>,
-                            MaybeUninit<NotZerocopy>,
-                            MaybeUninit<UnsafeCell<()>>,
+                            CoreMaybeUninit<u8>,
+                            CoreMaybeUninit<NotZerocopy>,
+                            CoreMaybeUninit<UnsafeCell<()>>,
                             ManuallyDrop<UnsafeCell<()>>,
                             ManuallyDrop<[UnsafeCell<u8>]>,
                             ManuallyDrop<[UnsafeCell<bool>]>,
@@ -1742,9 +1744,9 @@ mod tests {
         assert_impls!(ManuallyDrop<[UnsafeCell<u8>]>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !Immutable);
         assert_impls!(ManuallyDrop<[UnsafeCell<bool>]>: KnownLayout, TryFromBytes, FromZeros, IntoBytes, Unaligned, !Immutable, !FromBytes);
 
-        assert_impls!(MaybeUninit<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, Unaligned, !IntoBytes);
-        assert_impls!(MaybeUninit<NotZerocopy>: KnownLayout, TryFromBytes, FromZeros, FromBytes, !Immutable, !IntoBytes, !Unaligned);
-        assert_impls!(MaybeUninit<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, Unaligned, !Immutable, !IntoBytes);
+        assert_impls!(CoreMaybeUninit<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, Unaligned, !IntoBytes);
+        assert_impls!(CoreMaybeUninit<NotZerocopy>: KnownLayout, TryFromBytes, FromZeros, FromBytes, !Immutable, !IntoBytes, !Unaligned);
+        assert_impls!(CoreMaybeUninit<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, Unaligned, !Immutable, !IntoBytes);
 
         assert_impls!(Wrapping<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ use core::{
     fmt::{self, Debug, Display, Formatter},
     hash::Hasher,
     marker::PhantomData,
-    mem::{self, ManuallyDrop, MaybeUninit},
+    mem::{self, ManuallyDrop, MaybeUninit as CoreMaybeUninit},
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
         NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize, Wrapping,
@@ -711,6 +711,15 @@ pub unsafe trait KnownLayout {
     /// This is `()` for sized types and `usize` for slice DSTs.
     type PointerMetadata: PointerMetadata;
 
+    /// A maybe-uninitialized analog of `Self`
+    ///
+    /// # Safety
+    ///
+    /// `Self::LAYOUT` and `Self::MaybeUninit::LAYOUT` are identical.
+    /// `Self::MaybeUninit` admits uninitialized bytes in all positions.
+    #[doc(hidden)]
+    type MaybeUninit: ?Sized + KnownLayout<PointerMetadata = Self::PointerMetadata>;
+
     /// The layout of `Self`.
     ///
     /// # Safety
@@ -843,6 +852,35 @@ unsafe impl<T> KnownLayout for [T] {
 
     type PointerMetadata = usize;
 
+    // SAFETY: `CoreMaybeUninit<T>::LAYOUT` and `T::LAYOUT` are identical
+    // because `CoreMaybeUninit<T>` has the same size and alignment as `T` [1].
+    // Consequently, `[CoreMaybeUninit<T>]::LAYOUT` and `[T]::LAYOUT` are
+    // identical, because they both lack a fixed-sized prefix and because they
+    // inherit the alignments of their inner element type (which are identical)
+    // [2][3].
+    //
+    // `[CoreMaybeUninit<T>]` admits uninitialized bytes at all positions
+    // because `CoreMaybeUninit<T>` admits uninitialized bytes at all positions
+    // and because the inner elements of `[CoreMaybeUninit<T>]` are laid out
+    // back-to-back [2][3].
+    //
+    // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+    //
+    //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
+    //   `T`
+    //
+    // [2] Per https://doc.rust-lang.org/1.82.0/reference/type-layout.html#slice-layout:
+    //
+    //   Slices have the same layout as the section of the array they slice.
+    //
+    // [3] Per https://doc.rust-lang.org/1.82.0/reference/type-layout.html#array-layout:
+    //
+    //   An array of `[T; N]` has a size of `size_of::<T>() * N` and the same
+    //   alignment of `T`. Arrays are laid out so that the zero-based `nth`
+    //   element of the array is offset from the start of the array by `n *
+    //   size_of::<T>()` bytes.
+    type MaybeUninit = [CoreMaybeUninit<T>];
+
     const LAYOUT: DstLayout = DstLayout::for_slice::<T>();
 
     // SAFETY: `.cast` preserves address and provenance. The returned pointer
@@ -895,9 +933,11 @@ impl_known_layout!(
     T         => Option<T>,
     T: ?Sized => PhantomData<T>,
     T         => Wrapping<T>,
-    T         => MaybeUninit<T>,
+    T         => CoreMaybeUninit<T>,
     T: ?Sized => *const T,
-    T: ?Sized => *mut T
+    T: ?Sized => *mut T,
+    T: ?Sized => &'_ T,
+    T: ?Sized => &'_ mut T,
 );
 impl_known_layout!(const N: usize, T => [T; N]);
 
@@ -926,6 +966,21 @@ safety_comment! {
     unsafe_impl_known_layout!(#[repr([u8])] str);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] ManuallyDrop<T>);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] UnsafeCell<T>);
+}
+
+safety_comment! {
+    /// SAFETY:
+    /// - By consequence of the invariant on `T::MaybeUninit` that `T::LAYOUT`
+    ///   and `T::MaybeUninit::LAYOUT` are equal, `T` and `T::MaybeUninit`
+    ///   have the same:
+    ///   - Fixed prefix size
+    ///   - Alignment
+    ///   - (For DSTs) trailing slice element size
+    /// - By consequence of the above, referents `T::MaybeUninit` and `T` have
+    ///   the require the same kind of pointer metadata, and thus it is valid to
+    ///   perform an `as` cast from `*mut T` and `*mut T::MaybeUninit`, and this
+    ///   operation preserves referent size (ie, `size_of_val_raw`).
+    unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T::MaybeUninit)] MaybeUninit<T>);
 }
 
 /// Analyzes whether a type is [`FromZeros`].
@@ -2547,7 +2602,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: Sized,
     {
-        let candidate = match MaybeUninit::<Self>::read_from_bytes(source) {
+        let candidate = match CoreMaybeUninit::<Self>::read_from_bytes(source) {
             Ok(candidate) => candidate,
             Err(e) => {
                 return Err(TryReadError::Size(e.with_dst()));
@@ -2608,7 +2663,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: Sized,
     {
-        let (candidate, suffix) = match MaybeUninit::<Self>::read_from_prefix(source) {
+        let (candidate, suffix) = match CoreMaybeUninit::<Self>::read_from_prefix(source) {
             Ok(candidate) => candidate,
             Err(e) => {
                 return Err(TryReadError::Size(e.with_dst()));
@@ -2670,7 +2725,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: Sized,
     {
-        let (prefix, candidate) = match MaybeUninit::<Self>::read_from_suffix(source) {
+        let (prefix, candidate) = match CoreMaybeUninit::<Self>::read_from_suffix(source) {
             Ok(candidate) => candidate,
             Err(e) => {
                 return Err(TryReadError::Size(e.with_dst()));
@@ -2743,7 +2798,7 @@ fn swap<T, U>((t, u): (T, U)) -> (U, T) {
 #[inline(always)]
 unsafe fn try_read_from<S, T: TryFromBytes>(
     source: S,
-    mut candidate: MaybeUninit<T>,
+    mut candidate: CoreMaybeUninit<T>,
 ) -> Result<T, TryReadError<S, T>> {
     // We use `from_mut` despite not mutating via `c_ptr` so that we don't need
     // to add a `T: Immutable` bound.
@@ -3032,60 +3087,11 @@ pub unsafe trait FromZeros: TryFromBytes {
     where
         Self: KnownLayout<PointerMetadata = usize>,
     {
-        let size = match count.size_for_metadata(Self::LAYOUT) {
-            Some(size) => size,
-            None => return Err(AllocError),
-        };
-
-        let align = Self::LAYOUT.align.get();
-
-        // TODO(https://github.com/rust-lang/rust/issues/55724): Use
-        // `Layout::repeat` once it's stabilized.
-        let layout = Layout::from_size_align(size, align).or(Err(AllocError))?;
-
-        let ptr = if layout.size() != 0 {
-            // TODO(#429): Add a "SAFETY" comment and remove this `allow`.
-            #[allow(clippy::undocumented_unsafe_blocks)]
-            let ptr = unsafe { alloc::alloc::alloc_zeroed(layout) };
-            match NonNull::new(ptr) {
-                Some(ptr) => ptr,
-                None => return Err(AllocError),
-            }
-        } else {
-            // We use `transmute` instead of an `as` cast since Miri (with
-            // strict provenance enabled) notices and complains that an `as`
-            // cast creates a pointer with no provenance. Miri isn't smart
-            // enough to realize that we're only executing this branch when
-            // we're constructing a zero-sized `Box`, which doesn't require
-            // provenance.
-            //
-            // SAFETY: any initialized bit sequence is a bit-valid `*mut u8`.
-            // All bits of a `usize` are initialized.
-            #[allow(clippy::useless_transmute)]
-            let dangling = unsafe { mem::transmute::<usize, *mut u8>(align) };
-            // SAFETY: `dangling` is constructed from `Self::LAYOUT.align`,
-            // which is a `NonZeroUsize`, which is guaranteed to be non-zero.
-            //
-            // `Box<[T]>` does not allocate when `T` is zero-sized or when `len`
-            // is zero, but it does require a non-null dangling pointer for its
-            // allocation.
-            //
-            // TODO(https://github.com/rust-lang/rust/issues/95228): Use
-            // `std::ptr::without_provenance` once it's stable. That may
-            // optimize better. As written, Rust may assume that this consumes
-            // "exposed" provenance, and thus Rust may have to assume that this
-            // may consume provenance from any pointer whose provenance has been
-            // exposed.
-            unsafe { NonNull::new_unchecked(dangling) }
-        };
-
-        let ptr = Self::raw_from_ptr_len(ptr, count);
-
-        // TODO(#429): Add a "SAFETY" comment and remove this `allow`. Make sure
-        // to include a justification that `ptr.as_ptr()` is validly-aligned in
-        // the ZST case (in which we manually construct a dangling pointer).
-        #[allow(clippy::undocumented_unsafe_blocks)]
-        Ok(unsafe { Box::from_raw(ptr.as_ptr()) })
+        // SAFETY: `alloc::alloc::alloc_zeroed` is a valid argument of
+        // `new_box`. The referent of the pointer returned by `alloc_zeroed`
+        // (and, consequently, the `Box` derived from it) is a valid instance of
+        // `Self`, because `Self` is `FromZeros`.
+        unsafe { crate::util::new_box(count, alloc::alloc::alloc_zeroed) }
     }
 
     /// Creates a `Vec<Self>` from zeroed bytes.
@@ -4532,7 +4538,7 @@ pub unsafe trait FromBytes: FromZeros {
         Self: Sized,
         R: io::Read,
     {
-        let mut buf = MaybeUninit::<Self>::zeroed();
+        let mut buf = CoreMaybeUninit::<Self>::zeroed();
         let ptr = Ptr::from_mut(&mut buf);
         // SAFETY: `buf` consists entirely of initialized, zeroed bytes.
         let ptr = unsafe { ptr.assume_validity::<invariant::Initialized>() };

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -546,6 +546,17 @@ macro_rules! impl_known_layout {
 
                 type PointerMetadata = ();
 
+                // SAFETY: `CoreMaybeUninit<T>::LAYOUT` and `T::LAYOUT` are
+                // identical because `CoreMaybeUninit<T>` has the same size and
+                // alignment as `T` [1], and `CoreMaybeUninit` admits
+                // uninitialized bytes in all positions.
+                //
+                // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+                //
+                //   `MaybeUninit<T>` is guaranteed to have the same size,
+                //   alignment, and ABI as `T`
+                type MaybeUninit = core::mem::MaybeUninit<Self>;
+
                 const LAYOUT: crate::DstLayout = crate::DstLayout::for_type::<$ty>();
 
                 // SAFETY: `.cast` preserves address and provenance.
@@ -588,6 +599,7 @@ macro_rules! unsafe_impl_known_layout {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
 
                 type PointerMetadata = <$repr as KnownLayout>::PointerMetadata;
+                type MaybeUninit = <$repr as KnownLayout>::MaybeUninit;
 
                 const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -679,6 +679,134 @@ pub(crate) unsafe fn copy_unchecked(src: &[u8], dst: &mut [u8]) {
     };
 }
 
+/// Unsafely transmutes the given `src` into a type `Dst`.
+///
+/// # Safety
+///
+/// The value `src` must be a valid instance of `Dst`.
+#[inline(always)]
+pub(crate) const unsafe fn transmute_unchecked<Src, Dst>(src: Src) -> Dst {
+    static_assert!(Src, Dst => core::mem::size_of::<Src>() == core::mem::size_of::<Dst>());
+
+    #[repr(C)]
+    union Transmute<Src, Dst> {
+        src: ManuallyDrop<Src>,
+        dst: ManuallyDrop<Dst>,
+    }
+
+    // SAFETY: Since `Transmute<Src, Dst>` is `#[repr(C)]`, its `src` and `dst`
+    // fields both start at the same offset and the types of those fields are
+    // transparent wrappers around `Src` and `Dst` [1]. Consequently,
+    // initializng `Transmute` with with `src` and then reading out `dst` is
+    // equivalent to transmuting from `Src` to `Dst` [2]. Transmuting from `src`
+    // to `Dst` is valid because — by contract on the caller — `src` is a valid
+    // instance of `Dst`.
+    //
+    // [1] Per https://doc.rust-lang.org/1.82.0/std/mem/struct.ManuallyDrop.html:
+    //
+    //     `ManuallyDrop<T>` is guaranteed to have the same layout and bit
+    //     validity as `T`, and is subject to the same layout optimizations as
+    //     `T`.
+    //
+    // [2] Per https://doc.rust-lang.org/1.82.0/reference/items/unions.html#reading-and-writing-union-fields:
+    //
+    //     Effectively, writing to and then reading from a union with the C
+    //     representation is analogous to a transmute from the type used for
+    //     writing to the type used for reading.
+    unsafe { ManuallyDrop::into_inner(Transmute { src: ManuallyDrop::new(src) }.dst) }
+}
+
+/// Uses `allocate` to create a `Box<T>`.
+///
+/// # Errors
+///
+/// Returns an error on allocation failure. Allocation failure is guaranteed
+/// never to cause a panic or an abort.
+///
+/// # Safety
+///
+/// `allocate` must be either `alloc::alloc::alloc` or
+/// `alloc::alloc::alloc_zeroed`. The referent of the box returned by `new_box`
+/// has the same bit-validity as the referent of the pointer returned by the
+/// given `allocate` and sufficient size to store `T` with `meta`.
+#[must_use = "has no side effects (other than allocation)"]
+#[cfg(feature = "alloc")]
+#[inline]
+pub(crate) unsafe fn new_box<T>(
+    meta: T::PointerMetadata,
+    allocate: unsafe fn(core::alloc::Layout) -> *mut u8,
+) -> Result<alloc::boxed::Box<T>, crate::error::AllocError>
+where
+    T: ?Sized + crate::KnownLayout,
+{
+    use crate::error::AllocError;
+    use crate::PointerMetadata;
+    use core::alloc::Layout;
+
+    let size = match meta.size_for_metadata(T::LAYOUT) {
+        Some(size) => size,
+        None => return Err(AllocError),
+    };
+
+    let align = T::LAYOUT.align.get();
+
+    // TODO(https://github.com/rust-lang/rust/issues/55724): Use
+    // `Layout::repeat` once it's stabilized.
+    let layout = Layout::from_size_align(size, align).or(Err(AllocError))?;
+
+    let ptr = if layout.size() != 0 {
+        // SAFETY: By contract on the caller, `allocate` is either
+        // `alloc::alloc::alloc` or `alloc::alloc::alloc_zeroed`. The above
+        // check ensures their shared safety precondition: that the supplied
+        // layout is not zero-sized type [1].
+        //
+        // [1] Per https://doc.rust-lang.org/stable/std/alloc/trait.GlobalAlloc.html#tymethod.alloc:
+        //
+        //     This function is unsafe because undefined behavior can result if
+        //     the caller does not ensure that layout has non-zero size.
+        let ptr = unsafe { allocate(layout) };
+        match NonNull::new(ptr) {
+            Some(ptr) => ptr,
+            None => return Err(AllocError),
+        }
+    } else {
+        let align = T::LAYOUT.align.get();
+        // We use `transmute` instead of an `as` cast since Miri (with strict
+        // provenance enabled) notices and complains that an `as` cast creates a
+        // pointer with no provenance. Miri isn't smart enough to realize that
+        // we're only executing this branch when we're constructing a zero-sized
+        // `Box`, which doesn't require provenance.
+        //
+        // SAFETY: any initialized bit sequence is a bit-valid `*mut u8`. All
+        // bits of a `usize` are initialized.
+        #[allow(clippy::useless_transmute)]
+        let dangling = unsafe { mem::transmute::<usize, *mut u8>(align) };
+        // SAFETY: `dangling` is constructed from `T::LAYOUT.align`, which is a
+        // `NonZeroUsize`, which is guaranteed to be non-zero.
+        //
+        // `Box<[T]>` does not allocate when `T` is zero-sized or when `len` is
+        // zero, but it does require a non-null dangling pointer for its
+        // allocation.
+        //
+        // TODO(https://github.com/rust-lang/rust/issues/95228): Use
+        // `std::ptr::without_provenance` once it's stable. That may optimize
+        // better. As written, Rust may assume that this consumes "exposed"
+        // provenance, and thus Rust may have to assume that this may consume
+        // provenance from any pointer whose provenance has been exposed.
+        unsafe { NonNull::new_unchecked(dangling) }
+    };
+
+    let ptr = T::raw_from_ptr_len(ptr, meta);
+
+    // TODO(#429): Add a "SAFETY" comment and remove this `allow`. Make sure to
+    // include a justification that `ptr.as_ptr()` is validly-aligned in the ZST
+    // case (in which we manually construct a dangling pointer) and to justify
+    // why `Box` is safe to drop (it's because `allocate` uses the system
+    // allocator).
+    #[allow(clippy::undocumented_unsafe_blocks)]
+    Ok(unsafe { alloc::boxed::Box::from_raw(ptr.as_ptr()) })
+}
+
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet
 /// exist (stably) on our MSRV. This module provides polyfills for those

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -6,7 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use core::hash::Hash;
+use core::{fmt, hash::Hash};
 
 use super::*;
 
@@ -166,20 +166,8 @@ impl<T> Unalign<T> {
     /// Consumes `self`, returning the inner `T`.
     #[inline(always)]
     pub const fn into_inner(self) -> T {
-        // Use this instead of `mem::transmute` since the latter can't tell
-        // that `Unalign<T>` and `T` have the same size.
-        #[repr(C)]
-        union Transmute<T> {
-            u: ManuallyDrop<Unalign<T>>,
-            t: ManuallyDrop<T>,
-        }
-
-        // SAFETY: Since `Unalign` is `#[repr(C, packed)]`, it has the same
-        // layout as `T`. `ManuallyDrop<U>` is guaranteed to have the same
-        // layout as `U`, and so `ManuallyDrop<Unalign<T>>` has the same layout
-        // as `ManuallyDrop<T>`. Since `Transmute<T>` is `#[repr(C)]`, its `t`
-        // and `u` fields both start at the same offset (namely, 0) within the
-        // union.
+        // SAFETY: Since `Unalign` is `#[repr(C, packed)]`, it has the same size
+        // and bit validity as `T`.
         //
         // We do this instead of just destructuring in order to prevent
         // `Unalign`'s `Drop::drop` from being run, since dropping is not
@@ -187,7 +175,7 @@ impl<T> Unalign<T> {
         //
         // TODO(https://github.com/rust-lang/rust/issues/73255): Destructure
         // instead of using unsafe.
-        unsafe { ManuallyDrop::into_inner(Transmute { u: ManuallyDrop::new(self) }.t) }
+        unsafe { crate::util::transmute_unchecked(self) }
     }
 
     /// Attempts to return a reference to the wrapped `T`, failing if `self` is
@@ -459,6 +447,139 @@ impl<T: Unaligned + Display> Display for Unalign<T> {
     }
 }
 
+/// A wrapper type to construct uninitialized instances of `T`.
+///
+/// `MaybeUninit` is identical to the [standard library
+/// `MaybeUninit`][core-maybe-uninit] type except that it supports unsized
+/// types.
+///
+/// # Layout
+///
+/// The same layout guarantees and caveats apply to `MaybeUninit<T>` as apply to
+/// the [standard library `MaybeUninit`][core-maybe-uninit] with one exception:
+/// for `T: !Sized`, there is no single value for `T`'s size. Instead, for such
+/// types, the following are guaranteed:
+/// - Every [valid size][valid-size] for `T` is a valid size for
+///   `MaybeUninit<T>` and vice versa
+/// - Given `t: *const T` and `m: *const MaybeUninit<T>` with identical fat
+///   pointer metadata, `t` and `m` address the same number of bytes (and
+///   likewise for `*mut`)
+///
+/// [core-maybe-uninit]: core::mem::MaybeUninit
+/// [valid-size]: crate::KnownLayout#what-is-a-valid-size
+#[repr(transparent)]
+#[doc(hidden)]
+pub struct MaybeUninit<T: ?Sized + KnownLayout>(
+    // SAFETY: `MaybeUninit<T>` has the same size as `T`, because (by invariant
+    // on `T::MaybeUninit`) `T::MaybeUninit` has `T::LAYOUT` identical to `T`,
+    // and because (invariant on `T::LAYOUT`) we can trust that `LAYOUT`
+    // accurately reflects the layout of `T`. By invariant on `T::MaybeUninit`,
+    // it admits uninitialized bytes in all positions. Because `MabyeUninit` is
+    // marked `repr(transparent)`, these properties additionally hold true for
+    // `Self`.
+    T::MaybeUninit,
+);
+
+#[doc(hidden)]
+impl<T: ?Sized + KnownLayout> MaybeUninit<T> {
+    /// Constructs a `MaybeUninit<T>` initialized with the given value.
+    #[inline(always)]
+    pub const fn new(val: T) -> Self
+    where
+        T: Sized,
+        Self: Sized,
+    {
+        // SAFETY: It is valid to transmute `val` to `MaybeUninit<T>` because it
+        // is both valid to transmute `val` to `T::MaybeUninit`, and it is valid
+        // to transmute from `T::MaybeUninit` to `MaybeUninit<T>`.
+        //
+        // First, it is valid to transmute `val` to `T::MaybeUninit` because, by
+        // invariant on `T::MaybeUninit`:
+        // - For `T: Sized`, `T` and `T::MaybeUninit` have the same size.
+        // - All byte sequences of the correct size are valid values of
+        //   `T::MaybeUninit`.
+        //
+        // Second, it is additionally valid to transmute from `T::MaybeUninit`
+        // to `MaybeUninit<T>`, because `MaybeUninit<T>` is a
+        // `repr(transparent)` wrapper around `T::MaybeUninit`.
+        //
+        // These two transmutes are collapsed into one so we don't need to add a
+        // `T::MaybeUninit: Sized` bound to this function's `where` clause.
+        unsafe { crate::util::transmute_unchecked(val) }
+    }
+
+    /// Constructs an uninitialized `MaybeUninit<T>`.
+    #[must_use]
+    #[inline(always)]
+    pub const fn uninit() -> Self
+    where
+        T: Sized,
+        Self: Sized,
+    {
+        let uninit = CoreMaybeUninit::<T>::uninit();
+        // SAFETY: It is valid to transmute from `CoreMaybeUninit<T>` to
+        // `MaybeUninit<T>` since they both admit uninitialized bytes in all
+        // positions, and they have the same size (i.e., that of `T`).
+        //
+        // `MaybeUninit<T>` has the same size as `T`, because (by invariant on
+        // `T::MaybeUninit`) `T::MaybeUninit` has `T::LAYOUT` identical to `T`,
+        // and because (invariant on `T::LAYOUT`) we can trust that `LAYOUT`
+        // accurately reflects the layout of `T`.
+        //
+        // `CoreMaybeUninit<T>` has the same size as `T` [1] and admits
+        // uninitialized bytes in all positions.
+        //
+        // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+        //
+        //   `MaybeUninit<T>` is guaranteed to have the same size, alignment,
+        //   and ABI as `T`
+        unsafe { crate::util::transmute_unchecked(uninit) }
+    }
+
+    /// Creates a `Box<MaybeUninit<T>>`.
+    ///
+    /// This function is useful for allocating large, uninit values on the heap
+    /// without ever creating a temporary instance of `Self` on the stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on allocation failure. Allocation failure is guaranteed
+    /// never to cause a panic or an abort.
+    #[cfg(feature = "alloc")]
+    #[inline]
+    pub fn new_boxed_uninit(meta: T::PointerMetadata) -> Result<Box<Self>, AllocError> {
+        // SAFETY: `alloc::alloc::alloc_zeroed` is a valid argument of
+        // `new_box`. The referent of the pointer returned by `alloc` (and,
+        // consequently, the `Box` derived from it) is a valid instance of
+        // `Self`, because `Self` is `MaybeUninit` and thus admits arbitrary
+        // (un)initialized bytes.
+        unsafe { crate::util::new_box(meta, alloc::alloc::alloc) }
+    }
+
+    /// Extracts the value from the `MaybeUninit<T>` container.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `self` is in an bit-valid state. Depending
+    /// on subsequent use, it may also need to be in a library-valid state.
+    #[inline(always)]
+    pub const unsafe fn assume_init(self) -> T
+    where
+        T: Sized,
+        Self: Sized,
+    {
+        // SAFETY: The caller guarantees that `self` is in an bit-valid state.
+        unsafe { crate::util::transmute_unchecked(self) }
+    }
+}
+
+impl<T: ?Sized + KnownLayout> fmt::Debug for MaybeUninit<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(core::any::type_name::<Self>())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::panic::AssertUnwindSafe;
@@ -553,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn test_copy_clone() {
+    fn test_unalign_copy_clone() {
         // Test that `Copy` and `Clone` do not cause soundness issues. This test
         // is mainly meant to exercise UB that would be caught by Miri.
 
@@ -568,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trait_impls() {
+    fn test_unalign_trait_impls() {
         let zero = Unalign::new(0u8);
         let one = Unalign::new(1u8);
 
@@ -594,5 +715,38 @@ mod tests {
         assert_eq!(format!("{:?}", one), format!("{:?}", 1u8));
         assert_eq!(format!("{}", zero), format!("{}", 0u8));
         assert_eq!(format!("{}", one), format!("{}", 1u8));
+    }
+
+    #[test]
+    #[allow(clippy::as_conversions)]
+    fn test_maybe_uninit() {
+        // int
+        {
+            let input = 42;
+            let uninit = MaybeUninit::new(input);
+            // SAFETY: `uninit` is in an initialized state
+            let output = unsafe { uninit.assume_init() };
+            assert_eq!(input, output);
+        }
+
+        // thin ref
+        {
+            let input = 42;
+            let uninit = MaybeUninit::new(&input);
+            // SAFETY: `uninit` is in an initialized state
+            let output = unsafe { uninit.assume_init() };
+            assert_eq!(&input as *const _, output as *const _);
+            assert_eq!(input, *output);
+        }
+
+        // wide ref
+        {
+            let input = [1, 2, 3, 4];
+            let uninit = MaybeUninit::new(&input[..]);
+            // SAFETY: `uninit` is in an initialized state
+            let output = unsafe { uninit.assume_init() };
+            assert_eq!(&input[..] as *const _, output as *const _);
+            assert_eq!(input, *output);
+        }
     }
 }

--- a/tests/ui-msrv/diagnostic-not-implemented-known-layout.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-known-layout.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::KnownLayout` is not satisf
    |                          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotZerocopy`
    |
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
 note: required by a bound in `takes_known_layout`
   --> tests/ui-msrv/diagnostic-not-implemented-known-layout.rs:21:26

--- a/tests/ui-nightly/diagnostic-not-implemented-known-layout.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-known-layout.stderr
@@ -6,14 +6,14 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::KnownLayout` is not satisf
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
 note: required by a bound in `takes_known_layout`
   --> tests/ui-nightly/diagnostic-not-implemented-known-layout.rs:21:26

--- a/tests/ui-stable/diagnostic-not-implemented-known-layout.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-known-layout.stderr
@@ -6,14 +6,14 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::KnownLayout` is not satisf
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
 note: required by a bound in `takes_known_layout`
   --> tests/ui-stable/diagnostic-not-implemented-known-layout.rs:21:26

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -111,6 +111,8 @@ fn test_known_layout() {
 
                 type PointerMetadata = ();
 
+                type MaybeUninit = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<Self>;
+
                 const LAYOUT: ::zerocopy::DstLayout = ::zerocopy::DstLayout::for_type::<Self>();
 
                 #[inline(always)]
@@ -124,6 +126,104 @@ fn test_known_layout() {
                 #[inline(always)]
                 fn pointer_to_metadata(_ptr: *mut Self) -> () {}
             }
+        } no_build
+    }
+
+    test! {
+        KnownLayout {
+            #[repr(C, align(2))]
+            struct Foo<T, U>(T, U);
+        }
+        expands to {
+            const _: () = {
+                #[allow(deprecated)]
+                #[automatically_derived]
+                unsafe impl<T, U> ::zerocopy::KnownLayout for Foo<T, U>
+                where
+                    U: ::zerocopy::KnownLayout,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type PointerMetadata = <U as ::zerocopy::KnownLayout>::PointerMetadata;
+                    type MaybeUninit = __ZerocopyKnownLayoutMaybeUninit<T, U>;
+                    const LAYOUT: ::zerocopy::DstLayout = {
+                        use ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize;
+                        use ::zerocopy::{DstLayout, KnownLayout};
+                        let repr_align = ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize::new(
+                            2u32 as usize,
+                        );
+                        let repr_packed = ::zerocopy::util::macro_util::core_reexport::option::Option::None;
+                        DstLayout::new_zst(repr_align)
+                            .extend(DstLayout::for_type::<T>(), repr_packed)
+                            .extend(<U as KnownLayout>::LAYOUT, repr_packed)
+                            .pad_to_align()
+                    };
+                    #[inline(always)]
+                    fn raw_from_ptr_len(
+                        bytes: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<u8>,
+                        meta: Self::PointerMetadata,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self> {
+                        use ::zerocopy::KnownLayout;
+                        let trailing = <U as KnownLayout>::raw_from_ptr_len(bytes, meta);
+                        let slf = trailing.as_ptr() as *mut Self;
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                slf,
+                            )
+                        }
+                    }
+                    #[inline(always)]
+                    fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+                        <U>::pointer_to_metadata(ptr as *mut _)
+                    }
+                }
+                #[repr(C)]
+                #[repr(align(2))]
+                #[doc(hidden)]
+                struct __ZerocopyKnownLayoutMaybeUninit<T, U>(
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<T>,
+                    <U as ::zerocopy::KnownLayout>::MaybeUninit,
+                )
+                where
+                    U: ::zerocopy::KnownLayout;
+                unsafe impl<T, U> ::zerocopy::KnownLayout
+                for __ZerocopyKnownLayoutMaybeUninit<T, U>
+                where
+                    U: ::zerocopy::KnownLayout,
+                    <U as ::zerocopy::KnownLayout>::MaybeUninit: ::zerocopy::KnownLayout,
+                {
+                    #[allow(clippy::missing_inline_in_public_items)]
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type PointerMetadata = <Foo<T, U> as ::zerocopy::KnownLayout>::PointerMetadata;
+                    type MaybeUninit = Self;
+                    const LAYOUT: ::zerocopy::DstLayout = <Foo<
+                        T,
+                        U,
+                    > as ::zerocopy::KnownLayout>::LAYOUT;
+                    #[inline(always)]
+                    fn raw_from_ptr_len(
+                        bytes: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<u8>,
+                        meta: Self::PointerMetadata,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self> {
+                        use ::zerocopy::KnownLayout;
+                        let trailing = <<U as ::zerocopy::KnownLayout>::MaybeUninit as KnownLayout>::raw_from_ptr_len(
+                            bytes,
+                            meta,
+                        );
+                        let slf = trailing.as_ptr() as *mut Self;
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                slf,
+                            )
+                        }
+                    }
+                    #[inline(always)]
+                    fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+                        <<U as ::zerocopy::KnownLayout>::MaybeUninit>::pointer_to_metadata(
+                            ptr as *mut _,
+                        )
+                    }
+                }
+            };
         } no_build
     }
 }

--- a/zerocopy-derive/tests/ui-msrv/mid_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/mid_compile_pass.stderr
@@ -79,11 +79,11 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 39 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    |
 
-error[E0277]: the trait bound `T: KnownLayout` is not satisfied
+error[E0277]: the trait bound `KL12<T>: KnownLayout` is not satisfied
   --> tests/ui-msrv/mid_compile_pass.rs:50:15
    |
 50 |     assert_kl(kl)
-   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`
+   |     --------- ^^ the trait `KnownLayout` is not implemented for `KL12<T>`
    |     |
    |     required by a bound introduced by this call
    |
@@ -98,7 +98,9 @@ note: required by a bound in `assert_kl`
 23 | fn assert_kl<T: ?Sized + KnownLayout>(_: &T) {}
    |                          ^^^^^^^^^^^ required by this bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider borrowing here
    |
-49 | fn test_kl12<T: ?Sized + zerocopy::KnownLayout>(kl: &KL12<T>) {
-   |                        +++++++++++++++++++++++
+50 |     assert_kl(&kl)
+   |               +
+50 |     assert_kl(&mut kl)
+   |               ++++

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -123,14 +123,14 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
    |          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotKnownLayoutDst`
    |
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -142,14 +142,14 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
    |          ^^^^^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `NotKnownLayout`
    |
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/mid_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/mid_compile_pass.stderr
@@ -82,15 +82,14 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 39 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    |
 
-error[E0277]: the trait bound `T: KnownLayout` is not satisfied
+error[E0277]: the trait bound `KL12<T>: KnownLayout` is not satisfied
   --> tests/ui-nightly/mid_compile_pass.rs:50:15
    |
 50 |     assert_kl(kl)
-   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`
+   |     --------- ^^ the trait `KnownLayout` is not implemented for `KL12<T>`
    |     |
    |     required by a bound introduced by this call
    |
-   = note: Consider adding `#[derive(KnownLayout)]` to `T`
 note: required for `KL12<T>` to implement `KnownLayout`
   --> tests/ui-nightly/mid_compile_pass.rs:45:10
    |
@@ -102,7 +101,9 @@ note: required by a bound in `assert_kl`
 23 | fn assert_kl<T: ?Sized + KnownLayout>(_: &T) {}
    |                          ^^^^^^^^^^^ required by this bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider borrowing here
    |
-49 | fn test_kl12<T: ?Sized + zerocopy::KnownLayout>(kl: &KL12<T>) {
-   |                        +++++++++++++++++++++++
+50 |     assert_kl(&kl)
+   |               +
+50 |     assert_kl(&mut kl)
+   |               ++++

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -135,14 +135,14 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotKnownLayoutDst`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -159,14 +159,14 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotKnownLayout`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/mid_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/mid_compile_pass.stderr
@@ -82,15 +82,14 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
 39 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    |
 
-error[E0277]: the trait bound `T: KnownLayout` is not satisfied
+error[E0277]: the trait bound `KL12<T>: KnownLayout` is not satisfied
   --> tests/ui-stable/mid_compile_pass.rs:50:15
    |
 50 |     assert_kl(kl)
-   |     --------- ^^ the trait `KnownLayout` is not implemented for `T`
+   |     --------- ^^ the trait `KnownLayout` is not implemented for `KL12<T>`
    |     |
    |     required by a bound introduced by this call
    |
-   = note: Consider adding `#[derive(KnownLayout)]` to `T`
 note: required for `KL12<T>` to implement `KnownLayout`
   --> tests/ui-stable/mid_compile_pass.rs:45:10
    |
@@ -102,7 +101,9 @@ note: required by a bound in `assert_kl`
 23 | fn assert_kl<T: ?Sized + KnownLayout>(_: &T) {}
    |                          ^^^^^^^^^^^ required by this bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider borrowing here
    |
-49 | fn test_kl12<T: ?Sized + zerocopy::KnownLayout>(kl: &KL12<T>) {
-   |                        +++++++++++++++++++++++
+50 |     assert_kl(&kl)
+   |               +
+50 |     assert_kl(&mut kl)
+   |               ++++

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -124,14 +124,14 @@ error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy::KnownLayout` is not 
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotKnownLayoutDst`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -144,14 +144,14 @@ error[E0277]: the trait bound `NotKnownLayout: zerocopy::KnownLayout` is not sat
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `NotKnownLayout`
    = help: the following other types implement trait `zerocopy::KnownLayout`:
+             &T
+             &mut T
              ()
              *const T
              *mut T
              AU16
              AtomicBool
              AtomicI16
-             AtomicI32
-             AtomicI64
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This is achieved by adding a `MaybeUninit` associated type to `KnownLayout`, whose layout is identical to `Self` except that it admits uninitialized bytes in all positions.

For sized types, this is bound to `mem::MaybeUninit<Self>`. For potentially unsized structs, we synthesize a doppelganger with the same `repr`, whose leading fields are wrapped in `mem::MaybeUninit` and whose trailing field is the `MaybeUninit` associated type of struct's original trailing field type. This type-level recursion bottoms out at `[T]`, whose `MaybeUninit` associated type is bound to `[mem::MaybeUninit<T>]`.

Makes progress towards #1797

SKIP_CARGO_SEMVER_CHECKS=1

gherrit-pr-id: Idfc357094e28b54a15d947141241ca2da83dcc91

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
