### PR TITLE
[derive] `IntoBytes` padding error says number of bytes

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -999,14 +999,14 @@ macro_rules! cryptocorrosion_derive_traits {
         // SAFETY: `#[repr(transparent)]` structs cannot have the same layout as
         // their single non-zero-sized field, and so cannot have any padding
         // outside of that field.
-        false
+        0
     };
     (
         @struct_padding_check #[repr(C)]
         $(($($tuple_field_ty:ty),*))?
         $({$($field_ty:ty),*})?
     ) => {
-        $crate::struct_has_padding!(
+        $crate::struct_padding!(
             Self,
             [
                 $($($tuple_field_ty),*)?
@@ -1087,7 +1087,7 @@ macro_rules! cryptocorrosion_derive_traits {
             (): $crate::util::macro_util::PaddingFree<
                 Self,
                 {
-                    $crate::union_has_padding!(
+                    $crate::union_padding!(
                         Self,
                         [$($field_ty),*]
                     )

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -1489,9 +1489,9 @@ impl PaddingCheck {
     /// passes the padding check encoded by `PaddingCheck`.
     fn validator_macro_ident(&self) -> Ident {
         let s = match self {
-            PaddingCheck::Struct => "struct_has_padding",
-            PaddingCheck::Union => "union_has_padding",
-            PaddingCheck::Enum { .. } => "enum_has_padding",
+            PaddingCheck::Struct => "struct_padding",
+            PaddingCheck::Union => "union_padding",
+            PaddingCheck::Enum { .. } => "enum_padding",
         };
 
         Ident::new(s, Span::call_site())

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -477,7 +477,7 @@ fn test_into_bytes_struct() {
                 u8: ::zerocopy::IntoBytes,
                 (): ::zerocopy::util::macro_util::PaddingFree<
                     Self,
-                    { ::zerocopy::struct_has_padding!(Self, [u8, u8]) },
+                    { ::zerocopy::struct_padding!(Self, [u8, u8]) },
                 >,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}
@@ -501,7 +501,7 @@ fn test_into_bytes_struct() {
                 [Trailing]: ::zerocopy::IntoBytes,
                 (): ::zerocopy::util::macro_util::PaddingFree<
                     Self,
-                    { ::zerocopy::struct_has_padding!(Self, [u8, [Trailing]]) },
+                    { ::zerocopy::struct_padding!(Self, [u8, [Trailing]]) },
                 >,
             {
                 fn only_derive_is_allowed_to_implement_this_trait() {}

--- a/zerocopy-derive/tests/ui-msrv/enum.stderr
+++ b/zerocopy-derive/tests/ui-msrv/enum.stderr
@@ -359,36 +359,36 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, 1_usize>` is not satisfied
    --> tests/ui-msrv/enum.rs:538:10
     |
 538 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, 1_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+              <() as PaddingFree<T, 0_usize>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 3_usize>` is not satisfied
    --> tests/ui-msrv/enum.rs:549:10
     |
 549 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, 3_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+              <() as PaddingFree<T, 0_usize>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, 2_usize>` is not satisfied
    --> tests/ui-msrv/enum.rs:555:10
     |
 555 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, 2_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+              <() as PaddingFree<T, 0_usize>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui-msrv/struct.stderr
+++ b/zerocopy-derive/tests/ui-msrv/struct.stderr
@@ -162,25 +162,25 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 1_usize>` is not satisfied
    --> tests/ui-msrv/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, 1_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+              <() as PaddingFree<T, 0_usize>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, 1_usize>` is not satisfied
    --> tests/ui-msrv/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
-    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
+    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, 1_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
-              <() as PaddingFree<T, false>>
+              <() as PaddingFree<T, 0_usize>>
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -201,7 +201,7 @@ note: required by a bound in `std::mem::size_of`
     |
     | pub const fn size_of<T>() -> usize {
     |                      ^ required by this bound in `std::mem::size_of`
-    = note: this error originates in the macro `::zerocopy::struct_has_padding` (in Nightly builds, run with -Z macro-backtrace for more info)
+    = note: this error originates in the macro `::zerocopy::struct_padding` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
    --> tests/ui-msrv/struct.rs:129:8

--- a/zerocopy-derive/tests/ui-msrv/union.stderr
+++ b/zerocopy-derive/tests/ui-msrv/union.stderr
@@ -72,13 +72,13 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, true>` is not satisfied
+error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 1_usize>` is not satisfied
   --> tests/ui-msrv/union.rs:40:10
    |
 40 | #[derive(IntoBytes)]
-   |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
+   |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, 1_usize>` is not implemented for `()`
    |
    = help: the following implementations were found:
-             <() as PaddingFree<T, false>>
+             <() as PaddingFree<T, 0_usize>>
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -458,7 +458,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   9 + #![feature(trivial_bounds)]
     |
 
-error[E0277]: `IntoBytes1` has inter-field padding
+error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
    --> tests/ui-nightly/enum.rs:538:10
     |
 538 | #[derive(IntoBytes)]
@@ -466,9 +466,9 @@ error[E0277]: `IntoBytes1` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes1, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -476,7 +476,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   9 + #![feature(trivial_bounds)]
     |
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
    --> tests/ui-nightly/enum.rs:549:10
     |
 549 | #[derive(IntoBytes)]
@@ -484,9 +484,9 @@ error[E0277]: `IntoBytes2` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -494,7 +494,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   9 + #![feature(trivial_bounds)]
     |
 
-error[E0277]: `IntoBytes3` has inter-field padding
+error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
    --> tests/ui-nightly/enum.rs:555:10
     |
 555 | #[derive(IntoBytes)]
@@ -502,9 +502,9 @@ error[E0277]: `IntoBytes3` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes3, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -311,7 +311,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   9 + #![feature(trivial_bounds)]
     |
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
    --> tests/ui-nightly/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
@@ -319,9 +319,9 @@ error[E0277]: `IntoBytes2` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -329,7 +329,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
   9 + #![feature(trivial_bounds)]
     |
 
-error[E0277]: `IntoBytes3` has inter-field padding
+error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
    --> tests/ui-nightly/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
@@ -337,9 +337,9 @@ error[E0277]: `IntoBytes3` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes3, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -371,10 +371,10 @@ error[E0277]: `[u8]` is unsized
    --> tests/ui-nightly/struct.rs:129:8
     |
 129 |     b: [u8],
-    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is inter-field padding
+    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = note: consider using `#[repr(packed)]` to remove padding
     = note: `IntoBytes` does not require the fields of `#[repr(packed)]` types to be `Sized`
     = note: required for `[u8]` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -101,7 +101,7 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
  9 + #![feature(trivial_bounds)]
    |
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
   --> tests/ui-nightly/union.rs:40:10
    |
 40 | #[derive(IntoBytes)]
@@ -109,9 +109,9 @@ error[E0277]: `IntoBytes2` has inter-field padding
    |
    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
    = note: consider adding explicit fields where padding would be
-   = note: consider using `#[repr(packed)]` to remove inter-field padding
-   = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-           but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+   = note: consider using `#[repr(packed)]` to remove padding
+   = help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
+           but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -417,7 +417,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes1` has inter-field padding
+error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
    --> tests/ui-stable/enum.rs:538:10
     |
 538 | #[derive(IntoBytes)]
@@ -425,13 +425,13 @@ error[E0277]: `IntoBytes1` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes1, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes1, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
    --> tests/ui-stable/enum.rs:549:10
     |
 549 | #[derive(IntoBytes)]
@@ -439,13 +439,13 @@ error[E0277]: `IntoBytes2` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes3` has inter-field padding
+error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
    --> tests/ui-stable/enum.rs:555:10
     |
 555 | #[derive(IntoBytes)]
@@ -453,9 +453,9 @@ error[E0277]: `IntoBytes3` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes3, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -265,7 +265,7 @@ error[E0277]: the trait bound `AU16: zerocopy::Unaligned` is not satisfied
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
    --> tests/ui-stable/struct.rs:107:10
     |
 107 | #[derive(IntoBytes)]
@@ -273,13 +273,13 @@ error[E0277]: `IntoBytes2` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes3` has inter-field padding
+error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
    --> tests/ui-stable/struct.rs:114:10
     |
 114 | #[derive(IntoBytes)]
@@ -287,9 +287,9 @@ error[E0277]: `IntoBytes3` has inter-field padding
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
     = note: consider adding explicit fields where padding would be
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
-    = help: the trait `PaddingFree<IntoBytes3, true>` is not implemented for `()`
-            but trait `PaddingFree<IntoBytes3, false>` is implemented for it
+    = note: consider using `#[repr(packed)]` to remove padding
+    = help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
+            but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -317,10 +317,10 @@ error[E0277]: `[u8]` is unsized
    --> tests/ui-stable/struct.rs:129:8
     |
 129 |     b: [u8],
-    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is inter-field padding
+    |        ^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
-    = note: consider using `#[repr(packed)]` to remove inter-field padding
+    = note: consider using `#[repr(packed)]` to remove padding
     = note: `IntoBytes` does not require the fields of `#[repr(packed)]` types to be `Sized`
     = note: required for `[u8]` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`

--- a/zerocopy-derive/tests/ui-stable/union.stderr
+++ b/zerocopy-derive/tests/ui-stable/union.stderr
@@ -97,7 +97,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `IntoBytes2` has inter-field padding
+error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
   --> tests/ui-stable/union.rs:40:10
    |
 40 | #[derive(IntoBytes)]
@@ -105,9 +105,9 @@ error[E0277]: `IntoBytes2` has inter-field padding
    |
    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
    = note: consider adding explicit fields where padding would be
-   = note: consider using `#[repr(packed)]` to remove inter-field padding
-   = help: the trait `PaddingFree<IntoBytes2, true>` is not implemented for `()`
-           but trait `PaddingFree<IntoBytes2, false>` is implemented for it
+   = note: consider using `#[repr(packed)]` to remove padding
+   = help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
+           but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
While we're here, always say "padding" instead of "inter-field padding",
as all kinds (structs, enums, and unions) can have trailing padding too.

As an example, the diff for
`zerocopy-derive/tests/ui-stable/enum.stderr` contains:

-error[E0277]: `IntoBytes3` has inter-field padding
+error[E0277]: `IntoBytes3` has 2 total byte(s) of padding

Closes https://github.com/google/zerocopy/issues/1717