### PR TITLE
`derive(IntoBytes)`: support `repr(C)` structs with explicit trailing slices

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -520,7 +520,11 @@ mod len_of {
                         Some(size) => size,
                         None => return Err(MetadataCastError::Size),
                     };
-                    DstLayout { align: T::LAYOUT.align, size_info: crate::SizeInfo::Sized { size } }
+                    DstLayout {
+                        align: T::LAYOUT.align,
+                        size_info: crate::SizeInfo::Sized { size },
+                        statically_shallow_unpadded: false,
+                    }
                 }
             };
             // Lemma 0: By contract on `validate_cast_and_convert_metadata`, if

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -152,14 +152,13 @@ fn test_known_layout() {
                     const LAYOUT: ::zerocopy::DstLayout = {
                         use ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize;
                         use ::zerocopy::{DstLayout, KnownLayout};
-                        let repr_align = ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize::new(
-                            2u32 as usize,
-                        );
-                        let repr_packed = ::zerocopy::util::macro_util::core_reexport::option::Option::None;
-                        DstLayout::new_zst(repr_align)
-                            .extend(DstLayout::for_type::<T>(), repr_packed)
-                            .extend(<U as KnownLayout>::LAYOUT, repr_packed)
-                            .pad_to_align()
+                        DstLayout::for_repr_c_struct(
+                            ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize::new(
+                                2u32 as usize,
+                            ),
+                            ::zerocopy::util::macro_util::core_reexport::option::Option::None,
+                            &[DstLayout::for_type::<T>(), <U as KnownLayout>::LAYOUT],
+                        )
                     };
                     #[inline(always)]
                     fn raw_from_ptr_len(
@@ -206,7 +205,7 @@ fn test_known_layout() {
                             U,
                         > as ::zerocopy::util::macro_util::Field<
                             __Zerocopy_Field_1,
-                        >>::Type as ::zerocopy::KnownLayout>::MaybeUninit
+                        >>::Type as ::zerocopy::KnownLayout>::MaybeUninit,
                     >,
                 )
                 where
@@ -499,9 +498,9 @@ fn test_into_bytes_struct() {
             where
                 u8: ::zerocopy::IntoBytes,
                 [Trailing]: ::zerocopy::IntoBytes,
-                (): ::zerocopy::util::macro_util::PaddingFree<
+                (): ::zerocopy::util::macro_util::DynamicPaddingFree<
                     Self,
-                    { ::zerocopy::struct_padding!(Self, [u8, [Trailing]]) },
+                    { ::zerocopy::repr_c_struct_has_padding!(Self, [u8, [Trailing]]) },
                 >,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}

--- a/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy-derive/tests/struct_to_bytes.rs
@@ -35,6 +35,16 @@ struct C {
 util_assert_impl_all!(C: imp::IntoBytes);
 
 #[derive(imp::IntoBytes)]
+#[repr(C)]
+struct SyntacticUnsized {
+    a: u8,
+    b: u8,
+    c: [util::AU16],
+}
+
+util_assert_impl_all!(C: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
 #[repr(transparent)]
 struct Transparent {
     a: u8,

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -1,89 +1,89 @@
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:133:11
+   --> tests/ui-msrv/struct.rs:167:11
     |
-133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+167 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
     |           ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-msrv/struct.rs:138:10
+   --> tests/ui-msrv/struct.rs:172:10
     |
-138 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-msrv/struct.rs:143:10
+   --> tests/ui-msrv/struct.rs:177:10
     |
-143 | #[derive(IntoBytes)]
+177 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-msrv/struct.rs:166:10
+   --> tests/ui-msrv/struct.rs:200:10
     |
-166 | #[derive(IntoBytes)]
+200 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> tests/ui-msrv/struct.rs:177:11
+   --> tests/ui-msrv/struct.rs:211:11
     |
-177 | #[repr(C, align(2))]
+211 | #[repr(C, align(2))]
     |           ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:181:8
+   --> tests/ui-msrv/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:187:16
+   --> tests/ui-msrv/struct.rs:221:16
     |
-187 | #[repr(packed, align(2))]
+221 | #[repr(packed, align(2))]
     |                ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:191:18
+   --> tests/ui-msrv/struct.rs:225:18
     |
-191 | #[repr(align(1), align(2))]
+225 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:195:18
+   --> tests/ui-msrv/struct.rs:229:18
     |
-195 | #[repr(align(2), align(4))]
+229 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-msrv/struct.rs:198:10
+   --> tests/ui-msrv/struct.rs:232:10
     |
-198 | #[derive(Unaligned)]
+232 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-msrv/struct.rs:201:10
+   --> tests/ui-msrv/struct.rs:235:10
     |
-201 | #[derive(Unaligned)]
+235 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> tests/ui-msrv/struct.rs:211:8
+   --> tests/ui-msrv/struct.rs:245:8
     |
-211 | #[repr(C, packed(2))]
+245 | #[repr(C, packed(2))]
     |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-msrv/struct.rs:181:8
+   --> tests/ui-msrv/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -185,16 +185,16 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, 1_usize>` is not sati
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-msrv/struct.rs:125:10
+   --> tests/ui-msrv/struct.rs:130:10
     |
-125 | #[derive(IntoBytes)]
+130 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `IntoBytes4`
-   --> tests/ui-msrv/struct.rs:127:8
+   --> tests/ui-msrv/struct.rs:132:8
     |
-127 | struct IntoBytes4 {
+132 | struct IntoBytes4 {
     |        ^^^^^^^^^^
 note: required by a bound in `std::mem::size_of`
    --> $RUST/core/src/mem/mod.rs
@@ -204,10 +204,10 @@ note: required by a bound in `std::mem::size_of`
     = note: this error originates in the macro `::zerocopy::struct_padding` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-msrv/struct.rs:129:8
+   --> tests/ui-msrv/struct.rs:134:8
     |
-129 |     b: [u8],
-    |        ^^^^ doesn't have a size known at compile-time
+134 |     b: SliceU8,
+    |        ^^^^^^^ doesn't have a size known at compile-time
     |
     = help: the trait `Sized` is not implemented for `[u8]`
 note: required by a bound in `std::mem::size_of`
@@ -216,10 +216,43 @@ note: required by a bound in `std::mem::size_of`
     | pub const fn size_of<T>() -> usize {
     |                      ^ required by this bound in `std::mem::size_of`
 
-error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy::KnownLayout` is not satisfied
-   --> tests/ui-msrv/struct.rs:214:10
+error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes5, true>` is not satisfied
+   --> tests/ui-msrv/struct.rs:139:10
     |
-214 | #[derive(SplitAt)]
+139 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
+    |
+    = help: the following implementations were found:
+              <() as DynamicPaddingFree<T, false>>
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes6, true>` is not satisfied
+   --> tests/ui-msrv/struct.rs:148:10
+    |
+148 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
+    |
+    = help: the following implementations were found:
+              <() as DynamicPaddingFree<T, false>>
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes7, true>` is not satisfied
+   --> tests/ui-msrv/struct.rs:158:10
+    |
+158 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
+    |
+    = help: the following implementations were found:
+              <() as DynamicPaddingFree<T, false>>
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy::KnownLayout` is not satisfied
+   --> tests/ui-msrv/struct.rs:248:10
+    |
+248 | #[derive(SplitAt)]
     |          ^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
     |
 note: required by a bound in `SplitAt`
@@ -230,18 +263,18 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-msrv/struct.rs:218:10
+   --> tests/ui-msrv/struct.rs:252:10
     |
-218 | #[derive(SplitAt, KnownLayout)]
+252 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<u8 as zerocopy::KnownLayout>::PointerMetadata == usize`
-   --> tests/ui-msrv/struct.rs:218:10
+   --> tests/ui-msrv/struct.rs:252:10
     |
-218 | #[derive(SplitAt, KnownLayout)]
+252 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ expected `()`, found `usize`
     |
     = help: see issue #48214

--- a/zerocopy-derive/tests/ui-nightly/struct.rs
+++ b/zerocopy-derive/tests/ui-nightly/struct.rs
@@ -120,29 +120,63 @@ struct IntoBytes3 {
     bar: u64,
 }
 
+type SliceU8 = [u8];
+
+// Padding between `u8` and `SliceU8`. `SliceU8` doesn't syntactically look like
+// a slice, so this case is handled by our `Sized` support.
+//
 // NOTE(#1708): This exists to ensure that our error messages are good when a
 // field is unsized.
 #[derive(IntoBytes)]
 #[repr(C)]
 struct IntoBytes4 {
     a: u8,
+    b: SliceU8,
+}
+
+// Padding between `u8` and `[u16]`. `[u16]` is syntactically identifiable as a
+// slice, so this case is handled by our `repr(C)` slice DST support.
+#[derive(IntoBytes)]
+#[repr(C)]
+struct IntoBytes5 {
+    a: u8,
+    b: [u16],
+}
+
+// Trailing padding after `[u8]`. `[u8]` is syntactically identifiable as a
+// slice, so this case is handled by our `repr(C)` slice DST support.
+#[derive(IntoBytes)]
+#[repr(C)]
+struct IntoBytes6 {
+    a: u16,
     b: [u8],
+}
+
+// Padding between `u8` and `u16` and also trailing padding after `[u8]`. `[u8]`
+// is syntactically identifiable as a slice, so this case is handled by our
+// `repr(C)` slice DST support.
+#[derive(IntoBytes)]
+#[repr(C)]
+struct IntoBytes7 {
+    a: u8,
+    b: u16,
+    c: [u8],
 }
 
 #[derive(IntoBytes)]
 #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
-struct IntoBytes5 {
+struct IntoBytes8 {
     a: u8,
 }
 
 #[derive(IntoBytes)]
-struct IntoBytes8<T> {
+struct IntoBytes9<T> {
     t: T,
 }
 
 #[derive(IntoBytes)]
 #[repr(packed(2))]
-struct IntoBytes9<T> {
+struct IntoBytes10<T> {
     t: T,
 }
 

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -1,92 +1,92 @@
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:133:8
+   --> tests/ui-nightly/struct.rs:167:8
     |
-133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+167 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
     |        ^^^^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-nightly/struct.rs:138:10
+   --> tests/ui-nightly/struct.rs:172:10
     |
-138 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-nightly/struct.rs:143:10
+   --> tests/ui-nightly/struct.rs:177:10
     |
-143 | #[derive(IntoBytes)]
+177 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-nightly/struct.rs:166:10
+   --> tests/ui-nightly/struct.rs:200:10
     |
-166 | #[derive(IntoBytes)]
+200 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> tests/ui-nightly/struct.rs:177:11
+   --> tests/ui-nightly/struct.rs:211:11
     |
-177 | #[repr(C, align(2))]
+211 | #[repr(C, align(2))]
     |           ^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:181:8
+   --> tests/ui-nightly/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:187:8
+   --> tests/ui-nightly/struct.rs:221:8
     |
-187 | #[repr(packed, align(2))]
+221 | #[repr(packed, align(2))]
     |        ^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:191:8
+   --> tests/ui-nightly/struct.rs:225:8
     |
-191 | #[repr(align(1), align(2))]
+225 | #[repr(align(1), align(2))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:195:8
+   --> tests/ui-nightly/struct.rs:229:8
     |
-195 | #[repr(align(2), align(4))]
+229 | #[repr(align(2), align(4))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-nightly/struct.rs:198:10
+   --> tests/ui-nightly/struct.rs:232:10
     |
-198 | #[derive(Unaligned)]
+232 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-nightly/struct.rs:201:10
+   --> tests/ui-nightly/struct.rs:235:10
     |
-201 | #[derive(Unaligned)]
+235 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> tests/ui-nightly/struct.rs:209:19
+   --> tests/ui-nightly/struct.rs:243:19
     |
-209 |   #[repr(packed(2), C)]
+243 |   #[repr(packed(2), C)]
     |  ___________________^
-210 | | #[derive(Unaligned)]
-211 | | #[repr(C, packed(2))]
+244 | | #[derive(Unaligned)]
+245 | | #[repr(C, packed(2))]
     | |________^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-nightly/struct.rs:181:8
+   --> tests/ui-nightly/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -348,16 +348,16 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-nightly/struct.rs:125:10
+   --> tests/ui-nightly/struct.rs:130:10
     |
-125 | #[derive(IntoBytes)]
+130 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `IntoBytes4`
-   --> tests/ui-nightly/struct.rs:127:8
+   --> tests/ui-nightly/struct.rs:132:8
     |
-127 | struct IntoBytes4 {
+132 | struct IntoBytes4 {
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`
@@ -368,10 +368,10 @@ note: required by a bound in `macro_util::__size_of::size_of`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
-   --> tests/ui-nightly/struct.rs:129:8
+   --> tests/ui-nightly/struct.rs:134:8
     |
-129 |     b: [u8],
-    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
+134 |     b: SliceU8,
+    |        ^^^^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
     = note: consider using `#[repr(packed)]` to remove padding
@@ -383,22 +383,76 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
 
-error[E0587]: type has conflicting packed and align representation hints
-   --> tests/ui-nightly/struct.rs:188:1
+error[E0277]: `IntoBytes5` has one or more padding bytes
+   --> tests/ui-nightly/struct.rs:139:10
     |
-188 | struct Unaligned3;
+139 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+    |
+  9 + #![feature(trivial_bounds)]
+    |
+
+error[E0277]: `IntoBytes6` has one or more padding bytes
+   --> tests/ui-nightly/struct.rs:148:10
+    |
+148 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+    |
+  9 + #![feature(trivial_bounds)]
+    |
+
+error[E0277]: `IntoBytes7` has one or more padding bytes
+   --> tests/ui-nightly/struct.rs:158:10
+    |
+158 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+    |
+  9 + #![feature(trivial_bounds)]
+    |
+
+error[E0587]: type has conflicting packed and align representation hints
+   --> tests/ui-nightly/struct.rs:222:1
+    |
+222 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy::KnownLayout` is not satisfied
-   --> tests/ui-nightly/struct.rs:214:10
+   --> tests/ui-nightly/struct.rs:248:10
     |
-214 | #[derive(SplitAt)]
+248 | #[derive(SplitAt)]
     |          ^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
-   --> tests/ui-nightly/struct.rs:216:1
+   --> tests/ui-nightly/struct.rs:250:1
     |
-216 | struct SplitAtNotKnownLayout([u8]);
+250 | struct SplitAtNotKnownLayout([u8]);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
     = help: the following other types implement trait `zerocopy::KnownLayout`:
@@ -419,9 +473,9 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-nightly/struct.rs:218:10
+   --> tests/ui-nightly/struct.rs:252:10
     |
-218 | #[derive(SplitAt, KnownLayout)]
+252 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
@@ -437,9 +491,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
-   --> tests/ui-nightly/struct.rs:161:28
+   --> tests/ui-nightly/struct.rs:195:28
     |
-161 |         is_into_bytes_11::<IntoBytes11<AU16>>();
+195 |         is_into_bytes_11::<IntoBytes11<AU16>>();
     |                            ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy::Unaligned` is not implemented for `AU16`
@@ -459,13 +513,13 @@ help: the trait `zerocopy::Unaligned` is not implemented for `AU16`
               I128<O>
             and $N others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy::IntoBytes`
-   --> tests/ui-nightly/struct.rs:150:10
+   --> tests/ui-nightly/struct.rs:184:10
     |
-150 | #[derive(IntoBytes)]
+184 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `is_into_bytes_11`
-   --> tests/ui-nightly/struct.rs:159:24
+   --> tests/ui-nightly/struct.rs:193:24
     |
-159 | fn is_into_bytes_11<T: IntoBytes>() {
+193 | fn is_into_bytes_11<T: IntoBytes>() {
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -1,89 +1,89 @@
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:133:11
+   --> tests/ui-stable/struct.rs:167:11
     |
-133 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+167 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
     |           ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-stable/struct.rs:138:10
+   --> tests/ui-stable/struct.rs:172:10
     |
-138 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-stable/struct.rs:143:10
+   --> tests/ui-stable/struct.rs:177:10
     |
-143 | #[derive(IntoBytes)]
+177 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> tests/ui-stable/struct.rs:166:10
+   --> tests/ui-stable/struct.rs:200:10
     |
-166 | #[derive(IntoBytes)]
+200 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> tests/ui-stable/struct.rs:177:11
+   --> tests/ui-stable/struct.rs:211:11
     |
-177 | #[repr(C, align(2))]
+211 | #[repr(C, align(2))]
     |           ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:181:8
+   --> tests/ui-stable/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:187:16
+   --> tests/ui-stable/struct.rs:221:16
     |
-187 | #[repr(packed, align(2))]
+221 | #[repr(packed, align(2))]
     |                ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:191:18
+   --> tests/ui-stable/struct.rs:225:18
     |
-191 | #[repr(align(1), align(2))]
+225 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:195:18
+   --> tests/ui-stable/struct.rs:229:18
     |
-195 | #[repr(align(2), align(4))]
+229 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-stable/struct.rs:198:10
+   --> tests/ui-stable/struct.rs:232:10
     |
-198 | #[derive(Unaligned)]
+232 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> tests/ui-stable/struct.rs:201:10
+   --> tests/ui-stable/struct.rs:235:10
     |
-201 | #[derive(Unaligned)]
+235 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> tests/ui-stable/struct.rs:211:8
+   --> tests/ui-stable/struct.rs:245:8
     |
-211 | #[repr(C, packed(2))]
+245 | #[repr(C, packed(2))]
     |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> tests/ui-stable/struct.rs:181:8
+   --> tests/ui-stable/struct.rs:215:8
     |
-181 | #[repr(transparent, align(2))]
+215 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -294,16 +294,16 @@ error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> tests/ui-stable/struct.rs:125:10
+   --> tests/ui-stable/struct.rs:130:10
     |
-125 | #[derive(IntoBytes)]
+130 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `IntoBytes4`
-   --> tests/ui-stable/struct.rs:127:8
+   --> tests/ui-stable/struct.rs:132:8
     |
-127 | struct IntoBytes4 {
+132 | struct IntoBytes4 {
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`
@@ -314,10 +314,10 @@ note: required by a bound in `macro_util::__size_of::size_of`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
-   --> tests/ui-stable/struct.rs:129:8
+   --> tests/ui-stable/struct.rs:134:8
     |
-129 |     b: [u8],
-    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
+134 |     b: SliceU8,
+    |        ^^^^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
     = note: consider using `#[repr(packed)]` to remove padding
@@ -329,16 +329,58 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
 
-error[E0587]: type has conflicting packed and align representation hints
-   --> tests/ui-stable/struct.rs:188:1
+error[E0277]: `IntoBytes5` has one or more padding bytes
+   --> tests/ui-stable/struct.rs:139:10
     |
-188 | struct Unaligned3;
+139 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `IntoBytes6` has one or more padding bytes
+   --> tests/ui-stable/struct.rs:148:10
+    |
+148 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `IntoBytes7` has one or more padding bytes
+   --> tests/ui-stable/struct.rs:158:10
+    |
+158 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
+    |
+    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+    = note: consider adding explicit fields where padding would be
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
+            but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
+    = help: see issue #48214
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0587]: type has conflicting packed and align representation hints
+   --> tests/ui-stable/struct.rs:222:1
+    |
+222 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy::KnownLayout` is not satisfied
-   --> tests/ui-stable/struct.rs:214:10
+   --> tests/ui-stable/struct.rs:248:10
     |
-214 | #[derive(SplitAt)]
+248 | #[derive(SplitAt)]
     |          ^^^^^^^ the trait `zerocopy::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
     |
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
@@ -360,9 +402,9 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> tests/ui-stable/struct.rs:218:10
+   --> tests/ui-stable/struct.rs:252:10
     |
-218 | #[derive(SplitAt, KnownLayout)]
+252 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
@@ -374,9 +416,9 @@ error[E0277]: the trait bound `u8: SplitAt` is not satisfied
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
-   --> tests/ui-stable/struct.rs:161:28
+   --> tests/ui-stable/struct.rs:195:28
     |
-161 |         is_into_bytes_11::<IntoBytes11<AU16>>();
+195 |         is_into_bytes_11::<IntoBytes11<AU16>>();
     |                            ^^^^^^^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `AU16`
     |
     = note: Consider adding `#[derive(Unaligned)]` to `AU16`
@@ -391,13 +433,13 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
               I128<O>
             and $N others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy::IntoBytes`
-   --> tests/ui-stable/struct.rs:150:10
+   --> tests/ui-stable/struct.rs:184:10
     |
-150 | #[derive(IntoBytes)]
+184 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `is_into_bytes_11`
-   --> tests/ui-stable/struct.rs:159:24
+   --> tests/ui-stable/struct.rs:193:24
     |
-159 | fn is_into_bytes_11<T: IntoBytes>() {
+193 | fn is_into_bytes_11<T: IntoBytes>() {
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
For example:

    #[repr(C)]
    struct Example {
        leading: u8,
        trailing: [Trailing]
    }

Makes progress towards #1112

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
