### PR TITLE
Remove obsolete safety proofs

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,7 +7,11 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use core::{cell::UnsafeCell, mem::MaybeUninit as CoreMaybeUninit, ptr::NonNull};
+use core::{
+    cell::{Cell, UnsafeCell},
+    mem::MaybeUninit as CoreMaybeUninit,
+    ptr::NonNull,
+};
 
 use super::*;
 
@@ -861,6 +865,21 @@ safety_comment! {
     unsafe_impl!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>);
 }
 assert_unaligned!(ManuallyDrop<()>, ManuallyDrop<u8>);
+
+impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for Cell<T>[UnsafeCell<T>]);
+impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for Cell<T>[UnsafeCell<T>]);
+impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for Cell<T>[UnsafeCell<T>]);
+impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for Cell<T>[UnsafeCell<T>]);
+safety_comment! {
+    /// SAFETY:
+    /// `Cell<T>` has the same in-memory representation as `T` [1], and thus has
+    /// the same alignment as `T`.
+    ///
+    /// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.Cell.html#memory-layout:
+    ///
+    ///   `Cell<T>` has the same in-memory representation as its inner type `T`.
+    unsafe_impl!(T: ?Sized + Unaligned => Unaligned for Cell<T>);
+}
 
 impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for UnsafeCell<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for UnsafeCell<T>[<T>]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@ pub use crate::r#ref::*;
 pub use crate::wrappers::*;
 
 use core::{
-    cell::UnsafeCell,
+    cell::{Cell, UnsafeCell},
     cmp::Ordering,
     fmt::{self, Debug, Display, Formatter},
     hash::Hasher,
@@ -983,29 +983,27 @@ impl_known_layout!(const N: usize, T => [T; N]);
 
 safety_comment! {
     /// SAFETY:
-    /// `str`, `ManuallyDrop<[T]>` [1], and `UnsafeCell<T>` [2] have the same
-    /// representations as `[u8]`, `[T]`, and `T` repsectively. `str` has
-    /// different bit validity than `[u8]`, but that doesn't affect the
-    /// soundness of this impl.
+    /// `str` has the same representation as `[u8]`. `ManuallyDrop<T>` [1],
+    /// `UnsafeCell<T>` [2], and `Cell<T>` [3] have the same representation as
+    /// `T`.
     ///
-    /// [1] Per https://doc.rust-lang.org/nightly/core/mem/struct.ManuallyDrop.html:
+    /// [1] Per https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html:
     ///
     ///   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
     ///   validity as `T`
     ///
-    /// [2] Per https://doc.rust-lang.org/core/cell/struct.UnsafeCell.html#memory-layout:
+    /// [2] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.UnsafeCell.html#memory-layout:
     ///
     ///   `UnsafeCell<T>` has the same in-memory representation as its inner
     ///   type `T`.
     ///
-    /// TODO(#429):
-    /// -  Add quotes from docs.
-    /// -  Once [1] (added in
-    /// https://github.com/rust-lang/rust/pull/115522) is available on stable,
-    /// quote the stable docs instead of the nightly docs.
+    /// [3] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.Cell.html#memory-layout:
+    ///
+    ///   `Cell<T>` has the same in-memory representation as `T`.
     unsafe_impl_known_layout!(#[repr([u8])] str);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] ManuallyDrop<T>);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] UnsafeCell<T>);
+    unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] Cell<T>);
 }
 
 safety_comment! {

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -129,12 +129,6 @@ safety_comment! {
     ///   `UnsafeCell`s exactly when `T` does.
     /// - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as
     ///   `T`, so `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
-    ///   Furthermore:
-    ///   - Since `T` and `Unalign<T>` have the same layout, they have the same
-    ///     size (as required by `unsafe_impl!`).
-    ///   - Since `T` and `Unalign<T>` have the same fields, they have
-    ///     `UnsafeCell`s at the same byte ranges (as required by
-    ///     `unsafe_impl!`).
     impl_or_verify!(T => Unaligned for Unalign<T>);
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(

--- a/tests/ui-nightly/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-unaligned.stderr
@@ -10,10 +10,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfie
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
 note: required by a bound in `takes_unaligned`
   --> tests/ui-nightly/diagnostic-not-implemented-unaligned.rs:21:23

--- a/tests/ui-stable/diagnostic-not-implemented-unaligned.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-unaligned.stderr
@@ -10,10 +10,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfie
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
 note: required by a bound in `takes_unaligned`
   --> tests/ui-stable/diagnostic-not-implemented-unaligned.rs:21:23

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -126,10 +126,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfie
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::Unaligned`
   --> tests/ui-nightly/derive_transparent.rs:24:32

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -186,10 +186,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -210,10 +210,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -234,10 +234,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -284,10 +284,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
               AtomicBool
               AtomicI8
               AtomicU8
+              Cell<T>
               F32<O>
               F64<O>
               I128<O>
-              I16<O>
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -386,10 +386,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
               AtomicBool
               AtomicI8
               AtomicU8
+              Cell<T>
               F32<O>
               F64<O>
               I128<O>
-              I16<O>
             and $N others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy::IntoBytes`
    --> tests/ui-nightly/struct.rs:150:10

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -126,10 +126,10 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfie
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::Unaligned`
   --> tests/ui-stable/derive_transparent.rs:24:32

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -158,10 +158,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -178,10 +178,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -198,10 +198,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
              AtomicBool
              AtomicI8
              AtomicU8
+             Cell<T>
              F32<O>
              F64<O>
              I128<O>
-             I16<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -257,10 +257,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
               AtomicBool
               AtomicI8
               AtomicU8
+              Cell<T>
               F32<O>
               F64<O>
               I128<O>
-              I16<O>
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -347,10 +347,10 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
               AtomicBool
               AtomicI8
               AtomicU8
+              Cell<T>
               F32<O>
               F64<O>
               I128<O>
-              I16<O>
             and $N others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy::IntoBytes`
    --> tests/ui-stable/struct.rs:150:10


### PR DESCRIPTION
In #2408, we simplified the safety precondition of `unsafe_impl!`, but
did not remove safety proofs at call sites made redundant by that
simplification. This commit removes those now-obsolete proofs.




---

This PR is on branch [cell-traits](../tree/cell-traits).

- #2428
- #2423
- #2421