### PR TITLE
Replace safety_comment! with const blocks

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -489,19 +489,19 @@ example of how it can be used for parsing UDP packets.
         #[cfg(not(any(feature = "derive", test)))]
         impl_known_layout!(O => $name<O>);
 
-        safety_comment! {
-            /// SAFETY:
-            /// `$name<O>` is `repr(transparent)`, and so it has the same layout
-            /// as its only non-zero field, which is a `u8` array. `u8` arrays
-            /// are `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`,
-            /// `IntoBytes`, and `Unaligned`.
+        #[allow(unused_unsafe)] // Unused when `feature = "derive"`.
+        // SAFETY: `$name<O>` is `repr(transparent)`, and so it has the same
+        // layout as its only non-zero field, which is a `u8` array. `u8` arrays
+        // are `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`,
+        // `IntoBytes`, and `Unaligned`.
+        const _: () = unsafe {
             impl_or_verify!(O => Immutable for $name<O>);
             impl_or_verify!(O => TryFromBytes for $name<O>);
             impl_or_verify!(O => FromZeros for $name<O>);
             impl_or_verify!(O => FromBytes for $name<O>);
             impl_or_verify!(O => IntoBytes for $name<O>);
             impl_or_verify!(O => Unaligned for $name<O>);
-        }
+        };
 
         impl<O> Default for $name<O> {
             #[inline(always)]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -15,54 +15,51 @@ use core::{
 
 use super::*;
 
-safety_comment! {
-    /// SAFETY:
-    /// Per the reference [1], "the unit tuple (`()`) ... is guaranteed as a
-    /// zero-sized type to have a size of 0 and an alignment of 1."
-    /// - `Immutable`: `()` self-evidently does not contain any `UnsafeCell`s.
-    /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is
-    ///   only one possible sequence of 0 bytes, and `()` is inhabited.
-    /// - `IntoBytes`: Since `()` has size 0, it contains no padding bytes.
-    /// - `Unaligned`: `()` has alignment 1.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#tuple-layout
+// SAFETY: Per the reference [1], "the unit tuple (`()`) ... is guaranteed as a
+// zero-sized type to have a size of 0 and an alignment of 1."
+// - `Immutable`: `()` self-evidently does not contain any `UnsafeCell`s.
+// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is only
+//   one possible sequence of 0 bytes, and `()` is inhabited.
+// - `IntoBytes`: Since `()` has size 0, it contains no padding bytes.
+// - `Unaligned`: `()` has alignment 1.
+//
+// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#tuple-layout
+const _: () = unsafe {
     unsafe_impl!((): Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     assert_unaligned!(());
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// - `Immutable`: These types self-evidently do not contain any
-    ///   `UnsafeCell`s.
-    /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: all bit
-    ///   patterns are valid for numeric types [1]
-    /// - `IntoBytes`: numeric types have no padding bytes [1]
-    /// - `Unaligned` (`u8` and `i8` only): The reference [2] specifies the size
-    ///   of `u8` and `i8` as 1 byte. We also know that:
-    ///   - Alignment is >= 1 [3]
-    ///   - Size is an integer multiple of alignment [4]
-    ///   - The only value >= 1 for which 1 is an integer multiple is 1
-    ///   Therefore, the only possible alignment for `u8` and `i8` is 1.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/reference/types/numeric.html#bit-validity:
-    ///
-    ///     For every numeric type, `T`, the bit validity of `T` is equivalent to
-    ///     the bit validity of `[u8; size_of::<T>()]`. An uninitialized byte is
-    ///     not a valid `u8`.
-    ///
-    /// [2] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#primitive-data-layout
-    ///
-    /// [3] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
-    ///
-    ///     Alignment is measured in bytes, and must be at least 1.
-    ///
-    /// [4] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
-    ///
-    ///     The size of a value is always a multiple of its alignment.
-    ///
-    /// TODO(#278): Once we've updated the trait docs to refer to `u8`s rather
-    /// than bits or bytes, update this comment, especially the reference to
-    /// [1].
+// SAFETY:
+// - `Immutable`: These types self-evidently do not contain any `UnsafeCell`s.
+// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: all bit
+//   patterns are valid for numeric types [1]
+// - `IntoBytes`: numeric types have no padding bytes [1]
+// - `Unaligned` (`u8` and `i8` only): The reference [2] specifies the size of
+//   `u8` and `i8` as 1 byte. We also know that:
+//   - Alignment is >= 1 [3]
+//   - Size is an integer multiple of alignment [4]
+//   - The only value >= 1 for which 1 is an integer multiple is 1 Therefore,
+//   the only possible alignment for `u8` and `i8` is 1.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/reference/types/numeric.html#bit-validity:
+//
+//     For every numeric type, `T`, the bit validity of `T` is equivalent to
+//     the bit validity of `[u8; size_of::<T>()]`. An uninitialized byte is
+//     not a valid `u8`.
+//
+// [2] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#primitive-data-layout
+//
+// [3] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
+//
+//     Alignment is measured in bytes, and must be at least 1.
+//
+// [4] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
+//
+//     The size of a value is always a multiple of its alignment.
+//
+// TODO(#278): Once we've updated the trait docs to refer to `u8`s rather than
+// bits or bytes, update this comment, especially the reference to [1].
+const _: () = unsafe {
     unsafe_impl!(u8: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     unsafe_impl!(i8: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     assert_unaligned!(u8, i8);
@@ -82,102 +79,99 @@ safety_comment! {
     unsafe_impl!(#[cfg_attr(doc_cfg, doc(cfg(feature = "float-nightly")))] f16: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
     #[cfg(feature = "float-nightly")]
     unsafe_impl!(#[cfg_attr(doc_cfg, doc(cfg(feature = "float-nightly")))] f128: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// - `Immutable`: `bool` self-evidently does not contain any `UnsafeCell`s.
-    /// - `FromZeros`: Valid since "[t]he value false has the bit pattern 0x00"
-    ///   [1].
-    /// - `IntoBytes`: Since "the boolean type has a size and alignment of 1
-    ///   each" and "The value false has the bit pattern 0x00 and the value true
-    ///   has the bit pattern 0x01" [1]. Thus, the only byte of the bool is
-    ///   always initialized.
-    /// - `Unaligned`: Per the reference [1], "[a]n object with the boolean type
-    ///   has a size and alignment of 1 each."
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/reference/types/boolean.html
-    unsafe_impl!(bool: Immutable, FromZeros, IntoBytes, Unaligned);
-    assert_unaligned!(bool);
-    /// SAFETY:
-    /// The impl must only return `true` for its argument if the original
-    /// `Maybe<bool>` refers to a valid `bool`. We only return true if the `u8`
-    /// value is 0 or 1, and both of these are valid values for `bool` [1].
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/reference/types/boolean.html:
-    ///
-    ///   The value false has the bit pattern 0x00 and the value true has the
-    ///   bit pattern 0x01.
+// SAFETY:
+// - `Immutable`: `bool` self-evidently does not contain any `UnsafeCell`s.
+// - `FromZeros`: Valid since "[t]he value false has the bit pattern 0x00" [1].
+// - `IntoBytes`: Since "the boolean type has a size and alignment of 1 each"
+//   and "The value false has the bit pattern 0x00 and the value true has the
+//   bit pattern 0x01" [1]. Thus, the only byte of the bool is always
+//   initialized.
+// - `Unaligned`: Per the reference [1], "[a]n object with the boolean type has
+//   a size and alignment of 1 each."
+//
+// [1] https://doc.rust-lang.org/1.81.0/reference/types/boolean.html
+const _: () = unsafe { unsafe_impl!(bool: Immutable, FromZeros, IntoBytes, Unaligned) };
+assert_unaligned!(bool);
+
+// SAFETY: The impl must only return `true` for its argument if the original
+// `Maybe<bool>` refers to a valid `bool`. We only return true if the `u8` value
+// is 0 or 1, and both of these are valid values for `bool` [1].
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/reference/types/boolean.html:
+//
+//   The value false has the bit pattern 0x00 and the value true has the bit
+//   pattern 0x01.
+const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for bool; |byte| {
         let byte = byte.transmute::<u8, invariant::Valid, _>();
         *byte.unaligned_as_ref() < 2
-    });
-}
-
+    })
+};
 impl_size_eq!(bool, u8);
 
-safety_comment! {
-    /// SAFETY:
-    /// - `Immutable`: `char` self-evidently does not contain any `UnsafeCell`s.
-    /// - `FromZeros`: Per reference [1], "[a] value of type char is a Unicode
-    ///   scalar value (i.e. a code point that is not a surrogate), represented
-    ///   as a 32-bit unsigned word in the 0x0000 to 0xD7FF or 0xE000 to
-    ///   0x10FFFF range" which contains 0x0000.
-    /// - `IntoBytes`: `char` is per reference [1] "represented as a 32-bit
-    ///   unsigned word" (`u32`) which is `IntoBytes`. Note that unlike `u32`,
-    ///   not all bit patterns are valid for `char`.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/reference/types/textual.html
-    unsafe_impl!(char: Immutable, FromZeros, IntoBytes);
-    /// SAFETY:
-    /// The impl must only return `true` for its argument if the original
-    /// `Maybe<char>` refers to a valid `char`. `char::from_u32` guarantees that
-    /// it returns `None` if its input is not a valid `char` [1].
-    ///
-    /// [1] Per https://doc.rust-lang.org/core/primitive.char.html#method.from_u32:
-    ///
-    ///   `from_u32()` will return `None` if the input is not a valid value for
-    ///   a `char`.
+// SAFETY:
+// - `Immutable`: `char` self-evidently does not contain any `UnsafeCell`s.
+// - `FromZeros`: Per reference [1], "[a] value of type char is a Unicode scalar
+//   value (i.e. a code point that is not a surrogate), represented as a 32-bit
+//   unsigned word in the 0x0000 to 0xD7FF or 0xE000 to 0x10FFFF range" which
+//   contains 0x0000.
+// - `IntoBytes`: `char` is per reference [1] "represented as a 32-bit unsigned
+//   word" (`u32`) which is `IntoBytes`. Note that unlike `u32`, not all bit
+//   patterns are valid for `char`.
+//
+// [1] https://doc.rust-lang.org/1.81.0/reference/types/textual.html
+const _: () = unsafe { unsafe_impl!(char: Immutable, FromZeros, IntoBytes) };
+
+// SAFETY: The impl must only return `true` for its argument if the original
+// `Maybe<char>` refers to a valid `char`. `char::from_u32` guarantees that it
+// returns `None` if its input is not a valid `char` [1].
+//
+// [1] Per https://doc.rust-lang.org/core/primitive.char.html#method.from_u32:
+//
+//   `from_u32()` will return `None` if the input is not a valid value for a
+//   `char`.
+const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for char; |c| {
         let c = c.transmute::<Unalign<u32>, invariant::Valid, _>();
         let c = c.read_unaligned().into_inner();
         char::from_u32(c).is_some()
     });
-}
+};
 
 impl_size_eq!(char, Unalign<u32>);
 
-safety_comment! {
-    /// SAFETY:
-    /// Per the Reference [1], `str` has the same layout as `[u8]`.
-    /// - `Immutable`: `[u8]` does not contain any `UnsafeCell`s.
-    /// - `FromZeros`, `IntoBytes`, `Unaligned`: `[u8]` is `FromZeros`,
-    ///   `IntoBytes`, and `Unaligned`.
-    ///
-    /// Note that we don't `assert_unaligned!(str)` because `assert_unaligned!`
-    /// uses `align_of`, which only works for `Sized` types.
-    ///
-    /// TODO(#429):
-    /// - Add quotes from documentation.
-    /// - Improve safety proof for `FromZeros` and `IntoBytes`; having the same
-    ///   layout as `[u8]` isn't sufficient.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#str-layout
-    unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unaligned);
-    /// SAFETY:
-    /// The impl must only return `true` for its argument if the original
-    /// `Maybe<str>` refers to a valid `str`. `str::from_utf8` guarantees that
-    /// it returns `Err` if its input is not a valid `str` [1].
-    ///
-    /// [2] Per https://doc.rust-lang.org/core/str/fn.from_utf8.html#errors:
-    ///
-    ///   Returns `Err` if the slice is not UTF-8.
+// SAFETY: Per the Reference [1], `str` has the same layout as `[u8]`.
+// - `Immutable`: `[u8]` does not contain any `UnsafeCell`s.
+// - `FromZeros`, `IntoBytes`, `Unaligned`: `[u8]` is `FromZeros`, `IntoBytes`,
+//   and `Unaligned`.
+//
+// Note that we don't `assert_unaligned!(str)` because `assert_unaligned!` uses
+// `align_of`, which only works for `Sized` types.
+//
+// TODO(#429):
+// - Add quotes from documentation.
+// - Improve safety proof for `FromZeros` and `IntoBytes`; having the same
+//   layout as `[u8]` isn't sufficient.
+//
+// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#str-layout
+const _: () = unsafe { unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unaligned) };
+
+// SAFETY: The impl must only return `true` for its argument if the original
+// `Maybe<str>` refers to a valid `str`. `str::from_utf8` guarantees that it
+// returns `Err` if its input is not a valid `str` [1].
+//
+// [2] Per https://doc.rust-lang.org/core/str/fn.from_utf8.html#errors:
+//
+//   Returns `Err` if the slice is not UTF-8.
+const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for str; |c| {
         let c = c.transmute::<[u8], invariant::Valid, _>();
         let c = c.unaligned_as_ref();
         core::str::from_utf8(c).is_ok()
-    });
-}
+    })
+};
 
 // SAFETY: `str` and `[u8]` have the same layout [1].
 //
@@ -201,11 +195,13 @@ macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
     ($($nonzero:ident[$prim:ty]),*) => {
         $(
             unsafe_impl!(=> TryFromBytes for $nonzero; |n| {
+                // SAFETY: The caller promises that this is sound.
                 unsafe impl pointer::SizeEq<$nonzero> for Unalign<$prim> {
                     fn cast_from_raw(n: NonNull<$nonzero>) -> NonNull<Unalign<$prim>> {
                         cast!(n)
                     }
                 }
+                // SAFETY: The caller promises that this is sound.
                 unsafe impl pointer::SizeEq<Unalign<$prim>> for $nonzero {
                     fn cast_from_raw(p: NonNull<Unalign<$prim>>) -> NonNull<$nonzero> {
                         cast!(p)
@@ -219,39 +215,39 @@ macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
     }
 }
 
-safety_comment! {
-    // `NonZeroXxx` is `IntoBytes`, but not `FromZeros` or `FromBytes`.
-    //
-    /// SAFETY:
-    /// - `IntoBytes`: `NonZeroXxx` has the same layout as its associated
-    ///    primitive. Since it is the same size, this guarantees it has no
-    ///    padding - integers have no padding, and there's no room for padding
-    ///    if it can represent all of the same values except 0.
-    /// - `Unaligned`: `NonZeroU8` and `NonZeroI8` document that
-    ///   `Option<NonZeroU8>` and `Option<NonZeroI8>` both have size 1. [1] [2]
-    ///   This is worded in a way that makes it unclear whether it's meant as a
-    ///   guarantee, but given the purpose of those types, it's virtually
-    ///   unthinkable that that would ever change. `Option` cannot be smaller
-    ///   than its contained type, which implies that, and `NonZeroX8` are of
-    ///   size 1 or 0. `NonZeroX8` can represent multiple states, so they cannot
-    ///   be 0 bytes, which means that they must be 1 byte. The only valid
-    ///   alignment for a 1-byte type is 1.
-    ///
-    /// TODO(#429):
-    /// - Add quotes from documentation.
-    /// - Add safety comment for `Immutable`. How can we prove that `NonZeroXxx`
-    ///   doesn't contain any `UnsafeCell`s? It's obviously true, but it's not
-    ///   clear how we'd prove it short of adding text to the stdlib docs that
-    ///   says so explicitly, which likely wouldn't be accepted.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/std/num/type.NonZeroU8.html
-    ///
-    ///     `NonZeroU8` is guaranteed to have the same layout and bit validity as `u8` with
-    ///     the exception that 0 is not a valid instance
-    ///
-    /// [2] https://doc.rust-lang.org/1.81.0/std/num/type.NonZeroI8.html
-    /// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
-    /// that layout is the same as primitive layout.
+// `NonZeroXxx` is `IntoBytes`, but not `FromZeros` or `FromBytes`.
+//
+// SAFETY:
+// - `IntoBytes`: `NonZeroXxx` has the same layout as its associated primitive.
+//    Since it is the same size, this guarantees it has no padding - integers
+//    have no padding, and there's no room for padding if it can represent all
+//    of the same values except 0.
+// - `Unaligned`: `NonZeroU8` and `NonZeroI8` document that `Option<NonZeroU8>`
+//   and `Option<NonZeroI8>` both have size 1. [1] [2] This is worded in a way
+//   that makes it unclear whether it's meant as a guarantee, but given the
+//   purpose of those types, it's virtually unthinkable that that would ever
+//   change. `Option` cannot be smaller than its contained type, which implies
+//   that, and `NonZeroX8` are of size 1 or 0. `NonZeroX8` can represent
+//   multiple states, so they cannot be 0 bytes, which means that they must be 1
+//   byte. The only valid alignment for a 1-byte type is 1.
+//
+// TODO(#429):
+// - Add quotes from documentation.
+// - Add safety comment for `Immutable`. How can we prove that `NonZeroXxx`
+//   doesn't contain any `UnsafeCell`s? It's obviously true, but it's not clear
+//   how we'd prove it short of adding text to the stdlib docs that says so
+//   explicitly, which likely wouldn't be accepted.
+//
+// [1] https://doc.rust-lang.org/1.81.0/std/num/type.NonZeroU8.html
+//
+//     `NonZeroU8` is guaranteed to have the same layout and bit validity as `u8` with
+//     the exception that 0 is not a valid instance
+//
+// [2] https://doc.rust-lang.org/1.81.0/std/num/type.NonZeroI8.html
+//
+// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
+// that layout is the same as primitive layout.
+const _: () = unsafe {
     unsafe_impl!(NonZeroU8: Immutable, IntoBytes, Unaligned);
     unsafe_impl!(NonZeroI8: Immutable, IntoBytes, Unaligned);
     assert_unaligned!(NonZeroU8, NonZeroI8);
@@ -279,27 +275,27 @@ safety_comment! {
         NonZeroUsize[usize],
         NonZeroIsize[isize]
     );
-}
-safety_comment! {
-    /// SAFETY:
-    /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`,
-    ///   `IntoBytes`: The Rust compiler reuses `0` value to represent `None`,
-    ///   so `size_of::<Option<NonZeroXxx>>() == size_of::<xxx>()`; see
-    ///   `NonZeroXxx` documentation.
-    /// - `Unaligned`: `NonZeroU8` and `NonZeroI8` document that
-    ///   `Option<NonZeroU8>` and `Option<NonZeroI8>` both have size 1. [1] [2]
-    ///   This is worded in a way that makes it unclear whether it's meant as a
-    ///   guarantee, but given the purpose of those types, it's virtually
-    ///   unthinkable that that would ever change. The only valid alignment for
-    ///   a 1-byte type is 1.
-    ///
-    /// TODO(#429): Add quotes from documentation.
-    ///
-    /// [1] https://doc.rust-lang.org/stable/std/num/struct.NonZeroU8.html
-    /// [2] https://doc.rust-lang.org/stable/std/num/struct.NonZeroI8.html
-    ///
-    /// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
-    /// for layout guarantees.
+};
+
+// SAFETY:
+// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`, `IntoBytes`:
+//   The Rust compiler reuses `0` value to represent `None`, so
+//   `size_of::<Option<NonZeroXxx>>() == size_of::<xxx>()`; see `NonZeroXxx`
+//   documentation.
+// - `Unaligned`: `NonZeroU8` and `NonZeroI8` document that `Option<NonZeroU8>`
+//   and `Option<NonZeroI8>` both have size 1. [1] [2] This is worded in a way
+//   that makes it unclear whether it's meant as a guarantee, but given the
+//   purpose of those types, it's virtually unthinkable that that would ever
+//   change. The only valid alignment for a 1-byte type is 1.
+//
+// TODO(#429): Add quotes from documentation.
+//
+// [1] https://doc.rust-lang.org/stable/std/num/struct.NonZeroU8.html
+// [2] https://doc.rust-lang.org/stable/std/num/struct.NonZeroI8.html
+//
+// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
+// for layout guarantees.
+const _: () = unsafe {
     unsafe_impl!(Option<NonZeroU8>: TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     unsafe_impl!(Option<NonZeroI8>: TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     assert_unaligned!(Option<NonZeroU8>, Option<NonZeroI8>);
@@ -313,44 +309,42 @@ safety_comment! {
     unsafe_impl!(Option<NonZeroI128>: TryFromBytes, FromZeros, FromBytes, IntoBytes);
     unsafe_impl!(Option<NonZeroUsize>: TryFromBytes, FromZeros, FromBytes, IntoBytes);
     unsafe_impl!(Option<NonZeroIsize>: TryFromBytes, FromZeros, FromBytes, IntoBytes);
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// While it's not fully documented, the consensus is that `Box<T>` does not
-    /// contain any `UnsafeCell`s for `T: Sized` [1]. This is not a complete
-    /// proof, but we are accepting this as a known risk per #1358.
-    ///
-    /// [1] https://github.com/rust-lang/unsafe-code-guidelines/issues/492
-    #[cfg(feature = "alloc")]
+// SAFETY: While it's not fully documented, the consensus is that `Box<T>` does
+// not contain any `UnsafeCell`s for `T: Sized` [1]. This is not a complete
+// proof, but we are accepting this as a known risk per #1358.
+//
+// [1] https://github.com/rust-lang/unsafe-code-guidelines/issues/492
+#[cfg(feature = "alloc")]
+const _: () = unsafe {
     unsafe_impl!(
         #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
         T: Sized => Immutable for Box<T>
-    );
-}
+    )
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// The following types can be transmuted from `[0u8; size_of::<T>()]`. [1]
-    ///
-    /// [1] Per https://doc.rust-lang.org/nightly/core/option/index.html#representation:
-    ///
-    ///   Rust guarantees to optimize the following types `T` such that
-    ///   [`Option<T>`] has the same size and alignment as `T`. In some of these
-    ///   cases, Rust further guarantees that `transmute::<_, Option<T>>([0u8;
-    ///   size_of::<T>()])` is sound and produces `Option::<T>::None`. These
-    ///   cases are identified by the second column:
-    ///
-    ///   | `T`                   | `transmute::<_, Option<T>>([0u8; size_of::<T>()])` sound? |
-    ///   |-----------------------|-----------------------------------------------------------|
-    ///   | [`Box<U>`]            | when `U: Sized`                                           |
-    ///   | `&U`                  | when `U: Sized`                                           |
-    ///   | `&mut U`              | when `U: Sized`                                           |
-    ///   | [`ptr::NonNull<U>`]   | when `U: Sized`                                           |
-    ///   | `fn`, `extern "C" fn` | always                                                    |
-    ///
-    /// TODO(#429), TODO(https://github.com/rust-lang/rust/pull/115333): Cite
-    /// the Stable docs once they're available.
+// SAFETY: The following types can be transmuted from `[0u8; size_of::<T>()]`. [1]
+//
+// [1] Per https://doc.rust-lang.org/nightly/core/option/index.html#representation:
+//
+//   Rust guarantees to optimize the following types `T` such that [`Option<T>`]
+//   has the same size and alignment as `T`. In some of these cases, Rust
+//   further guarantees that `transmute::<_, Option<T>>([0u8; size_of::<T>()])`
+//   is sound and produces `Option::<T>::None`. These cases are identified by
+//   the second column:
+//
+//   | `T`                   | `transmute::<_, Option<T>>([0u8; size_of::<T>()])` sound? |
+//   |-----------------------|-----------------------------------------------------------|
+//   | [`Box<U>`]            | when `U: Sized`                                           |
+//   | `&U`                  | when `U: Sized`                                           |
+//   | `&mut U`              | when `U: Sized`                                           |
+//   | [`ptr::NonNull<U>`]   | when `U: Sized`                                           |
+//   | `fn`, `extern "C" fn` | always                                                    |
+//
+// TODO(#429), TODO(https://github.com/rust-lang/rust/pull/115333): Cite the
+// Stable docs once they're available.
+const _: () = unsafe {
     #[cfg(feature = "alloc")]
     unsafe_impl!(
         #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
@@ -383,16 +377,15 @@ safety_comment! {
         A, B, C, D, E, F, G, H, I, J, K, L -> M => TryFromBytes for opt_extern_c_fn!(...);
         |c| pointer::is_zeroed(c)
     );
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// `fn()` and `extern "C" fn()` self-evidently do not contain
-    /// `UnsafeCell`s. This is not a proof, but we are accepting this as a known
-    /// risk per #1358.
+// SAFETY: `fn()` and `extern "C" fn()` self-evidently do not contain
+// `UnsafeCell`s. This is not a proof, but we are accepting this as a known risk
+// per #1358.
+const _: () = unsafe {
     unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => Immutable for opt_fn!(...));
     unsafe_impl_for_power_set!(A, B, C, D, E, F, G, H, I, J, K, L -> M => Immutable for opt_extern_c_fn!(...));
-}
+};
 
 #[cfg(all(
     zerocopy_target_has_atomics_1_60_0,
@@ -427,72 +420,68 @@ mod atomics {
     ///
     /// `$atomic` must have the same size and bit validity as `$prim`.
     macro_rules! unsafe_impl_transmute_from_for_atomic {
-        ($($($tyvar:ident)? => $atomic:ty [$prim:ty]),*) => {
-            const _: () = {
-                use core::{cell::UnsafeCell, ptr::NonNull};
-                use crate::pointer::{TransmuteFrom, SizeEq, invariant::Valid};
+        ($($($tyvar:ident)? => $atomic:ty [$prim:ty]),*) => {{
+            crate::util::macros::__unsafe();
 
-                $(
-                    #[allow(unused_unsafe)] // Force the caller to call this macro inside `safety_comment!`.
-                    const _: () = unsafe {};
+            use core::{cell::UnsafeCell, ptr::NonNull};
+            use crate::pointer::{TransmuteFrom, SizeEq, invariant::Valid};
 
-                    // SAFETY: The caller promised that `$atomic` and `$prim` have
-                    // the same size and bit validity.
-                    unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for $prim {}
-                    // SAFETY: The caller promised that `$atomic` and `$prim` have
-                    // the same size and bit validity.
-                    unsafe impl<$($tyvar)?> TransmuteFrom<$prim, Valid, Valid> for $atomic {}
+            $(
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same size and bit validity.
+                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for $prim {}
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same size and bit validity.
+                unsafe impl<$($tyvar)?> TransmuteFrom<$prim, Valid, Valid> for $atomic {}
 
-                    // SAFETY: THe caller promised that `$atomic` and `$prim`
-                    // have the same size.
-                    unsafe impl<$($tyvar)?> SizeEq<$atomic> for $prim {
-                        fn cast_from_raw(a: NonNull<$atomic>) -> NonNull<$prim> {
-                            cast!(a)
-                        }
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same size.
+                unsafe impl<$($tyvar)?> SizeEq<$atomic> for $prim {
+                    fn cast_from_raw(a: NonNull<$atomic>) -> NonNull<$prim> {
+                        cast!(a)
                     }
-                    // SAFETY: THe caller promised that `$atomic` and `$prim`
-                    // have the same size.
-                    unsafe impl<$($tyvar)?> SizeEq<$prim> for $atomic {
-                        fn cast_from_raw(p: NonNull<$prim>) -> NonNull<$atomic> {
-                            cast!(p)
-                        }
+                }
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same size.
+                unsafe impl<$($tyvar)?> SizeEq<$prim> for $atomic {
+                    fn cast_from_raw(p: NonNull<$prim>) -> NonNull<$atomic> {
+                        cast!(p)
                     }
-                    // SAFETY: The caller promised that `$atomic` and `$prim`
-                    // have the same size. `UnsafeCell<T>` has the same size as
-                    // `T` [1].
-                    //
-                    // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
-                    //
-                    //   `UnsafeCell<T>` has the same in-memory representation as
-                    //   its inner type `T`. A consequence of this guarantee is that
-                    //   it is possible to convert between `T` and `UnsafeCell<T>`.
-                    unsafe impl<$($tyvar)?> SizeEq<$atomic> for UnsafeCell<$prim> {
-                        fn cast_from_raw(a: NonNull<$atomic>) -> NonNull<UnsafeCell<$prim>> {
-                            cast!(a)
-                        }
+                }
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same size. `UnsafeCell<T>` has the same size as `T` [1].
+                //
+                // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
+                //
+                //   `UnsafeCell<T>` has the same in-memory representation as
+                //   its inner type `T`. A consequence of this guarantee is that
+                //   it is possible to convert between `T` and `UnsafeCell<T>`.
+                unsafe impl<$($tyvar)?> SizeEq<$atomic> for UnsafeCell<$prim> {
+                    fn cast_from_raw(a: NonNull<$atomic>) -> NonNull<UnsafeCell<$prim>> {
+                        cast!(a)
                     }
-                    // SAFETY: See previous safety comment.
-                    unsafe impl<$($tyvar)?> SizeEq<UnsafeCell<$prim>> for $atomic {
-                        fn cast_from_raw(p: NonNull<UnsafeCell<$prim>>) -> NonNull<$atomic> {
-                            cast!(p)
-                        }
+                }
+                // SAFETY: See previous safety comment.
+                unsafe impl<$($tyvar)?> SizeEq<UnsafeCell<$prim>> for $atomic {
+                    fn cast_from_raw(p: NonNull<UnsafeCell<$prim>>) -> NonNull<$atomic> {
+                        cast!(p)
                     }
+                }
 
-                    // SAFETY: The caller promised that `$atomic` and `$prim`
-                    // have the same bit validity. `UnsafeCell<T>` has the same
-                    // bit validity as `T` [1].
-                    //
-                    // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
-                    //
-                    //   `UnsafeCell<T>` has the same in-memory representation as
-                    //   its inner type `T`. A consequence of this guarantee is that
-                    //   it is possible to convert between `T` and `UnsafeCell<T>`.
-                    unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for core::cell::UnsafeCell<$prim> {}
-                    // SAFETY: See previous safety comment.
-                    unsafe impl<$($tyvar)?> TransmuteFrom<core::cell::UnsafeCell<$prim>, Valid, Valid> for $atomic {}
-                )*
-            };
-        };
+                // SAFETY: The caller promised that `$atomic` and `$prim` have
+                // the same bit validity. `UnsafeCell<T>` has the same bit
+                // validity as `T` [1].
+                //
+                // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
+                //
+                //   `UnsafeCell<T>` has the same in-memory representation as
+                //   its inner type `T`. A consequence of this guarantee is that
+                //   it is possible to convert between `T` and `UnsafeCell<T>`.
+                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for core::cell::UnsafeCell<$prim> {}
+                // SAFETY: See previous safety comment.
+                unsafe impl<$($tyvar)?> TransmuteFrom<core::cell::UnsafeCell<$prim>, Valid, Valid> for $atomic {}
+            )*
+        }};
     }
 
     #[cfg(target_has_atomic = "8")]
@@ -510,55 +499,54 @@ mod atomics {
         impl_for_transmute_from!(=> FromZeros for AtomicBool [UnsafeCell<bool>]);
         impl_for_transmute_from!(=> IntoBytes for AtomicBool [UnsafeCell<bool>]);
 
-        safety_comment! {
-            /// SAFETY:
-            /// Per [1], `AtomicBool`, `AtomicU8`, and `AtomicI8` have the same
-            /// size as `bool`, `u8`, and `i8` respectively. Since a type's
-            /// alignment cannot be smaller than 1 [2], and since its alignment
-            /// cannot be greater than its size [3], the only possible value for
-            /// the alignment is 1. Thus, it is sound to implement `Unaligned`.
-            ///
-            /// [1] Per (for example) https://doc.rust-lang.org/1.81.0/std/sync/atomic/struct.AtomicU8.html:
-            ///
-            ///   This type has the same size, alignment, and bit validity as
-            ///   the underlying integer type
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
-            ///
-            ///     Alignment is measured in bytes, and must be at least 1.
-            ///
-            /// [3] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
-            ///
-            ///     The size of a value is always a multiple of its alignment.
+        // SAFETY: Per [1], `AtomicBool`, `AtomicU8`, and `AtomicI8` have the
+        // same size as `bool`, `u8`, and `i8` respectively. Since a type's
+        // alignment cannot be smaller than 1 [2], and since its alignment
+        // cannot be greater than its size [3], the only possible value for the
+        // alignment is 1. Thus, it is sound to implement `Unaligned`.
+        //
+        // [1] Per (for example) https://doc.rust-lang.org/1.81.0/std/sync/atomic/struct.AtomicU8.html:
+        //
+        //   This type has the same size, alignment, and bit validity as the
+        //   underlying integer type
+        //
+        // [2] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
+        //
+        //     Alignment is measured in bytes, and must be at least 1.
+        //
+        // [3] Per https://doc.rust-lang.org/1.81.0/reference/type-layout.html#size-and-alignment:
+        //
+        //     The size of a value is always a multiple of its alignment.
+        const _: () = unsafe {
             unsafe_impl!(AtomicBool: Unaligned);
             unsafe_impl!(AtomicU8: Unaligned);
             unsafe_impl!(AtomicI8: Unaligned);
             assert_unaligned!(AtomicBool, AtomicU8, AtomicI8);
+        };
 
-            /// SAFETY:
-            /// `AtomicU8`, `AtomicI8`, and `AtomicBool` have the same size and
-            /// bit validity as `u8`, `i8`, and `bool` respectively [1][2][3].
-            ///
-            /// [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU8.html:
-            ///
-            ///   This type has the same size, alignment, and bit validity as
-            ///   the underlying integer type, `u8`.
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI8.html:
-            ///
-            ///   This type has the same size, alignment, and bit validity as
-            ///   the underlying integer type, `i8`.
-            ///
-            /// [3] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicBool.html:
-            ///
-            ///   This type has the same size, alignment, and bit validity a
-            ///   `bool`.
+        // SAFETY: `AtomicU8`, `AtomicI8`, and `AtomicBool` have the same size
+        // and bit validity as `u8`, `i8`, and `bool` respectively [1][2][3].
+        //
+        // [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU8.html:
+        //
+        //   This type has the same size, alignment, and bit validity as the
+        //   underlying integer type, `u8`.
+        //
+        // [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI8.html:
+        //
+        //   This type has the same size, alignment, and bit validity as the
+        //   underlying integer type, `i8`.
+        //
+        // [3] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicBool.html:
+        //
+        //   This type has the same size, alignment, and bit validity a `bool`.
+        const _: () = unsafe {
             unsafe_impl_transmute_from_for_atomic!(
                 => AtomicU8 [u8],
                 => AtomicI8 [i8],
                 => AtomicBool [bool]
-            );
-        }
+            )
+        };
     }
 
     #[cfg(target_has_atomic = "16")]
@@ -570,22 +558,21 @@ mod atomics {
 
         impl_traits_for_atomics!(AtomicU16[u16], AtomicI16[i16]);
 
-        safety_comment! {
-            /// SAFETY:
-            /// `AtomicU16` and `AtomicI16` have the same size and bit validity
-            /// as `u16` and `i16` respectively [1][2].
-            ///
-            /// [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU16.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `u16`.
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI16.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `i16`.
-            unsafe_impl_transmute_from_for_atomic!(=> AtomicU16 [u16], => AtomicI16 [i16]);
-        }
+        // SAFETY: `AtomicU16` and `AtomicI16` have the same size and bit
+        // validity as `u16` and `i16` respectively [1][2].
+        //
+        // [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU16.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `u16`.
+        //
+        // [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI16.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `i16`.
+        const _: () = unsafe {
+            unsafe_impl_transmute_from_for_atomic!(=> AtomicU16 [u16], => AtomicI16 [i16])
+        };
     }
 
     #[cfg(target_has_atomic = "32")]
@@ -597,22 +584,21 @@ mod atomics {
 
         impl_traits_for_atomics!(AtomicU32[u32], AtomicI32[i32]);
 
-        safety_comment! {
-            /// SAFETY:
-            /// `AtomicU32` and `AtomicI32` have the same size and bit validity
-            /// as `u32` and `i32` respectively [1][2].
-            ///
-            /// [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU32.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `u32`.
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI32.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `i32`.
-            unsafe_impl_transmute_from_for_atomic!(=> AtomicU32 [u32], => AtomicI32 [i32]);
-        }
+        // SAFETY: `AtomicU32` and `AtomicI32` have the same size and bit
+        // validity as `u32` and `i32` respectively [1][2].
+        //
+        // [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU32.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `u32`.
+        //
+        // [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI32.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `i32`.
+        const _: () = unsafe {
+            unsafe_impl_transmute_from_for_atomic!(=> AtomicU32 [u32], => AtomicI32 [i32])
+        };
     }
 
     #[cfg(target_has_atomic = "64")]
@@ -624,22 +610,21 @@ mod atomics {
 
         impl_traits_for_atomics!(AtomicU64[u64], AtomicI64[i64]);
 
-        safety_comment! {
-            /// SAFETY:
-            /// `AtomicU64` and `AtomicI64` have the same size and bit validity
-            /// as `u64` and `i64` respectively [1][2].
-            ///
-            /// [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU64.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `u64`.
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI64.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `i64`.
-            unsafe_impl_transmute_from_for_atomic!(=> AtomicU64 [u64], => AtomicI64 [i64]);
-        }
+        // SAFETY: `AtomicU64` and `AtomicI64` have the same size and bit
+        // validity as `u64` and `i64` respectively [1][2].
+        //
+        // [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicU64.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `u64`.
+        //
+        // [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicI64.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `i64`.
+        const _: () = unsafe {
+            unsafe_impl_transmute_from_for_atomic!(=> AtomicU64 [u64], => AtomicI64 [i64])
+        };
     }
 
     #[cfg(target_has_atomic = "ptr")]
@@ -658,46 +643,41 @@ mod atomics {
         impl_for_transmute_from!(T => TryFromBytes for AtomicPtr<T> [UnsafeCell<*mut T>]);
         impl_for_transmute_from!(T => FromZeros for AtomicPtr<T> [UnsafeCell<*mut T>]);
 
-        safety_comment! {
-            /// SAFETY:
-            /// `AtomicUsize` and `AtomicIsize` have the same size and bit
-            /// validity as `usize` and `isize` respectively [1][2].
-            ///
-            /// [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicUsize.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `usize`.
-            ///
-            /// [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicIsize.html:
-            ///
-            ///   This type has the same size and bit validity as the underlying
-            ///   integer type, `isize`.
-            unsafe_impl_transmute_from_for_atomic!(=> AtomicUsize [usize], => AtomicIsize [isize]);
-            /// SAFETY:
-            /// Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicPtr.html:
-            ///
-            ///   This type has the same size and bit validity as a `*mut T`.
-            unsafe_impl_transmute_from_for_atomic!(T => AtomicPtr<T> [*mut T]);
-        }
+        // SAFETY: `AtomicUsize` and `AtomicIsize` have the same size and bit
+        // validity as `usize` and `isize` respectively [1][2].
+        //
+        // [1] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicUsize.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `usize`.
+        //
+        // [2] Per https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicIsize.html:
+        //
+        //   This type has the same size and bit validity as the underlying
+        //   integer type, `isize`.
+        const _: () = unsafe {
+            unsafe_impl_transmute_from_for_atomic!(=> AtomicUsize [usize], => AtomicIsize [isize])
+        };
+
+        // SAFETY: Per
+        // https://doc.rust-lang.org/1.85.0/std/sync/atomic/struct.AtomicPtr.html:
+        //
+        //   This type has the same size and bit validity as a `*mut T`.
+        const _: () = unsafe { unsafe_impl_transmute_from_for_atomic!(T => AtomicPtr<T> [*mut T]) };
     }
 }
 
-safety_comment! {
-    /// SAFETY:
-    /// Per reference [1]:
-    /// "For all T, the following are guaranteed:
-    /// size_of::<PhantomData<T>>() == 0
-    /// align_of::<PhantomData<T>>() == 1".
-    /// This gives:
-    /// - `Immutable`: `PhantomData` has no fields.
-    /// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is
-    ///   only one possible sequence of 0 bytes, and `PhantomData` is inhabited.
-    /// - `IntoBytes`: Since `PhantomData` has size 0, it contains no padding
-    ///   bytes.
-    /// - `Unaligned`: Per the preceding reference, `PhantomData` has alignment
-    ///   1.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/std/marker/struct.PhantomData.html#layout-1
+// SAFETY: Per reference [1]: "For all T, the following are guaranteed:
+// size_of::<PhantomData<T>>() == 0 align_of::<PhantomData<T>>() == 1". This
+// gives:
+// - `Immutable`: `PhantomData` has no fields.
+// - `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`: There is only
+//   one possible sequence of 0 bytes, and `PhantomData` is inhabited.
+// - `IntoBytes`: Since `PhantomData` has size 0, it contains no padding bytes.
+// - `Unaligned`: Per the preceding reference, `PhantomData` has alignment 1.
+//
+// [1] https://doc.rust-lang.org/1.81.0/std/marker/struct.PhantomData.html#layout-1
+const _: () = unsafe {
     unsafe_impl!(T: ?Sized => Immutable for PhantomData<T>);
     unsafe_impl!(T: ?Sized => TryFromBytes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => FromZeros for PhantomData<T>);
@@ -705,7 +685,7 @@ safety_comment! {
     unsafe_impl!(T: ?Sized => IntoBytes for PhantomData<T>);
     unsafe_impl!(T: ?Sized => Unaligned for PhantomData<T>);
     assert_unaligned!(PhantomData<()>, PhantomData<u8>, PhantomData<u64>);
-}
+};
 
 impl_for_transmute_from!(T: TryFromBytes => TryFromBytes for Wrapping<T>[<T>]);
 impl_for_transmute_from!(T: FromZeros => FromZeros for Wrapping<T>[<T>]);
@@ -713,127 +693,110 @@ impl_for_transmute_from!(T: FromBytes => FromBytes for Wrapping<T>[<T>]);
 impl_for_transmute_from!(T: IntoBytes => IntoBytes for Wrapping<T>[<T>]);
 assert_unaligned!(Wrapping<()>, Wrapping<u8>);
 
-safety_comment! {
-    /// SAFETY:
-    /// Per [1], `Wrapping<T>` has the same layout as `T`. Since its single
-    /// field (of type `T`) is public, it would be a breaking change to add or
-    /// remove fields. Thus, we know that `Wrapping<T>` contains a `T` (as
-    /// opposed to just having the same size and alignment as `T`) with no pre-
-    /// or post-padding. Thus, `Wrapping<T>` must have `UnsafeCell`s covering
-    /// the same byte ranges as `Inner = T`.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
-    ///
-    ///   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`
-    unsafe_impl!(T: Immutable => Immutable for Wrapping<T>);
-    /// SAFETY:
-    /// Per [1] in the preceding safety comment, `Wrapping<T>` has the same
-    /// alignment as `T`.
-    unsafe_impl!(T: Unaligned => Unaligned for Wrapping<T>);
-}
+// SAFETY: Per [1], `Wrapping<T>` has the same layout as `T`. Since its single
+// field (of type `T`) is public, it would be a breaking change to add or remove
+// fields. Thus, we know that `Wrapping<T>` contains a `T` (as opposed to just
+// having the same size and alignment as `T`) with no pre- or post-padding.
+// Thus, `Wrapping<T>` must have `UnsafeCell`s covering the same byte ranges as
+// `Inner = T`.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/num/struct.Wrapping.html#layout-1:
+//
+//   `Wrapping<T>` is guaranteed to have the same layout and ABI as `T`
+const _: () = unsafe { unsafe_impl!(T: Immutable => Immutable for Wrapping<T>) };
 
-safety_comment! {
-    /// SAFETY:
-    /// `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`:
-    /// `MaybeUninit<T>` has no restrictions on its contents.
+// SAFETY: Per [1] in the preceding safety comment, `Wrapping<T>` has the same
+// alignment as `T`.
+const _: () = unsafe { unsafe_impl!(T: Unaligned => Unaligned for Wrapping<T>) };
+
+// SAFETY: `TryFromBytes` (with no validator), `FromZeros`, `FromBytes`:
+// `MaybeUninit<T>` has no restrictions on its contents.
+const _: () = unsafe {
     unsafe_impl!(T => TryFromBytes for CoreMaybeUninit<T>);
     unsafe_impl!(T => FromZeros for CoreMaybeUninit<T>);
     unsafe_impl!(T => FromBytes for CoreMaybeUninit<T>);
-    /// SAFETY:
-    /// `MaybeUninit<T>` has `UnsafeCell`s covering the same byte ranges as
-    /// `Inner = T`. This is not explicitly documented, but it can be inferred.
-    /// Per [1], `MaybeUninit<T>` has the same size as `T`. Further, note the
-    /// signature of `MaybeUninit::assume_init_ref` [2]:
-    ///
-    ///   pub unsafe fn assume_init_ref(&self) -> &T
-    ///
-    /// If the argument `&MaybeUninit<T>` and the returned `&T` had
-    /// `UnsafeCell`s at different offsets, this would be unsound. Its existence
-    /// is proof that this is not the case.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
-    ///
-    /// `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI
-    /// as `T`.
-    ///
-    /// [2] https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#method.assume_init_ref
-    unsafe_impl!(T: Immutable => Immutable for CoreMaybeUninit<T>);
-    /// SAFETY:
-    /// Per [1] in the preceding safety comment, `MaybeUninit<T>` has the same
-    /// alignment as `T`.
-    unsafe_impl!(T: Unaligned => Unaligned for CoreMaybeUninit<T>);
-}
+};
+
+// SAFETY: `MaybeUninit<T>` has `UnsafeCell`s covering the same byte ranges as
+// `Inner = T`. This is not explicitly documented, but it can be inferred. Per
+// [1], `MaybeUninit<T>` has the same size as `T`. Further, note the signature
+// of `MaybeUninit::assume_init_ref` [2]:
+//
+//   pub unsafe fn assume_init_ref(&self) -> &T
+//
+// If the argument `&MaybeUninit<T>` and the returned `&T` had `UnsafeCell`s at
+// different offsets, this would be unsound. Its existence is proof that this is
+// not the case.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
+//
+// `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
+// `T`.
+//
+// [2] https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#method.assume_init_ref
+const _: () = unsafe { unsafe_impl!(T: Immutable => Immutable for CoreMaybeUninit<T>) };
+
+// SAFETY: Per [1] in the preceding safety comment, `MaybeUninit<T>` has the
+// same alignment as `T`.
+const _: () = unsafe { unsafe_impl!(T: Unaligned => Unaligned for CoreMaybeUninit<T>) };
 assert_unaligned!(CoreMaybeUninit<()>, CoreMaybeUninit<u8>);
 
-safety_comment! {
-    /// SAFETY:
-    /// `ManuallyDrop<T>` has the same layout as `T` [1]. This strongly implies,
-    /// but does not guarantee, that it contains `UnsafeCell`s covering the same
-    /// byte ranges as in `T`. However, it also implements `Defer<Target = T>`
-    /// [2], which provides the ability to convert `&ManuallyDrop<T> -> &T`.
-    /// This, combined with having the same size as `T`, implies that
-    /// `ManuallyDrop<T>` exactly contains a `T` with the same fields and
-    /// `UnsafeCell`s covering the same byte ranges, or else the `Deref` impl
-    /// would permit safe code to obtain different shared references to the same
-    /// region of memory with different `UnsafeCell` coverage, which would in
-    /// turn permit interior mutation that would violate the invariants of a
-    /// shared reference.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html:
-    ///
-    ///   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
-    ///   validity as `T`
-    ///
-    /// [2] https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html#impl-Deref-for-ManuallyDrop%3CT%3E
-    unsafe_impl!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>);
-}
+// SAFETY: `ManuallyDrop<T>` has the same layout as `T` [1]. This strongly
+// implies, but does not guarantee, that it contains `UnsafeCell`s covering the
+// same byte ranges as in `T`. However, it also implements `Defer<Target = T>`
+// [2], which provides the ability to convert `&ManuallyDrop<T> -> &T`. This,
+// combined with having the same size as `T`, implies that `ManuallyDrop<T>`
+// exactly contains a `T` with the same fields and `UnsafeCell`s covering the
+// same byte ranges, or else the `Deref` impl would permit safe code to obtain
+// different shared references to the same region of memory with different
+// `UnsafeCell` coverage, which would in turn permit interior mutation that
+// would violate the invariants of a shared reference.
+//
+// [1] Per https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html:
+//
+//   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
+//   `T`
+//
+// [2] https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html#impl-Deref-for-ManuallyDrop%3CT%3E
+const _: () = unsafe { unsafe_impl!(T: ?Sized + Immutable => Immutable for ManuallyDrop<T>) };
 
 impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for ManuallyDrop<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for ManuallyDrop<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for ManuallyDrop<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for ManuallyDrop<T>[<T>]);
-safety_comment! {
-    /// SAFETY:
-    /// `ManuallyDrop<T>` has the same layout as `T` [1], and thus has the same
-    /// alignment as `T`.
-    ///
-    /// [1] Per https://doc.rust-lang.org/nightly/core/mem/struct.ManuallyDrop.html:
-    ///
-    ///   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
-    ///   validity as `T`
-    unsafe_impl!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>);
-}
+// SAFETY: `ManuallyDrop<T>` has the same layout as `T` [1], and thus has the
+// same alignment as `T`.
+//
+// [1] Per https://doc.rust-lang.org/nightly/core/mem/struct.ManuallyDrop.html:
+//
+//   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
+//   `T`
+const _: () = unsafe { unsafe_impl!(T: ?Sized + Unaligned => Unaligned for ManuallyDrop<T>) };
 assert_unaligned!(ManuallyDrop<()>, ManuallyDrop<u8>);
 
 impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for Cell<T>[UnsafeCell<T>]);
 impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for Cell<T>[UnsafeCell<T>]);
 impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for Cell<T>[UnsafeCell<T>]);
 impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for Cell<T>[UnsafeCell<T>]);
-safety_comment! {
-    /// SAFETY:
-    /// `Cell<T>` has the same in-memory representation as `T` [1], and thus has
-    /// the same alignment as `T`.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.Cell.html#memory-layout:
-    ///
-    ///   `Cell<T>` has the same in-memory representation as its inner type `T`.
-    unsafe_impl!(T: ?Sized + Unaligned => Unaligned for Cell<T>);
-}
+// SAFETY: `Cell<T>` has the same in-memory representation as `T` [1], and thus
+// has the same alignment as `T`.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.Cell.html#memory-layout:
+//
+//   `Cell<T>` has the same in-memory representation as its inner type `T`.
+const _: () = unsafe { unsafe_impl!(T: ?Sized + Unaligned => Unaligned for Cell<T>) };
 
 impl_for_transmute_from!(T: ?Sized + FromZeros => FromZeros for UnsafeCell<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + FromBytes => FromBytes for UnsafeCell<T>[<T>]);
 impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>[<T>]);
-safety_comment! {
-    /// SAFETY:
-    /// `UnsafeCell<T>` has the same in-memory representation as `T` [1], and
-    /// thus has the same alignment as `T`.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.UnsafeCell.html#memory-layout:
-    ///
-    ///   `UnsafeCell<T>` has the same in-memory representation as its inner
-    ///   type `T`.
-    unsafe_impl!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>);
-}
+// SAFETY: `UnsafeCell<T>` has the same in-memory representation as `T` [1], and
+// thus has the same alignment as `T`.
+//
+// [1] Per https://doc.rust-lang.org/1.81.0/core/cell/struct.UnsafeCell.html#memory-layout:
+//
+//   `UnsafeCell<T>` has the same in-memory representation as its inner type
+//   `T`.
+const _: () = unsafe { unsafe_impl!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>) };
 assert_unaligned!(UnsafeCell<()>, UnsafeCell<u8>);
 
 // SAFETY: See safety comment in `is_bit_valid` impl.
@@ -872,30 +835,28 @@ unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
     }
 }
 
-safety_comment! {
-    /// SAFETY:
-    /// Per the reference [1]:
-    ///
-    ///   An array of `[T; N]` has a size of `size_of::<T>() * N` and the same
-    ///   alignment of `T`. Arrays are laid out so that the zero-based `nth`
-    ///   element of the array is offset from the start of the array by `n *
-    ///   size_of::<T>()` bytes.
-    ///
-    ///   ...
-    ///
-    ///   Slices have the same layout as the section of the array they slice.
-    ///
-    /// In other words, the layout of a `[T]` or `[T; N]` is a sequence of `T`s
-    /// laid out back-to-back with no bytes in between. Therefore, `[T]` or `[T;
-    /// N]` are `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`, and
-    /// `IntoBytes` if `T` is (respectively). Furthermore, since an array/slice
-    /// has "the same alignment of `T`", `[T]` and `[T; N]` are `Unaligned` if
-    /// `T` is.
-    ///
-    /// Note that we don't `assert_unaligned!` for slice types because
-    /// `assert_unaligned!` uses `align_of`, which only works for `Sized` types.
-    ///
-    /// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#array-layout
+// SAFETY: Per the reference [1]:
+//
+//   An array of `[T; N]` has a size of `size_of::<T>() * N` and the same
+//   alignment of `T`. Arrays are laid out so that the zero-based `nth` element
+//   of the array is offset from the start of the array by `n * size_of::<T>()`
+//   bytes.
+//
+//   ...
+//
+//   Slices have the same layout as the section of the array they slice.
+//
+// In other words, the layout of a `[T]` or `[T; N]` is a sequence of `T`s laid
+// out back-to-back with no bytes in between. Therefore, `[T]` or `[T; N]` are
+// `Immutable`, `TryFromBytes`, `FromZeros`, `FromBytes`, and `IntoBytes` if `T`
+// is (respectively). Furthermore, since an array/slice has "the same alignment
+// of `T`", `[T]` and `[T; N]` are `Unaligned` if `T` is.
+//
+// Note that we don't `assert_unaligned!` for slice types because
+// `assert_unaligned!` uses `align_of`, which only works for `Sized` types.
+//
+// [1] https://doc.rust-lang.org/1.81.0/reference/type-layout.html#array-layout
+const _: () = unsafe {
     unsafe_impl!(const N: usize, T: Immutable => Immutable for [T; N]);
     unsafe_impl!(const N: usize, T: TryFromBytes => TryFromBytes for [T; N]; |c| {
         // Note that this call may panic, but it would still be sound even if it
@@ -937,55 +898,49 @@ safety_comment! {
     unsafe_impl!(T: FromBytes => FromBytes for [T]);
     unsafe_impl!(T: IntoBytes => IntoBytes for [T]);
     unsafe_impl!(T: Unaligned => Unaligned for [T]);
-}
-safety_comment! {
-    /// SAFETY:
-    /// - `Immutable`: Raw pointers do not contain any `UnsafeCell`s.
-    /// - `FromZeros`: For thin pointers (note that `T: Sized`), the zero
-    ///   pointer is considered "null". [1] No operations which require
-    ///   provenance are legal on null pointers, so this is not a footgun.
-    /// - `TryFromBytes`: By the same reasoning as for `FromZeroes`, we can
-    ///   implement `TryFromBytes` for thin pointers provided that
-    ///   [`TryFromByte::is_bit_valid`] only produces `true` for zeroed bytes.
-    ///
-    /// NOTE(#170): Implementing `FromBytes` and `IntoBytes` for raw pointers
-    /// would be sound, but carries provenance footguns. We want to support
-    /// `FromBytes` and `IntoBytes` for raw pointers eventually, but we are
-    /// holding off until we can figure out how to address those footguns.
-    ///
-    /// [1] TODO(https://github.com/rust-lang/rust/pull/116988): Cite the
-    /// documentation once this PR lands.
+};
+
+// SAFETY:
+// - `Immutable`: Raw pointers do not contain any `UnsafeCell`s.
+// - `FromZeros`: For thin pointers (note that `T: Sized`), the zero pointer is
+//   considered "null". [1] No operations which require provenance are legal on
+//   null pointers, so this is not a footgun.
+// - `TryFromBytes`: By the same reasoning as for `FromZeroes`, we can implement
+//   `TryFromBytes` for thin pointers provided that
+//   [`TryFromByte::is_bit_valid`] only produces `true` for zeroed bytes.
+//
+// NOTE(#170): Implementing `FromBytes` and `IntoBytes` for raw pointers would
+// be sound, but carries provenance footguns. We want to support `FromBytes` and
+// `IntoBytes` for raw pointers eventually, but we are holding off until we can
+// figure out how to address those footguns.
+//
+// [1] TODO(https://github.com/rust-lang/rust/pull/116988): Cite the
+// documentation once this PR lands.
+const _: () = unsafe {
     unsafe_impl!(T: ?Sized => Immutable for *const T);
     unsafe_impl!(T: ?Sized => Immutable for *mut T);
     unsafe_impl!(T => TryFromBytes for *const T; |c| pointer::is_zeroed(c));
     unsafe_impl!(T => FromZeros for *const T);
     unsafe_impl!(T => TryFromBytes for *mut T; |c| pointer::is_zeroed(c));
     unsafe_impl!(T => FromZeros for *mut T);
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// `NonNull<T>` self-evidently does not contain `UnsafeCell`s. This is not
-    /// a proof, but we are accepting this as a known risk per #1358.
-    unsafe_impl!(T: ?Sized => Immutable for NonNull<T>);
-}
+// SAFETY: `NonNull<T>` self-evidently does not contain `UnsafeCell`s. This is
+// not a proof, but we are accepting this as a known risk per #1358.
+const _: () = unsafe { unsafe_impl!(T: ?Sized => Immutable for NonNull<T>) };
 
-safety_comment! {
-    /// SAFETY:
-    /// Reference types do not contain any `UnsafeCell`s.
+// SAFETY: Reference types do not contain any `UnsafeCell`s.
+const _: () = unsafe {
     unsafe_impl!(T: ?Sized => Immutable for &'_ T);
     unsafe_impl!(T: ?Sized => Immutable for &'_ mut T);
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// `Option` is not `#[non_exhaustive]` [1], which means that the types in
-    /// its variants cannot change, and no new variants can be added.
-    /// `Option<T>` does not contain any `UnsafeCell`s outside of `T`. [1]
-    ///
-    /// [1] https://doc.rust-lang.org/core/option/enum.Option.html
-    unsafe_impl!(T: Immutable => Immutable for Option<T>);
-}
+// SAFETY: `Option` is not `#[non_exhaustive]` [1], which means that the types
+// in its variants cannot change, and no new variants can be added. `Option<T>`
+// does not contain any `UnsafeCell`s outside of `T`. [1]
+//
+// [1] https://doc.rust-lang.org/core/option/enum.Option.html
+const _: () = unsafe { unsafe_impl!(T: Immutable => Immutable for Option<T>) };
 
 // SIMD support
 //
@@ -1075,11 +1030,10 @@ mod simd {
 
                 use crate::*;
                 impl_known_layout!($($typ),*);
-                safety_comment! {
-                    /// SAFETY:
-                    /// See comment on module definition for justification.
+                // SAFETY: See comment on module definition for justification.
+                const _: () = unsafe {
                     $( unsafe_impl!($typ: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes); )*
-                }
+                };
             }
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1010,45 +1010,45 @@ impl_known_layout!(
 );
 impl_known_layout!(const N: usize, T => [T; N]);
 
-safety_comment! {
-    /// SAFETY:
-    /// `str` has the same representation as `[u8]`. `ManuallyDrop<T>` [1],
-    /// `UnsafeCell<T>` [2], and `Cell<T>` [3] have the same representation as
-    /// `T`.
-    ///
-    /// [1] Per https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html:
-    ///
-    ///   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
-    ///   validity as `T`
-    ///
-    /// [2] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.UnsafeCell.html#memory-layout:
-    ///
-    ///   `UnsafeCell<T>` has the same in-memory representation as its inner
-    ///   type `T`.
-    ///
-    /// [3] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.Cell.html#memory-layout:
-    ///
-    ///   `Cell<T>` has the same in-memory representation as `T`.
-    unsafe_impl_known_layout!(#[repr([u8])] str);
+// SAFETY: `str` has the same representation as `[u8]`. `ManuallyDrop<T>` [1],
+// `UnsafeCell<T>` [2], and `Cell<T>` [3] have the same representation as `T`.
+//
+// [1] Per https://doc.rust-lang.org/1.85.0/std/mem/struct.ManuallyDrop.html:
+//
+//   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
+//   `T`
+//
+// [2] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.UnsafeCell.html#memory-layout:
+//
+//   `UnsafeCell<T>` has the same in-memory representation as its inner type
+//   `T`.
+//
+// [3] Per https://doc.rust-lang.org/1.85.0/core/cell/struct.Cell.html#memory-layout:
+//
+//   `Cell<T>` has the same in-memory representation as `T`.
+const _: () = unsafe {
+    unsafe_impl_known_layout!(
+        #[repr([u8])]
+        str
+    );
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] ManuallyDrop<T>);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] UnsafeCell<T>);
     unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T)] Cell<T>);
-}
+};
 
-safety_comment! {
-    /// SAFETY:
-    /// - By consequence of the invariant on `T::MaybeUninit` that `T::LAYOUT`
-    ///   and `T::MaybeUninit::LAYOUT` are equal, `T` and `T::MaybeUninit`
-    ///   have the same:
-    ///   - Fixed prefix size
-    ///   - Alignment
-    ///   - (For DSTs) trailing slice element size
-    /// - By consequence of the above, referents `T::MaybeUninit` and `T` have
-    ///   the require the same kind of pointer metadata, and thus it is valid to
-    ///   perform an `as` cast from `*mut T` and `*mut T::MaybeUninit`, and this
-    ///   operation preserves referent size (ie, `size_of_val_raw`).
-    unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T::MaybeUninit)] MaybeUninit<T>);
-}
+// SAFETY:
+// - By consequence of the invariant on `T::MaybeUninit` that `T::LAYOUT` and
+//   `T::MaybeUninit::LAYOUT` are equal, `T` and `T::MaybeUninit` have the same:
+//   - Fixed prefix size
+//   - Alignment
+//   - (For DSTs) trailing slice element size
+// - By consequence of the above, referents `T::MaybeUninit` and `T` have the
+//   require the same kind of pointer metadata, and thus it is valid to perform
+//   an `as` cast from `*mut T` and `*mut T::MaybeUninit`, and this operation
+//   preserves referent size (ie, `size_of_val_raw`).
+const _: () = unsafe {
+    unsafe_impl_known_layout!(T: ?Sized + KnownLayout => #[repr(T::MaybeUninit)] MaybeUninit<T>)
+};
 
 /// Analyzes whether a type is [`FromZeros`].
 ///

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,7 +7,7 @@
 // those terms.
 
 #[macro_use]
-mod macros;
+pub(crate) mod macros;
 
 #[doc(hidden)]
 pub mod macro_util;

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -119,16 +119,17 @@ pub struct Unalign<T>(T);
 // `KnownLayout` impl bounded on `T: KnownLayout.` This is overly restrictive.
 impl_known_layout!(T => Unalign<T>);
 
-safety_comment! {
-    /// SAFETY:
-    /// - `Unalign<T>` promises to have alignment 1, and so we don't require
-    ///   that `T: Unaligned`.
-    /// - `Unalign<T>` has the same bit validity as `T`, and so it is
-    ///   `FromZeros`, `FromBytes`, or `IntoBytes` exactly when `T` is as well.
-    /// - `Immutable`: `Unalign<T>` has the same fields as `T`, so it contains
-    ///   `UnsafeCell`s exactly when `T` does.
-    /// - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as
-    ///   `T`, so `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
+// SAFETY:
+// - `Unalign<T>` promises to have alignment 1, and so we don't require that `T:
+//   Unaligned`.
+// - `Unalign<T>` has the same bit validity as `T`, and so it is `FromZeros`,
+//   `FromBytes`, or `IntoBytes` exactly when `T` is as well.
+// - `Immutable`: `Unalign<T>` has the same fields as `T`, so it contains
+//   `UnsafeCell`s exactly when `T` does.
+// - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as `T`, so
+//   `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
+#[allow(unused_unsafe)] // Unused when `feature = "derive"`.
+const _: () = unsafe {
     impl_or_verify!(T => Unaligned for Unalign<T>);
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
@@ -138,7 +139,7 @@ safety_comment! {
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
     impl_or_verify!(T: IntoBytes => IntoBytes for Unalign<T>);
-}
+};
 
 // Note that `Unalign: Clone` only if `T: Copy`. Since the inner `T` may not be
 // aligned, there's no way to safely call `T::clone`, and so a `T: Clone` bound

--- a/tests/ui-msrv/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-msrv/invalid-impls/invalid-impls.stderr
@@ -4,10 +4,10 @@ error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
    |                                                                    ^^^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:5
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | ---------------------------------------------- in this macro invocation
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |     ---------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::TryFromBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
@@ -20,15 +20,15 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `_::Subtrait`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:26:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:5
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | ---------------------------------------------- in this macro invocation
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |     ---------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
-   |                  ++++++++++++++++++++++++
+27 |     impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
+   |                      ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/util/macros.rs
@@ -36,10 +36,10 @@ error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
    |                                                                    ^^^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:5
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::FromZeros` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
@@ -52,15 +52,15 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `_::Subtrait`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:27:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:5
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
-   |                  +++++++++++++++++++++
+28 |     impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/util/macros.rs
@@ -68,10 +68,10 @@ error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
    |                                                                    ^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:5
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::FromBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:10
@@ -84,15 +84,15 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `_::Subtrait`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:28:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:5
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+29 |     impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/util/macros.rs
@@ -100,10 +100,10 @@ error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
    |                                                                    ^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:5
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::IntoBytes` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:21
@@ -116,15 +116,15 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `_::Subtrait`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:29:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:5
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-29 | impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+30 |     impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
   --> tests/ui-msrv/invalid-impls/../../../src/util/macros.rs
@@ -132,10 +132,10 @@ error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
    |             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
    |                                                                    ^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:31:5
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    |
 note: required because of the requirements on the impl of `zerocopy::Unaligned` for `Foo<T>`
   --> tests/ui-msrv/invalid-impls/invalid-impls.rs:22:32
@@ -148,12 +148,12 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `_::Subtrait`
    |
-  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:30:1
+  ::: tests/ui-msrv/invalid-impls/invalid-impls.rs:31:5
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------- in this macro invocation
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |     ------------------------------------------- in this macro invocation
    = note: this error originates in the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-30 | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
-   |                  +++++++++++++++++++++
+31 |     impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+   |                      +++++++++++++++++++++

--- a/tests/ui-nightly/invalid-impls/invalid-impls.rs
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.rs
@@ -23,8 +23,10 @@ fn main() {}
 #[repr(transparent)]
 struct Foo<T>(T);
 
-impl_or_verify!(T => TryFromBytes for Foo<T>);
-impl_or_verify!(T => FromZeros for Foo<T>);
-impl_or_verify!(T => FromBytes for Foo<T>);
-impl_or_verify!(T => IntoBytes for Foo<T>);
-impl_or_verify!(T => Unaligned for Foo<T>);
+const _: () = unsafe {
+    impl_or_verify!(T => TryFromBytes for Foo<T>);
+    impl_or_verify!(T => FromZeros for Foo<T>);
+    impl_or_verify!(T => FromBytes for Foo<T>);
+    impl_or_verify!(T => IntoBytes for Foo<T>);
+    impl_or_verify!(T => Unaligned for Foo<T>);
+};

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:26:39
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:43
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   |                                       ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |                                           ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(TryFromBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
@@ -16,21 +16,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:26:1
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:27:5
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | --------------------------------------------- in this macro invocation
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |     --------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `TryFromBytes`
    |
-26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
-   |                  ++++++++++++++++++++++++
+27 |     impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
+   |                      ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:36
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:28:40
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
    |
    = note: Consider adding `#[derive(FromZeros)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::FromZeros`
@@ -44,21 +44,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:27:1
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:28:5
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `FromZeros`
    |
-27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
-   |                  +++++++++++++++++++++
+28 |     impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:28:36
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:29:40
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
@@ -72,21 +72,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:28:1
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:29:5
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `FromBytes`
    |
-28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+29 |     impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:29:36
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:30:40
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(IntoBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::IntoBytes`
@@ -100,21 +100,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:29:1
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:30:5
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `IntoBytes`
    |
-29 | impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+30 |     impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
-  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:30:36
+  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:31:40
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
@@ -128,12 +128,12 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:30:1
+  ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:31:5
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Unaligned`
    |
-30 | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
-   |                  +++++++++++++++++++++
+31 |     impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+   |                      +++++++++++++++++++++

--- a/tests/ui-stable/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-stable/invalid-impls/invalid-impls.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:26:39
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:27:43
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   |                                       ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |                                           ^^^^^^ the trait `zerocopy::TryFromBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(TryFromBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::TryFromBytes`
@@ -16,21 +16,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:26:1
+  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:27:5
    |
-26 | impl_or_verify!(T => TryFromBytes for Foo<T>);
-   | --------------------------------------------- in this macro invocation
+27 |     impl_or_verify!(T => TryFromBytes for Foo<T>);
+   |     --------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `TryFromBytes`
    |
-26 | impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
-   |                  ++++++++++++++++++++++++
+27 |     impl_or_verify!(T: zerocopy::TryFromBytes => TryFromBytes for Foo<T>);
+   |                      ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromZeros` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:27:36
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:28:40
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::FromZeros` is not implemented for `T`
    |
    = note: Consider adding `#[derive(FromZeros)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::FromZeros`
@@ -44,21 +44,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:27:1
+  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:28:5
    |
-27 | impl_or_verify!(T => FromZeros for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+28 |     impl_or_verify!(T => FromZeros for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `FromZeros`
    |
-27 | impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
-   |                  +++++++++++++++++++++
+28 |     impl_or_verify!(T: zerocopy::FromZeros => FromZeros for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::FromBytes` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:28:36
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:29:40
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::FromBytes`
@@ -72,21 +72,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:28:1
+  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:29:5
    |
-28 | impl_or_verify!(T => FromBytes for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+29 |     impl_or_verify!(T => FromBytes for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `FromBytes`
    |
-28 | impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+29 |     impl_or_verify!(T: zerocopy::FromBytes => FromBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:29:36
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:30:40
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `T`
    |
    = note: Consider adding `#[derive(IntoBytes)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::IntoBytes`
@@ -100,21 +100,21 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:29:1
+  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:30:5
    |
-29 | impl_or_verify!(T => IntoBytes for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+30 |     impl_or_verify!(T => IntoBytes for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `IntoBytes`
    |
-29 | impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
-   |                  +++++++++++++++++++++
+30 |     impl_or_verify!(T: zerocopy::IntoBytes => IntoBytes for Foo<T>);
+   |                      +++++++++++++++++++++
 
 error[E0277]: the trait bound `T: zerocopy::Unaligned` is not satisfied
-  --> tests/ui-stable/invalid-impls/invalid-impls.rs:30:36
+  --> tests/ui-stable/invalid-impls/invalid-impls.rs:31:40
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   |                                    ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |                                        ^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `T`
    |
    = note: Consider adding `#[derive(Unaligned)]` to `T`
 note: required for `Foo<T>` to implement `zerocopy::Unaligned`
@@ -128,12 +128,12 @@ note: required by a bound in `_::Subtrait`
    |             trait Subtrait: $trait {}
    |                             ^^^^^^ required by this bound in `Subtrait`
    |
-  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:30:1
+  ::: tests/ui-stable/invalid-impls/invalid-impls.rs:31:5
    |
-30 | impl_or_verify!(T => Unaligned for Foo<T>);
-   | ------------------------------------------ in this macro invocation
+31 |     impl_or_verify!(T => Unaligned for Foo<T>);
+   |     ------------------------------------------ in this macro invocation
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `impl_or_verify` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Unaligned`
    |
-30 | impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
-   |                  +++++++++++++++++++++
+31 |     impl_or_verify!(T: zerocopy::Unaligned => Unaligned for Foo<T>);
+   |                      +++++++++++++++++++++


### PR DESCRIPTION
Replace:

  safety_comment! {
      /// SAFETY:
      /// ...
      foo!();
      bar!();
  }

With:

  // SAFETY: ...
  const _: () = unsafe {
      foo!();
      bar!();
  };

Remove the `safety_comment!` macro.




---

This PR is on branch [remove-safety-comment-macro](../tree/remove-safety-comment-macro).

- #2483