### PR TITLE
Expect `stable_features` lint for stable SIMD types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ zerocopy-panic-in-const-and-vec-try-reserve-1-57-0 = "1.57.0"
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.
 pinned-stable = "1.87.0"
-pinned-nightly = "nightly-2025-06-07"
+pinned-nightly = "nightly-2025-06-09"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,19 @@
     clippy::indexing_slicing,
 ))]
 #![cfg_attr(not(any(test, kani, feature = "std")), no_std)]
+// NOTE: This attribute should have the effect of causing CI to fail if
+// `stdarch_x86_avx512` - which is currently stable in 1.89.0-nightly as of this
+// writing on 2025-06-10 - has its stabilization rolled back.
+//
+// FIXME(#2583): Remove once `stdarch_x86_avx512` is stabilized in 1.89.0, and
+// 1.89.0 has been released as stable.
+#![cfg_attr(
+    all(feature = "simd-nightly", any(target_arch = "x86", target_arch = "x86_64")),
+    expect(stable_features)
+)]
+// FIXME(#2583): Remove once `stdarch_x86_avx512` is stabilized in 1.89.0, and
+// 1.89.0 has been released as stable. Replace with version detection for 1.89.0
+// (see #2574 for a draft implementation).
 #![cfg_attr(
     all(feature = "simd-nightly", any(target_arch = "x86", target_arch = "x86_64")),
     feature(stdarch_x86_avx512)


### PR DESCRIPTION
Previously, x86 AVX-12 SIMD types were gated by the unstable
`stdarch_x86_avx512` feature. As of this writing, that feature has been
stabilized on 1.89.0-nightly, staged for inclusion in 1.89.0 when it is
released as stable.

This means that the `simd-nightly` Cargo feature, which gates
`stdarch_x86_avx512`, will now cause the `stable_features` lint to
trigger when compiling on x86.

This commit enables `expect(stable_features)` when compiling with
`simd-nightly` for x86. Once 1.89.0 is released as stable, we will
follow up with a commit which uses version detection to enable support
for AVX-12 types, and we will remove our use of the `stdarch_x86_avx512`
feature entirely.

Makes progress on #2583




---

This PR is on branch [simd-nightly-avx12](../tree/simd-nightly-avx12).

- #2584