### PR TITLE
[pointer][invariant] Remove AliasingMapping, Inaccessible (#2301)

### DIFF
--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -27,6 +27,11 @@ impl<A: Aliasing, AA: Alignment, V: Validity> Invariants for (A, AA, V) {
 }
 
 /// The aliasing invariant of a [`Ptr`][super::Ptr].
+///
+/// All aliasing invariants must permit reading from the bytes of a pointer's
+/// referent which are not covered by [`UnsafeCell`]s.
+///
+/// [`UnsafeCell`]: core::cell::UnsafeCell
 pub trait Aliasing: Sealed {
     /// Is `Self` [`Exclusive`]?
     #[doc(hidden)]
@@ -139,7 +144,7 @@ impl Validity for Valid {}
 /// permitted to perform unsynchronized reads from its referent.
 pub trait Read<A: Aliasing, R: ReadReason> {}
 
-impl<A: Reference, T: ?Sized + crate::Immutable> Read<A, BecauseImmutable> for T {}
+impl<A: Aliasing, T: ?Sized + crate::Immutable> Read<A, BecauseImmutable> for T {}
 impl<T: ?Sized> Read<Exclusive, BecauseExclusive> for T {}
 
 /// Used to disambiguate [`Read`] impls.


### PR DESCRIPTION
We previously used `AliasingMapping`s and `Inaccessible` to model `UnsafeCell` agreement. This abuses the notion of a mapping since one doesn't ever actually want to change the aliasing of a pointer (and certainly not to `Inaccessible`) - really this was meant to model pointer casts which should never be performed. In addition to being an awkward fit, the presence of `Inaccessible` meant that code could not assume that any `Aliasing` invariant permitted reading, and so we had to add extra machinery to work around this.

Future commits will use a different, simpler model for denoting `UnsafeCell` agreement or disagreement.

While we're here, make `Read` slightly more permissive, implemented for `A: Aliasing, T: Immutable` rather than just `A: Reference, T: Immutable`.

Makes progress on #1122, #1866

gherrit-pr-id: I1ac2ae177a235083e33b09fc848423220d3da042

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
