### PR TITLE
Generalize SizeEq to SizeFrom, support shrinking

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -105,11 +105,13 @@ assert_unaligned!(bool);
 //   pattern 0x01.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for bool; |byte| {
-        let byte = byte.transmute::<u8, invariant::Valid, _>();
+        let mut byte = byte;
+        let byte = byte.reborrow().into_shared().transmute::<u8, invariant::Valid, _>();
         *byte.unaligned_as_ref() < 2
     })
 };
-impl_size_eq!(bool, u8);
+
+impl_size_from!(bool, u8);
 
 // SAFETY:
 // - `Immutable`: `char` self-evidently does not contain any `UnsafeCell`s.
@@ -134,13 +136,14 @@ const _: () = unsafe { unsafe_impl!(char: Immutable, FromZeros, IntoBytes) };
 //   `char`.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for char; |c| {
-        let c = c.transmute::<Unalign<u32>, invariant::Valid, _>();
-        let c = c.read_unaligned().into_inner();
+        let mut c = c;
+        let c = c.reborrow().into_shared().transmute::<Unalign<u32>, invariant::Valid, _>();
+        let c = c.read_unaligned::<BecauseImmutable>().into_inner();
         char::from_u32(c).is_some()
     });
 };
 
-impl_size_eq!(char, Unalign<u32>);
+impl_size_from!(char, Unalign<u32>);
 
 // SAFETY: Per the Reference [1], `str` has the same layout as `[u8]`.
 // - `Immutable`: `[u8]` does not contain any `UnsafeCell`s.
@@ -167,22 +170,23 @@ const _: () = unsafe { unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unalig
 //   Returns `Err` if the slice is not UTF-8.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for str; |c| {
-        let c = c.transmute::<[u8], invariant::Valid, _>();
+        let mut c = c;
+        let c = c.reborrow().into_shared().transmute::<[u8], invariant::Valid, _>();
         let c = c.unaligned_as_ref();
         core::str::from_utf8(c).is_ok()
     })
 };
 
-impl_size_eq!(str, [u8]);
+impl_size_from!(str, [u8]);
 
 macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
     ($($nonzero:ident[$prim:ty]),*) => {
         $(
             unsafe_impl!(=> TryFromBytes for $nonzero; |n| {
-                impl_size_eq!($nonzero, Unalign<$prim>);
-
-                let n = n.transmute::<Unalign<$prim>, invariant::Valid, _>();
-                $nonzero::new(n.read_unaligned().into_inner()).is_some()
+                impl_size_from!($nonzero, Unalign<$prim>);
+                let mut n = n;
+                let n = n.reborrow().into_shared().transmute::<Unalign<$prim>, invariant::Valid, _>();
+                $nonzero::new(n.read_unaligned::<BecauseImmutable>().into_inner()).is_some()
             });
         )*
     }
@@ -396,45 +400,51 @@ mod atomics {
         ($($($tyvar:ident)? => $atomic:ty [$prim:ty]),*) => {{
             crate::util::macros::__unsafe();
 
-            use core::cell::UnsafeCell;
-            use crate::pointer::{PtrInner, SizeEq, TransmuteFrom, invariant::Valid};
+            use core::{cell::UnsafeCell};
+            use crate::pointer::{TransmuteFrom, PtrInner, SizeFrom, invariant::Valid};
 
             $(
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
-                // the same size and bit validity.
+                // the same size and bit validity. As a result of size equality,
+                // both impls of `SizeFrom::cast_from_raw` preserve referent
+                // size exactly.
                 unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for $prim {}
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
-                // the same size and bit validity.
+                // the same size and bit validity. As a result of size equality,
+                // both impls of `SizeFrom::cast_from_raw` preserve referent
+                // size exactly.
                 unsafe impl<$($tyvar)?> TransmuteFrom<$prim, Valid, Valid> for $atomic {}
 
-                // SAFETY: The caller promised that `$atomic` and `$prim` have
-                // the same size.
-                unsafe impl<$($tyvar)?> SizeEq<$atomic> for $prim {
+                // SAFETY: See inline safety comment.
+                unsafe impl<$($tyvar)?> SizeFrom<$atomic> for $prim {
                     #[inline]
                     fn cast_from_raw(a: PtrInner<'_, $atomic>) -> PtrInner<'_, $prim> {
-                        // SAFETY: The caller promised that `$atomic` and
-                        // `$prim` have the same size. Thus, this cast preserves
+                        // SAFETY: The caller promised that `$atomic` and `$prim`
+                        // have the same size. Thus, this cast preserves
                         // address, referent size, and provenance.
                         unsafe { cast!(a) }
                     }
                 }
                 // SAFETY: See previous safety comment.
-                unsafe impl<$($tyvar)?> SizeEq<$prim> for $atomic {
+                unsafe impl<$($tyvar)?> SizeFrom<$prim> for $atomic {
                     #[inline]
                     fn cast_from_raw(p: PtrInner<'_, $prim>) -> PtrInner<'_, $atomic> {
                         // SAFETY: See previous safety comment.
                         unsafe { cast!(p) }
                     }
                 }
-                // SAFETY: The caller promised that `$atomic` and `$prim` have
-                // the same size. `UnsafeCell<T>` has the same size as `T` [1].
+
+                // SAFETY: The caller promised that `$atomic` and `$prim`
+                // have the same size. `UnsafeCell<T>` has the same size as
+                // `T` [1]. Thus, this cast preserves address, referent
+                // size, and provenance.
                 //
                 // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
                 //
                 //   `UnsafeCell<T>` has the same in-memory representation as
                 //   its inner type `T`. A consequence of this guarantee is that
                 //   it is possible to convert between `T` and `UnsafeCell<T>`.
-                unsafe impl<$($tyvar)?> SizeEq<$atomic> for UnsafeCell<$prim> {
+                unsafe impl<$($tyvar)?> SizeFrom<$atomic> for UnsafeCell<$prim> {
                     #[inline]
                     fn cast_from_raw(a: PtrInner<'_, $atomic>) -> PtrInner<'_, UnsafeCell<$prim>> {
                         // SAFETY: See previous safety comment.
@@ -442,7 +452,7 @@ mod atomics {
                     }
                 }
                 // SAFETY: See previous safety comment.
-                unsafe impl<$($tyvar)?> SizeEq<UnsafeCell<$prim>> for $atomic {
+                unsafe impl<$($tyvar)?> SizeFrom<UnsafeCell<$prim>> for $atomic {
                     #[inline]
                     fn cast_from_raw(p: PtrInner<'_, UnsafeCell<$prim>>) -> PtrInner<'_, $atomic> {
                         // SAFETY: See previous safety comment.
@@ -452,7 +462,9 @@ mod atomics {
 
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
                 // the same bit validity. `UnsafeCell<T>` has the same bit
-                // validity as `T` [1].
+                // validity as `T` [1]. `UnsafeCell<T>` also has the same size
+                // as `T` [1], and so both impls of `SizeFrom::cast_from_raw`
+                // preserve referent size exactly.
                 //
                 // [1] Per https://doc.rust-lang.org/1.85.0/std/cell/struct.UnsafeCell.html#memory-layout:
                 //

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -612,15 +612,15 @@ pub(crate) use cast_from_raw::cast_from_raw;
 mod cast_from_raw {
     use crate::{pointer::PtrInner, *};
 
-    /// Implements [`<Dst as SizeEq<Src>>::cast_from_raw`][cast_from_raw].
+    /// Implements [`<Dst as SizeFrom<Src>>::cast_from_raw`][cast_from_raw].
     ///
     /// # PME
     ///
     /// Generates a post-monomorphization error if it is not possible to satisfy
-    /// the soundness conditions of [`SizeEq::cast_from_raw`][cast_from_raw]
+    /// the soundness conditions of [`SizeFrom::cast_from_raw`][cast_from_raw]
     /// for `Src` and `Dst`.
     ///
-    /// [cast_from_raw]: crate::pointer::SizeEq::cast_from_raw
+    /// [cast_from_raw]: crate::pointer::SizeFrom::cast_from_raw
     //
     // FIXME(#1817): Support Sized->Unsized and Unsized->Sized casts
     pub(crate) fn cast_from_raw<Src, Dst>(src: PtrInner<'_, Src>) -> PtrInner<'_, Dst>

--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -198,25 +198,6 @@ unsafe impl<ST: ?Sized, DT: ?Sized> CastableFrom<ST, Uninit, Uninit> for DT {}
 // SAFETY: `SV = DV = Initialized`.
 unsafe impl<ST: ?Sized, DT: ?Sized> CastableFrom<ST, Initialized, Initialized> for DT {}
 
-/// [`Ptr`](crate::Ptr) referents that permit unsynchronized read operations.
-///
-/// `T: Read<A, R>` implies that a pointer to `T` with aliasing `A` permits
-/// unsynchronized read operations. This can be because `A` is [`Exclusive`] or
-/// because `T` does not permit interior mutation.
-///
-/// # Safety
-///
-/// `T: Read<A, R>` if either of the following conditions holds:
-/// - `A` is [`Exclusive`]
-/// - `T` implements [`Immutable`](crate::Immutable)
-///
-/// As a consequence, if `T: Read<A, R>`, then any `Ptr<T, (A, ...)>` is
-/// permitted to perform unsynchronized reads from its referent.
-pub trait Read<A: Aliasing, R> {}
-
-impl<A: Aliasing, T: ?Sized + crate::Immutable> Read<A, BecauseImmutable> for T {}
-impl<T: ?Sized> Read<Exclusive, BecauseExclusive> for T {}
-
 /// Unsynchronized reads are permitted because only one live [`Ptr`](crate::Ptr)
 /// or reference may exist to the referent bytes at a time.
 #[derive(Copy, Clone, Debug)]

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -17,10 +17,7 @@ mod transmute;
 #[doc(hidden)]
 pub use {inner::PtrInner, transmute::*};
 #[doc(hidden)]
-pub use {
-    invariant::{BecauseExclusive, BecauseImmutable, Read},
-    ptr::Ptr,
-};
+pub use {invariant::BecauseExclusive, ptr::Ptr};
 
 /// A shorthand for a maybe-valid, maybe-aligned reference. Used as the argument
 /// to [`TryFromBytes::is_bit_valid`].
@@ -30,11 +27,11 @@ pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unali
     Ptr<'a, T, (Aliasing, Alignment, invariant::Initialized)>;
 
 /// Checks if the referent is zeroed.
-pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool
+pub(crate) fn is_zeroed<T, I>(mut ptr: Ptr<'_, T, I>) -> bool
 where
     T: crate::Immutable + crate::KnownLayout,
     I: invariant::Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::Reference,
 {
-    ptr.as_bytes::<BecauseImmutable>().as_ref().iter().all(|&byte| byte == 0)
+    ptr.reborrow().into_shared().as_bytes().as_ref().iter().all(|&byte| byte == 0)
 }

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -656,9 +656,9 @@ where
         // `b.into_byte_slice_mut()` produces a byte slice with identical
         // address and length to that produced by `b.deref_mut()`.
         let ptr = Ptr::from_mut(b.into_byte_slice_mut())
-            .try_cast_into_no_leftover::<T, BecauseExclusive>(None)
+            .try_cast_into_no_leftover(None)
             .expect("zerocopy internal error: into_ref should be infallible");
-        let ptr = ptr.recall_validity::<_, (_, (_, _))>();
+        let ptr = ptr.recall_validity::<_, BecauseBidirectional>();
         ptr.as_mut()
     }
 }
@@ -797,9 +797,9 @@ where
         // are preserved through `.deref_mut()`, so this `unwrap` will not
         // panic.
         let ptr = Ptr::from_mut(b.deref_mut())
-            .try_cast_into_no_leftover::<T, BecauseExclusive>(None)
+            .try_cast_into_no_leftover(None)
             .expect("zerocopy internal error: DerefMut::deref_mut should be infallible");
-        let ptr = ptr.recall_validity::<_, (_, (_, (BecauseExclusive, BecauseExclusive)))>();
+        let ptr = ptr.recall_validity::<_, BecauseBidirectional>();
         ptr.as_mut()
     }
 }

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -30,8 +30,8 @@ use core::ptr::{self, NonNull};
 
 use crate::{
     pointer::{
-        invariant::{self, BecauseExclusive, BecauseImmutable, Invariants},
-        BecauseInvariantsEq, InvariantsEq, SizeEq, TryTransmuteFromPtr,
+        invariant::{self, BecauseImmutable, Invariants},
+        BecauseBidirectional, InvariantsEq, MutationCompatible, SizeFrom, TryTransmuteFromPtr,
     },
     FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, Ptr, TryFromBytes, ValidityError,
 };
@@ -493,7 +493,7 @@ macro_rules! assert_size_eq {
 /// [`is_bit_valid`]: TryFromBytes::is_bit_valid
 #[doc(hidden)]
 #[inline]
-fn try_cast_or_pme<Src, Dst, I, R, S>(
+fn try_cast_or_pme<Src, Dst, I, R>(
     src: Ptr<'_, Src, I>,
 ) -> Result<
     Ptr<'_, Dst, (I::Aliasing, invariant::Unaligned, invariant::Valid)>,
@@ -502,10 +502,10 @@ fn try_cast_or_pme<Src, Dst, I, R, S>(
 where
     // FIXME(#2226): There should be a `Src: FromBytes` bound here, but doing so
     // requires deeper surgery.
-    Src: invariant::Read<I::Aliasing, R>,
+    Src: MutationCompatible<Dst, I::Aliasing, invariant::Initialized, invariant::Initialized, R>,
     Dst: TryFromBytes
-        + invariant::Read<I::Aliasing, R>
-        + TryTransmuteFromPtr<Dst, I::Aliasing, invariant::Initialized, invariant::Valid, S>,
+        + MutationCompatible<Src, I::Aliasing, invariant::Initialized, invariant::Initialized, R>
+        + TryTransmuteFromPtr<Dst, I::Aliasing, invariant::Initialized, invariant::Valid, R>,
     I: Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::Reference,
 {
@@ -620,7 +620,7 @@ where
 {
     let ptr = Ptr::from_ref(src);
     let ptr = ptr.bikeshed_recall_initialized_immutable();
-    match try_cast_or_pme::<Src, Dst, _, BecauseImmutable, _>(ptr) {
+    match try_cast_or_pme::<Src, Dst, _, BecauseImmutable>(ptr) {
         Ok(ptr) => {
             static_assert!(Src, Dst => mem::align_of::<Dst>() <= mem::align_of::<Src>());
             // SAFETY: We have checked that `Dst` does not have a stricter
@@ -664,7 +664,7 @@ where
 {
     let ptr = Ptr::from_mut(src);
     let ptr = ptr.bikeshed_recall_initialized_from_bytes();
-    match try_cast_or_pme::<Src, Dst, _, BecauseExclusive, _>(ptr) {
+    match try_cast_or_pme::<Src, Dst, _, _>(ptr) {
         Ok(ptr) => {
             static_assert!(Src, Dst => mem::align_of::<Dst>() <= mem::align_of::<Src>());
             // SAFETY: We have checked that `Dst` does not have a stricter
@@ -673,7 +673,7 @@ where
             Ok(ptr.as_mut())
         }
         Err(err) => {
-            Err(err.map_src(|ptr| ptr.recall_validity::<_, (_, BecauseInvariantsEq)>().as_mut()))
+            Err(err.map_src(|ptr| ptr.recall_validity::<_, BecauseBidirectional>().as_mut()))
         }
     }
 }
@@ -793,11 +793,11 @@ where
 
         // SAFETY: We only use `S` as `S<Src>` and `D` as `D<Dst>`.
         unsafe {
-            unsafe_with_size_eq!(<S<Src>, D<Dst>> {
+            unsafe_with_size_from!(<S<Src>, D<Dst>> {
                 let ptr = Ptr::from_ref(self.0)
-                    .transmute::<S<Src>, invariant::Valid, BecauseImmutable>()
+                    .transmute::<S<Src>, invariant::Valid, _>()
                     .recall_validity::<invariant::Initialized, _>()
-                    .transmute::<D<Dst>, invariant::Initialized, (crate::pointer::BecauseMutationCompatible, _)>()
+                    .transmute::<D<Dst>, invariant::Initialized, _>()
                     .recall_validity::<invariant::Valid, _>();
 
                 #[allow(unused_unsafe)]
@@ -833,12 +833,12 @@ where
 
         // SAFETY: We only use `S` as `S<Src>` and `D` as `D<Dst>`.
         unsafe {
-            unsafe_with_size_eq!(<S<Src>, D<Dst>> {
+            unsafe_with_size_from!(<S<Src>, D<Dst>> {
                 let ptr = Ptr::from_mut(self.0)
                     .transmute::<S<Src>, invariant::Valid, _>()
-                    .recall_validity::<invariant::Initialized, (_, (_, _))>()
+                    .recall_validity::<invariant::Initialized, BecauseBidirectional>()
                     .transmute::<D<Dst>, invariant::Initialized, _>()
-                    .recall_validity::<invariant::Valid, (_, (_, _))>();
+                    .recall_validity::<invariant::Valid, BecauseBidirectional>();
 
                 #[allow(unused_unsafe)]
                 // SAFETY: The preceding `static_assert!` ensures that

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -220,7 +220,7 @@ macro_rules! impl_for_transmute_from {
         #[inline]
         fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
             let c: Maybe<'_, Self, crate::pointer::invariant::Exclusive> = candidate.into_exclusive_or_pme();
-            let c: Maybe<'_, $repr, _> = c.transmute::<_, _, (_, (_, (BecauseExclusive, BecauseExclusive)))>();
+            let c: Maybe<'_, $repr, _> = c.transmute();
             // SAFETY: This macro ensures that `$repr` and `Self` have the same
             // size and bit validity. Thus, a bit-valid instance of `$repr` is
             // also a bit-valid instance of `Self`.
@@ -702,34 +702,42 @@ macro_rules! cast {
     }};
 }
 
-/// Implements `TransmuteFrom` and `SizeEq` for `T` and `$wrapper<T>`.
+/// Implements `TransmuteFrom` and `SizeFrom` for `T` and `$wrapper<T>`.
 ///
 /// # Safety
 ///
-/// `T` and `$wrapper<T>` must have the same bit validity, and must have the
-/// same size in the sense of `SizeEq`.
+/// `T` and `$wrapper<T>` must have the same bit validity, and must satisfy the
+/// following property: given `t: *mut T`, `let w = t as *mut $wrapper<T>`
+/// produces a pointer which address the same bytes as `t`. The inverse must
+/// also hold.
 macro_rules! unsafe_impl_for_transparent_wrapper {
     (T $(: ?$optbound:ident)? => $wrapper:ident<T>) => {{
         crate::util::macros::__unsafe();
 
-        use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+        use crate::pointer::{TransmuteFrom, TransmuteOverwrite, PtrInner, SizeFrom, invariant::Valid};
 
         // SAFETY: The caller promises that `T` and `$wrapper<T>` have the same
-        // bit validity.
+        // bit validity, and that both implementations of
+        // `SizeFrom::cast_from_raw` preserve referent size exactly.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<T, Valid, Valid> for $wrapper<T> {}
         // SAFETY: See previous safety comment.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<$wrapper<T>, Valid, Valid> for T {}
+        // SAFETY: See previous safety comment.
+        unsafe impl<T $(: ?$optbound)?> TransmuteOverwrite<T, Valid, Valid> for $wrapper<T> {}
+        // SAFETY: See previous safety comment.
+        unsafe impl<T $(: ?$optbound)?> TransmuteOverwrite<$wrapper<T>, Valid, Valid> for T {}
         // SAFETY: The caller promises that `T` and `$wrapper<T>` satisfy
-        // `SizeEq`.
-        unsafe impl<T $(: ?$optbound)?> SizeEq<T> for $wrapper<T> {
+        // `cast_from_raw`'s safety post-condition.
+        unsafe impl<T $(: ?$optbound)?> SizeFrom<T> for $wrapper<T> {
             #[inline(always)]
             fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, $wrapper<T>> {
-                // SAFETY: See previous safety comment.
+                // SAFETY: The caller promises that this cast produces a pointer
+                // which addresses the same bytes as `t`.
                 unsafe { cast!(t) }
             }
         }
         // SAFETY: See previous safety comment.
-        unsafe impl<T $(: ?$optbound)?> SizeEq<$wrapper<T>> for T {
+        unsafe impl<T $(: ?$optbound)?> SizeFrom<$wrapper<T>> for T {
             #[inline(always)]
             fn cast_from_raw(t: PtrInner<'_, $wrapper<T>>) -> PtrInner<'_, T> {
                 // SAFETY: See previous safety comment.
@@ -742,19 +750,20 @@ macro_rules! unsafe_impl_for_transparent_wrapper {
 macro_rules! impl_transitive_transmute_from {
     ($($tyvar:ident $(: ?$optbound:ident)?)? => $t:ty => $u:ty => $v:ty) => {
         const _: () = {
-            use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+            use crate::pointer::{TransmuteFrom, SizeFrom, invariant::Valid};
 
-            // SAFETY: Since `$u: SizeEq<$t>` and `$v: SizeEq<U>`, this impl is
-            // transitively sound.
-            unsafe impl<$($tyvar $(: ?$optbound)?)?> SizeEq<$t> for $v
+            // SAFETY: See safety comment on `cast_from_raw`.
+            unsafe impl<$($tyvar $(: ?$optbound)?)?> SizeFrom<$t> for $v
             where
-                $u: SizeEq<$t>,
-                $v: SizeEq<$u>,
+                $u: SizeFrom<$t>,
+                $v: SizeFrom<$u>,
             {
+                // SAFETY: Each inner call to `cast_from_raw` preserves
+                // provenance and addressed byte range.
                 #[inline(always)]
                 fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $v> {
-                    let u = <$u as SizeEq<_>>::cast_from_raw(t);
-                    <$v as SizeEq<_>>::cast_from_raw(u)
+                    let u = SizeFrom::cast_from_raw(t);
+                    SizeFrom::cast_from_raw(u)
                 }
             }
 
@@ -772,10 +781,10 @@ macro_rules! impl_transitive_transmute_from {
 }
 
 #[rustfmt::skip]
-macro_rules! impl_size_eq {
+macro_rules! impl_size_from {
     ($t:ty, $u:ty) => {
         const _: () = {
-            use crate::{KnownLayout, pointer::{PtrInner, SizeEq}};
+            use crate::{KnownLayout, pointer::{PtrInner, SizeFrom}};
 
             static_assert!(=> {
                 let t = <$t as KnownLayout>::LAYOUT;
@@ -791,7 +800,7 @@ macro_rules! impl_size_eq {
             });
 
             // SAFETY: See inline.
-            unsafe impl SizeEq<$t> for $u {
+            unsafe impl SizeFrom<$t> for $u {
                 #[inline(always)]
                 fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $u> {
                     // SAFETY: We've asserted that their
@@ -802,7 +811,7 @@ macro_rules! impl_size_eq {
                 }
             }
             // SAFETY: See previous safety comment.
-            unsafe impl SizeEq<$u> for $t {
+            unsafe impl SizeFrom<$u> for $t {
                 #[inline(always)]
                 fn cast_from_raw(u: PtrInner<'_, $u>) -> PtrInner<'_, $t> {
                     // SAFETY: See previous safety comment.
@@ -814,17 +823,17 @@ macro_rules! impl_size_eq {
 }
 
 /// Invokes `$blk` in a context in which `$src<$t>` and `$dst<$u>` implement
-/// `SizeEq`.
+/// `SizeFrom`.
 ///
-/// This macro emits code which implements `SizeEq`, and ensures that the impl
-/// is sound via PME.
+/// This macro emits code which implements `SizeComapt`, and ensures that the
+/// impl is sound via PME.
 ///
 /// # Safety
 ///
 /// Inside of `$blk`, the caller must only use `$src` and `$dst` as `$src<$t>`
 /// and `$dst<$u>`. The caller must not use `$src` or `$dst` to wrap any other
 /// types.
-macro_rules! unsafe_with_size_eq {
+macro_rules! unsafe_with_size_from {
     (<$src:ident<$t:ident>, $dst:ident<$u:ident>> $blk:expr) => {{
         crate::util::macros::__unsafe();
 
@@ -859,14 +868,14 @@ macro_rules! unsafe_with_size_eq {
         // We manually instantiate `cast_from_raw` below to ensure that this PME
         // can be triggered, and the caller promises not to use `$src` and
         // `$dst` with any wrapped types other than `$t` and `$u` respectively.
-        unsafe impl<T: ?Sized, U: ?Sized> SizeEq<$src<T>> for $dst<U>
+        unsafe impl<T: ?Sized, U: ?Sized> SizeFrom<$src<T>> for $dst<U>
         where
             T: KnownLayout<PointerMetadata = usize>,
             U: KnownLayout<PointerMetadata = usize>,
         {
             fn cast_from_raw(src: PtrInner<'_, $src<T>>) -> PtrInner<'_, Self> {
                 // SAFETY: `crate::layout::cast_from_raw` promises to satisfy
-                // the safety invariants of `SizeEq::cast_from_raw`, or to
+                // the safety invariants of `SizeFrom::cast_from_raw`, or to
                 // generate a PME. Since `$src<T>` and `$dst<U>` are
                 // `#[repr(transparent)]` wrappers around `T` and `U`
                 // respectively, a `cast_from_raw` impl which satisfies the
@@ -887,14 +896,12 @@ macro_rules! unsafe_with_size_eq {
         // See safety comment on the preceding `unsafe impl` block for an
         // explanation of why we need this block.
         if 1 == 0 {
-            let ptr = <$t as KnownLayout>::raw_dangling();
-            #[allow(unused_unsafe)]
-            // SAFETY: This call is never executed.
-            let ptr = unsafe { crate::pointer::PtrInner::new(ptr) };
-            #[allow(unused_unsafe)]
-            // SAFETY: This call is never executed.
-            let ptr = unsafe { cast!(ptr) };
-            let _ = <$dst<$u> as SizeEq<$src<$t>>>::cast_from_raw(ptr);
+            use crate::pointer::PtrInner;
+
+            #[allow(invalid_value, unused_unsafe)]
+            // SAFETY: This code is never executed.
+            let ptr: PtrInner<'_, $src<$t>> = unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+            let _ = <$dst<$u> as SizeFrom<$src<$t>>>::cast_from_raw(ptr);
         }
 
         impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for $src<T>[<T>]);

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -200,7 +200,7 @@ impl<T> Unalign<T> {
     /// callers may prefer [`DerefMut::deref_mut`], which is infallible.
     #[inline(always)]
     pub fn try_deref_mut(&mut self) -> Result<&mut T, AlignmentError<&mut Self, T>> {
-        let inner = Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>();
+        let inner = Ptr::from_mut(self).transmute::<_, _, BecauseBidirectional>();
         match inner.try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_mut()),
             Err(err) => Err(err.map_src(|src| src.into_unalign().as_mut())),
@@ -396,7 +396,10 @@ impl<T: Unaligned> Deref for Unalign<T> {
 impl<T: Unaligned> DerefMut for Unalign<T> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
-        Ptr::from_mut(self).transmute::<_, _, (_, (_, _))>().bikeshed_recall_aligned().as_mut()
+        Ptr::from_mut(self)
+            .transmute::<_, _, BecauseBidirectional>()
+            .bikeshed_recall_aligned()
+            .as_mut()
     }
 }
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -332,7 +332,7 @@ pub(crate) fn derive_is_bit_valid(
                 // is `Initialized`. Since we have not written uninitialized
                 // bytes into the referent, `tag_ptr` is also `Initialized`.
                 let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
+                tag_ptr.recall_validity().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
             };
 
             // SAFETY:

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -799,7 +799,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyTagPrimitive>() })
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>>() })
@@ -1140,7 +1140,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyTagPrimitive> ()})
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>> ()})
@@ -1481,7 +1481,7 @@ fn test_try_from_bytes_enum() {
                             candidate.reborrow().cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyTagPrimitive> ()})
                         };
                         let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<::zerocopy::BecauseImmutable>()
+                        tag_ptr.recall_validity().read_unaligned::<::zerocopy::BecauseImmutable>()
                     };
                     let raw_enum = unsafe {
                         candidate.cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| { p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>> ()})


### PR DESCRIPTION
Generalize `SizeEq`, renaming it to `SizeFrom`, and supporting casts
which shrink rather than preserve referent size.

This requires fairly deep surgery in our transmute taxonomy. We can no
longer rely on `SizeFrom::cast_from_raw` preserving referent size, which
means that all pointer transmutes must now reason about two types of
transmutes:
- Size-shrinking transmutes (in which the source value is larger than
  the destination value)
- Overwriting transmutes (in which the source value is larger than the
  destination value *and* the destination permits mutation). In an
  overwriting transmute, the resulting value is a concatenation of a
  valid `T` and the *suffix* of a valid `U`.

(Note that size-preserving transmutes can be viewed as a special case of
size-shrinking transmutes.)

In order to support these semantics, we split `TransmuteFrom` into two
traits: `TransmuteFrom` (which supports shriking transmutes) and
`TransmuteOverwrite` (which supports overwriting transmutes).

While we're here, we simplify the relationship between
`TryTransmuteFromPtr`, `MutationCompatible`, and `Read`. In particular,
`TryTransmuteFromPtr` now has a single blanket impl which is bounded by
`MutationCompatible`, and `MutationCompatible` now directly supports
three cases (and no longer delegates to `Read`):
- Exclusive reference transmutes in which the destination type may be
  transmuted into the source type
- Shared reference transmutes in which both the source and the
  destination type are `Immutable`
- Shared reference transmutes which permit interior mutation, in which
  the source and destination types may both be transmuted into one
  another, and in which the source and destination types support
  compatible interior mutation

Makes progress on #1817

Co-authored-by: Jack Wrenn <jswrenn@amazon.com>
gherrit-pr-id: I6c793a9620ad75bdc0d26ab7c7cd1a0c7bef1b8b
