### PR TITLE
[pointer] SizeEq supports raw pointer transmutes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,17 +805,6 @@ pub unsafe trait KnownLayout {
         // resulting size would not fit in a `usize`.
         meta.size_for_metadata(Self::LAYOUT)
     }
-
-    #[doc(hidden)]
-    #[must_use]
-    #[inline(always)]
-    fn cast_from_raw<P: KnownLayout<PointerMetadata = Self::PointerMetadata> + ?Sized>(
-        ptr: NonNull<P>,
-    ) -> NonNull<Self> {
-        let data = ptr.cast::<u8>();
-        let meta = P::pointer_to_metadata(ptr.as_ptr());
-        Self::raw_from_ptr_len(data, meta)
-    }
 }
 
 /// The metadata associated with a [`KnownLayout`] type.

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -393,12 +393,8 @@ mod _conversions {
     {
         pub(crate) fn transmute<U, V, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
-            T: KnownLayout,
             V: Validity,
-            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R>
-                + KnownLayout<PointerMetadata = T::PointerMetadata>
-                + SizeEq<T>
-                + ?Sized,
+            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeEq<T> + ?Sized,
         {
             // SAFETY:
             // - This cast preserves address and provenance
@@ -414,28 +410,6 @@ mod _conversions {
             // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
             unsafe { self.transmute_unchecked(|t: NonNull<T>| U::cast_from_raw(t)) }
-        }
-
-        pub(crate) fn transmute_sized<U, V, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
-        where
-            T: Sized,
-            V: Validity,
-            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeEq<T>,
-        {
-            // SAFETY:
-            // - This cast preserves address and provenance
-            // - `U: SizeEq<T>` guarantees that this cast preserves the number
-            //   of bytes in the referent
-            // - If aliasing is `Shared`, then by `U: TransmuteFromPtr<T>`, at
-            //   least one of the following holds:
-            //   - `T: Immutable` and `U: Immutable`, in which case it is
-            //     trivially sound for shared code to operate on a `&T` and `&U`
-            //     at the same time, as neither can perform interior mutation
-            //   - It is directly guaranteed that it is sound for shared code to
-            //     operate on these references simultaneously
-            // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
-            //   sound to perform this transmute.
-            unsafe { self.transmute_unchecked(cast!()) }
         }
 
         #[doc(hidden)]

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -139,7 +139,7 @@ safety_comment! {
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
         T: TryFromBytes => TryFromBytes for Unalign<T>;
-        |c| T::is_bit_valid(c.transmute_sized())
+        |c| T::is_bit_valid(c.transmute())
     );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
@@ -188,7 +188,7 @@ impl<T> Unalign<T> {
     /// may prefer [`Deref::deref`], which is infallible.
     #[inline(always)]
     pub fn try_deref(&self) -> Result<&T, AlignmentError<&Self, T>> {
-        let inner = Ptr::from_ref(self).transmute_sized();
+        let inner = Ptr::from_ref(self).transmute();
         match inner.bikeshed_try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_ref()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_ref())),
@@ -205,7 +205,7 @@ impl<T> Unalign<T> {
     /// callers may prefer [`DerefMut::deref_mut`], which is infallible.
     #[inline(always)]
     pub fn try_deref_mut(&mut self) -> Result<&mut T, AlignmentError<&mut Self, T>> {
-        let inner = Ptr::from_mut(self).transmute_sized::<_, _, (_, (_, _))>();
+        let inner = Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>();
         match inner.bikeshed_try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_mut()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_mut())),
@@ -394,17 +394,14 @@ impl<T: Unaligned> Deref for Unalign<T> {
 
     #[inline(always)]
     fn deref(&self) -> &T {
-        Ptr::from_ref(self).transmute_sized().bikeshed_recall_aligned().as_ref()
+        Ptr::from_ref(self).transmute().bikeshed_recall_aligned().as_ref()
     }
 }
 
 impl<T: Unaligned> DerefMut for Unalign<T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
-        Ptr::from_mut(self)
-            .transmute_sized::<_, _, (_, (_, _))>()
-            .bikeshed_recall_aligned()
-            .as_mut()
+        Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>().bikeshed_recall_aligned().as_mut()
     }
 }
 


### PR DESCRIPTION
This permits us to remove the `KnownLayout` bounds from
`Ptr::transmute`, and thus to remove `Ptr::transmute_sized` entirely.
This also allows us to remove the hand-rolled impl of `TryFromBytes` for
`ManuallyDrop<T>`, replacing it with an invocation of
`impl_for_transmute_from!`.




---

This PR is on branch [cell-traits](../tree/cell-traits).

- #2428
- #2423
- #2421
- #2427