### PR TITLE
Support x86 AVX-12 SIMD types on 1.89.0 stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           # These are the names of specific Rust versions detected in
           # `build.rs`. Each of these represents the minimum Rust version for
           # which a particular feature is supported.
+          "zerocopy-simd-x86-avx12-1-89-0",
           "zerocopy-core-error-1-81-0",
           "zerocopy-diagnostic-on-unimplemented-1-78-0",
           "zerocopy-generic-bounds-in-const-fn-1-61-0",
@@ -85,6 +86,8 @@ jobs:
             features: "--all-features"
           - toolchain: "stable"
             features: "--all-features"
+          - toolchain: "zerocopy-simd-x86-avx12-1-89-0"
+            features: "--all-features"
           - toolchain: "zerocopy-core-error-1-81-0"
             features: "--all-features"
           - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
@@ -108,7 +111,9 @@ jobs:
           # Exclue any combination of zerocopy-derive and any toolchain version
           # other than "msrv", "stable", and "nightly". These other versions
           # exist to exercise zerocopy behavior which differs by toolchain;
-          # zerocopy-derive doesn't behave different on these toolchains.
+          # zerocopy-derive doesn't behave differently on these toolchains.
+          - crate: "zerocopy-derive"
+            toolchain: "zerocopy-simd-x86-avx12-1-89-0"
           - crate: "zerocopy-derive"
             toolchain: "zerocopy-core-error-1-81-0"
           - crate: "zerocopy-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ exclude = [".*"]
 # used in the codebase to make it less likely for us to make mistakes when
 # writing `doc_cfg` attributes.
 
+# From 1.89.0, Rust supports x86 AVX-12 SIMD types (previously gated by the
+# `stdarch_x86_avx512` feature).
+zerocopy-simd-x86-avx12-1-89-0 = "1.89.0"
+
 # From 1.81.0, Rust supports the `core::error::Error` trait.
 zerocopy-core-error-1-81-0 = "1.81.0"
 
@@ -60,7 +64,7 @@ zerocopy-panic-in-const-and-vec-try-reserve-1-57-0 = "1.57.0"
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.87.0"
-pinned-nightly = "nightly-2025-06-07"
+pinned-nightly = "nightly-2025-06-08"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1026,16 +1026,20 @@ mod simd {
             #[cfg(target_arch = "x86")]
             x86, x86, __m128, __m128d, __m128i, __m256, __m256d, __m256i
         );
+        #[cfg(zerocopy_simd_x86_avx12_1_89_0)]
         simd_arch_mod!(
-            #[cfg(all(feature = "simd-nightly", target_arch = "x86"))]
+            #[cfg(target_arch = "x86")]
+            #[cfg_attr(doc_cfg, doc(cfg(rust = "1.89.0")))]
             x86, x86_nightly, __m512bh, __m512, __m512d, __m512i
         );
         simd_arch_mod!(
             #[cfg(target_arch = "x86_64")]
             x86_64, x86_64, __m128, __m128d, __m128i, __m256, __m256d, __m256i
         );
+        #[cfg(zerocopy_simd_x86_avx12_1_89_0)]
         simd_arch_mod!(
-            #[cfg(all(feature = "simd-nightly", target_arch = "x86_64"))]
+            #[cfg(target_arch = "x86_64")]
+            #[cfg_attr(doc_cfg, doc(cfg(rust = "1.89.0")))]
             x86_64, x86_64_nightly, __m512bh, __m512, __m512d, __m512i
         );
         simd_arch_mod!(
@@ -1050,11 +1054,11 @@ mod simd {
             #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
             powerpc64, powerpc64, vector_bool_long, vector_double, vector_signed_long, vector_unsigned_long
         );
+        #[cfg(zerocopy_aarch64_simd_1_59_0)]
         simd_arch_mod!(
             // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
             // broken on big-endian platforms.
             #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-            #[cfg(zerocopy_aarch64_simd_1_59_0)]
             #[cfg_attr(doc_cfg, doc(cfg(rust = "1.59.0")))]
             aarch64, aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,
             int8x8x3_t, int8x8x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int16x4_t,
@@ -2023,19 +2027,19 @@ mod tests {
             #[cfg(target_arch = "x86")]
             test_simd_arch_mod!(x86, __m128, __m128d, __m128i, __m256, __m256d, __m256i);
 
-            #[cfg(all(feature = "simd-nightly", target_arch = "x86"))]
+            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "x86"))]
             test_simd_arch_mod!(x86, __m512bh, __m512, __m512d, __m512i);
 
             #[cfg(target_arch = "x86_64")]
             test_simd_arch_mod!(x86_64, __m128, __m128d, __m128i, __m256, __m256d, __m256i);
 
-            #[cfg(all(feature = "simd-nightly", target_arch = "x86_64"))]
+            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "x86_64"))]
             test_simd_arch_mod!(x86_64, __m512bh, __m512, __m512d, __m512i);
 
             #[cfg(target_arch = "wasm32")]
             test_simd_arch_mod!(wasm32, v128);
 
-            #[cfg(all(feature = "simd-nightly", target_arch = "powerpc"))]
+            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "powerpc"))]
             test_simd_arch_mod!(
                 powerpc,
                 vector_bool_long,
@@ -2044,7 +2048,7 @@ mod tests {
                 vector_unsigned_long
             );
 
-            #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
+            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "powerpc64"))]
             test_simd_arch_mod!(
                 powerpc64,
                 vector_bool_long,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,10 +304,6 @@
 ))]
 #![cfg_attr(not(any(test, kani, feature = "std")), no_std)]
 #![cfg_attr(
-    all(feature = "simd-nightly", any(target_arch = "x86", target_arch = "x86_64")),
-    feature(stdarch_x86_avx512)
-)]
-#![cfg_attr(
     all(feature = "simd-nightly", target_arch = "arm"),
     feature(stdarch_arm_dsp, stdarch_arm_neon_intrinsics)
 )]


### PR DESCRIPTION
Previously, these types were gated by the `stdarch_x86_avx512` nightly
Rust feature. As of 1.89.0, they are supported on stable.

gherrit-pr-id: I6907ba8f144bd90d917b85c9687443fc7cf19de2
