### PR TITLE
Fix parsing bug when --cfg doc_cfg is passed on aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.26-alpha"
+version = "0.8.26"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = ["embedded", "encoding", "no-std::no-alloc", "parsing", "rust-patterns"]
@@ -82,13 +82,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.26-alpha", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.26", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.26-alpha", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.26", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # More recent versions of `either` have an MSRV higher than ours.
@@ -106,4 +106,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.26-alpha", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.26", path = "zerocopy-derive" }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1050,11 +1050,11 @@ mod simd {
             #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
             powerpc64, powerpc64, vector_bool_long, vector_double, vector_signed_long, vector_unsigned_long
         );
+        #[cfg(zerocopy_aarch64_simd_1_59_0)]
         simd_arch_mod!(
             // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
             // broken on big-endian platforms.
             #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-            #[cfg(zerocopy_aarch64_simd_1_59_0)]
             #[cfg_attr(doc_cfg, doc(cfg(rust = "1.59.0")))]
             aarch64, aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,
             int8x8x3_t, int8x8x4_t, int8x16_t, int8x16x2_t, int8x16x3_t, int8x16x4_t, int16x4_t,

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.26-alpha"
+version = "0.8.26"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
Release 0.8.26.

Closes #2594


gherrit-pr-id: Ifc7e078cd78e57767e884923d6142557c3e8f843


---

This PR is on branch [doc-cfg-parse](../tree/doc-cfg-parse).

- #2596