### PR TITLE
[pointer] Use PME acronym in method name

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -683,7 +683,7 @@ unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
         // that if we make a mistake, it will cause downstream code to fail to
         // compile, which will immediately surface the mistake and give us a
         // chance to fix it quickly.
-        let c = candidate.into_exclusive_or_post_monomorphization_error();
+        let c = candidate.into_exclusive_or_pme();
 
         // SAFETY: Since `UnsafeCell<T>` and `T` have the same layout and bit
         // validity, `UnsafeCell<T>` is bit-valid exactly when its wrapped `T`

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -530,14 +530,14 @@ mod _transitions {
         I: Invariants,
     {
         /// Returns a `Ptr` with [`Exclusive`] aliasing if `self` already has
-        /// `Exclusive` aliasing.
+        /// `Exclusive` aliasing, or generates a compile-time assertion failure.
         ///
         /// This allows code which is generic over aliasing to down-cast to a
         /// concrete aliasing.
         ///
         /// [`Exclusive`]: crate::pointer::invariant::Exclusive
         #[inline]
-        pub(crate) fn into_exclusive_or_post_monomorphization_error(
+        pub(crate) fn into_exclusive_or_pme(
             self,
         ) -> Ptr<'a, T, (Exclusive, I::Alignment, I::Validity)> {
             // NOTE(https://github.com/rust-lang/rust/issues/131625): We do this


### PR DESCRIPTION
Rename `into_exclusive_or_post_monomorphization_error` to
`into_exclusive_or_pme` for brevity.




---

This PR is on branch [ptr-validity](../tree/ptr-validity).

- #2406
- #2408
- #2403
- #2412