### PR TITLE
[pointer] Improve soundness of invariant modeling

### DIFF
--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -24,14 +24,14 @@ use crate::Unaligned;
 /// to [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
+pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unaligned> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
 
 /// A semi-user-facing wrapper type representing a maybe-aligned reference, for
 /// use in [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unknown> =
+pub type MaybeAligned<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unaligned> =
     Ptr<'a, T, (Aliasing, Alignment, invariant::Valid)>;
 
 // These methods are defined on the type alias, `MaybeAligned`, so as to bring

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -26,7 +26,7 @@ use core::ptr::{self, NonNull};
 
 use crate::{
     pointer::invariant::{self, BecauseExclusive, BecauseImmutable, Invariants, ReadReason},
-    FromBytes, Immutable, IntoBytes, Ptr, TryFromBytes, Unalign, ValidityError,
+    FromBytes, Immutable, IntoBytes, Ptr, TryFromBytes, ValidityError,
 };
 
 /// Projects the type of the field at `Index` in `Self`.
@@ -529,9 +529,14 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 ///
 /// # Safety
 ///
-/// Unsafe code may assume that, if `try_cast_or_pme(src)` returns `Some`,
+/// Unsafe code may assume that, if `try_cast_or_pme(src)` returns `Ok`,
 /// `*src` is a bit-valid instance of `Dst`, and that the size of `Src` is
 /// greater than or equal to the size of `Dst`.
+///
+/// Unsafe code may assume that, if `try_cast_or_pme(src)` returns `Err`, the
+/// encapsulated `Ptr` value is the original `src`. `try_cast_or_pme` cannot
+/// guarantee that the referent has not been modified, as it calls user-defined
+/// code (`TryFromBytes::is_bit_valid`).
 ///
 /// # Panics
 ///
@@ -545,15 +550,15 @@ pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 fn try_cast_or_pme<Src, Dst, I, R>(
     src: Ptr<'_, Src, I>,
 ) -> Result<
-    Ptr<'_, Dst, (I::Aliasing, invariant::Unknown, invariant::Valid)>,
+    Ptr<'_, Dst, (I::Aliasing, invariant::Unaligned, invariant::Valid)>,
     ValidityError<Ptr<'_, Src, I>, Dst>,
 >
 where
     // TODO(#2226): There should be a `Src: FromBytes` bound here, but doing so
     // requires deeper surgery.
-    Src: IntoBytes + invariant::Read<I::Aliasing, R>,
+    Src: invariant::Read<I::Aliasing, R>,
     Dst: TryFromBytes + invariant::Read<I::Aliasing, R>,
-    I: Invariants<Validity = invariant::Valid>,
+    I: Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::Reference,
     R: ReadReason,
 {
@@ -566,11 +571,6 @@ where
     // - `p as *mut Dst` is a provenance-preserving cast
     #[allow(clippy::as_conversions)]
     let c_ptr = unsafe { src.cast_unsized(|p| p as *mut Dst) };
-
-    // SAFETY: `c_ptr` is derived from `src` which is `IntoBytes`. By
-    // invariant on `IntoByte`s, `c_ptr`'s referent consists entirely of
-    // initialized bytes.
-    let c_ptr = unsafe { c_ptr.assume_initialized() };
 
     match c_ptr.try_into_valid() {
         Ok(ptr) => Ok(ptr),
@@ -611,19 +611,44 @@ where
     Src: IntoBytes,
     Dst: TryFromBytes,
 {
-    let mut src = ManuallyDrop::new(src);
-    let ptr = Ptr::from_mut(&mut src);
-    // Wrapping `Dst` in `Unalign` ensures that this cast does not fail due to
-    // alignment requirements.
-    match try_cast_or_pme::<_, ManuallyDrop<Unalign<Dst>>, _, BecauseExclusive>(ptr) {
-        Ok(ptr) => {
-            let dst = ptr.bikeshed_recall_aligned().as_mut();
-            // SAFETY: By shadowing `dst`, we ensure that `dst` is not re-used
-            // after taking its inner value.
-            let dst = unsafe { ManuallyDrop::take(dst) };
-            Ok(dst.into_inner())
-        }
-        Err(_) => Err(ValidityError::new(ManuallyDrop::into_inner(src))),
+    static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());
+
+    let mu_src = mem::MaybeUninit::new(src);
+    // SAFETY: By invariant on `&`, the following are satisfied:
+    // - `&mu_src` is valid for reads
+    // - `&mu_src` is properly aligned
+    // - `&mu_src`'s referent is bit-valid
+    let mu_src_copy = unsafe { core::ptr::read(&mu_src) };
+    // SAFETY: `MaybeUninit` has no validity constraints.
+    let mut mu_dst: mem::MaybeUninit<Dst> =
+        unsafe { crate::util::transmute_unchecked(mu_src_copy) };
+
+    let ptr = Ptr::from_mut(&mut mu_dst);
+
+    // SAFETY: Since `Src: IntoBytes`, and since `size_of::<Src>() ==
+    // size_of::<Dst>()` by the preceding assertion, all of `mu_dst`'s bytes are
+    // initialized.
+    let ptr = unsafe { ptr.assume_validity::<invariant::Initialized>() };
+
+    // SAFETY: `MaybeUninit<T>` and `T` have the same size [1], so this cast
+    // preserves the referent's size. This cast preserves provenance.
+    //
+    // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+    //
+    //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and
+    //   ABI as `T`
+    let ptr: Ptr<'_, Dst, _> =
+        unsafe { ptr.cast_unsized(|mu: *mut mem::MaybeUninit<Dst>| mu.cast()) };
+
+    if Dst::is_bit_valid(ptr.forget_aligned()) {
+        // SAFETY: Since `Dst::is_bit_valid`, we know that `ptr`'s referent is
+        // bit-valid for `Dst`. `ptr` points to `mu_dst`, and no intervening
+        // operations have mutated it, so it is a bit-valid `Dst`.
+        Ok(unsafe { mu_dst.assume_init() })
+    } else {
+        // SAFETY: `mu_src` was constructed from `src` and never modified, so it
+        // is still bit-valid.
+        Err(ValidityError::new(unsafe { mu_src.assume_init() }))
     }
 }
 
@@ -645,7 +670,9 @@ where
     Src: IntoBytes + Immutable,
     Dst: TryFromBytes + Immutable,
 {
-    match try_cast_or_pme::<Src, Dst, _, BecauseImmutable>(Ptr::from_ref(src)) {
+    let ptr = Ptr::from_ref(src);
+    let ptr = ptr.bikeshed_recall_initialized_immutable();
+    match try_cast_or_pme::<Src, Dst, _, BecauseImmutable>(ptr) {
         Ok(ptr) => {
             static_assert!(Src, Dst => mem::align_of::<Dst>() <= mem::align_of::<Src>());
             // SAFETY: We have checked that `Dst` does not have a stricter
@@ -653,7 +680,19 @@ where
             let ptr = unsafe { ptr.assume_alignment::<invariant::Aligned>() };
             Ok(ptr.as_ref())
         }
-        Err(err) => Err(err.map_src(Ptr::as_ref)),
+        Err(err) => Err(err.map_src(|ptr| {
+            // SAFETY: Because `Src: Immutable` and we create a `Ptr` via
+            // `Ptr::from_ref`, the resulting `Ptr` is a shared-and-`Immutable`
+            // `Ptr`, which does not permit mutation of its referent. Therefore,
+            // no mutation could have happened during the call to
+            // `try_cast_or_pme` (any such mutation would be unsound).
+            //
+            // `try_cast_or_pme` promises to return its original argument, and
+            // so we know that we are getting back the same `ptr` that we
+            // originally passed, and that `ptr` was a bit-valid `Src`.
+            let ptr = unsafe { ptr.assume_valid() };
+            ptr.as_ref()
+        })),
     }
 }
 
@@ -675,7 +714,9 @@ where
     Src: FromBytes + IntoBytes,
     Dst: TryFromBytes + IntoBytes,
 {
-    match try_cast_or_pme::<Src, Dst, _, BecauseExclusive>(Ptr::from_mut(src)) {
+    let ptr = Ptr::from_mut(src);
+    let ptr = ptr.bikeshed_recall_initialized_from_bytes();
+    match try_cast_or_pme::<Src, Dst, _, BecauseExclusive>(ptr) {
         Ok(ptr) => {
             static_assert!(Src, Dst => mem::align_of::<Dst>() <= mem::align_of::<Src>());
             // SAFETY: We have checked that `Dst` does not have a stricter
@@ -683,7 +724,7 @@ where
             let ptr = unsafe { ptr.assume_alignment::<invariant::Aligned>() };
             Ok(ptr.as_mut())
         }
-        Err(err) => Err(err.map_src(Ptr::as_mut)),
+        Err(err) => Err(err.map_src(|ptr| ptr.bikeshed_recall_valid().as_mut())),
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -99,11 +99,11 @@ impl<I: invariant::Validity> ValidityVariance<I> for Covariant {
 pub enum Invariant {}
 
 impl<I: invariant::Alignment> AlignmentVariance<I> for Invariant {
-    type Applied = invariant::Unknown;
+    type Applied = invariant::Unaligned;
 }
 
 impl<I: invariant::Validity> ValidityVariance<I> for Invariant {
-    type Applied = invariant::Unknown;
+    type Applied = invariant::Uninit;
 }
 
 // SAFETY:

--- a/tests/ui-msrv/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-msrv/diagnostic-not-implemented-unaligned.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/diagnostic-not-implemented-unaligned.rs:18:23
    |
 18 |     takes_unaligned::<NotZerocopy>();
-   |                       ^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_unaligned`
   --> tests/ui-msrv/diagnostic-not-implemented-unaligned.rs:21:23

--- a/tests/ui-nightly/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-unaligned.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/diagnostic-not-implemented-unaligned.rs:18:23
    |
 18 |     takes_unaligned::<NotZerocopy>();
-   |                       ^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `NotZerocopy`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8

--- a/tests/ui-stable/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-unaligned.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-stable/diagnostic-not-implemented-unaligned.rs:18:23
    |
 18 |     takes_unaligned::<NotZerocopy>();
-   |                       ^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `NotZerocopy`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -118,11 +118,12 @@ pub mod util {
 
         let buf = super::imp::MaybeUninit::<T>::uninit();
         let ptr = super::imp::Ptr::from_ref(&buf);
+        // SAFETY: This is intentionally unsound; see the preceding comment.
+        let ptr = unsafe { ptr.assume_initialized() };
+
         // SAFETY: `T` and `MaybeUninit<T>` have the same layout, so this is a
         // size-preserving cast. It is also a provenance-preserving cast.
         let ptr = unsafe { ptr.cast_unsized_unchecked(|p| p as *mut T) };
-        // SAFETY: This is intentionally unsound; see the preceding comment.
-        let ptr = unsafe { ptr.assume_initialized() };
         assert!(<T as super::imp::TryFromBytes>::is_bit_valid(ptr));
     }
 }

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -157,6 +157,7 @@ fn test_maybe_from_bytes() {
     // that we *don't* spuriously do that when generic parameters are present.
 
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
+    let candidate = candidate.bikeshed_recall_initialized_from_bytes();
 
     // SAFETY:
     // - The cast preserves address and size. As a result, the cast will address

--- a/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-msrv/derive_transparent.stderr
@@ -70,13 +70,13 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/derive_transparent.rs:38:1
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
-note: required because of the requirements on the impl of `Unaligned` for `TransparentStruct<NotZerocopy>`
+note: required because of the requirements on the impl of `zerocopy::Unaligned` for `TransparentStruct<NotZerocopy>`
   --> tests/ui-msrv/derive_transparent.rs:24:32
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-msrv/late_compile_pass.stderr
@@ -69,29 +69,29 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:65:10
    |
 65 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:73:10
    |
 73 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/late_compile_pass.rs:80:10
    |
 80 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-msrv/msrv_specific.stderr
+++ b/zerocopy-derive/tests/ui-msrv/msrv_specific.stderr
@@ -6,11 +6,11 @@ warning: unused `#[macro_use]` import
    |
    = note: `#[warn(unused_imports)]` on by default
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/msrv_specific.rs:35:9
    |
 35 |         is_into_bytes_1::<IntoBytes1<AU16>>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
 note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `IntoBytes1<AU16>`
   --> tests/ui-msrv/msrv_specific.rs:24:10

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -153,11 +153,11 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satis
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
    --> tests/ui-msrv/struct.rs:100:10
     |
 100 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+    |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -114,14 +114,14 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/derive_transparent.rs:38:23
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `NotZerocopy`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -131,7 +131,7 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              I128<O>
              I16<O>
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::Unaligned`
   --> tests/ui-nightly/derive_transparent.rs:24:32
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -174,14 +174,14 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:65:10
    |
 65 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -198,14 +198,14 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:73:10
    |
 73 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -222,14 +222,14 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 9  + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-nightly/late_compile_pass.rs:80:10
    |
 80 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -272,14 +272,14 @@ note: `AU16` has a `#[repr(align)]` attribute
    |     pub struct AU16(pub u16);
    |     ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
    --> tests/ui-nightly/struct.rs:100:10
     |
 100 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+    |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-    = help: the following other types implement trait `Unaligned`:
+    = help: the following other types implement trait `zerocopy::Unaligned`:
               ()
               AtomicBool
               AtomicI8
@@ -374,14 +374,14 @@ error[E0587]: type has conflicting packed and align representation hints
 188 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
    --> tests/ui-nightly/struct.rs:161:28
     |
 161 |         is_into_bytes_11::<IntoBytes11<AU16>>();
-    |                            ^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+    |                            ^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-    = help: the following other types implement trait `Unaligned`:
+    = help: the following other types implement trait `zerocopy::Unaligned`:
               ()
               AtomicBool
               AtomicI8

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -114,14 +114,14 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
+error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> tests/ui-stable/derive_transparent.rs:38:23
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `NotZerocopy`
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `NotZerocopy`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -131,7 +131,7 @@ error[E0277]: the trait bound `NotZerocopy: Unaligned` is not satisfied
              I128<O>
              I16<O>
            and $N others
-note: required for `TransparentStruct<NotZerocopy>` to implement `Unaligned`
+note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::Unaligned`
   --> tests/ui-stable/derive_transparent.rs:24:32
    |
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -146,14 +146,14 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::IntoBytes` is not satisfie
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:65:10
    |
 65 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -166,14 +166,14 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:73:10
    |
 73 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8
@@ -186,14 +186,14 @@ error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
   --> tests/ui-stable/late_compile_pass.rs:80:10
    |
 80 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+   |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `Unaligned`:
+   = help: the following other types implement trait `zerocopy::Unaligned`:
              ()
              AtomicBool
              AtomicI8

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -245,14 +245,14 @@ note: `AU16` has a `#[repr(align)]` attribute
    |     pub struct AU16(pub u16);
    |     ^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
    --> tests/ui-stable/struct.rs:100:10
     |
 100 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+    |          ^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-    = help: the following other types implement trait `Unaligned`:
+    = help: the following other types implement trait `zerocopy::Unaligned`:
               ()
               AtomicBool
               AtomicI8
@@ -335,14 +335,14 @@ error[E0587]: type has conflicting packed and align representation hints
 188 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `AU16: Unaligned` is not satisfied
+error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
    --> tests/ui-stable/struct.rs:161:28
     |
 161 |         is_into_bytes_11::<IntoBytes11<AU16>>();
-    |                            ^^^^^^^^^^^^^^^^^ the trait `Unaligned` is not implemented for `AU16`
+    |                            ^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-    = help: the following other types implement trait `Unaligned`:
+    = help: the following other types implement trait `zerocopy::Unaligned`:
               ()
               AtomicBool
               AtomicI8

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -124,6 +124,7 @@ fn test_maybe_from_bytes() {
     // that we *don't* spuriously do that when generic parameters are present.
 
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
+    let candidate = candidate.bikeshed_recall_initialized_from_bytes();
 
     // SAFETY:
     // - The cast preserves address and size. As a result, the cast will address


### PR DESCRIPTION
This commit makes the following improvements:
- Removes the `Inaccessible` aliasing mode. This mode was not unsound,
  but it was unnecessary in practice.
- Replaces `Unknown` with `Unaligned` for alignment.
- Replaces `Unknown` with `Uninit` for validity.

Finally, with the exception of `transparent_wrapper_into_inner`, this
commit ensures that all `Ptr` methods which modify the type or validity
of a `Ptr` are sound.

Previously, we modeled validity as "knowledge" about the `Ptr`'s
referent (see #1866 for a more in-depth explanation). In particular, we
assumed that it was always sound to "forget" information about a `Ptr`'s
referent in the same way in which it is sound to "forget" that a `Ptr`
is validly-aligned, converting a `Ptr<T, (_, Aligned, _)>` to a
`Ptr<T, (_, Unaligned, _)>`.

The problem with this approach is that validity doesn't just specify
what bit patterns can be expected to be read from a `Ptr`'s referent, it
also specifies what bit patterns are permitted to be *written* to the
referent. Thus, "forgetting" about validity and expanding the set of
expected bit patterns also expands the set of bit patterns which can be
written.

Consider, for example, "forgetting" that a `Ptr<bool, (_, _, Valid)>` is
bit-valid, and downgrading it to a `Ptr<bool, (_, _, Initialized)>`. If
the aliasing is `Exclusive`, then the resulting `Ptr` would permit
writing arbitrary `u8`s to the referent, violating the bit validity of
the `bool`.

This commit moves us in the direction of a new model, in which changes
to the referent type or the validity of a `Ptr` must abide by the
following rules:
- If the resulting `Ptr` permits mutation of its referent (either via
  interior mutation or `Exclusive` aliasing), then the set of allowed
  bit patterns in the referent may not expand
- If the original `Ptr` permits mutation of its referent while the
  resulting `Ptr` is also live (i.e., via interior mutation on a
  `Shared` `Ptr`), then the set of allowed bit patterns in the referent
  may not shrink

This commit does not fix `transparent_wrapper_into_inner`, which will
require an overhaul or replacement of the `TransparentWrapper` trait.

Makes progress on #2226, #1866

Co-authored-by: Jack Wrenn <jswrenn@amazon.com>



---

This PR is on branch [v0.8.x-ptr-invariant-mapping](../tree/v0.8.x-ptr-invariant-mapping).

- #2397