### PR TITLE
[byteorder] Note that network-endian is a synonym for big-endian

### DIFF
--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -27,6 +27,7 @@
 //!
 //! Type aliases are provided for common byte orders in the [`big_endian`],
 //! [`little_endian`], [`network_endian`], and [`native_endian`] submodules.
+//! Note that network-endian is a synonym for big-endian.
 //!
 //! # Example
 //!


### PR DESCRIPTION
Closes #2033

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
