### PR TITLE
Remove `Deref` bound on `Display` and `Error` for `ValidityError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -607,7 +607,6 @@ impl<Src, Dst: ?Sized + TryFromBytes> ValidityError<Src, Dst> {
     /// This formatting may include potentially sensitive information.
     fn display_verbose_extras(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
     where
-        Src: Deref,
         Dst: KnownLayout,
     {
         f.write_str("Destination type: ")?;
@@ -630,7 +629,6 @@ impl<Src, Dst: ?Sized + TryFromBytes> fmt::Debug for ValidityError<Src, Dst> {
 /// potentially sensitive information.
 impl<Src, Dst: ?Sized> fmt::Display for ValidityError<Src, Dst>
 where
-    Src: Deref,
     Dst: KnownLayout + TryFromBytes,
 {
     #[inline]
@@ -646,12 +644,7 @@ where
 
 #[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
 #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
-impl<Src, Dst: ?Sized> Error for ValidityError<Src, Dst>
-where
-    Src: Deref,
-    Dst: KnownLayout + TryFromBytes,
-{
-}
+impl<Src, Dst: ?Sized> Error for ValidityError<Src, Dst> where Dst: KnownLayout + TryFromBytes {}
 
 impl<Src, Dst: ?Sized + TryFromBytes, A, S> From<ValidityError<Src, Dst>>
     for ConvertError<A, S, ValidityError<Src, Dst>>


### PR DESCRIPTION
These impls should not (and do not) reflect on the address of the source. Even if they were to display the source value, they should do so by debug/display-printing the source, not by explicitly dereferencing the pointer.

Fixes #2535

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
