### PR TITLE
Add `KnownLayout::size_for_metadata`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,8 @@ zerocopy-derive = { version = "=0.8.26", path = "zerocopy-derive" }
 either = "=1.13.0"
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"
+# More recent versions of `glob` have an MSRV higher than ours.
+glob = "=0.3.2"
 itertools = "0.11"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = "1.0"

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -479,7 +479,7 @@ where
     #[inline]
     pub fn from_bytes_with_elems(source: B, count: usize) -> Result<Ref<B, T>, CastError<B, T>> {
         static_assert_dst_is_not_zst!(T);
-        let expected_len = match count.size_for_metadata(T::LAYOUT) {
+        let expected_len = match T::size_for_metadata(count) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
         };
@@ -533,7 +533,7 @@ where
         count: usize,
     ) -> Result<(Ref<B, T>, B), CastError<B, T>> {
         static_assert_dst_is_not_zst!(T);
-        let expected_len = match count.size_for_metadata(T::LAYOUT) {
+        let expected_len = match T::size_for_metadata(count) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
         };
@@ -579,7 +579,7 @@ where
         count: usize,
     ) -> Result<(B, Ref<B, T>), CastError<B, T>> {
         static_assert_dst_is_not_zst!(T);
-        let expected_len = match count.size_for_metadata(T::LAYOUT) {
+        let expected_len = match T::size_for_metadata(count) {
             Some(len) => len,
             None => return Err(SizeError::new(source).into()),
         };

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -323,7 +323,7 @@ pub(crate) unsafe fn new_box<T>(
 where
     T: ?Sized + crate::KnownLayout,
 {
-    let size = match meta.size_for_metadata(T::LAYOUT) {
+    let size = match T::size_for_metadata(meta) {
         Some(size) => size,
         None => return Err(AllocError),
     };
@@ -515,7 +515,7 @@ mod len_of {
                 // This can return `None` if the metadata describes an object
                 // which can't fit in an `isize`.
                 Some(meta) => {
-                    let size = match meta.size_for_metadata(T::LAYOUT) {
+                    let size = match T::size_for_metadata(meta) {
                         Some(size) => size,
                         None => return Err(MetadataCastError::Size),
                     };


### PR DESCRIPTION
Computes the size of an object of type `Self` with the given pointer metadata.

Makes progress towards #2541

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
