### PR TITLE
[pointer] Store validity in the referent type

### DIFF
--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -25,14 +25,14 @@ use crate::Unaligned;
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
 pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
-    Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
+    Ptr<'a, invariant::Initialized<T>, (Aliasing, Alignment)>;
 
 /// A semi-user-facing wrapper type representing a maybe-aligned reference, for
 /// use in [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
 pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
-    Ptr<'a, T, (Aliasing, Alignment, invariant::Valid)>;
+    Ptr<'a, invariant::Valid<T>, (Aliasing, Alignment)>;
 
 // These methods are defined on the type alias, `MaybeAligned`, so as to bring
 // them to the forefront of the rendered rustdoc for that type alias.
@@ -77,10 +77,10 @@ where
 }
 
 /// Checks if the referent is zeroed.
-pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
+pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, invariant::Initialized<T>, I>) -> bool
 where
     T: crate::Immutable + crate::KnownLayout,
-    I: invariant::Invariants<Validity = invariant::Initialized>,
+    I: invariant::Invariants,
     I::Aliasing: invariant::Reference,
 {
     ptr.as_bytes::<BecauseImmutable>().as_ref().iter().all(|&byte| byte == 0)

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -266,13 +266,13 @@ macro_rules! impl_for_transparent_wrapper {
             #[allow(dead_code, clippy::missing_inline_in_public_items)]
             #[cfg_attr(coverage_nightly, coverage(off))]
             fn only_derive_is_allowed_to_implement_this_trait() {
-                use crate::{pointer::invariant::Invariants, util::*};
+                use crate::util::*;
 
                 impl_for_transparent_wrapper!(@define_is_transparent_wrapper $trait);
 
                 #[cfg_attr(coverage_nightly, coverage(off))]
-                const fn f<I: Invariants, $($tyvar $(: $(? $optbound +)* $($bound +)*)?)?>() {
-                    is_transparent_wrapper::<I, $ty>();
+                const fn f<$($tyvar $(: $(? $optbound +)* $($bound +)*)?)?>() {
+                    is_transparent_wrapper::<$ty>();
                 }
             }
 
@@ -343,7 +343,7 @@ macro_rules! impl_for_transparent_wrapper {
     };
     (@define_is_transparent_wrapper $trait:ident, $variance:ident) => {
         #[cfg_attr(coverage_nightly, coverage(off))]
-        const fn is_transparent_wrapper<I: Invariants, W: TransparentWrapper<I, $variance = Covariant> + ?Sized>()
+        const fn is_transparent_wrapper<W: TransparentWrapper<$variance = Covariant> + ?Sized>()
         where
             W::Inner: $trait,
         {}


### PR DESCRIPTION
Previously, validity was stored as part of the `I: Invariants` type
parameter on a `Ptr<T, I>`. In this commit, we migrate the validity to
being stored as the `V` in `Ptr<V, I>`; `I` now only stores aliasing and
alignment.

Bit validity is subtle, in that the pair of referent type and validity
invariant define a set of bit patterns which may appear in the `Ptr`'s
referent. By encoding the validity in the referent type instead of in
the `I` parameter, we ensure that the validity of the referent is
captured entirely by a single type parameter rather than by a pair of
two separate type parameters. This makes future changes (e.g. #1359)
easier to model.

This idea was originally proposed in https://github.com/google/zerocopy/issues/1866#issuecomment-2654625725

Makes progress on #1866




---

This PR is on branch [transmute-from](../tree/transmute-from).

- #2335
- #2339
- #2334