### PR TITLE
[pointer] Rename Any -> Unknown/Inaccessible (#1909)

### DIFF
--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -47,13 +47,18 @@ pub trait Validity: Sealed {}
 /// Exclusive`.
 pub trait Reference: Aliasing + Sealed {}
 
-/// No requirement - any invariant is allowed.
-pub enum Any {}
-impl Aliasing for Any {
+/// It is unknown whether any invariant holds.
+pub enum Unknown {}
+
+impl Alignment for Unknown {}
+impl Validity for Unknown {}
+
+/// The `Ptr<'a, T>` does not permit any reads or writes from or to its referent.
+pub enum Inaccessible {}
+
+impl Aliasing for Inaccessible {
     const IS_EXCLUSIVE: bool = false;
 }
-impl Alignment for Any {}
-impl Validity for Any {}
 
 /// The `Ptr<'a, T>` adheres to the aliasing rules of a `&'a T`.
 ///
@@ -165,8 +170,9 @@ mod sealed {
 
     pub trait Sealed {}
 
-    impl Sealed for Any {}
+    impl Sealed for Unknown {}
 
+    impl Sealed for Inaccessible {}
     impl Sealed for Shared {}
     impl Sealed for Exclusive {}
 

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -24,14 +24,14 @@ use crate::Unaligned;
 /// to [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Any> =
+pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
 
 /// A semi-user-facing wrapper type representing a maybe-aligned reference, for
 /// use in [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Any> =
+pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Valid)>;
 
 // These methods are defined on the type alias, `MaybeAligned`, so as to bring

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -545,7 +545,7 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 fn try_cast_or_pme<Src, Dst, I, R>(
     src: Ptr<'_, Src, I>,
 ) -> Result<
-    Ptr<'_, Dst, (I::Aliasing, invariant::Any, invariant::Valid)>,
+    Ptr<'_, Dst, (I::Aliasing, invariant::Unknown, invariant::Valid)>,
     ValidityError<Ptr<'_, Src, I>, Dst>,
 >
 where

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -99,11 +99,11 @@ impl<I: invariant::Validity> ValidityVariance<I> for Covariant {
 pub enum Invariant {}
 
 impl<I: invariant::Alignment> AlignmentVariance<I> for Invariant {
-    type Applied = invariant::Any;
+    type Applied = invariant::Unknown;
 }
 
 impl<I: invariant::Validity> ValidityVariance<I> for Invariant {
-    type Applied = invariant::Any;
+    type Applied = invariant::Unknown;
 }
 
 // SAFETY:


### PR DESCRIPTION
For aliasing, use `Inaccessible`. For alignment and validity, use `Unknown`.

gherrit-pr-id: I6b21a2d3a712196aed8897780da405dbc4ac6da1

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
