### PR TITLE
[ci] Don't run on push (#1882)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ name: Build & Tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
-      - v0.8.x
   merge_group:
 
 permissions: read-all


### PR DESCRIPTION
We already have the merge queue; running on push is redundant.

gherrit-pr-id: I48ecff7f2ed189bf87ba0dcb451345c0d0278b83

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
