### PR TITLE
[pointer] Remove Ptr::project method

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1077,32 +1077,6 @@ mod _casts {
 mod _project {
     use super::*;
 
-    impl<'a, T: ?Sized, I> Ptr<'a, Initialized<T>, I>
-    where
-        I: Invariants,
-    {
-        /// Projects a field from `self`.
-        ///
-        /// # Safety
-        ///
-        /// `project` has the same safety preconditions as
-        /// `cast_unsized_unchecked`.
-        #[doc(hidden)]
-        #[inline]
-        pub unsafe fn project<W: 'a + ?Sized>(
-            self,
-            projector: impl FnOnce(*mut T) -> *mut W,
-        ) -> Ptr<'a, Initialized<W>, (I::Aliasing, Unknown)> {
-            // TODO(#1122): If `cast_unsized` were able to reason that, when
-            // casting from an `Initialized` pointer, the result is another
-            // `Initialized` pointer, we could remove this method entirely.
-
-            // SAFETY: This method has the same safety preconditions as
-            // `cast_unsized_unchecked`.
-            unsafe { self.cast_unsized_unchecked(projector) }
-        }
-    }
-
     impl<V, T, I> Ptr<'_, V, I>
     where
         V: Validity<Inner = [T]>,

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -349,7 +349,7 @@ pub(crate) fn derive_is_bit_valid(
             //   subfield pointer just points to a smaller portion of the
             //   overall struct.
             let variants = unsafe {
-                raw_enum.project(|p: *mut ___ZerocopyRawEnum #ty_generics| {
+                raw_enum.cast_unsized_unchecked(|p: *mut ___ZerocopyRawEnum #ty_generics| {
                     core_reexport::ptr::addr_of_mut!((*p).variants)
                 })
             };

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -571,7 +571,7 @@ fn derive_try_from_bytes_struct(
                         let project = |slf: *mut Self|
                             ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).#field_names);
 
-                        candidate.reborrow().project(project)
+                        candidate.reborrow().cast_unsized_unchecked(project)
                     };
 
                     <#field_tys as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
@@ -629,7 +629,7 @@ fn derive_try_from_bytes_union(
                         let project = |slf: *mut Self|
                             ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).#field_names);
 
-                        candidate.reborrow().project(project)
+                        candidate.reborrow().cast_unsized_unchecked(project)
                     };
 
                     <#field_tys as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -591,7 +591,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -601,7 +601,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -609,7 +609,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -617,7 +617,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -625,7 +625,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -633,7 +633,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).5)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <[(X, Y); N] as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -641,7 +641,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).6)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -685,7 +685,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -695,7 +695,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <bool as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -703,7 +703,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -711,7 +711,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <PhantomData<&'a [(X, Y); N]> as ::zerocopy::TryFromBytes>::is_bit_valid(
                                     field_candidate,
@@ -721,7 +721,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -753,7 +753,7 @@ fn test_try_from_bytes_enum() {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let variants = unsafe {
-                        raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
+                        raw_enum.cast_unsized_unchecked(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
                         })
                     };
@@ -881,7 +881,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -891,7 +891,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -899,7 +899,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -907,7 +907,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -915,7 +915,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -923,7 +923,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).5)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <[(X, Y); N] as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -931,7 +931,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).6)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -975,7 +975,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -985,7 +985,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <bool as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -993,7 +993,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1001,7 +1001,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <PhantomData<&'a [(X, Y); N]> as ::zerocopy::TryFromBytes>::is_bit_valid(
                                     field_candidate,
@@ -1011,7 +1011,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -1043,7 +1043,7 @@ fn test_try_from_bytes_enum() {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let variants = unsafe {
-                        raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
+                        raw_enum.cast_unsized_unchecked(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
                         })
                     };
@@ -1171,7 +1171,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -1181,7 +1181,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1189,7 +1189,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1197,7 +1197,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1205,7 +1205,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1213,7 +1213,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).5)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <[(X, Y); N] as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1221,7 +1221,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).6)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -1265,7 +1265,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).0)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::mem::MaybeUninit<
                                         ___ZerocopyInnerTag,
@@ -1275,7 +1275,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).1)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <bool as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1283,7 +1283,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).2)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <Y as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             } && {
@@ -1291,7 +1291,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).3)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <PhantomData<&'a [(X, Y); N]> as ::zerocopy::TryFromBytes>::is_bit_valid(
                                     field_candidate,
@@ -1301,7 +1301,7 @@ fn test_try_from_bytes_enum() {
                                     let project = |slf: *mut Self| {
                                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).4)
                                     };
-                                    candidate.reborrow().project(project)
+                                    candidate.reborrow().cast_unsized_unchecked(project)
                                 };
                                 <core_reexport::marker::PhantomData<
                                         ComplexWithGenerics<'a, N, X, Y>,
@@ -1333,7 +1333,7 @@ fn test_try_from_bytes_enum() {
                         candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let variants = unsafe {
-                        raw_enum.project(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
+                        raw_enum.cast_unsized_unchecked(|p: *mut ___ZerocopyRawEnum<'a, N, X, Y>| {
                             core_reexport::ptr::addr_of_mut!((*p).variants)
                         })
                     };


### PR DESCRIPTION
Now that #1122 is complete in #1896, `project` is redundant.




---

This PR is on branch [transmute-from](../tree/transmute-from).

- #2335
- #2339