### PR TITLE
[macros] Support shrinking value transmutes

### DIFF
--- a/tests/ui-msrv/include_value_not_from_bytes.stderr
+++ b/tests/ui-msrv/include_value_not_from_bytes.stderr
@@ -4,9 +4,12 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
    |
-note: required by `AssertIsFromBytes`
+note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> tests/ui-msrv/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                          |
+   |                                          required by a bound in this
+   |                                          required by this bound in `NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-msrv/transmute-dst-not-frombytes.stderr
@@ -4,9 +4,12 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
    |                                         ^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
-note: required by `AssertIsFromBytes`
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> tests/ui-msrv/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
    |                                         ^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                         |
+   |                                         required by a bound in this
+   |                                         required by this bound in `DST_NOT_FROM_BYTES::transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-ptr-to-usize.stderr
+++ b/tests/ui-msrv/transmute-ptr-to-usize.stderr
@@ -4,22 +4,12 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
-note: required by `AssertIsIntoBytes`
+note: required by a bound in `POINTER_VALUE::transmute`
   --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
-   |
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-msrv/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                              |
+   |                              required by a bound in this
+   |                              required by this bound in `POINTER_VALUE::transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-size-increase-allow-shrink.rs
+++ b/tests/ui-msrv/transmute-size-increase-allow-shrink.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-size-increase-allow-shrink.rs

--- a/tests/ui-msrv/transmute-size-increase-allow-shrink.stderr
+++ b/tests/ui-msrv/transmute-size-increase-allow-shrink.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-msrv/transmute-size-increase-allow-shrink.rs:20:29
+   |
+20 | const INCREASE_SIZE: AU16 = transmute!(#![allow(shrink)] 0u8);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `Transmute<u8, AU16>` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-msrv/transmute-src-not-intobytes.stderr
+++ b/tests/ui-msrv/transmute-src-not-intobytes.stderr
@@ -4,22 +4,12 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
    |
-note: required by `AssertIsIntoBytes`
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
-   |
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-msrv/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                                |
+   |                                required by a bound in this
+   |                                required by this bound in `SRC_NOT_AS_BYTES::transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/include_value_not_from_bytes.stderr
+++ b/tests/ui-nightly/include_value_not_from_bytes.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
   --> tests/ui-nightly/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                          |
-   |                                          the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
-   |                                          required by a bound introduced by this call
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy<u32>`
    = help: the following other types implement trait `zerocopy::FromBytes`:
@@ -18,9 +15,12 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
              AtomicIsize
              AtomicU16
            and $N others
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> tests/ui-nightly/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
-   = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          required by a bound in this function
+   |                                          required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-dst-not-frombytes.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^
-   |                                         |
-   |                                         the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
-   |                                         required by a bound introduced by this call
+   |                                         ^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
@@ -18,9 +15,12 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AtomicIsize
              AtomicU16
            and $N others
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         required by a bound in this function
+   |                                         required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` which comes from the expansion of the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-ptr-to-usize.stderr
+++ b/tests/ui-nightly/transmute-ptr-to-usize.stderr
@@ -9,24 +9,12 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
    |
    = note: Consider adding `#[derive(IntoBytes)]` to `*const usize`
    = help: the trait `IntoBytes` is implemented for `usize`
-note: required by a bound in `AssertIsIntoBytes`
+note: required by a bound in `POINTER_VALUE::transmute`
   --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
-   |
-   = note: Consider adding `#[derive(IntoBytes)]` to `*const usize`
-   = help: the trait `IntoBytes` is implemented for `usize`
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-nightly/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              required by a bound in this function
+   |                              required by this bound in `transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-size-increase-allow-shrink.rs
+++ b/tests/ui-nightly/transmute-size-increase-allow-shrink.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+include!("../../zerocopy-derive/tests/include.rs");
+
+extern crate zerocopy;
+
+use util::AU16;
+use zerocopy::transmute;
+
+fn main() {}
+
+// `transmute!` does not support transmuting from a smaller type to a larger
+// one.
+const INCREASE_SIZE: AU16 = transmute!(#![allow(shrink)] 0u8);

--- a/tests/ui-nightly/transmute-size-increase-allow-shrink.stderr
+++ b/tests/ui-nightly/transmute-size-increase-allow-shrink.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-nightly/transmute-size-increase-allow-shrink.rs:20:29
+   |
+20 | const INCREASE_SIZE: AU16 = transmute!(#![allow(shrink)] 0u8);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `Transmute<u8, AU16>` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-nightly/transmute-src-not-intobytes.stderr
+++ b/tests/ui-nightly/transmute-src-not-intobytes.stderr
@@ -18,33 +18,12 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicI8
              AtomicIsize
            and $N others
-note: required by a bound in `AssertIsIntoBytes`
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
-   |
-   = note: Consider adding `#[derive(IntoBytes)]` to `NotZerocopy<AU16>`
-   = help: the following other types implement trait `zerocopy::IntoBytes`:
-             ()
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-           and $N others
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-nightly/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                required by a bound in this function
+   |                                required by this bound in `transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/include_value_not_from_bytes.stderr
+++ b/tests/ui-stable/include_value_not_from_bytes.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
   --> tests/ui-stable/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                                          |
-   |                                          the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
-   |                                          required by a bound introduced by this call
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy<u32>`
    = help: the following other types implement trait `zerocopy::FromBytes`:
@@ -18,9 +15,12 @@ error[E0277]: the trait bound `NotZerocopy<u32>: zerocopy::FromBytes` is not sat
              AtomicIsize
              AtomicU16
            and $N others
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> tests/ui-stable/include_value_not_from_bytes.rs:19:42
    |
 19 | const NOT_FROM_BYTES: NotZerocopy<u32> = include_value!("../../testdata/include_value/data");
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
-   = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          required by a bound in this function
+   |                                          required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` which comes from the expansion of the macro `include_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-dst-not-frombytes.stderr
@@ -2,10 +2,7 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^
-   |                                         |
-   |                                         the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
-   |                                         required by a bound introduced by this call
+   |                                         ^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    |
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
@@ -18,9 +15,12 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::FromBytes` is not satisfie
              AtomicIsize
              AtomicU16
            and $N others
-note: required by a bound in `AssertIsFromBytes`
+note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:19:41
    |
 19 | const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
-   |                                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsFromBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                                         ^^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         required by a bound in this function
+   |                                         required by this bound in `transmute`
+   = note: this error originates in the macro `$crate::__transmute_inner` which comes from the expansion of the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-ptr-to-usize.stderr
+++ b/tests/ui-stable/transmute-ptr-to-usize.stderr
@@ -9,24 +9,12 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
    |
    = note: Consider adding `#[derive(IntoBytes)]` to `*const usize`
    = help: the trait `IntoBytes` is implemented for `usize`
-note: required by a bound in `AssertIsIntoBytes`
+note: required by a bound in `POINTER_VALUE::transmute`
   --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
    |
 20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
-   |
-   = note: Consider adding `#[derive(IntoBytes)]` to `*const usize`
-   = help: the trait `IntoBytes` is implemented for `usize`
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-stable/transmute-ptr-to-usize.rs:20:30
-   |
-20 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              required by a bound in this function
+   |                              required by this bound in `transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-size-increase-allow-shrink.rs
+++ b/tests/ui-stable/transmute-size-increase-allow-shrink.rs
@@ -1,0 +1,1 @@
+../ui-nightly/transmute-size-increase-allow-shrink.rs

--- a/tests/ui-stable/transmute-size-increase-allow-shrink.stderr
+++ b/tests/ui-stable/transmute-size-increase-allow-shrink.stderr
@@ -1,0 +1,9 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> tests/ui-stable/transmute-size-increase-allow-shrink.rs:20:29
+   |
+20 | const INCREASE_SIZE: AU16 = transmute!(#![allow(shrink)] 0u8);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u8` (8 bits)
+   = note: target type: `Transmute<u8, AU16>` (16 bits)
+   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui-stable/transmute-src-not-intobytes.stderr
+++ b/tests/ui-stable/transmute-src-not-intobytes.stderr
@@ -18,33 +18,12 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not sa
              AtomicI8
              AtomicIsize
            and $N others
-note: required by a bound in `AssertIsIntoBytes`
+note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
    |
 19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
-   = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `NotZerocopy<AU16>: zerocopy::IntoBytes` is not satisfied
-  --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy::IntoBytes` is not implemented for `NotZerocopy<AU16>`
-   |
-   = note: Consider adding `#[derive(IntoBytes)]` to `NotZerocopy<AU16>`
-   = help: the following other types implement trait `zerocopy::IntoBytes`:
-             ()
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-           and $N others
-note: required by a bound in `AssertIsIntoBytes`
-  --> tests/ui-stable/transmute-src-not-intobytes.rs:19:32
-   |
-19 | const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertIsIntoBytes`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                required by a bound in this function
+   |                                required by this bound in `transmute`
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
In `transmute!`, support an `#![allow(shrink)]` attribute which is
invoked as follows:

  transmute!(#![allow(shrink)] src);

When this attribute is provided, `transmute!` will permit shrinking
transmutes, in which the destination value may be smaller than the
source value.

gherrit-pr-id: I46b18b4b1d10507b7e1d2e01b09dc4960cfcdce1
