### PR TITLE
Support 16-bit target platforms

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -117,7 +117,15 @@ impl DstLayout {
     ///   The alignment value must be a power of two from 1 up to
     ///   2<sup>29</sup>.
     #[cfg(not(kani))]
+    #[cfg(not(target_pointer_width = "16"))]
     pub(crate) const CURRENT_MAX_ALIGN: NonZeroUsize = match NonZeroUsize::new(1 << 28) {
+        Some(max_align) => max_align,
+        None => const_unreachable!(),
+    };
+
+    #[cfg(not(kani))]
+    #[cfg(target_pointer_width = "16")]
+    pub(crate) const CURRENT_MAX_ALIGN: NonZeroUsize = match NonZeroUsize::new(1 << 15) {
         Some(max_align) => max_align,
         None => const_unreachable!(),
     };

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -98,6 +98,7 @@ impl<T, U> MaxAlignsOf<T, U> {
     }
 }
 
+#[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 const _64K: usize = 1 << 16;
 
 // TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this


### PR DESCRIPTION
Since we currently can't roll our pinned nightly toolchain, and since
support for the avr target which initially caused us to notice this
issue was only added on nightly recently, this commit does not add a
regression test. That will be done later as part of #2400 once we are
able to roll our pinned nightly toolchain.

Makes progress on #2400




---

This PR is on branch [avr-artmega](../tree/avr-artmega).

- #2401