### PR TITLE
[pointer] Simplify AliasingSafe, rename to Read (#1908)

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -962,6 +962,7 @@ mod simd {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pointer::invariant;
 
     #[test]
     fn test_impls() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ use core::{
 #[cfg(feature = "std")]
 use std::io;
 
-use crate::pointer::{invariant, BecauseExclusive};
+use crate::pointer::invariant::{self, BecauseExclusive};
 
 #[cfg(any(feature = "alloc", test))]
 extern crate alloc;
@@ -387,7 +387,7 @@ use core::alloc::Layout;
 
 // Used by `TryFromBytes::is_bit_valid`.
 #[doc(hidden)]
-pub use crate::pointer::{BecauseImmutable, Maybe, MaybeAligned, Ptr};
+pub use crate::pointer::{invariant::BecauseImmutable, Maybe, MaybeAligned, Ptr};
 // Used by `KnownLayout`.
 #[doc(hidden)]
 pub use crate::layout::*;

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -14,9 +14,7 @@ pub mod invariant;
 mod ptr;
 
 #[doc(hidden)]
-pub use invariant::aliasing_safety::{
-    AliasingSafe, AliasingSafeReason, BecauseExclusive, BecauseImmutable,
-};
+pub use invariant::{BecauseExclusive, BecauseImmutable, Read, ReadReason};
 #[doc(hidden)]
 pub use ptr::Ptr;
 
@@ -50,11 +48,11 @@ where
     pub fn read_unaligned<R>(self) -> T
     where
         T: Copy,
-        R: AliasingSafeReason,
-        T: AliasingSafe<T, Aliasing, R>,
+        R: invariant::ReadReason,
+        T: invariant::Read<Aliasing, R>,
     {
         // SAFETY: By invariant on `MaybeAligned`, `raw` contains
-        // validly-initialized data for `T`. By `T: AliasingSafe`, we are
+        // validly-initialized data for `T`. By `T: Read<Aliasing>`, we are
         // permitted to perform a read of `self`'s referent.
         unsafe { self.as_inner().read_unaligned() }
     }

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -25,10 +25,7 @@ use core::mem::{self, ManuallyDrop};
 use core::ptr::{self, NonNull};
 
 use crate::{
-    pointer::{
-        invariant::{self, Invariants},
-        AliasingSafe, AliasingSafeReason, BecauseExclusive, BecauseImmutable,
-    },
+    pointer::invariant::{self, BecauseExclusive, BecauseImmutable, Invariants, ReadReason},
     FromBytes, Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
 };
 
@@ -554,11 +551,11 @@ fn try_cast_or_pme<Src, Dst, I, R>(
 where
     // TODO(#2226): There should be a `Src: FromBytes` bound here, but doing so
     // requires deeper surgery.
-    Src: IntoBytes,
-    Dst: TryFromBytes + AliasingSafe<Src, I::Aliasing, R>,
+    Src: IntoBytes + invariant::Read<I::Aliasing, R>,
+    Dst: TryFromBytes + invariant::Read<I::Aliasing, R>,
     I: Invariants<Validity = invariant::Valid>,
     I::Aliasing: invariant::Reference,
-    R: AliasingSafeReason,
+    R: ReadReason,
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());
 
@@ -567,10 +564,6 @@ where
     //   because we assert above that the size of `Dst` equal to the size of
     //   `Src`.
     // - `p as *mut Dst` is a provenance-preserving cast
-    // - Because `Dst: AliasingSafe<Src, I::Aliasing, _>`, either:
-    //   - `I::Aliasing` is `Exclusive`
-    //   - `Src` and `Dst` are both `Immutable`, in which case they
-    //     trivially contain `UnsafeCell`s at identical locations
     #[allow(clippy::as_conversions)]
     let c_ptr = unsafe { src.cast_unsized(|p| p as *mut Dst) };
 
@@ -590,10 +583,6 @@ where
             //   `ptr`, because we assert above that the size of `Dst` is equal
             //   to the size of `Src`.
             // - `p as *mut Src` is a provenance-preserving cast
-            // - Because `Dst: AliasingSafe<Src, I::Aliasing, _>`, either:
-            //   - `I::Aliasing` is `Exclusive`
-            //   - `Src` and `Dst` are both `Immutable`, in which case they
-            //     trivially contain `UnsafeCell`s at identical locations
             #[allow(clippy::as_conversions)]
             let ptr = unsafe { ptr.cast_unsized(|p| p as *mut Src) };
             // SAFETY: `ptr` is `src`, and has the same alignment invariant.

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -178,7 +178,7 @@ macro_rules! unsafe_impl {
             // - The caller has promised that the destination type has
             //   `UnsafeCell`s at the same byte ranges as the source type.
             #[allow(clippy::as_conversions)]
-            let candidate = unsafe { candidate.cast_unsized::<$repr, _>(|p| p as *mut _) };
+            let candidate = unsafe { candidate.cast_unsized_unchecked::<$repr, _>(|p| p as *mut _) };
 
             // SAFETY: The caller has promised that the referenced memory region
             // will contain a valid `$repr`.
@@ -202,7 +202,7 @@ macro_rules! unsafe_impl {
             // - The caller has promised that the destination type has
             //   `UnsafeCell`s at the same byte ranges as the source type.
             #[allow(clippy::as_conversions)]
-            let $candidate = unsafe { candidate.cast_unsized::<$repr, _>(|p| p as *mut _) };
+            let $candidate = unsafe { candidate.cast_unsized_unchecked::<$repr, _>(|p| p as *mut _) };
 
             // Restore the invariant that the referent bytes are initialized.
             // SAFETY: The above cast does not uninitialize any referent bytes;

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -259,15 +259,15 @@ pub(crate) fn derive_is_bit_valid(
                     //   `UnsafeCell`s will have the same location as in the
                     //   original type.
                     let variant = unsafe {
-                        variants.cast_unsized(
+                        variants.cast_unsized_unchecked(
                             |p: *mut ___ZerocopyVariants #ty_generics| {
                                 p as *mut #variant_struct_ident #ty_generics
                             }
                         )
                     };
-                    // SAFETY: `cast_unsized` removes the initialization
-                    // invariant from `p`, so we re-assert that all of the bytes
-                    // are initialized.
+                    // SAFETY: `cast_unsized_unchecked` removes the
+                    // initialization invariant from `p`, so we re-assert that
+                    // all of the bytes are initialized.
                     let variant = unsafe { variant.assume_initialized() };
                     <
                         #variant_struct_ident #ty_generics as #trait_path
@@ -321,7 +321,7 @@ pub(crate) fn derive_is_bit_valid(
                 // - There are no `UnsafeCell`s in the tag because it is a
                 //   primitive integer.
                 let tag_ptr = unsafe {
-                    candidate.reborrow().cast_unsized(|p: *mut Self| {
+                    candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| {
                         p as *mut ___ZerocopyTagPrimitive
                     })
                 };
@@ -343,12 +343,13 @@ pub(crate) fn derive_is_bit_valid(
             //   original enum, and so preserves the locations of any
             //   `UnsafeCell`s.
             let raw_enum = unsafe {
-                candidate.cast_unsized(|p: *mut Self| {
+                candidate.cast_unsized_unchecked(|p: *mut Self| {
                     p as *mut ___ZerocopyRawEnum #ty_generics
                 })
             };
-            // SAFETY: `cast_unsized` removes the initialization invariant from
-            // `p`, so we re-assert that all of the bytes are initialized.
+            // SAFETY: `cast_unsized_unchecked` removes the initialization
+            // invariant from `p`, so we re-assert that all of the bytes are
+            // initialized.
             let raw_enum = unsafe { raw_enum.assume_initialized() };
             // SAFETY:
             // - This projection returns a subfield of `this` using

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -706,7 +706,7 @@ fn derive_try_from_bytes_union(
             // is guaranteed to be no more strict than this definition. See #696
             // for a more in-depth discussion.
             fn is_bit_valid<___ZerocopyAliasing>(
-                mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>
+                mut candidate: ::zerocopy::Maybe<'_, Self,___ZerocopyAliasing>
             ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
             where
                 ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -748,13 +748,13 @@ fn test_try_from_bytes_enum() {
                     }
                     let tag = {
                         let tag_ptr = unsafe {
-                            candidate.reborrow().cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
+                            candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
-                        candidate.cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
+                        candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
@@ -767,7 +767,7 @@ fn test_try_from_bytes_enum() {
                         ___ZEROCOPY_TAG_UnitLike => true,
                         ___ZEROCOPY_TAG_StructLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
@@ -777,7 +777,7 @@ fn test_try_from_bytes_enum() {
                         }
                         ___ZEROCOPY_TAG_TupleLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };
@@ -1042,13 +1042,13 @@ fn test_try_from_bytes_enum() {
                     }
                     let tag = {
                         let tag_ptr = unsafe {
-                            candidate.reborrow().cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
+                            candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
-                        candidate.cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
+                        candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
@@ -1061,7 +1061,7 @@ fn test_try_from_bytes_enum() {
                         ___ZEROCOPY_TAG_UnitLike => true,
                         ___ZEROCOPY_TAG_StructLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
@@ -1071,7 +1071,7 @@ fn test_try_from_bytes_enum() {
                         }
                         ___ZEROCOPY_TAG_TupleLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };
@@ -1336,13 +1336,13 @@ fn test_try_from_bytes_enum() {
                     }
                     let tag = {
                         let tag_ptr = unsafe {
-                            candidate.reborrow().cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
+                            candidate.reborrow().cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyTagPrimitive })
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
                         tag_ptr.bikeshed_recall_valid().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
-                        candidate.cast_unsized(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
+                        candidate.cast_unsized_unchecked(|p: *mut Self| { p as *mut ___ZerocopyRawEnum<'a, N, X, Y> })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
                     let variants = unsafe {
@@ -1355,7 +1355,7 @@ fn test_try_from_bytes_enum() {
                         ___ZEROCOPY_TAG_UnitLike => true,
                         ___ZEROCOPY_TAG_StructLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>
                                 })
                             };
@@ -1365,7 +1365,7 @@ fn test_try_from_bytes_enum() {
                         }
                         ___ZEROCOPY_TAG_TupleLike => {
                             let variant = unsafe {
-                                variants.cast_unsized(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
+                                variants.cast_unsized_unchecked(|p: *mut ___ZerocopyVariants<'a, N, X, Y>| {
                                     p as *mut ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>
                                 })
                             };

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -120,7 +120,7 @@ pub mod util {
         let ptr = super::imp::Ptr::from_ref(&buf);
         // SAFETY: `T` and `MaybeUninit<T>` have the same layout, so this is a
         // size-preserving cast. It is also a provenance-preserving cast.
-        let ptr = unsafe { ptr.cast_unsized(|p| p as *mut T) };
+        let ptr = unsafe { ptr.cast_unsized_unchecked(|p| p as *mut T) };
         // SAFETY: This is intentionally unsound; see the preceding comment.
         let ptr = unsafe { ptr.assume_initialized() };
         assert!(<T as super::imp::TryFromBytes>::is_bit_valid(ptr));

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -78,7 +78,7 @@ fn two_bad() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Two) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut Two) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -108,7 +108,7 @@ fn un_sized() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Unsized) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut Unsized) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -163,7 +163,7 @@ fn test_maybe_from_bytes() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut MaybeFromBytes<bool>) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut MaybeFromBytes<bool>) };
 
     // SAFETY: `[u8]` consists entirely of initialized bytes.
     let candidate = unsafe { candidate.assume_initialized() };

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -73,7 +73,7 @@ fn two_bad() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut Two) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut Two) };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -102,7 +102,7 @@ fn bool_and_zst() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut BoolAndZst) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut BoolAndZst) };
 
     // SAFETY: `candidate`'s referent is fully initialized.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -130,7 +130,7 @@ fn test_maybe_from_bytes() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized(|p| p as *mut MaybeFromBytes<bool>) };
+    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p as *mut MaybeFromBytes<bool>) };
 
     // SAFETY: `[u8]` consists entirely of initialized bytes.
     let candidate = unsafe { candidate.assume_initialized() };


### PR DESCRIPTION
`AliasingSafe` is really about whether a pointer permits unsynchronized reads - either because the referent contains no `UnsafeCell`s or because the aliasing mode is `Exclusive`. Previously, `AliasingSafe` was not named consistent with this meaning, and was a function of a *pair* of types rather than of a single type. This commit fixes both oversights.

While we're here, we also add `Read` bounds in some places, allowing us to simplify many safety comments.

gherrit-pr-id: I88b9101a614459af3b062dc3d38142ba76427f34

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
