### PR TITLE
Ban TODO comments, require FIXME comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,6 +774,14 @@ jobs:
       - name: Run dependency check
         run: ./ci/check_job_dependencies.sh
 
+  check-todo:
+    runs-on: ubuntu-latest
+    name: Check for todo comments
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Run todo check
+        run: ./ci/check_todo.sh
+
   run-git-hooks:
     runs-on: ubuntu-latest
     name: Run Git hooks
@@ -800,7 +808,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_readme, check_versions, generate_cache, check-all-toolchains-tested, check-job-dependencies, run-git-hooks]
+      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_readme, check_versions, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ zerocopy-derive = { version = "=0.8.25-alpha.3", path = "zerocopy-derive" }
 [dev-dependencies]
 # More recent versions of `either` have an MSRV higher than ours.
 either = "=1.13.0"
-# TODO(#381) Remove this dependency once we have our own layout gadgets.
+# FIXME(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"
 itertools = "0.11"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }

--- a/build.rs
+++ b/build.rs
@@ -76,7 +76,7 @@ fn main() {
         for version_cfg in &version_cfgs {
             println!("cargo:rustc-check-cfg=cfg({})", version_cfg.cfg_name);
         }
-        // TODO(https://github.com/rust-lang/rust/issues/124816): Remove these
+        // FIXME(https://github.com/rust-lang/rust/issues/124816): Remove these
         // once they're no longer needed.
         println!("cargo:rustc-check-cfg=cfg(doc_cfg)");
         println!("cargo:rustc-check-cfg=cfg(kani)");

--- a/ci/check_todo.sh
+++ b/ci/check_todo.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -euo pipefail
+
+# This allows us to leave XODO comments in this file and have them still be
+# picked up by this script without having the script itself trigger false
+# positives. The alternative would be to exclude this script entirely, which
+# would mean that we couldn't use XODO comments in this script.
+KEYWORD=$(echo XODO | sed -e 's/X/T/')
+
+# -H: Print filename (default for multiple files/recursive)
+# -n: Print line number
+# -w: Match whole words
+output=$(rg -H -n -w "$KEYWORD" || true)
+
+if [ -n "$output" ]; then
+  echo "Found $KEYWORD markers in the codebase." >&2
+  echo "$KEYWORD is used for tasks that should be done before merging a PR; if you want to leave a message in the codebase, use FIXME." >&2
+  echo "" >&2
+  echo "$output" >&2
+  exit 1
+fi

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -18,6 +18,7 @@ echo "Running pre-push git hook: $0"
 ./ci/check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_PID=$!
 ./ci/check_job_dependencies.sh      >/dev/null & JOB_DEPS_PID=$!
 ./ci/check_readme.sh                >/dev/null & README_PID=$!
+./ci/check_todo.sh                  >/dev/null & XODO_PID=$!
 ./ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
 
 # `wait <pid>` exits with the same status code as the job it's waiting for.
@@ -30,6 +31,7 @@ wait $FMT_PID
 wait $TOOLCHAINS_PID
 wait $JOB_DEPS_PID
 wait $README_PID
+wait $XODO_PID
 wait $VERSIONS_PID
 
 # Ensure that this script calls all scripts in `ci/*`. This isn't a foolproof

--- a/src/byte_slice.rs
+++ b/src/byte_slice.rs
@@ -194,15 +194,15 @@ pub unsafe trait IntoByteSliceMut<'a>: IntoByteSlice<'a> + ByteSliceMut {
     fn into_byte_slice_mut(self) -> &'a mut [u8];
 }
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl ByteSlice for &[u8] {}
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl CopyableByteSlice for &[u8] {}
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl CloneableByteSlice for &[u8] {}
 
@@ -229,7 +229,7 @@ unsafe impl<'a> IntoByteSlice<'a> for &'a [u8] {
     }
 }
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl ByteSlice for &mut [u8] {}
 
@@ -254,7 +254,7 @@ unsafe impl SplitByteSlice for &mut [u8] {
         // SAFETY: By contract on caller, `mid` is not greater than
         // `self.len()`.
         //
-        // TODO(#67): Remove this allow. See NumExt for more details.
+        // FIXME(#67): Remove this allow. See NumExt for more details.
         #[allow(unstable_name_collisions)]
         let r_len = unsafe { self.len().unchecked_sub(mid) };
 
@@ -314,7 +314,7 @@ unsafe impl<'a> IntoByteSliceMut<'a> for &'a mut [u8] {
     }
 }
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl ByteSlice for cell::Ref<'_, [u8]> {}
 
@@ -334,7 +334,7 @@ unsafe impl SplitByteSlice for cell::Ref<'_, [u8]> {
     }
 }
 
-// TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+// FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
 #[allow(clippy::undocumented_unsafe_blocks)]
 unsafe impl ByteSlice for cell::RefMut<'_, [u8]> {}
 

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -868,7 +868,7 @@ define_type!(
     []
 );
 
-// TODO(https://github.com/rust-lang/rust/issues/72447): Use the endianness
+// FIXME(https://github.com/rust-lang/rust/issues/72447): Use the endianness
 // conversion methods directly once those are const-stable.
 macro_rules! define_float_conversion {
     ($ty:ty, $bits:ident, $bytes:expr, $mod:ident) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -797,9 +797,9 @@ impl<Src, Dst: ?Sized + Unaligned> From<CastError<Src, Dst>> for SizeError<Src, 
 pub type TryCastError<Src, Dst: ?Sized + TryFromBytes> =
     ConvertError<AlignmentError<Src, Dst>, SizeError<Src, Dst>, ValidityError<Src, Dst>>;
 
-// TODO(#1139): Remove the `TryFromBytes` here and in other downstream locations
-// (all the way to `ValidityError`) if we determine it's not necessary for rich
-// validity errors.
+// FIXME(#1139): Remove the `TryFromBytes` here and in other downstream
+// locations (all the way to `ValidityError`) if we determine it's not necessary
+// for rich validity errors.
 impl<Src, Dst: ?Sized + TryFromBytes> TryCastError<Src, Dst> {
     /// Produces the source underlying the failed conversion.
     #[inline]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -57,7 +57,7 @@ const _: () = unsafe {
 //
 //     The size of a value is always a multiple of its alignment.
 //
-// TODO(#278): Once we've updated the trait docs to refer to `u8`s rather than
+// FIXME(#278): Once we've updated the trait docs to refer to `u8`s rather than
 // bits or bytes, update this comment, especially the reference to [1].
 const _: () = unsafe {
     unsafe_impl!(u8: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
@@ -150,7 +150,7 @@ impl_size_eq!(char, Unalign<u32>);
 // Note that we don't `assert_unaligned!(str)` because `assert_unaligned!` uses
 // `align_of`, which only works for `Sized` types.
 //
-// TODO(#429):
+// FIXME(#429):
 // - Add quotes from documentation.
 // - Improve safety proof for `FromZeros` and `IntoBytes`; having the same
 //   layout as `[u8]` isn't sufficient.
@@ -231,7 +231,7 @@ macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
 //   multiple states, so they cannot be 0 bytes, which means that they must be 1
 //   byte. The only valid alignment for a 1-byte type is 1.
 //
-// TODO(#429):
+// FIXME(#429):
 // - Add quotes from documentation.
 // - Add safety comment for `Immutable`. How can we prove that `NonZeroXxx`
 //   doesn't contain any `UnsafeCell`s? It's obviously true, but it's not clear
@@ -245,8 +245,8 @@ macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
 //
 // [2] https://doc.rust-lang.org/1.81.0/std/num/type.NonZeroI8.html
 //
-// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
-// that layout is the same as primitive layout.
+// FIXME(https://github.com/rust-lang/rust/pull/104082): Cite documentation that
+// layout is the same as primitive layout.
 const _: () = unsafe {
     unsafe_impl!(NonZeroU8: Immutable, IntoBytes, Unaligned);
     unsafe_impl!(NonZeroI8: Immutable, IntoBytes, Unaligned);
@@ -288,13 +288,13 @@ const _: () = unsafe {
 //   purpose of those types, it's virtually unthinkable that that would ever
 //   change. The only valid alignment for a 1-byte type is 1.
 //
-// TODO(#429): Add quotes from documentation.
+// FIXME(#429): Add quotes from documentation.
 //
 // [1] https://doc.rust-lang.org/stable/std/num/struct.NonZeroU8.html
 // [2] https://doc.rust-lang.org/stable/std/num/struct.NonZeroI8.html
 //
-// TODO(https://github.com/rust-lang/rust/pull/104082): Cite documentation
-// for layout guarantees.
+// FIXME(https://github.com/rust-lang/rust/pull/104082): Cite documentation for
+// layout guarantees.
 const _: () = unsafe {
     unsafe_impl!(Option<NonZeroU8>: TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
     unsafe_impl!(Option<NonZeroI8>: TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
@@ -342,7 +342,7 @@ const _: () = unsafe {
 //   | [`ptr::NonNull<U>`]   | when `U: Sized`                                           |
 //   | `fn`, `extern "C" fn` | always                                                    |
 //
-// TODO(#429), TODO(https://github.com/rust-lang/rust/pull/115333): Cite the
+// FIXME(#429), FIXME(https://github.com/rust-lang/rust/pull/115333): Cite the
 // Stable docs once they're available.
 const _: () = unsafe {
     #[cfg(feature = "alloc")]
@@ -638,7 +638,7 @@ mod atomics {
 
         impl_known_layout!(T => AtomicPtr<T>);
 
-        // TODO(#170): Implement `FromBytes` and `IntoBytes` once we implement
+        // FIXME(#170): Implement `FromBytes` and `IntoBytes` once we implement
         // those traits for `*mut T`.
         impl_for_transmute_from!(T => TryFromBytes for AtomicPtr<T> [UnsafeCell<*mut T>]);
         impl_for_transmute_from!(T => FromZeros for AtomicPtr<T> [UnsafeCell<*mut T>]);
@@ -914,7 +914,7 @@ const _: () = unsafe {
 // `IntoBytes` for raw pointers eventually, but we are holding off until we can
 // figure out how to address those footguns.
 //
-// [1] TODO(https://github.com/rust-lang/rust/pull/116988): Cite the
+// [1] FIXME(https://github.com/rust-lang/rust/pull/116988): Cite the
 // documentation once this PR lands.
 const _: () = unsafe {
     unsafe_impl!(T: ?Sized => Immutable for *const T);
@@ -1474,7 +1474,7 @@ mod tests {
                 }
 
                 <$ty as TryFromBytesTestable>::with_passing_test_cases(|mut val| {
-                    // TODO(#494): These tests only get exercised for types
+                    // FIXME(#494): These tests only get exercised for types
                     // which are `IntoBytes`. Once we implement #494, we should
                     // be able to support non-`IntoBytes` types by zeroing
                     // padding.
@@ -1492,7 +1492,7 @@ mod tests {
 
                     let c = Ptr::from_ref(&*val);
                     let c = c.forget_aligned();
-                    // SAFETY: TODO(#899): This is unsound. `$ty` is not
+                    // SAFETY: FIXME(#899): This is unsound. `$ty` is not
                     // necessarily `IntoBytes`, but that's the corner we've
                     // backed ourselves into by using `Ptr::from_ref`.
                     let c = unsafe { c.assume_initialized() };
@@ -1503,7 +1503,7 @@ mod tests {
 
                     let c = Ptr::from_mut(&mut *val);
                     let c = c.forget_aligned();
-                    // SAFETY: TODO(#899): This is unsound. `$ty` is not
+                    // SAFETY: FIXME(#899): This is unsound. `$ty` is not
                     // necessarily `IntoBytes`, but that's the corner we've
                     // backed ourselves into by using `Ptr::from_ref`.
                     let c = unsafe { c.assume_initialized() };

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -484,7 +484,7 @@ impl DstLayout {
         // would have failed anyway for runtime reasons (such as a too-small
         // memory region).
         //
-        // TODO(#67): Once our MSRV is 1.65, use let-else:
+        // FIXME(#67): Once our MSRV is 1.65, use let-else:
         // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
         let size_info = match self.size_info.try_to_nonzero_elem_size() {
             Some(size_info) => size_info,
@@ -544,7 +544,7 @@ impl DstLayout {
                 // Calculate the maximum number of bytes that could be consumed
                 // by the trailing slice.
                 //
-                // TODO(#67): Once our MSRV is 1.65, use let-else:
+                // FIXME(#67): Once our MSRV is 1.65, use let-else:
                 // https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#let-else-statements
                 let max_slice_and_padding_bytes = match max_total_bytes.checked_sub(offset) {
                     Some(max) => max,
@@ -608,7 +608,7 @@ impl DstLayout {
     }
 }
 
-// TODO(#67): For some reason, on our MSRV toolchain, this `allow` isn't
+// FIXME(#67): For some reason, on our MSRV toolchain, this `allow` isn't
 // enforced despite having `#![allow(unknown_lints)]` at the crate root, but
 // putting it here works. Once our MSRV is high enough that this bug has been
 // fixed, remove this `allow`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ mod macros;
 pub mod pointer;
 mod r#ref;
 mod split_at;
-// TODO(#252): If we make this pub, come up with a better name.
+// FIXME(#252): If we make this pub, come up with a better name.
 mod wrappers;
 
 pub use crate::byte_slice::*;
@@ -948,7 +948,7 @@ unsafe impl<T> KnownLayout for [T] {
     // refers to an object with `elems` elements by construction.
     #[inline(always)]
     fn raw_from_ptr_len(data: NonNull<u8>, elems: usize) -> NonNull<Self> {
-        // TODO(#67): Remove this allow. See NonNullExt for more details.
+        // FIXME(#67): Remove this allow. See NonNullExt for more details.
         #[allow(unstable_name_collisions)]
         NonNull::slice_from_raw_parts(data.cast::<T>(), elems)
     }
@@ -1138,7 +1138,7 @@ const _: () = unsafe {
 ///
 /// Whether a struct is soundly `FromZeros` therefore solely depends on whether
 /// its fields are `FromZeros`.
-// TODO(#146): Document why we don't require an enum to have an explicit `repr`
+// FIXME(#146): Document why we don't require an enum to have an explicit `repr`
 // attribute.
 #[cfg(any(feature = "derive", test))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
@@ -3045,7 +3045,7 @@ pub unsafe trait FromZeros: TryFromBytes {
         // - Since `Self: FromZeros`, the all-zeros instance is a valid instance
         //   of `Self.`
         //
-        // TODO(#429): Add references to docs and quotes.
+        // FIXME(#429): Add references to docs and quotes.
         unsafe { ptr::write_bytes(slf.cast::<u8>(), 0, len) };
     }
 
@@ -3132,13 +3132,13 @@ pub unsafe trait FromZeros: TryFromBytes {
             return Ok(unsafe { Box::from_raw(NonNull::dangling().as_ptr()) });
         }
 
-        // TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+        // FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
         #[allow(clippy::undocumented_unsafe_blocks)]
         let ptr = unsafe { alloc::alloc::alloc_zeroed(layout).cast::<Self>() };
         if ptr.is_null() {
             return Err(AllocError);
         }
-        // TODO(#429): Add a "SAFETY" comment and remove this `allow`.
+        // FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
         #[allow(clippy::undocumented_unsafe_blocks)]
         Ok(unsafe { Box::from_raw(ptr) })
     }
@@ -3386,7 +3386,7 @@ pub unsafe trait FromZeros: TryFromBytes {
 ///
 /// Whether a struct is soundly `FromBytes` therefore solely depends on whether
 /// its fields are `FromBytes`.
-// TODO(#146): Document why we don't require an enum to have an explicit `repr`
+// FIXME(#146): Document why we don't require an enum to have an explicit `repr`
 // attribute.
 #[cfg(any(feature = "derive", test))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
@@ -5032,7 +5032,7 @@ pub unsafe trait IntoBytes {
         //   `isize::MAX` because no allocation produced by safe code can be
         //   larger than `isize::MAX`.
         //
-        // TODO(#429): Add references to docs and quotes.
+        // FIXME(#429): Add references to docs and quotes.
         unsafe { slice::from_raw_parts(slf.cast::<u8>(), len) }
     }
 
@@ -5104,7 +5104,7 @@ pub unsafe trait IntoBytes {
         //   `isize::MAX` because no allocation produced by safe code can be
         //   larger than `isize::MAX`.
         //
-        // TODO(#429): Add references to docs and quotes.
+        // FIXME(#429): Add references to docs and quotes.
         unsafe { slice::from_raw_parts_mut(slf.cast::<u8>(), len) }
     }
 

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -371,11 +371,11 @@ impl<'a, T> PtrInner<'a, [T]> {
 
     /// Iteratively projects the elements `PtrInner<T>` from `PtrInner<[T]>`.
     pub(crate) fn iter(&self) -> impl Iterator<Item = PtrInner<'a, T>> {
-        // TODO(#429): Once `NonNull::cast` documents that it preserves
+        // FIXME(#429): Once `NonNull::cast` documents that it preserves
         // provenance, cite those docs.
         let base = self.as_non_null().cast::<T>().as_ptr();
         (0..self.meta().get()).map(move |i| {
-            // TODO(https://github.com/rust-lang/rust/issues/74265): Use
+            // FIXME(https://github.com/rust-lang/rust/issues/74265): Use
             // `NonNull::get_unchecked_mut`.
 
             // SAFETY: If the following conditions are not satisfied
@@ -407,7 +407,7 @@ impl<'a, T> PtrInner<'a, [T]> {
             //     contained in `self`, the computed offset of `elem` must wrap
             //     around the address space.
             //
-            // TODO(#429): Once `pointer::add` documents that it preserves
+            // FIXME(#429): Once `pointer::add` documents that it preserves
             // provenance, cite those docs.
             let elem = unsafe { base.add(i) };
 
@@ -415,7 +415,7 @@ impl<'a, T> PtrInner<'a, [T]> {
             // `NonNull` pointer, and the addition that produces `elem` must not
             // overflow or wrap around, so `elem >= base > 0`.
             //
-            // TODO(#429): Once `NonNull::new_unchecked` documents that it
+            // FIXME(#429): Once `NonNull::new_unchecked` documents that it
             // preserves provenance, cite those docs.
             let elem = unsafe { NonNull::new_unchecked(elem) };
 

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -713,7 +713,7 @@ mod _transitions {
 
         /// Recalls that `self`'s referent is validly-aligned for `T`.
         #[inline]
-        // TODO(#859): Reconsider the name of this method before making it
+        // FIXME(#859): Reconsider the name of this method before making it
         // public.
         pub(crate) fn bikeshed_recall_aligned(
             self,
@@ -780,7 +780,7 @@ mod _transitions {
         #[doc(hidden)]
         #[must_use]
         #[inline]
-        // TODO(#859): Reconsider the name of this method before making it
+        // FIXME(#859): Reconsider the name of this method before making it
         // public.
         pub fn bikeshed_recall_initialized_from_bytes(
             self,
@@ -802,7 +802,7 @@ mod _transitions {
         #[doc(hidden)]
         #[must_use]
         #[inline]
-        // TODO(#859): Reconsider the name of this method before making it
+        // FIXME(#859): Reconsider the name of this method before making it
         // public.
         pub fn bikeshed_recall_initialized_immutable(
             self,
@@ -1163,7 +1163,7 @@ mod _casts {
             I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
         {
-            // TODO(#67): Remove this allow. See NonNulSlicelExt for more
+            // FIXME(#67): Remove this allow. See NonNulSlicelExt for more
             // details.
             #[allow(unstable_name_collisions)]
             match self.try_cast_into(CastType::Prefix, meta) {
@@ -1267,7 +1267,7 @@ mod _project {
             // 1. `elem`, conditionally, conforms to the validity invariant of
             //    `I::Alignment`. If `elem` is projected from data well-aligned
             //    for `[T]`, `elem` will be valid for `T`.
-            // 2. TODO: Need to cite facts about `[T]`'s layout (same for the
+            // 2. FIXME: Need to cite facts about `[T]`'s layout (same for the
             //    preceding points)
             self.as_inner().iter().map(|elem| unsafe { Ptr::from_inner(elem) })
         }

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -318,7 +318,7 @@ where
 {
 }
 
-// TODO(#2354): This seems like a smell - the soundness of this bound has
+// FIXME(#2354): This seems like a smell - the soundness of this bound has
 // nothing to do with `Src` or `Dst` - we're basically just saying `[u8; N]` is
 // transmutable into `[u8; N]`.
 
@@ -331,7 +331,7 @@ where
 {
 }
 
-// TODO(#2354): This seems like a smell - the soundness of this bound has
+// FIXME(#2354): This seems like a smell - the soundness of this bound has
 // nothing to do with `Dst` - we're basically just saying that any type is
 // transmutable into `MaybeUninit<[u8; N]>`.
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -778,7 +778,7 @@ where
 impl<B, T> DerefMut for Ref<B, T>
 where
     B: ByteSliceMut,
-    // TODO(#251): We can't remove `Immutable` here because it's required by
+    // FIXME(#251): We can't remove `Immutable` here because it's required by
     // the impl of `Deref`, which is a super-trait of `DerefMut`. Maybe we can
     // add a separate inherent method for this?
     T: FromBytes + IntoBytes + KnownLayout + Immutable + ?Sized,

--- a/src/split_at.rs
+++ b/src/split_at.rs
@@ -759,7 +759,7 @@ where
     #[inline(always)]
     fn via_runtime_check(self) -> Result<(Ptr<'a, T, I>, Ptr<'a, [T::Elem], I>), Self> {
         let l_len = self.l_len();
-        // TODO(#1290): Once we require `KnownLayout` on all fields, add an
+        // FIXME(#1290): Once we require `KnownLayout` on all fields, add an
         // `IS_IMMUTABLE` associated const, and add `T::IS_IMMUTABLE ||` to the
         // below check.
         if l_len.padding_needed_for() == 0 {

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -22,8 +22,8 @@ use core::{
     ptr::NonNull,
 };
 
-// TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this
-// `cfg` when `size_of_val_raw` is stabilized.
+// FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
+// this `cfg` when `size_of_val_raw` is stabilized.
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 #[cfg(not(target_pointer_width = "16"))]
 use core::ptr;
@@ -109,8 +109,8 @@ impl<T, U> MaxAlignsOf<T, U> {
 #[cfg(not(target_pointer_width = "16"))]
 const _64K: usize = 1 << 16;
 
-// TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this
-// `cfg` when `size_of_val_raw` is stabilized.
+// FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
+// this `cfg` when `size_of_val_raw` is stabilized.
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 #[cfg(not(target_pointer_width = "16"))]
 #[repr(C, align(65536))]
@@ -122,8 +122,8 @@ struct Aligned64kAllocation([u8; _64K]);
 ///
 /// `ALIGNED_64K_ALLOCATION` is guaranteed to point to the entirety of an
 /// allocation with size and alignment 2^16, and to have valid provenance.
-// TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this
-// `cfg` when `size_of_val_raw` is stabilized.
+// FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
+// this `cfg` when `size_of_val_raw` is stabilized.
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 #[cfg(not(target_pointer_width = "16"))]
 pub const ALIGNED_64K_ALLOCATION: NonNull<[u8]> = {
@@ -139,9 +139,9 @@ pub const ALIGNED_64K_ALLOCATION: NonNull<[u8]> = {
     // - `ptr` is derived from a Rust reference, which is guaranteed to have
     //   valid provenance.
     //
-    // TODO(#429): Once `NonNull::new_unchecked` docs document that it preserves
-    // provenance, cite those docs.
-    // TODO: Replace this `as` with `ptr.cast_mut()` once our MSRV >= 1.65
+    // FIXME(#429): Once `NonNull::new_unchecked` docs document that it
+    // preserves provenance, cite those docs.
+    // FIXME: Replace this `as` with `ptr.cast_mut()` once our MSRV >= 1.65
     #[allow(clippy::as_conversions)]
     unsafe {
         NonNull::new_unchecked(ptr as *mut _)
@@ -152,8 +152,8 @@ pub const ALIGNED_64K_ALLOCATION: NonNull<[u8]> = {
 /// the type `$ty`.
 ///
 /// `trailing_field_offset!` produces code which is valid in a `const` context.
-// TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this
-// `cfg` when `size_of_val_raw` is stabilized.
+// FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
+// this `cfg` when `size_of_val_raw` is stabilized.
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 #[doc(hidden)] // `#[macro_export]` bypasses this module's `#[doc(hidden)]`.
 #[macro_export]
@@ -232,7 +232,7 @@ macro_rules! trailing_field_offset {
         //   address space. This is guaranteed because the same is guaranteed of
         //   allocated objects. [1]
         //
-        // [1] TODO(#429), TODO(https://github.com/rust-lang/rust/pull/116675):
+        // [1] FIXME(#429), FIXME(https://github.com/rust-lang/rust/pull/116675):
         //     Once these are guaranteed in the Reference, cite it.
         let offset = unsafe { field.cast::<u8>().offset_from(ptr.cast::<u8>()) };
         // Guaranteed not to be lossy: `field` comes after `ptr`, so the offset
@@ -250,8 +250,8 @@ macro_rules! trailing_field_offset {
 /// Computes alignment of `$ty: ?Sized`.
 ///
 /// `align_of!` produces code which is valid in a `const` context.
-// TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove this
-// `cfg` when `size_of_val_raw` is stabilized.
+// FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
+// this `cfg` when `size_of_val_raw` is stabilized.
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
 #[doc(hidden)] // `#[macro_export]` bypasses this module's `#[doc(hidden)]`.
 #[macro_export]
@@ -496,7 +496,7 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     // - We know that the returned lifetime will not outlive the input lifetime
     //   thanks to the lifetime bounds on this function.
     //
-    // TODO(#67): Once our MSRV is 1.58, replace this `transmute` with `&*dst`.
+    // FIXME(#67): Once our MSRV is 1.58, replace this `transmute` with `&*dst`.
     #[allow(clippy::transmute_ptr_to_ref)]
     unsafe {
         mem::transmute(dst)
@@ -513,7 +513,7 @@ pub const unsafe fn transmute_ref<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
 /// - `Dst: FromBytes + IntoBytes`
 /// - `size_of::<Src>() == size_of::<Dst>()`
 /// - `align_of::<Src>() >= align_of::<Dst>()`
-// TODO(#686): Consider removing the `Immutable` requirement.
+// FIXME(#686): Consider removing the `Immutable` requirement.
 #[inline(always)]
 pub unsafe fn transmute_mut<'dst, 'src: 'dst, Src: 'src, Dst: 'dst>(
     src: &'src mut Src,
@@ -563,7 +563,7 @@ fn try_cast_or_pme<Src, Dst, I, R, S>(
     ValidityError<Ptr<'_, Src, I>, Dst>,
 >
 where
-    // TODO(#2226): There should be a `Src: FromBytes` bound here, but doing so
+    // FIXME(#2226): There should be a `Src: FromBytes` bound here, but doing so
     // requires deeper surgery.
     Src: invariant::Read<I::Aliasing, R>,
     Dst: TryFromBytes
@@ -812,7 +812,7 @@ mod tests {
         assert_t_align_gteq_u_align!(u8, AU64, false);
     }
 
-    // TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove
+    // FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
     // this `cfg` when `size_of_val_raw` is stabilized.
     #[allow(clippy::decimal_literal_representation)]
     #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
@@ -914,7 +914,7 @@ mod tests {
         */
     }
 
-    // TODO(#29), TODO(https://github.com/rust-lang/rust/issues/69835): Remove
+    // FIXME(#29), FIXME(https://github.com/rust-lang/rust/issues/69835): Remove
     // this `cfg` when `size_of_val_raw` is stabilized.
     #[allow(clippy::decimal_literal_representation)]
     #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -441,7 +441,7 @@ macro_rules! impl_known_layout {
 
                 // SAFETY: `.cast` preserves address and provenance.
                 //
-                // TODO(#429): Add documentation to `.cast` that promises that
+                // FIXME(#429): Add documentation to `.cast` that promises that
                 // it preserves provenance.
                 #[inline(always)]
                 fn raw_from_ptr_len(bytes: NonNull<u8>, _meta: ()) -> NonNull<Self> {
@@ -485,11 +485,11 @@ macro_rules! unsafe_impl_known_layout {
 
             const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
 
-            // SAFETY: All operations preserve address and provenance.
-            // Caller has promised that the `as` cast preserves size.
+            // SAFETY: All operations preserve address and provenance. Caller
+            // has promised that the `as` cast preserves size.
             //
-            // TODO(#429): Add documentation to `NonNull::new_unchecked`
-            // that it preserves provenance.
+            // FIXME(#429): Add documentation to `NonNull::new_unchecked` that
+            // it preserves provenance.
             #[inline(always)]
             fn raw_from_ptr_len(bytes: NonNull<u8>, meta: <$repr as KnownLayout>::PointerMetadata) -> NonNull<Self> {
                 #[allow(clippy::as_conversions)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -76,9 +76,10 @@ impl<T: ?Sized> AsAddress for NonNull<T> {
 impl<T: ?Sized> AsAddress for *const T {
     #[inline(always)]
     fn addr(self) -> usize {
-        // TODO(#181), TODO(https://github.com/rust-lang/rust/issues/95228): Use
-        // `.addr()` instead of `as usize` once it's stable, and get rid of this
-        // `allow`. Currently, `as usize` is the only way to accomplish this.
+        // FIXME(#181), FIXME(https://github.com/rust-lang/rust/issues/95228):
+        // Use `.addr()` instead of `as usize` once it's stable, and get rid of
+        // this `allow`. Currently, `as usize` is the only way to accomplish
+        // this.
         #[allow(clippy::as_conversions)]
         #[cfg_attr(
             __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS,
@@ -333,14 +334,14 @@ where
     // alignment, overflow `isize`) are not rejected, which can cause undefined
     // behavior. See #64 for details.
     //
-    // TODO(#67): Once our MSRV is > 1.64.0, remove this assertion.
+    // FIXME(#67): Once our MSRV is > 1.64.0, remove this assertion.
     #[allow(clippy::as_conversions)]
     let max_alloc = (isize::MAX as usize).saturating_sub(align);
     if size > max_alloc {
         return Err(AllocError);
     }
 
-    // TODO(https://github.com/rust-lang/rust/issues/55724): Use
+    // FIXME(https://github.com/rust-lang/rust/issues/55724): Use
     // `Layout::repeat` once it's stabilized.
     let layout = Layout::from_size_align(size, align).or(Err(AllocError))?;
 
@@ -378,7 +379,7 @@ where
         // zero, but it does require a non-null dangling pointer for its
         // allocation.
         //
-        // TODO(https://github.com/rust-lang/rust/issues/95228): Use
+        // FIXME(https://github.com/rust-lang/rust/issues/95228): Use
         // `std::ptr::without_provenance` once it's stable. That may optimize
         // better. As written, Rust may assume that this consumes "exposed"
         // provenance, and thus Rust may have to assume that this may consume
@@ -388,7 +389,7 @@ where
 
     let ptr = T::raw_from_ptr_len(ptr, meta);
 
-    // TODO(#429): Add a "SAFETY" comment and remove this `allow`. Make sure to
+    // FIXME(#429): Add a "SAFETY" comment and remove this `allow`. Make sure to
     // include a justification that `ptr.as_ptr()` is validly-aligned in the ZST
     // case (in which we manually construct a dangling pointer) and to justify
     // why `Box` is safe to drop (it's because `allocate` uses the system
@@ -492,7 +493,7 @@ mod len_of {
             // size of such a `&T` without any trailing padding, and so neither
             // the multiplication nor the addition will overflow.
             //
-            // TODO(#67): Remove this allow. See NumExt for more details.
+            // FIXME(#67): Remove this allow. See NumExt for more details.
             #[allow(unstable_name_collisions, clippy::incompatible_msrv)]
             let unpadded_size = unsafe {
                 let trailing_size = self.meta.unchecked_mul(trailing_slice_layout.elem_size);
@@ -583,7 +584,7 @@ pub(crate) use len_of::MetadataOf;
 /// exist (stably) on our MSRV. This module provides polyfills for those
 /// features so that we can write more "modern" code, and just remove the
 /// polyfill once our MSRV supports the corresponding feature. Without this,
-/// we'd have to write worse/more verbose code and leave TODO comments sprinkled
+/// we'd have to write worse/more verbose code and leave FIXME comments sprinkled
 /// throughout the codebase to update to the new pattern once it's stabilized.
 ///
 /// Each trait is imported as `_` at the crate root; each polyfill should "just
@@ -598,7 +599,7 @@ pub(crate) mod polyfills {
     // toolchain versions, `ptr.slice_from_raw_parts()` resolves to the inherent
     // method rather than to this trait, and so this trait is considered unused.
     //
-    // TODO(#67): Once our MSRV is 1.70, remove this.
+    // FIXME(#67): Once our MSRV is 1.70, remove this.
     #[allow(unused)]
     pub(crate) trait NonNullExt<T> {
         fn slice_from_raw_parts(data: Self, len: usize) -> NonNull<[T]>;
@@ -627,7 +628,7 @@ pub(crate) mod polyfills {
     // toolchain versions, `ptr.slice_from_raw_parts()` resolves to the inherent
     // method rather than to this trait, and so this trait is considered unused.
     //
-    // TODO(#67): Once our MSRV is high enough, remove this.
+    // FIXME(#67): Once our MSRV is high enough, remove this.
     #[allow(unused)]
     pub(crate) trait NumExt {
         /// Subtract without checking for underflow.

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -168,7 +168,7 @@ impl<T> Unalign<T> {
         // `Unalign`'s `Drop::drop` from being run, since dropping is not
         // supported in `const fn`s.
         //
-        // TODO(https://github.com/rust-lang/rust/issues/73255): Destructure
+        // FIXME(https://github.com/rust-lang/rust/issues/73255): Destructure
         // instead of using unsafe.
         unsafe { crate::util::transmute_unchecked(self) }
     }
@@ -287,14 +287,14 @@ impl<T> Unalign<T> {
     /// such as [`read_unaligned`].
     ///
     /// [`read_unaligned`]: core::ptr::read_unaligned
-    // TODO(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
+    // FIXME(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
     #[inline(always)]
     pub fn get_mut_ptr(&mut self) -> *mut T {
         ptr::addr_of_mut!(self.0)
     }
 
     /// Sets the inner `T`, dropping the previous value.
-    // TODO(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
+    // FIXME(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
     #[inline(always)]
     pub fn set(&mut self, t: T) {
         *self = Unalign::new(t);
@@ -376,7 +376,7 @@ impl<T> Unalign<T> {
 
 impl<T: Copy> Unalign<T> {
     /// Gets a copy of the inner `T`.
-    // TODO(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
+    // FIXME(https://github.com/rust-lang/rust/issues/57349): Make this `const`.
     #[inline(always)]
     pub fn get(&self) -> T {
         let Unalign(val) = *self;
@@ -630,7 +630,7 @@ mod tests {
         const _U64: u64 = _UNALIGN.into_inner();
         // Make sure all code is considered "used".
         //
-        // TODO(https://github.com/rust-lang/rust/issues/104084): Remove this
+        // FIXME(https://github.com/rust-lang/rust/issues/104084): Remove this
         // attribute.
         #[allow(dead_code)]
         const _: () = {

--- a/zerocopy-derive/src/ext.rs
+++ b/zerocopy-derive/src/ext.rs
@@ -11,11 +11,11 @@ use quote::ToTokens;
 use syn::{Data, DataEnum, DataStruct, DataUnion, Field, Ident, Index, Type, Visibility};
 
 pub(crate) trait DataExt {
-    /// Extracts the names and types of all fields. For enums, extracts the names
-    /// and types of fields from each variant. For tuple structs, the names are
-    /// the indices used to index into the struct (ie, `0`, `1`, etc).
+    /// Extracts the names and types of all fields. For enums, extracts the
+    /// names and types of fields from each variant. For tuple structs, the
+    /// names are the indices used to index into the struct (ie, `0`, `1`, etc).
     ///
-    /// TODO: Extracting field names for enums doesn't really make sense. Types
+    /// FIXME: Extracting field names for enums doesn't really make sense. Types
     /// makes sense because we don't care about where they live - we just care
     /// about transitive ownership. But for field names, we'd only use them when
     /// generating is_bit_valid, which cares about where they live.

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -48,7 +48,7 @@ use {
 
 use {crate::ext::*, crate::repr::*};
 
-// TODO(https://github.com/rust-lang/rust/issues/54140): Some errors could be
+// FIXME(https://github.com/rust-lang/rust/issues/54140): Some errors could be
 // made better if we could add multiple lines of error output like this:
 //
 // error: unsupported representation
@@ -435,7 +435,7 @@ fn derive_known_layout_inner(
 
                 // SAFETY: `.cast` preserves address and provenance.
                 //
-                // TODO(#429): Add documentation to `.cast` that promises that
+                // FIXME(#429): Add documentation to `.cast` that promises that
                 // it preserves provenance.
                 #[inline(always)]
                 fn raw_from_ptr_len(
@@ -602,7 +602,7 @@ fn derive_hash_inner(
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let where_predicates = where_clause.map(|clause| &clause.predicates);
     Ok(quote! {
-        // TODO(#553): Add a test that generates a warning when
+        // FIXME(#553): Add a test that generates a warning when
         // `#[allow(deprecated)]` isn't present.
         #[allow(deprecated)]
         // While there are not currently any warnings that this suppresses (that
@@ -650,7 +650,7 @@ fn derive_eq_inner(
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
     let where_predicates = where_clause.map(|clause| &clause.predicates);
     Ok(quote! {
-        // TODO(#553): Add a test that generates a warning when
+        // FIXME(#553): Add a test that generates a warning when
         // `#[allow(deprecated)]` isn't present.
         #[allow(deprecated)]
         // While there are not currently any warnings that this suppresses (that
@@ -669,7 +669,7 @@ fn derive_eq_inner(
             }
         }
 
-        // TODO(#553): Add a test that generates a warning when
+        // FIXME(#553): Add a test that generates a warning when
         // `#[allow(deprecated)]` isn't present.
         #[allow(deprecated)]
         // While there are not currently any warnings that this suppresses (that
@@ -806,7 +806,7 @@ fn derive_try_from_bytes_union(
     top_level: Trait,
     zerocopy_crate: &Path,
 ) -> TokenStream {
-    // TODO(#5): Remove the `Immutable` bound.
+    // FIXME(#5): Remove the `Immutable` bound.
     let field_type_trait_bounds =
         FieldBounds::All(&[TraitBound::Slf, TraitBound::Other(Trait::Immutable)]);
     let extras =
@@ -1144,7 +1144,7 @@ fn derive_from_zeros_union(
     unn: &DataUnion,
     zerocopy_crate: &Path,
 ) -> TokenStream {
-    // TODO(#5): Remove the `Immutable` bound. It's only necessary for
+    // FIXME(#5): Remove the `Immutable` bound. It's only necessary for
     // compatibility with `derive(TryFromBytes)` on unions; not for soundness.
     let field_type_trait_bounds =
         FieldBounds::All(&[TraitBound::Slf, TraitBound::Other(Trait::Immutable)]);
@@ -1221,7 +1221,7 @@ fn derive_from_bytes_union(
     unn: &DataUnion,
     zerocopy_crate: &Path,
 ) -> TokenStream {
-    // TODO(#5): Remove the `Immutable` bound. It's only necessary for
+    // FIXME(#5): Remove the `Immutable` bound. It's only necessary for
     // compatibility with `derive(TryFromBytes)` on unions; not for soundness.
     let field_type_trait_bounds =
         FieldBounds::All(&[TraitBound::Slf, TraitBound::Other(Trait::Immutable)]);
@@ -1285,7 +1285,7 @@ fn derive_into_bytes_struct(
         // padding unless #[repr(align)] explicitly adds padding, which we check
         // for in this branch's condition.
         //
-        // TODO(#10): Support type parameters for non-transparent, non-packed
+        // FIXME(#10): Support type parameters for non-transparent, non-packed
         // structs without requiring `Unaligned`.
         (None, true)
     } else {
@@ -1354,7 +1354,7 @@ please let us know you use this feature: https://github.com/google/zerocopy/disc
         )
     };
 
-    // TODO(#10): Support type parameters.
+    // FIXME(#10): Support type parameters.
     if !ast.generics.params.is_empty() {
         return Err(Error::new(Span::call_site(), "unsupported on types with type parameters"));
     }
@@ -1563,8 +1563,8 @@ enum SelfBounds<'a> {
     All(&'a [Trait]),
 }
 
-// TODO(https://github.com/rust-lang/rust-clippy/issues/12908): This is a false positive.
-// Explicit lifetimes are actually necessary here.
+// FIXME(https://github.com/rust-lang/rust-clippy/issues/12908): This is a false
+// positive. Explicit lifetimes are actually necessary here.
 #[allow(clippy::needless_lifetimes)]
 impl<'a> SelfBounds<'a> {
     const SIZED: Self = Self::All(&[Trait::Sized]);
@@ -1792,7 +1792,7 @@ impl<'a, D: DataExt> ImplBlockBuilder<'a, D> {
 
         let inner_extras = self.inner_extras;
         let impl_tokens = quote! {
-            // TODO(#553): Add a test that generates a warning when
+            // FIXME(#553): Add a test that generates a warning when
             // `#[allow(deprecated)]` isn't present.
             #[allow(deprecated)]
             // While there are not currently any warnings that this suppresses
@@ -1830,7 +1830,7 @@ impl<'a, D: DataExt> ImplBlockBuilder<'a, D> {
 // versions, `b.then_some(...)` resolves to the inherent method rather than to
 // this trait, and so this trait is considered unused.
 //
-// TODO(#67): Remove this once our MSRV is >= 1.62.
+// FIXME(#67): Remove this once our MSRV is >= 1.62.
 #[allow(unused)]
 trait BoolExt {
     fn then_some<T>(self, t: T) -> Option<T>;

--- a/zerocopy-derive/tests/priv_in_pub.rs
+++ b/zerocopy-derive/tests/priv_in_pub.rs
@@ -12,7 +12,7 @@
 
 include!("include.rs");
 
-// TODO(#847): Make this test succeed on earlier Rust versions.
+// FIXME(#847): Make this test succeed on earlier Rust versions.
 #[::rustversion::stable(1.59)]
 mod test {
     use super::*;

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -17,7 +17,7 @@ include!("include.rs");
 
 #[test]
 fn zst() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&());
     let candidate = candidate.forget_aligned();
     // SAFETY: `&()` trivially consists entirely of initialized bytes.
@@ -36,7 +36,7 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
     let candidate = candidate.forget_aligned();
     // SAFETY: `&One` consists entirely of initialized bytes.
@@ -56,7 +56,7 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&Two { a: false, b: () });
     let candidate = candidate.forget_aligned();
     // SAFETY: `&Two` consists entirely of initialized bytes.
@@ -67,7 +67,7 @@ fn two() {
 
 #[test]
 fn two_bad() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
     let candidate = candidate.forget_aligned();
     // SAFETY: `&Two` consists entirely of initialized bytes.
@@ -97,7 +97,7 @@ util_assert_impl_all!(Unsized: imp::TryFromBytes);
 
 #[test]
 fn un_sized() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[16, 12, 42][..]);
     let candidate = candidate.forget_aligned();
     // SAFETY: `&Unsized` consists entirely of initialized bytes.

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -24,7 +24,7 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
     let candidate = candidate.forget_aligned();
     // SAFETY: `&One` consists entirely of initialized bytes.
@@ -44,7 +44,7 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate_a = ::zerocopy::Ptr::from_ref(&Two { a: false });
     let candidate_a = candidate_a.forget_aligned();
     // SAFETY: `&Two` consists entirely of initialized bytes.
@@ -62,7 +62,7 @@ fn two() {
 
 #[test]
 fn two_bad() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
     let candidate = candidate.forget_aligned();
     // SAFETY: `&[u8]` consists entirely of initialized bytes.
@@ -91,7 +91,7 @@ union BoolAndZst {
 
 #[test]
 fn bool_and_zst() {
-    // TODO(#5): Use `try_transmute` in this test once it's available.
+    // FIXME(#5): Use `try_transmute` in this test once it's available.
     let candidate = ::zerocopy::Ptr::from_ref(&[2u8][..]);
     let candidate = candidate.forget_aligned();
     // SAFETY: `&[u8]` consists entirely of initialized bytes.


### PR DESCRIPTION
This allows us to leave TODO comments for things that should be resolved
before a PR is merged, and have stronger guarantees that these will
actually be resolved. Previously, we've manually created GitHub PR
review comments for TODO comments, which has let some TODOs through by
accident, and is generally a waste of developer time.




---

This PR is on branch [ban-todo](../tree/ban-todo).

- #2511