### PR TITLE
[pointer] Clarify semantics of aliasing invariants (#1889)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ zerocopy-derive = { version = "=0.8.20", path = "zerocopy-derive", optional = tr
 zerocopy-derive = { version = "=0.8.20", path = "zerocopy-derive" }
 
 [dev-dependencies]
+# More recent versions of `either` have an MSRV higher than ours.
+either = "=1.13.0"
+# TODO(#381) Remove this dependency once we have our own layout gadgets.
+elain = "0.3.0"
 itertools = "0.11"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = "1.0"
@@ -103,5 +107,3 @@ testutil = { path = "testutil" }
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
 zerocopy-derive = { version = "=0.8.20", path = "zerocopy-derive" }
-# TODO(#381) Remove this dependency once we have our own layout gadgets.
-elain = "0.3.0"

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -667,9 +667,7 @@ unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
     }
 
     #[inline]
-    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
-        candidate: Maybe<'_, Self, A>,
-    ) -> bool {
+    fn is_bit_valid<A: invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
         // The only way to implement this function is using an exclusive-aliased
         // pointer. `UnsafeCell`s cannot be read via shared-aliased pointers
         // (other than by using `unsafe` code, which we can't use since we can't
@@ -1146,10 +1144,7 @@ mod tests {
 
             pub(super) trait TestIsBitValidShared<T: ?Sized> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<
-                    'ptr,
-                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
-                >(
+                fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool>;
@@ -1157,10 +1152,7 @@ mod tests {
 
             impl<T: TryFromBytes + Immutable + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<
-                    'ptr,
-                    A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>,
-                >(
+                fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                     &self,
                     candidate: Maybe<'ptr, T, A>,
                 ) -> Option<bool> {
@@ -1268,7 +1260,7 @@ mod tests {
                 #[allow(unused, non_local_definitions)]
                 impl AutorefWrapper<$ty> {
                     #[allow(clippy::needless_lifetimes)]
-                    fn test_is_bit_valid_shared<'ptr, A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
+                    fn test_is_bit_valid_shared<'ptr, A: invariant::Reference>(
                         &mut self,
                         candidate: Maybe<'ptr, $ty, A>,
                     ) -> Option<bool> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1423,9 +1423,7 @@ pub unsafe trait TryFromBytes {
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(
-        candidate: Maybe<'_, Self, A>,
-    ) -> bool;
+    fn is_bit_valid<A: invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool;
 
     /// Attempts to interpret the given `source` as a `&Self`.
     ///

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -123,182 +123,143 @@ mod def {
 #[allow(unreachable_pub)] // This is a false positive on our MSRV toolchain.
 pub use def::Ptr;
 
-/// Used to define the system of [invariants][invariant] of `Ptr`.
-macro_rules! define_system {
-    ($(#[$system_attr:meta])* $system:ident {
-        $($(#[$set_attr:meta])* $set:ident {
-            $( $(#[$elem_attr:meta])* $elem:ident $(< $($stronger_elem:ident)|*)?,)*
-        })*
-    }) => {
-        /// No requirement - any invariant is allowed.
-        #[allow(missing_copy_implementations, missing_debug_implementations)]
-        pub enum Any {}
-
-        /// `Self` imposes a requirement at least as strict as `I`.
-        pub trait AtLeast<I> {}
-
-        mod sealed {
-            pub trait Sealed {}
-
-            impl<$($set,)*> Sealed for ($($set,)*)
-            where
-                $($set: super::$set,)*
-            {}
-
-            impl Sealed for super::Any {}
-
-            $($(
-                impl Sealed for super::$elem {}
-            )*)*
-        }
-
-        $(#[$system_attr])*
-        ///
-        #[doc = concat!(
-            stringify!($system),
-            " are encoded as tuples of (",
-        )]
-        $(#[doc = concat!(
-            "[`",
-            stringify!($set),
-            "`],"
-        )])*
-        #[doc = concat!(
-            ").",
-        )]
-        /// This trait is implemented for such tuples, and can be used to
-        /// project out the components of these tuples via its associated types.
-        pub trait $system: sealed::Sealed {
-            $(
-                $(#[$set_attr])*
-                type $set: $set;
-            )*
-        }
-
-        impl<$($set,)*> $system for ($($set,)*)
-        where
-            $($set: self::$set,)*
-        {
-            $(type $set = $set;)*
-        }
-
-        $(
-            $(#[$set_attr])*
-            pub trait $set: 'static + sealed::Sealed {
-                // This only exists for use in
-                // `into_exclusive_or_post_monomorphization_error`.
-                #[doc(hidden)]
-                const NAME: &'static str;
-            }
-
-            impl $set for Any {
-                const NAME: &'static str = stringify!(Any);
-            }
-
-            $(
-                $(#[$elem_attr])*
-                #[allow(missing_copy_implementations, missing_debug_implementations)]
-                pub enum $elem {}
-
-                $(#[$elem_attr])*
-                impl $set for $elem {
-                    const NAME: &'static str = stringify!($elem);
-                }
-            )*
-        )*
-
-        $($(
-            impl AtLeast<Any> for $elem {}
-            impl AtLeast<$elem> for $elem {}
-
-            $($(impl AtLeast<$elem> for $stronger_elem {})*)?
-        )*)*
-    };
-}
-
 /// The parameterized invariants of a [`Ptr`].
 ///
 /// Invariants are encoded as ([`Aliasing`], [`Alignment`], [`Validity`])
 /// triples implementing the [`Invariants`] trait.
 #[doc(hidden)]
+#[allow(missing_copy_implementations, missing_debug_implementations)]
 pub mod invariant {
-    define_system! {
-        /// The invariants of a [`Ptr`][super::Ptr].
-        Invariants {
-            /// The aliasing invariant of a [`Ptr`][super::Ptr].
-            Aliasing {
-                /// The `Ptr<'a, T>` adheres to the aliasing rules of a `&'a T`.
-                ///
-                /// The referent of a shared-aliased `Ptr` may be concurrently
-                /// referenced by any number of shared-aliased `Ptr` or `&T`
-                /// references, and may not be concurrently referenced by any
-                /// exclusively-aliased `Ptr`s or `&mut T` references. The
-                /// referent must not be mutated, except via [`UnsafeCell`]s.
-                ///
-                /// [`UnsafeCell`]: core::cell::UnsafeCell
-                Shared < Exclusive,
+    /// The invariants of a [`Ptr`][super::Ptr].
+    pub trait Invariants: Sealed {
+        type Aliasing: Aliasing;
+        type Alignment: Alignment;
+        type Validity: Validity;
+    }
 
-                /// The `Ptr<'a, T>` adheres to the aliasing rules of a `&'a mut
-                /// T`.
-                ///
-                /// The referent of an exclusively-aliased `Ptr` may not be
-                /// concurrently referenced by any other `Ptr`s or references,
-                /// and may not be accessed (read or written) other than via
-                /// this `Ptr`.
-                Exclusive,
-            }
+    impl<A: Aliasing, AA: Alignment, V: Validity> Invariants for (A, AA, V) {
+        type Aliasing = A;
+        type Alignment = AA;
+        type Validity = V;
+    }
 
-            /// The alignment invariant of a [`Ptr`][super::Ptr].
-            Alignment {
-                /// The referent is aligned: for `Ptr<T>`, the referent's
-                /// address is a multiple of the `T`'s alignment.
-                Aligned,
-            }
+    /// The aliasing invariant of a [`Ptr`][super::Ptr].
+    pub trait Aliasing: Sealed {
+        /// Is `Self` [`Exclusive`]?
+        #[doc(hidden)]
+        const IS_EXCLUSIVE: bool;
+    }
 
-            /// The validity invariant of a [`Ptr`][super::Ptr].
-            Validity {
-                /// The byte ranges initialized in `T` are also initialized in
-                /// the referent.
-                ///
-                /// Formally: uninitialized bytes may only be present in
-                /// `Ptr<T>`'s referent where they are guaranteed to be present
-                /// in `T`. This is a dynamic property: if, at a particular byte
-                /// offset, a valid enum discriminant is set, the subsequent
-                /// bytes may only have uninitialized bytes as specificed by the
-                /// corresponding enum.
-                ///
-                /// Formally, given `len = size_of_val_raw(ptr)`, at every byte
-                /// offset, `b`, in the range `[0, len)`:
-                /// - If, in any instance `t: T` of length `len`, the byte at
-                ///   offset `b` in `t` is initialized, then the byte at offset
-                ///   `b` within `*ptr` must be initialized.
-                /// - Let `c` be the contents of the byte range `[0, b)` in
-                ///   `*ptr`. Let `S` be the subset of valid instances of `T` of
-                ///   length `len` which contain `c` in the offset range `[0,
-                ///   b)`. If, in any instance of `t: T` in `S`, the byte at
-                ///   offset `b` in `t` is initialized, then the byte at offset
-                ///   `b` in `*ptr` must be initialized.
-                ///
-                ///   Pragmatically, this means that if `*ptr` is guaranteed to
-                ///   contain an enum type at a particular offset, and the enum
-                ///   discriminant stored in `*ptr` corresponds to a valid
-                ///   variant of that enum type, then it is guaranteed that the
-                ///   appropriate bytes of `*ptr` are initialized as defined by
-                ///   that variant's bit validity (although note that the
-                ///   variant may contain another enum type, in which case the
-                ///   same rules apply depending on the state of its
-                ///   discriminant, and so on recursively).
-                AsInitialized < Initialized | Valid,
+    /// The alignment invariant of a [`Ptr`][super::Ptr].
+    pub trait Alignment: Sealed {}
 
-                /// The byte ranges in the referent are fully initialized. In
-                /// other words, if the referent is `N` bytes long, then it
-                /// contains a bit-valid `[u8; N]`.
-                Initialized,
+    /// The validity invariant of a [`Ptr`][super::Ptr].
+    pub trait Validity: Sealed {}
 
-                /// The referent is bit-valid for `T`.
-                Valid,
-            }
-        }
+    /// An [`Aliasing`] invariant which is either [`Shared`] or [`Exclusive`].
+    ///
+    /// # Safety
+    ///
+    /// Given `A: Reference`, callers may assume that either `A = Shared` or `A
+    /// = Exclusive`.
+    pub trait Reference: Aliasing + Sealed {}
+
+    /// No requirement - any invariant is allowed.
+    pub enum Any {}
+    impl Aliasing for Any {
+        const IS_EXCLUSIVE: bool = false;
+    }
+    impl Alignment for Any {}
+    impl Validity for Any {}
+
+    /// The `Ptr<'a, T>` adheres to the aliasing rules of a `&'a T`.
+    ///
+    /// The referent of a shared-aliased `Ptr` may be concurrently referenced by
+    /// any number of shared-aliased `Ptr` or `&T` references, and may not be
+    /// concurrently referenced by any exclusively-aliased `Ptr`s or `&mut T`
+    /// references. The referent must not be mutated, except via
+    /// [`UnsafeCell`]s.
+    ///
+    /// [`UnsafeCell`]: core::cell::UnsafeCell
+    pub enum Shared {}
+    impl Aliasing for Shared {
+        const IS_EXCLUSIVE: bool = false;
+    }
+    impl Reference for Shared {}
+
+    /// The `Ptr<'a, T>` adheres to the aliasing rules of a `&'a mut T`.
+    ///
+    /// The referent of an exclusively-aliased `Ptr` may not be concurrently
+    /// referenced by any other `Ptr`s or references, and may not be accessed
+    /// (read or written) other than via this `Ptr`.
+    pub enum Exclusive {}
+    impl Aliasing for Exclusive {
+        const IS_EXCLUSIVE: bool = true;
+    }
+    impl Reference for Exclusive {}
+
+    /// The referent is aligned: for `Ptr<T>`, the referent's address is a
+    /// multiple of the `T`'s alignment.
+    pub enum Aligned {}
+    impl Alignment for Aligned {}
+
+    /// The byte ranges initialized in `T` are also initialized in the referent.
+    ///
+    /// Formally: uninitialized bytes may only be present in `Ptr<T>`'s referent
+    /// where they are guaranteed to be present in `T`. This is a dynamic
+    /// property: if, at a particular byte offset, a valid enum discriminant is
+    /// set, the subsequent bytes may only have uninitialized bytes as
+    /// specificed by the corresponding enum.
+    ///
+    /// Formally, given `len = size_of_val_raw(ptr)`, at every byte offset, `b`,
+    /// in the range `[0, len)`:
+    /// - If, in any instance `t: T` of length `len`, the byte at offset `b` in
+    ///   `t` is initialized, then the byte at offset `b` within `*ptr` must be
+    ///   initialized.
+    /// - Let `c` be the contents of the byte range `[0, b)` in `*ptr`. Let `S`
+    ///   be the subset of valid instances of `T` of length `len` which contain
+    ///   `c` in the offset range `[0, b)`. If, in any instance of `t: T` in
+    ///   `S`, the byte at offset `b` in `t` is initialized, then the byte at
+    ///   offset `b` in `*ptr` must be initialized.
+    ///
+    ///   Pragmatically, this means that if `*ptr` is guaranteed to contain an
+    ///   enum type at a particular offset, and the enum discriminant stored in
+    ///   `*ptr` corresponds to a valid variant of that enum type, then it is
+    ///   guaranteed that the appropriate bytes of `*ptr` are initialized as
+    ///   defined by that variant's bit validity (although note that the variant
+    ///   may contain another enum type, in which case the same rules apply
+    ///   depending on the state of its discriminant, and so on recursively).
+    pub enum AsInitialized {}
+    impl Validity for AsInitialized {}
+
+    /// The byte ranges in the referent are fully initialized. In other words,
+    /// if the referent is `N` bytes long, then it contains a bit-valid `[u8;
+    /// N]`.
+    pub enum Initialized {}
+    impl Validity for Initialized {}
+
+    /// The referent is bit-valid for `T`.
+    pub enum Valid {}
+    impl Validity for Valid {}
+
+    use sealed::Sealed;
+    mod sealed {
+        use super::*;
+
+        pub trait Sealed {}
+
+        impl Sealed for Any {}
+
+        impl Sealed for Shared {}
+        impl Sealed for Exclusive {}
+
+        impl Sealed for Aligned {}
+
+        impl Sealed for AsInitialized {}
+        impl Sealed for Initialized {}
+        impl Sealed for Valid {}
+
+        impl<A: Sealed, AA: Sealed, V: Sealed> Sealed for (A, AA, V) {}
     }
 }
 
@@ -309,27 +270,23 @@ mod _external {
     use super::*;
     use core::fmt::{Debug, Formatter};
 
-    /// SAFETY: Shared pointers are safely `Copy`. We do not implement `Copy`
-    /// for exclusive pointers, since at most one may exist at a time. `Ptr`'s
-    /// other invariants are unaffected by the number of references that exist
+    /// SAFETY: Shared pointers are safely `Copy`. `Ptr`'s other invariants
+    /// (besides aliasing) are unaffected by the number of references that exist
     /// to `Ptr`'s referent.
     impl<'a, T, I> Copy for Ptr<'a, T, I>
     where
         T: 'a + ?Sized,
-        I: Invariants,
-        Shared: AtLeast<I::Aliasing>,
+        I: Invariants<Aliasing = Shared>,
     {
     }
 
-    /// SAFETY: Shared pointers are safely `Clone`. We do not implement `Clone`
-    /// for exclusive pointers, since at most one may exist at a time. `Ptr`'s
-    /// other invariants are unaffected by the number of references that exist
+    /// SAFETY: Shared pointers are safely `Clone`. `Ptr`'s other invariants
+    /// (besides aliasing) are unaffected by the number of references that exist
     /// to `Ptr`'s referent.
     impl<'a, T, I> Clone for Ptr<'a, T, I>
     where
         T: 'a + ?Sized,
-        I: Invariants,
-        Shared: AtLeast<I::Aliasing>,
+        I: Invariants<Aliasing = Shared>,
     {
         #[inline]
         fn clone(&self) -> Self {
@@ -429,7 +386,7 @@ mod _conversions {
     where
         T: 'a + ?Sized,
         I: Invariants<Alignment = Aligned, Validity = Valid>,
-        I::Aliasing: AtLeast<Shared>,
+        I::Aliasing: Reference,
     {
         /// Converts `self` to a shared reference.
         // This consumes `self`, not `&self`, because `self` is, logically, a
@@ -460,10 +417,10 @@ mod _conversions {
             //    `Valid`.
             //
             // 4. You must enforce Rust’s aliasing rules. This is ensured by
-            //    contract on `Ptr`, because the `I::Aliasing` is
-            //    `AtLeast<Shared>`. Either it is `Shared` or `Exclusive`. If it
-            //    is `Shared`, other references may not mutate the referent
-            //    outside of `UnsafeCell`s.
+            //    contract on `Ptr`, because the `I::Aliasing: Reference`.
+            //    Either it is `Shared` or `Exclusive`. If it is `Shared`, other
+            //    references may not mutate the referent outside of
+            //    `UnsafeCell`s.
             //
             // [1]: https://doc.rust-lang.org/std/ptr/struct.NonNull.html#method.as_ref
             // [2]: https://doc.rust-lang.org/std/ptr/index.html#safety
@@ -475,7 +432,7 @@ mod _conversions {
     where
         T: 'a + ?Sized,
         I: Invariants,
-        I::Aliasing: AtLeast<Shared>,
+        I::Aliasing: Reference,
     {
         /// Reborrows `self`, producing another `Ptr`.
         ///
@@ -508,7 +465,7 @@ mod _conversions {
             // 8. `ptr` conforms to the validity invariant of
             //   [`I::Validity`](invariant::Validity).
             //
-            // For aliasing (6 above), since `I::Aliasing: AtLeast<Shared>`,
+            // For aliasing (6 above), since `I::Aliasing: Reference`,
             // there are two cases for `I::Aliasing`:
             // - For `invariant::Shared`: `'a` outlives `'b`, and so the
             //   returned `Ptr` does not permit accessing the referent any
@@ -667,48 +624,29 @@ mod _transitions {
         pub(crate) fn into_exclusive_or_post_monomorphization_error(
             self,
         ) -> Ptr<'a, T, (Exclusive, I::Alignment, I::Validity)> {
+            // NOTE(https://github.com/rust-lang/rust/issues/131625): We do this
+            // rather than just having `Aliasing::IS_EXCLUSIVE` have the panic
+            // behavior because doing it that way causes rustdoc to fail while
+            // attempting to document hidden items (since it evaluates the
+            // constant - and thus panics).
             trait AliasingExt: Aliasing {
-                const IS_EXCLUSIVE: bool;
+                const IS_EXCL: bool;
             }
 
             impl<A: Aliasing> AliasingExt for A {
-                const IS_EXCLUSIVE: bool = {
-                    let is_exclusive =
-                        strs_are_equal(<Self as Aliasing>::NAME, <Exclusive as Aliasing>::NAME);
-                    const_assert!(is_exclusive);
+                const IS_EXCL: bool = {
+                    const_assert!(Self::IS_EXCLUSIVE);
                     true
                 };
             }
 
-            const fn strs_are_equal(s: &str, t: &str) -> bool {
-                if s.len() != t.len() {
-                    return false;
-                }
-
-                let s = s.as_bytes();
-                let t = t.as_bytes();
-
-                let mut i = 0;
-                #[allow(clippy::arithmetic_side_effects)]
-                while i < s.len() {
-                    #[allow(clippy::indexing_slicing)]
-                    if s[i] != t[i] {
-                        return false;
-                    }
-
-                    i += 1;
-                }
-
-                true
-            }
-
-            assert!(I::Aliasing::IS_EXCLUSIVE);
+            assert!(I::Aliasing::IS_EXCL);
 
             // SAFETY: We've confirmed that `self` already has the aliasing
             // `Exclusive`. If it didn't, either the preceding assert would fail
-            // or evaluating `I::Aliasing::IS_EXCLUSIVE` would fail. We're
-            // *pretty* sure that it's guaranteed to fail const eval, but the
-            // `assert!` provides a backstop in case that doesn't work.
+            // or evaluating `I::Aliasing::IS_EXCL` would fail. We're *pretty*
+            // sure that it's guaranteed to fail const eval, but the `assert!`
+            // provides a backstop in case that doesn't work.
             unsafe { self.assume_exclusive() }
         }
 
@@ -901,7 +839,7 @@ mod _transitions {
         ) -> Result<Ptr<'a, T, (I::Aliasing, I::Alignment, Valid)>, ValidityError<Self, T>>
         where
             T: TryFromBytes,
-            I::Aliasing: AtLeast<Shared>,
+            I::Aliasing: Reference,
             I: Invariants<Validity = Initialized>,
         {
             // This call may panic. If that happens, it doesn't cause any soundness
@@ -914,19 +852,6 @@ mod _transitions {
             } else {
                 Err(ValidityError::new(self))
             }
-        }
-
-        /// Forgets that `self`'s referent exclusively references `T`,
-        /// downgrading to a shared reference.
-        #[doc(hidden)]
-        #[must_use]
-        #[inline]
-        pub fn forget_exclusive(self) -> Ptr<'a, T, (Shared, I::Alignment, I::Validity)>
-        where
-            I::Aliasing: AtLeast<Shared>,
-        {
-            // SAFETY: `I::Aliasing` is at least as restrictive as `Shared`.
-            unsafe { self.assume_invariants() }
         }
 
         /// Forgets that `self`'s referent is validly-aligned for `T`.
@@ -1176,6 +1101,7 @@ mod _casts {
         >
         where
             R: AliasingSafeReason,
+            I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + AliasingSafe<[u8], I::Aliasing, R>,
         {
             let layout = match meta {
@@ -1294,6 +1220,7 @@ mod _casts {
             meta: Option<U::PointerMetadata>,
         ) -> Result<Ptr<'a, U, (I::Aliasing, Aligned, Initialized)>, CastError<Self, U>>
         where
+            I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + AliasingSafe<[u8], I::Aliasing, R>,
             R: AliasingSafeReason,
         {
@@ -1449,7 +1376,14 @@ mod _project {
         pub(crate) fn len(&self) -> usize {
             self.trailing_slice_len()
         }
+    }
 
+    impl<'a, T, I> Ptr<'a, [T], I>
+    where
+        T: 'a,
+        I: Invariants,
+        I::Aliasing: Reference,
+    {
         /// Creates a pointer which addresses the given `range` of self.
         ///
         /// # Safety
@@ -1523,8 +1457,13 @@ mod _project {
         ///
         /// The caller promises that `l_len <= self.len()`.
         pub(crate) unsafe fn split_at(self, l_len: usize) -> (Self, Self) {
-            // SAFETY: `Any` imposes no invariants, and so this is always sound.
-            let slf = unsafe { self.assume_aliasing::<Any>() };
+            // SAFETY: TODO(#1890): This is explicitly unsound! It's sound
+            // *given how `slice_unchecked` is implemented*, and it's sound
+            // *given what we do with `slf` in this method body*, but it's
+            // unsound in the general case. We do it temporarily as part of
+            // broader `Ptr` changes, but it must be fixed before releasing a
+            // stable zerocopy version.
+            let slf = unsafe { self.assume_aliasing::<Shared>() };
 
             // SAFETY: The caller promises that `l_len <= self.len()`.
             // Trivially, `0 <= l_len`.
@@ -1644,8 +1583,6 @@ mod _project {
 #[cfg(test)]
 mod tests {
     use core::mem::{self, MaybeUninit};
-
-    use static_assertions::{assert_impl_all, assert_not_impl_any};
 
     use super::*;
     use crate::{pointer::BecauseImmutable, util::testutil::AU64, FromBytes, Immutable};
@@ -1836,21 +1773,6 @@ mod tests {
         test!(u8, u16, u32, u64, u128, usize, AU64);
         test!(i8, i16, i32, i64, i128, isize);
         test!(f32, f64);
-    }
-
-    #[test]
-    fn test_invariants() {
-        // Test that the correct invariant relationships hold.
-        use super::invariant::*;
-
-        assert_not_impl_any!(Any: AtLeast<Shared>);
-        assert_impl_all!(Shared: AtLeast<Shared>);
-        assert_impl_all!(Exclusive: AtLeast<Shared>);
-
-        assert_not_impl_any!(Any: AtLeast<AsInitialized>);
-        assert_impl_all!(AsInitialized: AtLeast<AsInitialized>);
-        assert_impl_all!(Initialized: AtLeast<AsInitialized>);
-        assert_impl_all!(Valid: AtLeast<AsInitialized>);
     }
 
     #[test]

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -26,7 +26,7 @@ use core::ptr::{self, NonNull};
 
 use crate::{
     pointer::{
-        invariant::{self, AtLeast, Invariants},
+        invariant::{self, Invariants},
         AliasingSafe, AliasingSafeReason, BecauseExclusive, BecauseImmutable,
     },
     FromBytes, Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
@@ -557,7 +557,7 @@ where
     Src: IntoBytes,
     Dst: TryFromBytes + AliasingSafe<Src, I::Aliasing, R>,
     I: Invariants<Validity = invariant::Valid>,
-    I::Aliasing: AtLeast<invariant::Shared>,
+    I::Aliasing: invariant::Reference,
     R: AliasingSafeReason,
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -168,7 +168,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The cast preserves address. The caller has promised that the
             //   cast results in an object of equal or lesser size, and so the
@@ -192,7 +192,7 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<AA: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, AA>) -> bool {
+        fn is_bit_valid<AA: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, AA>) -> bool {
             // SAFETY:
             // - The cast preserves address. The caller has promised that the
             //   cast results in an object of equal or lesser size, and so the
@@ -216,7 +216,7 @@ macro_rules! unsafe_impl {
         #[allow(clippy::missing_inline_in_public_items)]
         #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        #[inline(always)] fn is_bit_valid<A: invariant::Aliasing + invariant::AtLeast<invariant::Shared>>(_: Maybe<'_, Self, A>) -> bool { true }
+        #[inline(always)] fn is_bit_valid<AA: crate::pointer::invariant::Reference>(_: Maybe<'_, Self, AA>) -> bool { true }
     };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items)]
@@ -368,7 +368,7 @@ macro_rules! impl_for_transparent_wrapper {
         // TryFromBytes)` macro arm for an explanation of why this is a sound
         // implementation of `is_bit_valid`.
         #[inline]
-        fn is_bit_valid<A: crate::pointer::invariant::Aliasing + crate::pointer::invariant::AtLeast<invariant::Shared>>(candidate: Maybe<'_, Self, A>) -> bool {
+        fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
             TryFromBytes::is_bit_valid(candidate.transparent_wrapper_into_inner())
         }
     };

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -286,8 +286,7 @@ pub(crate) fn derive_is_bit_valid(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
-            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
         {
             use ::zerocopy::util::macro_util::core_reexport;
 

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -651,8 +651,7 @@ fn derive_try_from_bytes_struct(
                 mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 true #(&& {
                     // SAFETY:
@@ -710,8 +709,7 @@ fn derive_try_from_bytes_union(
                 mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 false #(|| {
                     // SAFETY:
@@ -806,8 +804,7 @@ fn try_gen_trivial_is_bit_valid(
                 _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
-                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                    + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
             {
                 if false {
                     fn assert_is_from_bytes<T>()
@@ -850,8 +847,7 @@ unsafe fn gen_trivial_is_bit_valid_unchecked() -> proc_macro2::TokenStream {
             _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
-            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
         {
             true
         }

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -300,8 +300,7 @@ fn test_try_from_bytes() {
                     mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }
@@ -325,8 +324,7 @@ fn test_from_zeros() {
                     mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }
@@ -356,8 +354,7 @@ fn test_from_bytes_struct() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -407,8 +404,7 @@ fn test_from_bytes_union() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -534,8 +530,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(u8)]
@@ -592,8 +587,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -687,8 +681,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -831,8 +824,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(u32)]
@@ -889,8 +881,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -984,8 +975,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -1128,8 +1118,7 @@ fn test_try_from_bytes_enum() {
                     mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     use ::zerocopy::util::macro_util::core_reexport;
                     #[repr(C)]
@@ -1186,8 +1175,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -1281,8 +1269,7 @@ fn test_try_from_bytes_enum() {
                             mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                         where
-                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                                + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                         {
                             true && {
                                 let field_candidate = unsafe {
@@ -1669,8 +1656,7 @@ fn test_from_bytes_enum() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     if false {
                         fn assert_is_from_bytes<T>()
@@ -1977,8 +1963,7 @@ fn test_try_from_bytes_trivial_is_bit_valid_enum() {
                     _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                 ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Aliasing
-                        + ::zerocopy::pointer::invariant::AtLeast<::zerocopy::pointer::invariant::Shared>,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
                     true
                 }


### PR DESCRIPTION
Previously, we supported the `AtLeast` bound, which was used to describe a subset relationship in which `I: AtLeast<J>` implied that `I` as at least as restrictive as `J`. However, as described in #1866, this incorrectly models invariants as monotonic. In reality, invariants both provide guarantees but also *require* guarantees.

This commit takes a step in the direction of resolving #1866 by removing `AtLeast`. Uses of `AtLeast<Shared>` are replaced by a new `Reference` trait, which is implemented for `Shared` and `Exclusive`. This serves two purposes: First, it makes it explicit what this bound means. Previously, `AtLeast<Shared>` had an ambiguous meaning, while `Reference` means precisely that an invariant is either `Shared` or `Exclusive` and nothing else. Second, it paves the way for #1183, in which we may add new aliasing invariants which convey ownership. In that case, it will be important for existing methods to add `Reference` bounds when those methods would not be sound in the face of ownership semantics.

We also inline the items in the `invariant` module, which were previously generated by macro. The addition of the `Reference` trait did not play nicely with that macro, and we will likely need to go further from the macro in order to fix #1839 – this fix will likely require making aliasing invariants meaningfully different than other invariants, for example by adding an associated type.

Makes progress on #1866

gherrit-pr-id: I86ef959643b97a34da81bf55a1fed5060b9cf6b2

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
