### PR TITLE
[pointer] Fix Ptr[Inner] variance (#2351)

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -38,7 +38,7 @@ mod def {
     /// - `ptr` conforms to the validity invariant of
     ///   [`I::Validity`](invariant::Validity).
     ///
-    /// `Ptr<'a, T>` is [covariant] in `'a` and `T`.
+    /// `Ptr<'a, T>` is [covariant] in `'a` and invariant in `T`.
     ///
     /// [covariant]: https://doc.rust-lang.org/reference/subtyping.html
     pub struct Ptr<'a, T, I>
@@ -54,7 +54,7 @@ mod def {
         ///    [`I::Alignment`](invariant::Alignment).
         /// 2. `ptr` conforms to the validity invariant of
         ///    [`I::Validity`](invariant::Validity).
-        // SAFETY: `PtrInner<'a, T>` is covariant over `'a` and `T`.
+        // SAFETY: `PtrInner<'a, T>` is covariant in `'a` and invariant in `T`.
         ptr: PtrInner<'a, T>,
         _invariants: PhantomData<I>,
     }

--- a/tests/ui-msrv/ptr-is-invariant-over-v.rs
+++ b/tests/ui-msrv/ptr-is-invariant-over-v.rs
@@ -1,0 +1,1 @@
+../ui-nightly/ptr-is-invariant-over-v.rs

--- a/tests/ui-msrv/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-msrv/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,17 @@
+error[E0623]: lifetime mismatch
+  --> tests/ui-msrv/ptr-is-invariant-over-v.rs:10:14
+   |
+7  |     big: Ptr<'small, &'big u32, (Exclusive, Aligned, Valid)>,
+   |          --------------------------------------------------- these two types are declared with different lifetimes...
+...
+10 |     _small = big;
+   |              ^^^ ...but data from `big` flows into `big` here
+
+error[E0623]: lifetime mismatch
+  --> tests/ui-msrv/ptr-is-invariant-over-v.rs:17:14
+   |
+14 |     big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
+   |          ------------------------------------------------ these two types are declared with different lifetimes...
+...
+17 |     _small = big;
+   |              ^^^ ...but data from `big` flows into `big` here

--- a/tests/ui-nightly/ptr-is-invariant-over-v.rs
+++ b/tests/ui-nightly/ptr-is-invariant-over-v.rs
@@ -1,0 +1,20 @@
+use zerocopy::pointer::{
+    invariant::{Aligned, Exclusive, Shared, Valid},
+    Ptr,
+};
+
+fn _when_exclusive<'big: 'small, 'small>(
+    big: Ptr<'small, &'big u32, (Exclusive, Aligned, Valid)>,
+    mut _small: Ptr<'small, &'small u32, (Exclusive, Aligned, Valid)>,
+) {
+    _small = big;
+}
+
+fn _when_shared<'big: 'small, 'small>(
+    big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
+    mut _small: Ptr<'small, &'small u32, (Shared, Aligned, Valid)>,
+) {
+    _small = big;
+}
+
+fn main() {}

--- a/tests/ui-nightly/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-nightly/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,31 @@
+error: lifetime may not live long enough
+  --> tests/ui-nightly/ptr-is-invariant-over-v.rs:10:5
+   |
+6  | fn _when_exclusive<'big: 'small, 'small>(
+   |                    ----          ------ lifetime `'small` defined here
+   |                    |
+   |                    lifetime `'big` defined here
+...
+10 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (invariant::Exclusive, Aligned, Valid)>`, which makes the generic argument `&u32` invariant
+   = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui-nightly/ptr-is-invariant-over-v.rs:17:5
+   |
+13 | fn _when_shared<'big: 'small, 'small>(
+   |                 ----          ------ lifetime `'small` defined here
+   |                 |
+   |                 lifetime `'big` defined here
+...
+17 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, Valid)>`, which makes the generic argument `&u32` invariant
+   = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/tests/ui-stable/ptr-is-invariant-over-v.rs
+++ b/tests/ui-stable/ptr-is-invariant-over-v.rs
@@ -1,0 +1,1 @@
+../ui-nightly/ptr-is-invariant-over-v.rs

--- a/tests/ui-stable/ptr-is-invariant-over-v.stderr
+++ b/tests/ui-stable/ptr-is-invariant-over-v.stderr
@@ -1,0 +1,31 @@
+error: lifetime may not live long enough
+  --> tests/ui-stable/ptr-is-invariant-over-v.rs:10:5
+   |
+6  | fn _when_exclusive<'big: 'small, 'small>(
+   |                    ----          ------ lifetime `'small` defined here
+   |                    |
+   |                    lifetime `'big` defined here
+...
+10 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (invariant::Exclusive, Aligned, Valid)>`, which makes the generic argument `&u32` invariant
+   = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> tests/ui-stable/ptr-is-invariant-over-v.rs:17:5
+   |
+13 | fn _when_shared<'big: 'small, 'small>(
+   |                 ----          ------ lifetime `'small` defined here
+   |                 |
+   |                 lifetime `'big` defined here
+...
+17 |     _small = big;
+   |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
+   |
+   = help: consider adding the following bound: `'small: 'big`
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, Valid)>`, which makes the generic argument `&u32` invariant
+   = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
Previously, `Ptr<'a, T>` and `PtrInner<'a, T>` documented themselves to be covariant in both `'a` and `T`. This was true for `PtrInner`, but not for `Ptr`, which used GATs, which are invariant. This is also not the desired variance: for `Exclusive` aliasing, the desired variance matches that of `&mut` references - namely, covariant in `'a` but invariant in `T`.

This commit fixes this by making `Ptr<'a, T>` and `PtrInner<'a, T>` unconditionally covariant in `'a` and invariant in `T`.

gherrit-pr-id: I29f8429d9d7b14026313f030f8dc1e895a98ad56

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
