### PR TITLE
[WIP] Break TransmuteFrom into Shrink vs Overwrite

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -612,15 +612,15 @@ pub(crate) use cast_from_raw::cast_from_raw;
 mod cast_from_raw {
     use crate::{pointer::PtrInner, *};
 
-    /// Implements [`<Dst as SizeEq<Src>>::cast_from_raw`][cast_from_raw].
+    /// Implements [`<Dst as SizeCompat<Src>>::cast_from_raw`][cast_from_raw].
     ///
     /// # PME
     ///
     /// Generates a post-monomorphization error if it is not possible to satisfy
-    /// the soundness conditions of [`SizeEq::cast_from_raw`][cast_from_raw]
+    /// the soundness conditions of [`SizeCompat::cast_from_raw`][cast_from_raw]
     /// for `Src` and `Dst`.
     ///
-    /// [cast_from_raw]: crate::pointer::SizeEq::cast_from_raw
+    /// [cast_from_raw]: crate::pointer::SizeCompat::cast_from_raw
     //
     // FIXME(#1817): Support Sized->Unsized and Unsized->Sized casts
     pub(crate) fn cast_from_raw<Src, Dst>(src: PtrInner<'_, Src>) -> PtrInner<'_, Dst>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ use core::{
 #[cfg(feature = "std")]
 use std::io;
 
-use crate::pointer::invariant::{self, BecauseExclusive};
+use crate::pointer::{invariant, BecauseBidirectional};
 
 #[cfg(any(feature = "alloc", test, kani))]
 extern crate alloc;
@@ -1840,7 +1840,7 @@ pub unsafe trait TryFromBytes {
         Self: KnownLayout + IntoBytes,
     {
         static_assert_dst_is_not_zst!(Self);
-        match Ptr::from_mut(bytes).try_cast_into_no_leftover::<Self, BecauseExclusive>(None) {
+        match Ptr::from_mut(bytes).try_cast_into_no_leftover(None) {
             Ok(source) => {
                 // This call may panic. If that happens, it doesn't cause any soundness
                 // issues, as we have not generated any invalid state which we need to
@@ -1852,9 +1852,7 @@ pub unsafe trait TryFromBytes {
                 // condition will not happen.
                 match source.try_into_valid() {
                     Ok(source) => Ok(source.as_mut()),
-                    Err(e) => {
-                        Err(e.map_src(|src| src.as_bytes::<BecauseExclusive>().as_mut()).into())
-                    }
+                    Err(e) => Err(e.map_src(|src| src.as_bytes().as_mut()).into()),
                 }
             }
             Err(e) => Err(e.map_src(Ptr::as_mut).into()),
@@ -2421,8 +2419,7 @@ pub unsafe trait TryFromBytes {
     where
         Self: KnownLayout<PointerMetadata = usize> + IntoBytes,
     {
-        match Ptr::from_mut(source).try_cast_into_no_leftover::<Self, BecauseExclusive>(Some(count))
-        {
+        match Ptr::from_mut(source).try_cast_into_no_leftover(Some(count)) {
             Ok(source) => {
                 // This call may panic. If that happens, it doesn't cause any soundness
                 // issues, as we have not generated any invalid state which we need to
@@ -2434,9 +2431,7 @@ pub unsafe trait TryFromBytes {
                 // condition will not happen.
                 match source.try_into_valid() {
                     Ok(source) => Ok(source.as_mut()),
-                    Err(e) => {
-                        Err(e.map_src(|src| src.as_bytes::<BecauseExclusive>().as_mut()).into())
-                    }
+                    Err(e) => Err(e.map_src(|src| src.as_bytes().as_mut()).into()),
                 }
             }
             Err(e) => Err(e.map_src(Ptr::as_mut).into()),
@@ -2844,7 +2839,7 @@ fn try_mut_from_prefix_suffix<T: IntoBytes + TryFromBytes + KnownLayout + ?Sized
     cast_type: CastType,
     meta: Option<T::PointerMetadata>,
 ) -> Result<(&mut T, &mut [u8]), TryCastError<&mut [u8], T>> {
-    match Ptr::from_mut(candidate).try_cast_into::<T, BecauseExclusive>(cast_type, meta) {
+    match Ptr::from_mut(candidate).try_cast_into(cast_type, meta) {
         Ok((candidate, prefix_suffix)) => {
             // This call may panic. If that happens, it doesn't cause any soundness
             // issues, as we have not generated any invalid state which we need to
@@ -2856,7 +2851,7 @@ fn try_mut_from_prefix_suffix<T: IntoBytes + TryFromBytes + KnownLayout + ?Sized
             // condition will not happen.
             match candidate.try_into_valid() {
                 Ok(valid) => Ok((valid.as_mut(), prefix_suffix.as_mut())),
-                Err(e) => Err(e.map_src(|src| src.as_bytes::<BecauseExclusive>().as_mut()).into()),
+                Err(e) => Err(e.map_src(|src| src.as_bytes().as_mut()).into()),
             }
         }
         Err(e) => Err(e.map_src(Ptr::as_mut).into()),
@@ -3835,8 +3830,8 @@ pub unsafe trait FromBytes: FromZeros {
         Self: IntoBytes + KnownLayout,
     {
         static_assert_dst_is_not_zst!(Self);
-        match Ptr::from_mut(source).try_cast_into_no_leftover::<_, BecauseExclusive>(None) {
-            Ok(ptr) => Ok(ptr.recall_validity::<_, (_, (_, _))>().as_mut()),
+        match Ptr::from_mut(source).try_cast_into_no_leftover(None) {
+            Ok(ptr) => Ok(ptr.recall_validity::<_, BecauseBidirectional>().as_mut()),
             Err(err) => Err(err.map_src(|src| src.as_mut())),
         }
     }
@@ -4304,11 +4299,9 @@ pub unsafe trait FromBytes: FromZeros {
         Self: IntoBytes + KnownLayout<PointerMetadata = usize> + Immutable,
     {
         let source = Ptr::from_mut(source);
-        let maybe_slf = source.try_cast_into_no_leftover::<_, BecauseImmutable>(Some(count));
+        let maybe_slf = source.try_cast_into_no_leftover(Some(count));
         match maybe_slf {
-            Ok(slf) => Ok(slf
-                .recall_validity::<_, (_, (_, (BecauseExclusive, BecauseExclusive)))>()
-                .as_mut()),
+            Ok(slf) => Ok(slf.recall_validity::<_, BecauseBidirectional>().as_mut()),
             Err(err) => Err(err.map_src(|s| s.as_mut())),
         }
     }
@@ -4665,7 +4658,7 @@ pub unsafe trait FromBytes: FromZeros {
         // cannot be violated even though `buf` may have more permissive bit
         // validity than `ptr`.
         let ptr = unsafe { ptr.assume_validity::<invariant::Initialized>() };
-        let ptr = ptr.as_bytes::<BecauseExclusive>();
+        let ptr = ptr.as_bytes();
         src.read_exact(ptr.as_mut())?;
         // SAFETY: `buf` entirely consists of initialized bytes, and `Self` is
         // `FromBytes`.
@@ -4784,9 +4777,9 @@ fn mut_from_prefix_suffix<T: FromBytes + IntoBytes + KnownLayout + ?Sized>(
     cast_type: CastType,
 ) -> Result<(&mut T, &mut [u8]), CastError<&mut [u8], T>> {
     let (slf, prefix_suffix) = Ptr::from_mut(source)
-        .try_cast_into::<_, BecauseExclusive>(cast_type, meta)
+        .try_cast_into(cast_type, meta)
         .map_err(|err| err.map_src(|s| s.as_mut()))?;
-    Ok((slf.recall_validity::<_, (_, (_, _))>().as_mut(), prefix_suffix.as_mut()))
+    Ok((slf.recall_validity::<_, BecauseBidirectional>().as_mut(), prefix_suffix.as_mut()))
 }
 
 /// Analyzes whether a type is [`IntoBytes`].

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -18,7 +18,7 @@ mod transmute;
 pub use {inner::PtrInner, transmute::*};
 #[doc(hidden)]
 pub use {
-    invariant::{BecauseExclusive, BecauseImmutable, Read},
+    invariant::{BecauseExclusive, Read},
     ptr::Ptr,
 };
 
@@ -30,11 +30,11 @@ pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unali
     Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
 
 /// Checks if the referent is zeroed.
-pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
+pub(crate) fn is_zeroed<T, I>(mut ptr: Ptr<'_, T, I>) -> bool
 where
     T: crate::Immutable + crate::KnownLayout,
     I: invariant::Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::Reference,
 {
-    ptr.as_bytes::<BecauseImmutable>().as_ref().iter().all(|&byte| byte == 0)
+    ptr.reborrow().into_shared().as_bytes().as_ref().iter().all(|&byte| byte == 0)
 }

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -9,14 +9,13 @@
 use core::{
     fmt::{Debug, Formatter},
     marker::PhantomData,
-    ptr::NonNull,
 };
 
 use crate::{
     pointer::{
         inner::PtrInner,
         invariant::*,
-        transmute::{MutationCompatible, SizeEq, TransmuteFromPtr},
+        transmute::{MutationCompatible, SizeCompat, TransmuteFromPtr},
     },
     AlignmentError, CastError, CastType, KnownLayout, SizeError, TryFromBytes, ValidityError,
 };
@@ -74,32 +73,6 @@ mod def {
         T: 'a + ?Sized,
         I: Invariants,
     {
-        /// Constructs a `Ptr` from a [`NonNull`].
-        ///
-        /// # Safety
-        ///
-        /// The caller promises that:
-        ///
-        /// 0. If `ptr`'s referent is not zero sized, then `ptr` has valid
-        ///    provenance for its referent, which is entirely contained in some
-        ///    Rust allocation, `A`.
-        /// 1. If `ptr`'s referent is not zero sized, `A` is guaranteed to live
-        ///    for at least `'a`.
-        /// 2. `ptr` conforms to the aliasing invariant of
-        ///    [`I::Aliasing`](invariant::Aliasing).
-        /// 3. `ptr` conforms to the alignment invariant of
-        ///    [`I::Alignment`](invariant::Alignment).
-        /// 4. `ptr` conforms to the validity invariant of
-        ///    [`I::Validity`](invariant::Validity).
-        pub(super) unsafe fn new(ptr: NonNull<T>) -> Ptr<'a, T, I> {
-            // SAFETY: The caller has promised (in 0 - 1) to satisfy all safety
-            // invariants of `PtrInner::new`.
-            let ptr = unsafe { PtrInner::new(ptr) };
-            // SAFETY: The caller has promised (in 2 - 4) to satisfy all safety
-            // invariants of `Ptr`.
-            Self { ptr, _invariants: PhantomData }
-        }
-
         /// Constructs a new `Ptr` from a [`PtrInner`].
         ///
         /// # Safety
@@ -388,11 +361,11 @@ mod _conversions {
         pub(crate) fn transmute<U, V, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
             V: Validity,
-            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeEq<T> + ?Sized,
+            U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, R> + SizeCompat<T> + ?Sized,
         {
             // SAFETY:
-            // - `SizeEq::cast_from_raw` promises to preserve address,
-            //   provenance, and the number of bytes in the referent
+            // - `SizeCompat::cast_from_raw` promises to preserve address and to
+            //   address a prefix of the bytes addressed by its argument
             // - If aliasing is `Shared`, then by `U: TransmuteFromPtr<T>`, at
             //   least one of the following holds:
             //   - `T: Immutable` and `U: Immutable`, in which case it is
@@ -402,7 +375,7 @@ mod _conversions {
             //     operate on these references simultaneously
             // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
-            unsafe { self.transmute_unchecked(|ptr| SizeEq::cast_from_raw(ptr).as_non_null()) }
+            unsafe { self.transmute_unchecked(SizeCompat::cast_from_raw) }
         }
 
         #[doc(hidden)]
@@ -420,7 +393,7 @@ mod _conversions {
             //   referent simultaneously
             // - By `T: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
-            let ptr = unsafe { self.transmute_unchecked(|t| t.as_non_null()) };
+            let ptr = unsafe { self.transmute_unchecked(SizeCompat::cast_from_raw) };
             // SAFETY: `self` and `ptr` have the same address and referent type.
             // Therefore, if `self` satisfies `I::Alignment`, then so does
             // `ptr`.
@@ -438,8 +411,7 @@ mod _conversions {
         ///
         /// The caller promises that `u = cast(p)` is a pointer cast with the
         /// following properties:
-        /// - `u` addresses a subset of the bytes addressed by `p`
-        /// - `u` has the same provenance as `p`
+        /// - `u` addresses a prefix of the bytes addressed by `p`
         /// - If `I::Aliasing` is [`Shared`], it must not be possible for safe
         ///   code, operating on a `&T` and `&U` with the same referent
         ///   simultaneously, to cause undefined behavior
@@ -450,12 +422,6 @@ mod _conversions {
         ///   `I::Aliasing`, `I::Validity`, and `V`, and may depend upon the
         ///   presence, absence, or specific location of `UnsafeCell`s in `T`
         ///   and/or `U`. See [`Validity`] for more details.
-        ///
-        /// `transmute_unchecked` guarantees that the pointer passed to `cast`
-        /// will reference a byte sequence which is either contained inside a
-        /// single allocated object or is zero sized. In either case, this means
-        /// that its size will fit in an `isize` and it will not wrap around the
-        /// address space.
         #[doc(hidden)]
         #[inline]
         pub unsafe fn transmute_unchecked<U: ?Sized, V, F>(
@@ -464,25 +430,18 @@ mod _conversions {
         ) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
             V: Validity,
-            F: FnOnce(PtrInner<'_, T>) -> NonNull<U>,
+            F: FnOnce(PtrInner<'a, T>) -> PtrInner<'a, U>,
         {
-            // SAFETY: By invariant on `self`, `self.as_inner().as_non_null()`
-            // either references a zero-sized byte range, or else it references
-            // a byte range contained inside of a single allocated objection.
             let ptr = cast(self.as_inner());
 
             // SAFETY:
             //
-            // Lemma 1: `ptr` has the same provenance as `self`. The caller
-            // promises that `cast` preserves provenance, and we call it with
-            // `self.as_inner().as_non_null()`.
+            // The following safety arguments rely on the fact that the caller
+            // promises that `cast` returns a `PtrInner` which addresses a
+            // prefix of the bytes of `*self`, and so properties that hold of
+            // `*self` also hold of `*ptr`.
             //
-            // 0. By invariant, if `self`'s referent is not zero sized, then
-            //    `self` has valid provenance for its entire referent, which is
-            //    entirely contained in `A`. By Lemma 1, so does `ptr`.
-            // 1. By invariant on `self`, if `self`'s referent is not zero
-            //    sized, then `A` is guaranteed to live for at least `'a`.
-            // 2. `ptr` conforms to the aliasing invariant of `I::Aliasing`:
+            // 0. `ptr` conforms to the aliasing invariant of `I::Aliasing`:
             //    - `Exclusive`: `self` is the only `Ptr` or reference which is
             //      permitted to read or modify the referent for the lifetime
             //      `'a`. Since we consume `self` by value, the returned pointer
@@ -499,10 +458,10 @@ mod _conversions {
             //      of `UnsafeCell`s is unsound, this must be impossible using
             //      `&T` and `&U`.
             //    - `Inaccessible`: There are no restrictions we need to uphold.
-            // 3. `ptr` trivially satisfies the alignment invariant `Unaligned`.
-            // 4. The caller promises that `ptr` conforms to the validity
+            // 1. `ptr` trivially satisfies the alignment invariant `Unaligned`.
+            // 2. The caller promises that `ptr` conforms to the validity
             //    invariant `V` with respect to its referent type, `U`.
-            unsafe { Ptr::new(ptr) }
+            unsafe { Ptr::from_inner(ptr) }
         }
     }
 
@@ -535,7 +494,7 @@ mod _conversions {
             //   validity of the other.
             let ptr = unsafe {
                 #[allow(clippy::as_conversions)]
-                self.transmute_unchecked(|ptr| ptr.as_non_null().cast::<crate::Unalign<T>>())
+                self.transmute_unchecked(|p| p.cast_sized::<crate::Unalign<T>>())
             };
             ptr.bikeshed_recall_aligned()
         }
@@ -858,9 +817,13 @@ mod _transitions {
                 // SAFETY: If `T::is_bit_valid`, code may assume that `self`
                 // contains a bit-valid instance of `T`. By `T:
                 // TryTransmuteFromPtr<T, I::Aliasing, I::Validity, Valid>`, so
-                // long as `self`'s referent conforms to the `Valid` validity
-                // for `T` (which we just confired), then this transmute is
-                // sound.
+                // long as `SizeCompat::cast_from_raw(self.into_inner)`'s
+                // referent conforms to the `Valid` validity for `T`, then this
+                // transmute is sound. Since `<T as
+                // SizeCompat<T>>::cast_from_raw` is guaranteed to be the
+                // identity function, this is equivalent to the statement that
+                // `self`'s referent conforms to the `Valid` validity for `T`,
+                // which we just confirmed using `T::is_bit_valid`.
                 Ok(unsafe { self.assume_valid() })
             } else {
                 Err(ValidityError::new(self))
@@ -911,7 +874,7 @@ mod _casts {
         /// around the address space.
         #[doc(hidden)]
         #[inline]
-        pub unsafe fn cast_unsized_unchecked<U, F: FnOnce(PtrInner<'_, T>) -> NonNull<U>>(
+        pub unsafe fn cast_unsized_unchecked<U, F: FnOnce(PtrInner<'a, T>) -> PtrInner<'a, U>>(
             self,
             cast: F,
         ) -> Ptr<'a, U, (I::Aliasing, Unaligned, I::Validity)>
@@ -959,7 +922,7 @@ mod _casts {
         where
             T: MutationCompatible<U, I::Aliasing, I::Validity, I::Validity, R>,
             U: 'a + ?Sized + CastableFrom<T, I::Validity, I::Validity>,
-            F: FnOnce(PtrInner<'_, T>) -> NonNull<U>,
+            F: FnOnce(PtrInner<'_, T>) -> PtrInner<'_, U>,
         {
             // SAFETY: Because `T: MutationCompatible<U, I::Aliasing, R>`, one
             // of the following holds:
@@ -1010,7 +973,10 @@ mod _casts {
                     );
                     // SAFETY: `ptr` has the same address as `p`, which is
                     // non-null.
-                    core::ptr::NonNull::new_unchecked(ptr)
+                    let ptr = core::ptr::NonNull::new_unchecked(ptr);
+
+                    // TODO: SAFETY
+                    PtrInner::new(ptr)
                 })
             };
 
@@ -1234,7 +1200,7 @@ mod _casts {
             //   inner type `T`. A consequence of this guarantee is that it is
             //   possible to convert between `T` and `UnsafeCell<T>`.
             #[allow(clippy::as_conversions)]
-            let ptr = unsafe { self.transmute_unchecked(|ptr| cast!(ptr).as_non_null()) };
+            let ptr = unsafe { self.transmute_unchecked(|ptr| cast!(ptr)) };
 
             // SAFETY: `UnsafeCell<T>` has the same alignment as `T` [1],
             // and so if `self` is guaranteed to be aligned, then so is the

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -34,15 +34,15 @@ use crate::{
 /// following:
 ///
 /// Given `src: Ptr<'a, Src, (A, _, SV)>` and `dst_inner =
-/// SizeCompat::cast_from_raw(src.into_inner())`, if the referent of `dst_inner`
+/// SizeFrom::cast_from_raw(src.into_inner())`, if the referent of `dst_inner`
 /// is `DV`-valid for `Dst`, then it is sound to construct `dst: Ptr<'a, Dst,
 /// (A, Unaligned, DV)>` from `dst_inner`. Equivalently, it is sound to
-/// transmute `src` into `dst` using [`SizeCompat::cast_from_raw`].
+/// transmute `src` into `dst` using [`SizeFrom::cast_from_raw`].
 ///
 /// ## Pre-conditions
 ///
 /// Given `src: Ptr<Src, (A, _, SV)>` and `dst: Ptr<Dst, (A, Unaligned, DV)>`
-/// constructed from `SizeCompat::cast_from_raw(src.into_inner())`, `Dst:
+/// constructed from `SizeFrom::cast_from_raw(src.into_inner())`, `Dst:
 /// TryTransmuteFromPtr<Src, A, SV, DV, _>` is sound if all of the following
 /// hold:
 /// - Forwards transmutation: Either of the following hold:
@@ -64,13 +64,12 @@ use crate::{
 /// Given:
 /// - `src: Ptr<'a, Src, (A, _, SV)>`
 /// - The leading `N` bytes of `src`'s referent are a `DV`-valid `Dst`, where
-///   `N` is the referent size of `SizeCompat::cast_from_raw(src)`
+///   `N` is the referent size of `SizeFrom::cast_from_raw(src)`
 ///
-/// We are trying to prove that it is sound to use `SizeCompat::cast_from_raw`
-/// to transmute from `src` to a `dst: Ptr<'a, Dst, (A, Unaligned, DV)>`. We
-/// need to prove that such a transmute does not violate any of `src`'s
-/// invariants, and that it satisfies all invariants of the destination `Ptr`
-/// type.
+/// We are trying to prove that it is sound to use `SizeFrom::cast_from_raw` to
+/// transmute from `src` to a `dst: Ptr<'a, Dst, (A, Unaligned, DV)>`. We need
+/// to prove that such a transmute does not violate any of `src`'s invariants,
+/// and that it satisfies all invariants of the destination `Ptr` type.
 ///
 /// First, all of `src`'s `PtrInner` invariants are upheld. `src`'s address and
 /// metadata are unchanged, so:
@@ -80,8 +79,8 @@ use crate::{
 /// - If its referent is not zero sized, `A` is guaranteed to live for at least
 ///   `'a`
 ///
-/// By post-condition on `SizeCompat::cast_from_raw`, `dst` addresses a prefix
-/// of the bytes addressed by `src`. `dst` also has the same lifetime as `src`.
+/// By post-condition on `SizeFrom::cast_from_raw`, `dst` addresses a prefix of
+/// the bytes addressed by `src`. `dst` also has the same lifetime as `src`.
 /// Therefore, all of the `PtrInner` invariants mentioned above also hold for
 /// `dst`.
 ///
@@ -104,8 +103,8 @@ use crate::{
 /// as an `SV`-valid `Src`. It is guaranteed to remain so, as either of the
 /// following hold:
 /// - `dst` does not permit mutation of its referent.
-/// - `Src: TransmuteFrom<Dst, DV, SV>`. Since `Dst: SizeCompat<Src>`, and since
-///   `dst` is produced using `SizeCompat::cast_from_raw`, given `src'` composed
+/// - `Src: TransmuteFrom<Dst, DV, SV>`. Since `Dst: SizeFrom<Src>`, and since
+///   `dst` is produced using `SizeFrom::cast_from_raw`, given `src'` composed
 ///   by concatenating any `DV`-valid `Dst` of size `size_of_val(dst)` with the
 ///   trailing `size_of_val(src) - size_of_val(dst)` bytes of `src`, `src'` is
 ///   an `SV`-valid `Src`. Thus, any value written to `dst` is guaranteed not to
@@ -116,62 +115,23 @@ use crate::{
 /// remain so, as either of the following hold:
 /// - So long as `dst` is active, no mutation of the referent is allowed except
 ///   via `dst` itself.
-/// - `Dst: TransmuteFrom<Src, SV, DV>`. Since `Dst: SizeCompat<Src>`, and since
-///   `dst` is produced using `SizeCompat::cast_from_raw`, the leading
+/// - `Dst: TransmuteFrom<Src, SV, DV>`. Since `Dst: SizeFrom<Src>`, and since
+///   `dst` is produced using `SizeFrom::cast_from_raw`, the leading
 ///   `size_of_val(dst)` bytes of any `SV`-valid `Src` constitute a `DV`-valid
 ///   `Dst`. Thus, any value written via `src` is guaranteed not to violate the
 ///   `DV`-validity of `Dst`.
 pub unsafe trait TryTransmuteFromPtr<Src: ?Sized, A: Aliasing, SV: Validity, DV: Validity, R>:
-    SizeCompat<Src>
+    SizeFrom<Src>
 {
 }
 
-#[allow(missing_copy_implementations, missing_debug_implementations)]
-pub enum BecauseMutationCompatible {}
-
-// SAFETY:
-// - Forwards transmutation: By `Dst: MutationCompatible<Src, A, SV, DV, _>`, we
-//   know that at least one of the following holds:
-//   - So long as `dst: Ptr<Dst>` is active, no mutation of its referent is
-//     allowed except via `dst` itself if either of the following hold:
-//     - Aliasing is `Exclusive`, in which case, so long as the `Dst` `Ptr`
-//       exists, no mutation is permitted except via that `Ptr`
-//     - Aliasing is `Shared`, `Src: Immutable`, and `Dst: Immutable`, in which
-//       case no mutation is possible via either `Ptr`
-//   - `Dst: TransmuteFrom<Src, SV, DV>`
-// - Reverse transmutation: `Src: TransmuteFrom<Dst, DV, SV>`, and so the set of
-//   `DV`-valid `Dst`s is a subset of the set of `SV`-valid `Src`s
-// - No safe code, given access to `src` and `dst`, can cause undefined
-//   behavior: By `Dst: MutationCompatible<Src, A, SV, DV, _>`, at least one of
-//   the following holds:
-//   - `A` is `Exclusive`
-//   - `Src: Immutable` and `Dst: Immutable`
-//   - `Dst: InvariantsEq<Src>`, which guarantees that `Src` and `Dst` have the
-//     same invariants, and have `UnsafeCell`s covering the same byte ranges
-unsafe impl<Src, Dst, SV, DV, A, R>
-    TryTransmuteFromPtr<Src, A, SV, DV, (BecauseMutationCompatible, R)> for Dst
+unsafe impl<Src, Dst, A, SV, DV, R> TryTransmuteFromPtr<Src, A, SV, DV, R> for Dst
 where
     A: Aliasing,
     SV: Validity,
     DV: Validity,
-    Src: TransmuteFrom<Dst, DV, SV> + ?Sized,
-    Dst: MutationCompatible<Src, A, SV, DV, R> + SizeCompat<Src> + ?Sized,
-{
-}
-
-// SAFETY:
-// - Forwards transmutation: Since aliasing is `Shared` and `Src: Immutable`,
-//   `src` does not permit mutation of its referent.
-// - Reverse transmutation: Since aliasing is `Shared` and `Dst: Immutable`,
-//   `dst` does not permit mutation of its referent.
-// - No safe code, given access to `src` and `dst`, can cause undefined
-//   behavior: `Src: Immutable` and `Dst: Immutable`
-unsafe impl<Src, Dst, SV, DV> TryTransmuteFromPtr<Src, Shared, SV, DV, BecauseImmutable> for Dst
-where
-    SV: Validity,
-    DV: Validity,
-    Src: Immutable + ?Sized,
-    Dst: Immutable + SizeCompat<Src> + ?Sized,
+    Src: ?Sized,
+    Dst: MutationCompatible<Src, A, SV, DV, R> + SizeFrom<Src> + ?Sized,
 {
 }
 
@@ -182,21 +142,38 @@ where
 /// # Safety
 ///
 /// At least one of the following must hold:
-/// - `Src: Read<A, _>` and `Self: Read<A, _>`
-/// - `Self: InvariantsEq<Src>` and:
-///   - `Dst: TransmuteFrom<Src, SV, DV>`
-///   - `Src: TransmuteFrom<Dst, DV, SV>`
+/// - `A = Exclusive` and `Src: TransmuteFromTear<Dst, DV, SV>`
+/// - `A = Shared`, `Src: Immutable`, and `Dst: Immutable`
+/// - `A = Shared`, `Dst: TransmuteFromShrink<Src, SV, DV>`, `Src:
+///   TransmuteFromTear<Dst, DV, SV>`, and `Dst: InvariantsEq<Src>`
 pub unsafe trait MutationCompatible<Src: ?Sized, A: Aliasing, SV, DV, R> {}
 
 #[allow(missing_copy_implementations, missing_debug_implementations)]
-pub enum BecauseRead {}
+pub enum BecauseReversible {}
 
-// SAFETY: `Src: Read<A, _>` and `Dst: Read<A, _>`.
-unsafe impl<Src: ?Sized, Dst: ?Sized, A: Aliasing, SV: Validity, DV: Validity, R, S>
-    MutationCompatible<Src, A, SV, DV, (BecauseRead, (R, S))> for Dst
+#[allow(missing_copy_implementations, missing_debug_implementations)]
+pub enum BecauseBidirectional {}
+
+unsafe impl<Src: ?Sized, Dst: ?Sized, SV: Validity, DV: Validity>
+    MutationCompatible<Src, Exclusive, SV, DV, BecauseReversible> for Dst
 where
-    Src: Read<A, R>,
-    Dst: Read<A, S>,
+    Src: TransmuteOverwrite<Dst, DV, SV>,
+{
+}
+
+unsafe impl<Src: ?Sized, Dst: ?Sized, SV: Validity, DV: Validity>
+    MutationCompatible<Src, Shared, SV, DV, BecauseImmutable> for Dst
+where
+    Src: Immutable,
+    Dst: Immutable,
+{
+}
+
+unsafe impl<Src: ?Sized, Dst: ?Sized, A: Reference, SV: Validity, DV: Validity>
+    MutationCompatible<Src, A, SV, DV, BecauseBidirectional> for Dst
+where
+    Dst: TransmuteFrom<Src, SV, DV> + InvariantsEq<Src>,
+    Src: TransmuteOverwrite<Dst, DV, SV>,
 {
 }
 
@@ -211,18 +188,6 @@ pub unsafe trait InvariantsEq<T: ?Sized> {}
 
 // SAFETY: Trivially sound to have multiple `&T` pointing to the same referent.
 unsafe impl<T: ?Sized> InvariantsEq<T> for T {}
-
-// SAFETY: `Dst: InvariantsEq<Src> + TransmuteFrom<Src, SV, DV>`, and `Src:
-// TransmuteFrom<Dst, DV, SV>`.
-unsafe impl<Src: ?Sized, Dst: ?Sized, A: Aliasing, SV: Validity, DV: Validity>
-    MutationCompatible<Src, A, SV, DV, BecauseInvariantsEq> for Dst
-where
-    Src: TransmuteFrom<Dst, DV, SV>,
-    Dst: TransmuteFrom<Src, SV, DV> + InvariantsEq<Src>,
-{
-}
-
-pub(crate) enum BecauseInvariantsEq {}
 
 macro_rules! unsafe_impl_invariants_eq {
     ($tyvar:ident => $t:ty, $u:ty) => {{
@@ -264,7 +229,7 @@ unsafe impl<T: ?Sized> InvariantsEq<ManuallyDrop<T>> for T {}
 ///
 /// Further, if `Dst: TransmuteFromPtr<Src, A, SV, DV>`, then given `src:
 /// Ptr<'_, (A, _, SV)>`, it is sound to transmute `src` to `dst: Ptr<'_, (A, _,
-/// DV)>` using [`SizeCompat::cast_from_raw`] to perform the raw pointer
+/// DV)>` using [`SizeFrom::cast_from_raw`] to perform the raw pointer
 /// transmute.
 ///
 /// ## Proof
@@ -291,57 +256,43 @@ where
 ///
 /// *In this section, we refer to `Self` as `Dst`.*
 ///
-/// If `Src` is an inhabited type, then `Dst` must also be an inhabited type.
-///
-/// ## By-value transmutation
-///
-/// If `Src: Sized` and `Dst: Sized`, then it must be sound to transmute an
-/// `SV`-valid `Src` into a `DV`-valid `Dst` by value via size-preserving or
-/// size-shrinking transmute. In particular, the first `size_of::<Dst>()` bytes
-/// of any `SV`-valid `Src` must be a `DV`-valid `Dst`.
-///
-/// If either `Src: !Sized` or `Dst: !Sized`, then this condition does not need
-/// to hold.
-///
-/// ## By-reference transmutation
-///
-/// If `Dst: SizeCompat<Src>`, then the following must hold: For all [valid
-/// sizes] of `Src`, `ssize` let `s: PtrInner<'_, Src>` with referent size
-/// `ssize`. Let `dsize` be the referent size of `SizeCompat::cast_from_raw(s)`.
-/// Note that, by invariant on `cast_from_raw`, `ssize >= dsize`. For all
-/// `SV`-valid values of `Src` with size `ssize`, `src`, it must be the case
-/// that the leading `dsize` bytes of `src` constitute a `DV`-valid `Dst`.
-///
-/// *This case corresponds to a `&Src` to `&Dst` transmute.*
-///
-/// If `Src: SizeCompat<Dst>`, then the following must hold: For all [valid
-/// sizes] of `Dst`, `dsize`, let `d: PtrInner<'_, Dst>` with referent size
-/// `dsize`. Let `ssize` be the referent size of `SizeCompat::cast_from_raw(d)`.
-/// Note that, by invariant on `cast_from_raw`, `dsize >= ssize`. For all
-/// `DV`-valid values of `Dst` with size `dsize`, `dst`, and for all `SV`-valid
-/// values of `Src` with size `ssize`, `src`, let `dst'` be constructed by
-/// concatenating `src` with the trailing `dsize - ssize` bytes of `dst`. It
-/// must be the case that `dst'` is a `DV`-valid `Dst`.
-///
-/// *This case corresponds to a `&Dst` to `&Src` transmute where `Src` and `Dst`
-/// permit interior mutation, or to a `&mut Dst` to `&mut Src` transmute. In
-/// particular, it ensures that, once values have been written to the `&Src` or
-/// `&mut Src` and the `&Src` or `&mut Src` have been dropped, the original
-/// `&Src` or `&mut Src` still refer to an `SV`-valid `Src`.*
-///
-/// Note that, if `<Dst as SizeCompat<Src>>::cast_from_raw` and `<Src as
-/// SizeCompat<Dst>>::cast_from_raw` both preserve referent size exactly, then
-/// the conditions in this section are a logical consequence of the conditions
-/// in the "By-value transmutation" section.
+/// If `Dst: SizeFrom<Src>` (or `Dst: Sized` and `Src: Sized` where
+/// `size_of::<Dst>() <= size_of::<Src>()`), then the following must hold: For
+/// all [valid sizes] of `Src` (or for `size_of::<Src>()`), `ssize`, let `s:
+/// PtrInner<'_, Src>` with referent size `ssize`. Let `dsize` be the referent
+/// size of `SizeFrom::cast_from_raw(s)` (or `size_of::<Dst>()`). Note that, by
+/// invariant on `cast_from_raw` (or by `size_of::<Dst>() <= size_of::<Src>()`),
+/// `ssize >= dsize`. For all `SV`-valid values of `Src` with size `ssize`,
+/// `src`, it must be the case that the leading `dsize` bytes of `src`
+/// constitute a `DV`-valid `Dst`.
 ///
 /// [valid sizes]: crate::KnownLayout#what-is-a-valid-size
 pub unsafe trait TransmuteFrom<Src: ?Sized, SV, DV> {}
+
+/// Denotes that any `BV`-valid `Self` may have its prefix overwritten with any
+/// `OV`-valid `Overlay` and remain `BV`-valid.
+///
+/// # Safety
+///
+/// *In this section, we refer to `Self` as `Base`.*
+///
+/// If `Overlay: SizeFrom<Base>`, then the following must hold: For all [valid
+/// sizes] of `Base`, `bsize`, let `b: PtrInner<'_, Base>` with referent size
+/// `bsize`. Let `osize` be the referent size of `SizeFrom::cast_from_raw(b)`.
+/// Note that, by invariant on `cast_from_raw`, `bsize >= osize`. For all
+/// `BV`-valid values of `Base` with size `bsize`, `base`, and for all
+/// `OV`-valid values of `Overlay` with size `osize`, `overlay`, let `base'` be
+/// constructed by concatenating `overlay` with the trailing `bsize - osize`
+/// bytes of `base`. It must be the case that `base'` is a `BV`-valid `Base`.
+///
+/// [valid sizes]: crate::KnownLayout#what-is-a-valid-size
+pub unsafe trait TransmuteOverwrite<Overlay: ?Sized, OV, BV> {}
 
 /// # Safety
 ///
 /// Implementations of `cast_from_raw` must satisfy that method's safety
 /// post-condition.
-pub unsafe trait SizeCompat<Src: ?Sized> {
+pub unsafe trait SizeFrom<Src: ?Sized> {
     /// # Safety
     ///
     /// Given `src: PtrInner<'_, Src>`, `let dst = Self::cast_from_raw(src)`
@@ -352,7 +303,7 @@ pub unsafe trait SizeCompat<Src: ?Sized> {
     /// The size of `dst` must only be a function of the size of `src`. It must
     /// not be a function of `src`'s address.
     ///
-    /// `<Self as SizeCompat<Self>>::cast_from_raw` is guaranteed to be the
+    /// `<Self as SizeFrom<Self>>::cast_from_raw` is guaranteed to be the
     /// identity function.
     fn cast_from_raw(src: PtrInner<'_, Src>) -> PtrInner<'_, Self>;
 }
@@ -360,7 +311,7 @@ pub unsafe trait SizeCompat<Src: ?Sized> {
 // SAFETY: `T` trivially has the same size and vtable kind as `T`, and since
 // pointer `*mut T -> *mut T` pointer casts are no-ops, this cast trivially
 // preserves referent size (when `T: ?Sized`).
-unsafe impl<T: ?Sized> SizeCompat<T> for T {
+unsafe impl<T: ?Sized> SizeFrom<T> for T {
     #[inline(always)]
     fn cast_from_raw<'a>(t: PtrInner<'a, T>) -> PtrInner<'a, T> {
         t
@@ -368,17 +319,9 @@ unsafe impl<T: ?Sized> SizeCompat<T> for T {
 }
 
 /// `Valid<Src: IntoBytes> → Initialized<Dst>`
-// SAFETY:
-// - By-value: Since `Src: IntoBytes`, the set of valid `Src`'s is the set of
-//   initialized bit patterns, which is exactly the set allowed in the referent
-//   of any `Initialized` `Ptr`. This holds for both size-preserving and
-//   size-shrinking transmutes.
-// - By-reference:
-//   - Shrinking: See above.
-//   - Tearing: Let `src` be a `Valid` `Src` and `dst` be an `Initialized`
-//     `Dst`. The trailing bytes of `dst` have bit validity `[u8; N]`. `src` has
-//     bit validity `[u8; M]`. Thus, `dst' = src + trailing_bytes_of(dst)` has
-//     bit validity `[u8; N + M]`, which is a valid `Initialized` value.
+// SAFETY: Since `Src: IntoBytes`, the set of valid `Src`'s is the set of
+// initialized bit patterns, which is exactly the set allowed in the referent of
+// any `Initialized` `Ptr`. This holds even for shrinking transmutes.
 unsafe impl<Src, Dst> TransmuteFrom<Src, Valid, Initialized> for Dst
 where
     Src: IntoBytes + ?Sized,
@@ -386,16 +329,40 @@ where
 {
 }
 
+/// `Valid<Overlay: IntoBytes> → Initialized<Base>`
+// SAFETY: Let `overlay` be a `Valid` `Overlay` and `base` be an `Initialized`
+// `Base`. The trailing bytes of `base` have bit validity `[u8; N]`. By
+// `Overlay: IntoBytes`, `overlay`'s bit validity is at least as restrictive as
+// `[u8; M]` (some `[u8; M]` values may not be valid `Overlay` values). Thus,
+// `base' = overlay + trailing_bytes_of(base)` is a valid `[u8; N + M]`, which
+// is a valid `Initialized` value.
+unsafe impl<Overlay, Base> TransmuteOverwrite<Overlay, Valid, Initialized> for Base
+where
+    Overlay: IntoBytes + ?Sized,
+    Base: ?Sized,
+{
+}
+
 /// `Initialized<Src> → Valid<Dst: FromBytes>`
-// SAFETY: Since `Dst: FromBytes`, any initialized bit pattern may appear in the
-// referent of a `Ptr<Dst, (_, _, Valid)>`. This is exactly equal to the set of
-// bit patterns which may appear in the referent of any `Initialized` `Ptr`.
-//
-// TODO: Prove `TransmuteFrom` reference transmutation conditions.
+// SAFETY: Since `Dst: FromBytes`, any initialized bit pattern is a valid `Dst`.
+// An `Initialized<Src>` is guaranteed to have all its bytes initialized, so any
+// (prefix of an) `Initialized<Src>` is a valid `Dst`.
 unsafe impl<Src, Dst> TransmuteFrom<Src, Initialized, Valid> for Dst
 where
     Src: ?Sized,
     Dst: FromBytes + ?Sized,
+{
+}
+
+/// `Initialized<Overlay> → Valid<Base: FromBytes + IntoBytes>`
+// SAFETY: The bit validity of `Initialized<Overlay>` is equivalent to that of
+// `[u8]`. By `Base: FromBytes + IntoBytes`, the validity of `Valid<Base>` is
+// also equivalent to that of `[u8]`. Any two `[u8]`s concatenated together are
+// a valid `[u8]`.
+unsafe impl<Overlay, Base> TransmuteOverwrite<Overlay, Initialized, Valid> for Base
+where
+    Overlay: ?Sized,
+    Base: FromBytes + IntoBytes + ?Sized,
 {
 }
 
@@ -404,14 +371,26 @@ where
 // transmutable into `[u8; N]`.
 
 /// `Initialized<Src> → Initialized<Dst>`
-// SAFETY: The set of allowed bit patterns in the referent of any `Initialized`
-// `Ptr` is the same regardless of referent type.
-//
-// TODO: Prove `TransmuteFrom` reference transmutation conditions.
+// SAFETY: The validity of `Initialized<T>` is equal to that of `[u8]`. `[u8]`'s
+// validity does not depend on a value's length, so any prefix of an
+// `Initialized<Src>` is a valid `Initialized<Dst>`.
 unsafe impl<Src, Dst> TransmuteFrom<Src, Initialized, Initialized> for Dst
 where
     Src: ?Sized,
     Dst: ?Sized,
+{
+}
+
+/// `Initialized<Overlay> → Initialized<Base>`
+// SAFETY: The validity of `Initialized<T>` is equal to that of `[u8]`. `[u8]`'s
+// validity does not depend on a value's length, so two `[u8]`s concatenated
+// together are also a valid `[u8]`. Thus, an `Initialized<Overlay>`
+// concatenated with the `[u8]` suffix of an `Initialized<Base>` is a valid
+// `Initialized<Base>`.
+unsafe impl<Overlay, Base> TransmuteOverwrite<Overlay, Initialized, Initialized> for Base
+where
+    Overlay: ?Sized,
+    Base: ?Sized,
 {
 }
 
@@ -420,14 +399,21 @@ where
 // transmutable into `MaybeUninit<[u8; N]>`.
 
 /// `V<Src> → Uninit<Dst>`
-// SAFETY: A `Dst` with validity `Uninit` permits any byte sequence, and
-// therefore can be transmuted from any value.
-//
-// TODO: Prove `TransmuteFrom` reference transmutation conditions.
+// SAFETY: A `Dst` with validity `Uninit` permits any byte sequence.
 unsafe impl<Src, Dst, V> TransmuteFrom<Src, V, Uninit> for Dst
 where
     Src: ?Sized,
     Dst: ?Sized,
+    V: Validity,
+{
+}
+
+/// `V<Overlay> → Uninit<Base>`
+// SAFETY: A `Base` with validity `Uninit` permits any byte sequence.
+unsafe impl<Overlay, Base, V> TransmuteOverwrite<Overlay, V, Uninit> for Base
+where
+    Overlay: ?Sized,
+    Base: ?Sized,
     V: Validity,
 {
 }
@@ -527,9 +513,11 @@ impl_transitive_transmute_from!(T: ?Sized => UnsafeCell<T> => T => Cell<T>);
 // explicitly guaranteed, but it's obvious from `MaybeUninit`'s documentation
 // that this is the intention:
 // https://doc.rust-lang.org/1.85.0/core/mem/union.MaybeUninit.html
-//
-// TODO: Prove `TransmuteFrom` reference transmutation conditions.
 unsafe impl<Src, Dst> TransmuteFrom<Src, Uninit, Valid> for MaybeUninit<Dst> {}
+
+/// `Uninit<Overlay> → Valid<MaybeUninit<Base>>`
+// SAFETY: See previous safety comment.
+unsafe impl<Overlay, Base> TransmuteOverwrite<Overlay, Uninit, Valid> for MaybeUninit<Base> {}
 
 // SAFETY: `MaybeUninit<T>` has the same size as `T` [1]. Thus, a pointer cast
 // preserves address and referent size.
@@ -538,7 +526,7 @@ unsafe impl<Src, Dst> TransmuteFrom<Src, Uninit, Valid> for MaybeUninit<Dst> {}
 //
 //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
 //   `T`
-unsafe impl<T> SizeCompat<T> for MaybeUninit<T> {
+unsafe impl<T> SizeFrom<T> for MaybeUninit<T> {
     #[inline(always)]
     fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, MaybeUninit<T>> {
         // SAFETY: Per preceding safety comment, `MaybeUninit<T>` and `T` have
@@ -548,7 +536,7 @@ unsafe impl<T> SizeCompat<T> for MaybeUninit<T> {
 }
 
 // SAFETY: See previous safety comment.
-unsafe impl<T> SizeCompat<MaybeUninit<T>> for T {
+unsafe impl<T> SizeFrom<MaybeUninit<T>> for T {
     #[inline(always)]
     fn cast_from_raw(t: PtrInner<'_, MaybeUninit<T>>) -> PtrInner<'_, T> {
         // SAFETY: Per preceding safety comment, `MaybeUninit<T>` and `T` have

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -656,9 +656,9 @@ where
         // `b.into_byte_slice_mut()` produces a byte slice with identical
         // address and length to that produced by `b.deref_mut()`.
         let ptr = Ptr::from_mut(b.into_byte_slice_mut())
-            .try_cast_into_no_leftover::<T, BecauseExclusive>(None)
+            .try_cast_into_no_leftover(None)
             .expect("zerocopy internal error: into_ref should be infallible");
-        let ptr = ptr.recall_validity::<_, (_, (_, _))>();
+        let ptr = ptr.recall_validity::<_, BecauseBidirectional>();
         ptr.as_mut()
     }
 }
@@ -797,9 +797,9 @@ where
         // are preserved through `.deref_mut()`, so this `unwrap` will not
         // panic.
         let ptr = Ptr::from_mut(b.deref_mut())
-            .try_cast_into_no_leftover::<T, BecauseExclusive>(None)
+            .try_cast_into_no_leftover(None)
             .expect("zerocopy internal error: DerefMut::deref_mut should be infallible");
-        let ptr = ptr.recall_validity::<_, (_, (_, (BecauseExclusive, BecauseExclusive)))>();
+        let ptr = ptr.recall_validity::<_, BecauseBidirectional>();
         ptr.as_mut()
     }
 }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -677,22 +677,21 @@ macro_rules! static_assert_dst_is_not_zst {
     }}
 }
 
+/// # Safety
+///
+/// The caller must ensure that the cast does not grow the size of the referent.
+/// Preserving or shrinking the size of the referent are both acceptable.
 macro_rules! cast {
-    () => {
-        |p| {
-            // SAFETY: `NonNull::as_ptr` returns a non-null pointer, so the
-            // argument to `NonNull::new_unchecked` is also non-null.
-            #[allow(clippy::as_conversions, unused_unsafe)]
-            #[allow(clippy::undocumented_unsafe_blocks)] // Clippy false positive
-            return unsafe {
-                core::ptr::NonNull::new_unchecked(core::ptr::NonNull::as_ptr(p) as *mut _)
-            };
-        }
-    };
     ($p:expr) => {{
         let ptr: crate::pointer::PtrInner<'_, _> = $p;
         let ptr = ptr.as_non_null();
-        let ptr = cast!()(ptr);
+        let ptr = ptr.as_ptr();
+        #[allow(clippy::as_conversions)]
+        let ptr = ptr as *mut _;
+        #[allow(unused_unsafe)]
+        // SAFETY: `NonNull::as_ptr` returns a non-null pointer, so the argument
+        // to `NonNull::new_unchecked` is also non-null.
+        let ptr = unsafe { core::ptr::NonNull::new_unchecked(ptr) };
         // SAFETY: The caller promises that the cast preserves or shrinks
         // referent size. By invariant on `$p: PtrInner` (guaranteed by type
         // annotation above), `$p` refers to a byte range entirely contained
@@ -703,37 +702,38 @@ macro_rules! cast {
     }};
 }
 
-/// Implements `TransmuteFrom` and `SizeEq` for `T` and `$wrapper<T>`.
+/// Implements `TransmuteFrom` and `SizeCompat` for `T` and `$wrapper<T>`.
 ///
 /// # Safety
 ///
-/// `T` and `$wrapper<T>` must have the same bit validity, and must have the
-/// same size in the sense of `SizeEq`.
+/// `T` and `$wrapper<T>` must have the same bit validity, and must satisfy the
+/// following property: given `t: *mut T`, `let w = t as *mut $wrapper<T>`
+/// produces a pointer which address the same bytes as `t`. The inverse must
+/// also hold.
 macro_rules! unsafe_impl_for_transparent_wrapper {
     (T $(: ?$optbound:ident)? => $wrapper:ident<T>) => {{
         crate::util::macros::__unsafe();
 
-        use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+        use crate::pointer::{TransmuteFrom, PtrInner, SizeCompat, invariant::Valid};
 
         // SAFETY: The caller promises that `T` and `$wrapper<T>` have the same
-        // bit validity.
+        // bit validity, and that both implementations of
+        // `SizeCompat::cast_from_raw` preserve referent size exactly.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<T, Valid, Valid> for $wrapper<T> {}
         // SAFETY: See previous safety comment.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<$wrapper<T>, Valid, Valid> for T {}
         // SAFETY: The caller promises that `T` and `$wrapper<T>` satisfy
-        // `SizeEq`.
-        unsafe impl<T $(: ?$optbound)?> SizeEq<T> for $wrapper<T> {
+        // `cast_from_raw`'s safety post-condition.
+        unsafe impl<T $(: ?$optbound)?> SizeCompat<T> for $wrapper<T> {
             #[inline(always)]
             fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, $wrapper<T>> {
-                // SAFETY: See previous safety comment.
                 unsafe { cast!(t) }
             }
         }
         // SAFETY: See previous safety comment.
-        unsafe impl<T $(: ?$optbound)?> SizeEq<$wrapper<T>> for T {
+        unsafe impl<T $(: ?$optbound)?> SizeCompat<$wrapper<T>> for T {
             #[inline(always)]
             fn cast_from_raw(t: PtrInner<'_, $wrapper<T>>) -> PtrInner<'_, T> {
-                // SAFETY: See previous safety comment.
                 unsafe { cast!(t) }
             }
         }
@@ -743,19 +743,20 @@ macro_rules! unsafe_impl_for_transparent_wrapper {
 macro_rules! impl_transitive_transmute_from {
     ($($tyvar:ident $(: ?$optbound:ident)?)? => $t:ty => $u:ty => $v:ty) => {
         const _: () = {
-            use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+            use crate::pointer::{TransmuteFrom, SizeCompat, invariant::Valid};
 
-            // SAFETY: Since `$u: SizeEq<$t>` and `$v: SizeEq<U>`, this impl is
-            // transitively sound.
-            unsafe impl<$($tyvar $(: ?$optbound)?)?> SizeEq<$t> for $v
+            // SAFETY: See safety comment on `cast_from_raw`.
+            unsafe impl<$($tyvar $(: ?$optbound)?)?> SizeCompat<$t> for $v
             where
-                $u: SizeEq<$t>,
-                $v: SizeEq<$u>,
+                $u: SizeCompat<$t>,
+                $v: SizeCompat<$u>,
             {
+                // SAFETY: Each inner call to `cast_from_raw` preserves
+                // provenance and addressed byte range.
                 #[inline(always)]
                 fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $v> {
-                    let u = <$u as SizeEq<_>>::cast_from_raw(t);
-                    <$v as SizeEq<_>>::cast_from_raw(u)
+                    let u = SizeCompat::cast_from_raw(t);
+                    SizeCompat::cast_from_raw(u)
                 }
             }
 
@@ -773,10 +774,10 @@ macro_rules! impl_transitive_transmute_from {
 }
 
 #[rustfmt::skip]
-macro_rules! impl_size_eq {
+macro_rules! impl_size_compat {
     ($t:ty, $u:ty) => {
         const _: () = {
-            use crate::{KnownLayout, pointer::{PtrInner, SizeEq}};
+            use crate::{KnownLayout, pointer::{PtrInner, SizeCompat}};
 
             static_assert!(=> {
                 let t = <$t as KnownLayout>::LAYOUT;
@@ -792,7 +793,7 @@ macro_rules! impl_size_eq {
             });
 
             // SAFETY: See inline.
-            unsafe impl SizeEq<$t> for $u {
+            unsafe impl SizeCompat<$t> for $u {
                 #[inline(always)]
                 fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $u> {
                     // SAFETY: We've asserted that their
@@ -803,7 +804,7 @@ macro_rules! impl_size_eq {
                 }
             }
             // SAFETY: See previous safety comment.
-            unsafe impl SizeEq<$u> for $t {
+            unsafe impl SizeCompat<$u> for $t {
                 #[inline(always)]
                 fn cast_from_raw(u: PtrInner<'_, $u>) -> PtrInner<'_, $t> {
                     // SAFETY: See previous safety comment.
@@ -815,17 +816,17 @@ macro_rules! impl_size_eq {
 }
 
 /// Invokes `$blk` in a context in which `$src<$t>` and `$dst<$u>` implement
-/// `SizeEq`.
+/// `SizeCompat`.
 ///
-/// This macro emits code which implements `SizeEq`, and ensures that the impl
-/// is sound via PME.
+/// This macro emits code which implements `SizeComapt`, and ensures that the
+/// impl is sound via PME.
 ///
 /// # Safety
 ///
 /// Inside of `$blk`, the caller must only use `$src` and `$dst` as `$src<$t>`
 /// and `$dst<$u>`. The caller must not use `$src` or `$dst` to wrap any other
 /// types.
-macro_rules! unsafe_with_size_eq {
+macro_rules! unsafe_with_size_compat {
     (<$src:ident<$t:ident>, $dst:ident<$u:ident>> $blk:expr) => {{
         crate::util::macros::__unsafe();
 
@@ -860,14 +861,14 @@ macro_rules! unsafe_with_size_eq {
         // We manually instantiate `cast_from_raw` below to ensure that this PME
         // can be triggered, and the caller promises not to use `$src` and
         // `$dst` with any wrapped types other than `$t` and `$u` respectively.
-        unsafe impl<T: ?Sized, U: ?Sized> SizeEq<$src<T>> for $dst<U>
+        unsafe impl<T: ?Sized, U: ?Sized> SizeCompat<$src<T>> for $dst<U>
         where
             T: KnownLayout<PointerMetadata = usize>,
             U: KnownLayout<PointerMetadata = usize>,
         {
             fn cast_from_raw(src: PtrInner<'_, $src<T>>) -> PtrInner<'_, Self> {
                 // SAFETY: `crate::layout::cast_from_raw` promises to satisfy
-                // the safety invariants of `SizeEq::cast_from_raw`, or to
+                // the safety invariants of `SizeCompat::cast_from_raw`, or to
                 // generate a PME. Since `$src<T>` and `$dst<U>` are
                 // `#[repr(transparent)]` wrappers around `T` and `U`
                 // respectively, a `cast_from_raw` impl which satisfies the
@@ -888,14 +889,12 @@ macro_rules! unsafe_with_size_eq {
         // See safety comment on the preceding `unsafe impl` block for an
         // explanation of why we need this block.
         if 1 == 0 {
-            let ptr = <$t as KnownLayout>::raw_dangling();
-            #[allow(unused_unsafe)]
-            // SAFETY: This call is never executed.
-            let ptr = unsafe { crate::pointer::PtrInner::new(ptr) };
-            #[allow(unused_unsafe)]
-            // SAFETY: This call is never executed.
-            let ptr = unsafe { cast!(ptr) };
-            let _ = <$dst<$u> as SizeEq<$src<$t>>>::cast_from_raw(ptr);
+            use crate::pointer::PtrInner;
+
+            #[allow(invalid_value, unused_unsafe)]
+            // SAFETY: This code is never executed.
+            let ptr: PtrInner<'_, $src<$t>> = unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+            let _ = <$dst<$u> as SizeCompat<$src<$t>>>::cast_from_raw(ptr);
         }
 
         impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for $src<T>[<T>]);

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -200,7 +200,7 @@ impl<T> Unalign<T> {
     /// callers may prefer [`DerefMut::deref_mut`], which is infallible.
     #[inline(always)]
     pub fn try_deref_mut(&mut self) -> Result<&mut T, AlignmentError<&mut Self, T>> {
-        let inner = Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>();
+        let inner = Ptr::from_mut(self).transmute::<_, _, BecauseBidirectional>();
         match inner.try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_mut()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_mut())),
@@ -396,7 +396,10 @@ impl<T: Unaligned> Deref for Unalign<T> {
 impl<T: Unaligned> DerefMut for Unalign<T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
-        Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>().bikeshed_recall_aligned().as_mut()
+        Ptr::from_mut(self)
+            .transmute::<_, _, BecauseBidirectional>()
+            .bikeshed_recall_aligned()
+            .as_mut()
     }
 }
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -264,7 +264,7 @@ pub(crate) fn derive_is_bit_valid(
                     let variant = unsafe {
                         variants.cast_unsized_unchecked(
                             |p: #zerocopy_crate::pointer::PtrInner<'_, ___ZerocopyVariants #ty_generics>| {
-                                p.as_non_null().cast::<#variant_struct_ident #ty_generics>()
+                                p.cast_sized::<#variant_struct_ident #ty_generics>()
                             }
                         )
                     };
@@ -325,7 +325,7 @@ pub(crate) fn derive_is_bit_valid(
                 //   primitive integer.
                 let tag_ptr = unsafe {
                     candidate.reborrow().cast_unsized_unchecked(|p: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
-                        p.as_non_null().cast::<___ZerocopyTagPrimitive>()
+                        p.cast_sized::<___ZerocopyTagPrimitive>()
                     })
                 };
                 // SAFETY: `tag_ptr` is casted from `candidate`, whose referent
@@ -347,7 +347,7 @@ pub(crate) fn derive_is_bit_valid(
             //   `UnsafeCell`s.
             let raw_enum = unsafe {
                 candidate.cast_unsized_unchecked(|p: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
-                    p.as_non_null().cast::<___ZerocopyRawEnum #ty_generics>()
+                    p.cast_sized::<___ZerocopyRawEnum #ty_generics>()
                 })
             };
             // SAFETY: `cast_unsized_unchecked` removes the initialization
@@ -364,13 +364,15 @@ pub(crate) fn derive_is_bit_valid(
             //   subfield pointer just points to a smaller portion of the
             //   overall struct.
             let variants = unsafe {
-                raw_enum.cast_unsized_unchecked( |p: #zerocopy_crate::pointer::PtrInner<'_, ___ZerocopyRawEnum #ty_generics>| {
+                use #zerocopy_crate::pointer::PtrInner;
+                raw_enum.cast_unsized_unchecked( |p: PtrInner<'_, ___ZerocopyRawEnum #ty_generics>| {
                     let p = p.as_non_null().as_ptr();
                     let ptr = core_reexport::ptr::addr_of_mut!((*p).variants);
                     // SAFETY: `ptr` is a projection into `p`, which is
                     // `NonNull`, and guaranteed not to wrap around the address
                     // space. Thus, `ptr` cannot be null.
-                    unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) }
+                    let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) };
+                    unsafe { PtrInner::new(ptr) }
                 })
             };
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -332,7 +332,7 @@ pub(crate) fn derive_is_bit_valid(
                 // is `Initialized`. Since we have not written uninitialized
                 // bytes into the referent, `tag_ptr` is also `Initialized`.
                 let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
+                tag_ptr.recall_validity().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
             };
 
             // SAFETY:

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -758,6 +758,7 @@ fn derive_try_from_bytes_struct(
                     ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
                 {
                     use #zerocopy_crate::util::macro_util::core_reexport;
+                    use #zerocopy_crate::pointer::PtrInner;
 
                     true #(&& {
                         // SAFETY:
@@ -768,7 +769,7 @@ fn derive_try_from_bytes_struct(
                         //   the same byte ranges in the returned pointer's referent
                         //   as they do in `*slf`
                         let field_candidate = unsafe {
-                            let project = |slf: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
+                            let project = |slf: PtrInner<'_, Self>| {
                                 let slf = slf.as_non_null().as_ptr();
                                 let field = core_reexport::ptr::addr_of_mut!((*slf).#field_names);
                                 // SAFETY: `cast_unsized_unchecked` promises that
@@ -778,7 +779,9 @@ fn derive_try_from_bytes_struct(
                                 // object. In either case, this guarantees that
                                 // field projection will not wrap around the address
                                 // space, and so `field` will be non-null.
-                                unsafe { core_reexport::ptr::NonNull::new_unchecked(field) }
+                                let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(field) };
+                                // TODO: Safety comment
+                                unsafe { PtrInner::new(ptr) }
                             };
 
                             candidate.reborrow().cast_unsized_unchecked(project)
@@ -829,6 +832,7 @@ fn derive_try_from_bytes_union(
                     ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
                 {
                     use #zerocopy_crate::util::macro_util::core_reexport;
+                    use #zerocopy_crate::pointer::PtrInner;
 
                     false #(|| {
                         // SAFETY:
@@ -839,7 +843,7 @@ fn derive_try_from_bytes_union(
                         //   `self_type_trait_bounds`, neither `*slf` nor the
                         //   returned pointer's referent contain any `UnsafeCell`s
                         let field_candidate = unsafe {
-                            let project = |slf: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
+                            let project = |slf: PtrInner<'_, Self>| {
                                 let slf = slf.as_non_null().as_ptr();
                                 let field = core_reexport::ptr::addr_of_mut!((*slf).#field_names);
                                 // SAFETY: `cast_unsized_unchecked` promises that
@@ -849,7 +853,9 @@ fn derive_try_from_bytes_union(
                                 // object. In either case, this guarantees that
                                 // field projection will not wrap around the address
                                 // space, and so `field` will be non-null.
-                                unsafe { core_reexport::ptr::NonNull::new_unchecked(field) }
+                                let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(field) };
+                                // TODO: Safety comment
+                                unsafe { PtrInner::new(ptr) }
                             };
 
                             candidate.reborrow().cast_unsized_unchecked(project)

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -782,7 +782,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyTagPrimitive>() })
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyRawEnum<'a, N, X, Y>>() })
@@ -1106,7 +1106,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyTagPrimitive> ()})
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyRawEnum<'a, N, X, Y>> ()})
@@ -1430,7 +1430,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyTagPrimitive> ()})
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.as_non_null().cast::<___ZerocopyRawEnum<'a, N, X, Y>> ()})


### PR DESCRIPTION
Also, only implement TryTransmuteFromPtr once in terms of
MutationCompatible.




---

This PR is on branch [transmute-ref-dst](../tree/transmute-ref-dst).

- #2487
- #2567
- #2472