### PR TITLE
Separate `SplitAt`'s bounds checking and overlap checking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub use crate::byte_slice::*;
 pub use crate::byteorder::*;
 pub use crate::error::*;
 pub use crate::r#ref::*;
-pub use crate::split_at::SplitAt;
+pub use crate::split_at::{Split, SplitAt};
 pub use crate::wrappers::*;
 
 use core::{

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -422,6 +422,7 @@ mod len_of {
         T: KnownLayout,
     {
         /// Returns `None` if `meta` is greater than `t`'s metadata.
+        #[inline(always)]
         pub(crate) fn new_in_bounds(t: &T, meta: usize) -> Option<Self>
         where
             T: KnownLayout<PointerMetadata = usize>,

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -2139,6 +2139,25 @@ fn test_eq() {
 fn test_split_at() {
     test! {
         SplitAt {
+            #[repr(C)]
+            struct Foo<T: ?Sized + Copy>(T) where Self: Copy;
+        } expands to {
+            #[allow(deprecated)]
+            #[automatically_derived]
+            unsafe impl<T: ?Sized + Copy> ::zerocopy::SplitAt for Foo<T>
+            where
+                Self: Copy,
+                T: ::zerocopy::SplitAt,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Elem = <T as ::zerocopy::SplitAt>::Elem;
+            }
+        } no_build
+    }
+
+    test! {
+        SplitAt {
+            #[repr(transparent)]
             struct Foo<T: ?Sized + Copy>(T) where Self: Copy;
         } expands to {
             #[allow(deprecated)]
@@ -2192,6 +2211,16 @@ fn test_split_at() {
         } expands to {
             ::core::compile_error! {
                 "can only be applied to structs"
+            }
+        } no_build
+    }
+
+    test! {
+        SplitAt {
+            struct Foo<T: ?Sized + Copy>(T) where Self: Copy;
+        } expands to {
+            ::core::compile_error! {
+                "must have #[repr(C)] or #[repr(transparent)] in order to guarantee this type's layout is splitable"
             }
         } no_build
     }

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -230,18 +230,18 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-msrv/struct.rs:217:10
+   --> tests/ui-msrv/struct.rs:218:10
     |
-217 | #[derive(SplitAt, KnownLayout)]
+218 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<u8 as zerocopy::KnownLayout>::PointerMetadata == usize`
-   --> tests/ui-msrv/struct.rs:217:10
+   --> tests/ui-msrv/struct.rs:218:10
     |
-217 | #[derive(SplitAt, KnownLayout)]
+218 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ expected `()`, found `usize`
     |
     = help: see issue #48214

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -212,6 +212,7 @@ struct Unaligned7;
 struct WeirdReprSpan;
 
 #[derive(SplitAt)]
+#[repr(C)]
 struct SplitAtNotKnownLayout([u8]);
 
 #[derive(SplitAt, KnownLayout)]

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -399,9 +399,9 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-nightly/struct.rs:217:10
+   --> tests/ui-nightly/struct.rs:218:10
     |
-217 | #[derive(SplitAt, KnownLayout)]
+218 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -360,9 +360,9 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-stable/struct.rs:217:10
+   --> tests/ui-stable/struct.rs:218:10
     |
-217 | #[derive(SplitAt, KnownLayout)]
+218 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`


### PR DESCRIPTION
Previously, `SplitAt`'s methods returned `Option<(&(mut) Self, &(mut) Self::Trailing)>`, where `None` reflects an index that's either out of bounds, or results in the split parts overlapping in a problematic manner. This design conflated two failure conditions into one and, worse, presented an overly expensive and conservative API: dynamically checking for overlap is expensive, and there are many cases in which overlapping parts are *not* problematic, and this API could not scale to accommodate them all. 

`SplitAt`'s methods now return `Option<Split<&(mut) Self>>`, where `None` reflects an out-of-bounds index, and `Split<&(mut) Self>` encodes the possibly-overlapping parts. `Split<&(mut) Self>` provides methods for producing references to the split parts via both dynamic overlap checking and via static bounds (e.g., `Self: Immutable`). This API is more both cheaper and more expressive.

This API is, in fact, slightly more expressive than is possible to demonstrate within zerocopy's current capabilities. `Split::via_runtime_check` is overly conservative when `T: Immutable`, but it is not currently possible to construct a DST which would have overlapping parts *without* `T: Immutable`. We intend to follow up with mechanisms for DST construction that don't have this limitation.

Makes progress towards #1290.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
