### PR TITLE
Inline try_cast_into()

### DIFF
--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -394,6 +394,7 @@ impl<'a> PtrInner<'a, [u8]> {
     /// `self`. Finally:
     /// - If this is a prefix cast, `ptr` has the same address as `self`.
     /// - If this is a suffix cast, `remainder` has the same address as `self`.
+    #[inline]
     pub(crate) fn try_cast_into<U>(
         self,
         cast_type: CastType,


### PR DESCRIPTION
This significantly improves codegen on embedded targets, allowing many checks to be optimized out.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
