### PR TITLE
[pointer] Fix Ptr[Inner] variance

### DIFF
--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -58,12 +58,6 @@ pub trait Aliasing: Sealed {
     /// Is `Self` [`Exclusive`]?
     #[doc(hidden)]
     const IS_EXCLUSIVE: bool;
-
-    /// A type which has the correct variance over `'a` and `T` for this
-    /// aliasing invariant. `Ptr` stores a `<I::Aliasing as
-    /// Aliasing>::Variance<'a, T>` to inherit this variance.
-    #[doc(hidden)]
-    type Variance<'a, T: 'a + ?Sized>;
 }
 
 /// The alignment invariant of a [`Ptr`][super::Ptr].
@@ -132,7 +126,6 @@ impl<T: ?Sized> Validity for Uninit<T> {
 pub enum Shared {}
 impl Aliasing for Shared {
     const IS_EXCLUSIVE: bool = false;
-    type Variance<'a, T: 'a + ?Sized> = &'a T;
 }
 impl Reference for Shared {}
 
@@ -144,7 +137,6 @@ impl Reference for Shared {}
 pub enum Exclusive {}
 impl Aliasing for Exclusive {
     const IS_EXCLUSIVE: bool = true;
-    type Variance<'a, T: 'a + ?Sized> = &'a mut T;
 }
 impl Reference for Exclusive {}
 

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -37,7 +37,7 @@ mod def {
     /// - `ptr` conforms to the alignment invariant of
     ///   [`I::Alignment`](invariant::Alignment).
     ///
-    /// `Ptr<'a, T>` is [covariant] in `'a` and `T`.
+    /// `Ptr<'a, T>` is [covariant] in `'a` and invariant in `T`.
     ///
     /// [covariant]: https://doc.rust-lang.org/reference/subtyping.html
     pub struct Ptr<'a, V, I>
@@ -54,9 +54,8 @@ mod def {
         ///    [`I::Aliasing`](invariant::Aliasing).
         /// 2. `ptr` conforms to the alignment invariant of
         ///    [`I::Alignment`](invariant::Alignment).
-        // SAFETY: `PtrInner<'a, T>` is covariant over `'a` and `T`.
+        // SAFETY: `PtrInner<'a, T>` is covariant in `'a` and invariant in `T`.
         ptr: PtrInner<'a, V::Inner>,
-        _variance: PhantomData<<I::Aliasing as Aliasing>::Variance<'a, V::Inner>>,
         _invariants: PhantomData<I>,
     }
 
@@ -94,7 +93,7 @@ mod def {
             let ptr = unsafe { PtrInner::new(ptr) };
             // SAFETY: The caller has promised (in 6 - 8) to satisfy all safety
             // invariants of `Ptr`.
-            Self { ptr, _variance: PhantomData, _invariants: PhantomData }
+            Self { ptr, _invariants: PhantomData }
         }
 
         /// Constructs a new `Ptr` from a [`PtrInner`].
@@ -112,7 +111,7 @@ mod def {
         pub(super) const unsafe fn from_inner(ptr: PtrInner<'a, V::Inner>) -> Ptr<'a, V, I> {
             // SAFETY: The caller has promised to satisfy all safety invariants
             // of `Ptr`.
-            Self { ptr, _variance: PhantomData, _invariants: PhantomData }
+            Self { ptr, _invariants: PhantomData }
         }
 
         /// Converts this `Ptr<T>` to a [`PtrInner<T>`].

--- a/tests/ui-msrv/ptr-is-invariant-over-v.rs
+++ b/tests/ui-msrv/ptr-is-invariant-over-v.rs
@@ -1,0 +1,1 @@
+../ui-nightly/ptr-is-invariant-over-v.rs

--- a/tests/ui-msrv/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-msrv/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,31 @@
+error: lifetime may not live long enough
+  --> tests/ui-msrv/ptr-is-invariant-over-v.rs:10:5
+   |
+6  | fn _when_exclusive<'big: 'small, 'small>(
+   |                    ----          ------ lifetime `'small` defined here
+   |                    |
+   |                    lifetime `'big` defined here
+...
+10 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (invariant::Exclusive, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui-msrv/ptr-is-invariant-over-v.rs:17:5
+   |
+13 | fn _when_shared<'big: 'small, 'small>(
+   |                 ----          ------ lifetime `'small` defined here
+   |                 |
+   |                 lifetime `'big` defined here
+...
+17 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (Shared, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui-nightly/ptr-is-invariant-over-v.rs
+++ b/tests/ui-nightly/ptr-is-invariant-over-v.rs
@@ -1,0 +1,20 @@
+use zerocopy::pointer::{
+    invariant::{Aligned, Exclusive, Shared, Valid},
+    Ptr,
+};
+
+fn _when_exclusive<'big: 'small, 'small>(
+    big: Ptr<'small, Valid<&'big u32>, (Exclusive, Aligned)>,
+    mut _small: Ptr<'small, Valid<&'small u32>, (Exclusive, Aligned)>,
+) {
+    _small = big;
+}
+
+fn _when_shared<'big: 'small, 'small>(
+    big: Ptr<'small, Valid<&'big u32>, (Shared, Aligned)>,
+    mut _small: Ptr<'small, Valid<&'small u32>, (Shared, Aligned)>,
+) {
+    _small = big;
+}
+
+fn main() {}

--- a/tests/ui-nightly/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-nightly/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,31 @@
+error: lifetime may not live long enough
+  --> tests/ui-nightly/ptr-is-invariant-over-v.rs:10:5
+   |
+6  | fn _when_exclusive<'big: 'small, 'small>(
+   |                    ----          ------ lifetime `'small` defined here
+   |                    |
+   |                    lifetime `'big` defined here
+...
+10 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (invariant::Exclusive, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui-nightly/ptr-is-invariant-over-v.rs:17:5
+   |
+13 | fn _when_shared<'big: 'small, 'small>(
+   |                 ----          ------ lifetime `'small` defined here
+   |                 |
+   |                 lifetime `'big` defined here
+...
+17 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (Shared, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui-stable/ptr-is-invariant-over-v.rs
+++ b/tests/ui-stable/ptr-is-invariant-over-v.rs
@@ -1,0 +1,1 @@
+../ui-nightly/ptr-is-invariant-over-v.rs

--- a/tests/ui-stable/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-stable/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,31 @@
+error: lifetime may not live long enough
+  --> tests/ui-stable/ptr-is-invariant-over-v.rs:10:5
+   |
+6  | fn _when_exclusive<'big: 'small, 'small>(
+   |                    ----          ------ lifetime `'small` defined here
+   |                    |
+   |                    lifetime `'big` defined here
+...
+10 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (invariant::Exclusive, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui-stable/ptr-is-invariant-over-v.rs:17:5
+   |
+13 | fn _when_shared<'big: 'small, 'small>(
+   |                 ----          ------ lifetime `'small` defined here
+   |                 |
+   |                 lifetime `'big` defined here
+...
+17 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, Valid<&u32>, (Shared, Aligned)>`, which makes the generic argument `Valid<&u32>` invariant
+   = note: the struct `Ptr<'a, V, I>` is invariant over the parameter `V`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
Previously, `Ptr<'a, T>` and `PtrInner<'a, T>` documented themselves to
be covariant in both `'a` and `T`. This was true for `PtrInner`, but not
for `Ptr`, which used GATs, which are invariant. This is also not the
desired variance: for `Exclusive` aliasing, the desired variance matches
that of `&mut` references - namely, covariant in `'a` but invariant in
`T`.

This commit fixes this by making `Ptr<'a, T>` and `PtrInner<'a, T>`
unconditionally covariant in `'a` and invariant in `T`.




---

This PR is on branch [transmute-from](../tree/transmute-from).

- #2335
- #2351