### PR TITLE
`derive(FromBytes)`: don't claim to support `repr(C)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3357,12 +3357,11 @@ pub unsafe trait FromZeros: TryFromBytes {
 ///
 /// - If the type is a struct, all of its fields must be `FromBytes`.
 /// - If the type is an enum:
-///   - It must have a defined representation (`repr`s `C`, `u8`, `u16`, `u32`,
+///   - It must have a defined representation (`repr`s `u8`, `u16`, `u32`,
 ///     `u64`, `usize`, `i8`, `i16`, `i32`, `i64`, or `isize`).
 ///   - The maximum number of discriminants must be used (so that every possible
-///     bit pattern is a valid one). Be very careful when using the `C`,
-///     `usize`, or `isize` representations, as their size is
-///     platform-dependent.
+///     bit pattern is a valid one). Be very careful when using the `usize` or
+///     `isize` representations, as their size is platform-dependent.
 ///   - Its fields must be `FromBytes`.
 ///
 /// This analysis is subject to change. Unsafe code may *only* rely on the
@@ -3395,8 +3394,6 @@ pub unsafe trait FromZeros: TryFromBytes {
 ///
 /// Whether a struct is soundly `FromBytes` therefore solely depends on whether
 /// its fields are `FromBytes`.
-// FIXME(#146): Document why we don't require an enum to have an explicit `repr`
-// attribute.
 #[cfg(any(feature = "derive", test))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
 pub use zerocopy_derive::FromBytes;


### PR DESCRIPTION
We cannot support `repr(C)` because their discriminant size depends on the behavior of what Rust thinks the system C compiler will do, which we don't have visibility into.

Fixes #2537

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
