### PR TITLE
Output test `derive(IntoBytes)` on structs with trailing slices

### DIFF
--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -484,6 +484,50 @@ fn test_into_bytes_struct() {
             }
         } no_build
     }
+
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo {
+                a: u8,
+                b: [Trailing],
+            }
+        } expands to {
+            #[allow(deprecated)]
+            #[automatically_derived]
+            unsafe impl ::zerocopy::IntoBytes for Foo
+            where
+                u8: ::zerocopy::IntoBytes,
+                [Trailing]: ::zerocopy::IntoBytes,
+                (): ::zerocopy::util::macro_util::PaddingFree<
+                    Self,
+                    { ::zerocopy::struct_has_padding!(Self, [u8, [Trailing]]) },
+                >,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+        } no_build
+    }
+
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo<Trailing> {
+                a: u8,
+                b: [Trailing],
+            }
+        } expands to {
+            #[allow(deprecated)]
+            #[automatically_derived]
+            unsafe impl<Trailing> ::zerocopy::IntoBytes for Foo<Trailing>
+            where
+                u8: ::zerocopy::IntoBytes + ::zerocopy::Unaligned,
+                [Trailing]: ::zerocopy::IntoBytes + ::zerocopy::Unaligned,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+        } no_build
+    }
 }
 
 #[test]


### PR DESCRIPTION
Just so we get a nice output test diff on the follow-up PR. :-)

Makes progress towards #1112

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
