### PR TITLE
Invert build.rs version detection flags and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
           # These are the names of specific Rust versions detected in
           # `build.rs`. Each of these represents the minimum Rust version for
           # which a particular feature is supported.
-          "zerocopy-simd-x86-avx12-1-89-0",
-          "zerocopy-core-error-1-81-0",
-          "zerocopy-diagnostic-on-unimplemented-1-78-0",
-          "zerocopy-generic-bounds-in-const-fn-1-61-0",
-          "zerocopy-target-has-atomics-1-60-0",
-          "zerocopy-aarch64-simd-1-59-0",
-          "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
+          "no-zerocopy-simd-x86-avx12-1-89-0",
+          "no-zerocopy-core-error-1-81-0",
+          "no-zerocopy-diagnostic-on-unimplemented-1-78-0",
+          "no-zerocopy-generic-bounds-in-const-fn-1-61-0",
+          "no-zerocopy-target-has-atomics-1-60-0",
+          "no-zerocopy-aarch64-simd-1-59-0",
+          "no-zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
         ]
         target: [
           "i686-unknown-linux-gnu",
@@ -86,19 +86,19 @@ jobs:
             features: "--all-features"
           - toolchain: "stable"
             features: "--all-features"
-          - toolchain: "zerocopy-simd-x86-avx12-1-89-0"
+          - toolchain: "no-zerocopy-simd-x86-avx12-1-89-0"
             features: "--all-features"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             features: "--all-features"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             features: "--all-features"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
             features: "--all-features"
-          - toolchain: "zerocopy-target-has-atomics-1-60-0"
+          - toolchain: "no-zerocopy-target-has-atomics-1-60-0"
             features: "--all-features"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             features: "--all-features"
-          - toolchain: "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
+          - toolchain: "no-zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
             features: "--all-features"
           # Exclude any combination for the zerocopy-derive crate which
           # uses zerocopy features.
@@ -113,109 +113,109 @@ jobs:
           # exist to exercise zerocopy behavior which differs by toolchain;
           # zerocopy-derive doesn't behave differently on these toolchains.
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-simd-x86-avx12-1-89-0"
+            toolchain: "no-zerocopy-simd-x86-avx12-1-89-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-core-error-1-81-0"
+            toolchain: "no-zerocopy-core-error-1-81-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
+            toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+            toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-target-has-atomics-1-60-0"
+            toolchain: "no-zerocopy-target-has-atomics-1-60-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-aarch64-simd-1-59-0"
+            toolchain: "no-zerocopy-aarch64-simd-1-59-0"
           - crate: "zerocopy-derive"
-            toolchain: "zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
+            toolchain: "no-zerocopy-panic-in-const-and-vec-try-reserve-1-57-0"
           # Exclude stable/wasm since wasm is no longer provided via rustup on
           # stable.
           - toolchain: "stable"
             target: "wasm32-unknown-unknown"
-          # Exclude non-aarch64 targets from the `zerocopy-aarch64-simd-1-59-0`
+          # Exclude non-aarch64 targets from the `no-zerocopy-aarch64-simd-1-59-0`
           # toolchain.
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "i686-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "x86_64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-aarch64-simd-1-59-0"
+          - toolchain: "no-zerocopy-aarch64-simd-1-59-0"
             target: "wasm32-unknown-unknown"
-          # Exclude most targets targets from the `zerocopy-core-error-1-81-0`
-          # toolchain since the `zerocopy-core-error-1-81-0` feature is unrelated to
+          # Exclude most targets targets from the `no-zerocopy-core-error-1-81-0`
+          # toolchain since the `no-zerocopy-core-error-1-81-0` feature is unrelated to
           # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-core-error-1-81-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-core-error-1-81-0"
-            target: "wasm32-unknown-unknown"
-          # Exclude most targets targets from the
-          # `zerocopy-diagnostic-on-unimplemented-1-78-0` toolchain since the
-          # `zerocopy-diagnostic-on-unimplemented-1-78-0` feature is unrelated to
-          # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
-            target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-diagnostic-on-unimplemented-1-78-0"
+          - toolchain: "no-zerocopy-core-error-1-81-0"
             target: "wasm32-unknown-unknown"
           # Exclude most targets targets from the
-          # `zerocopy-generic-bounds-in-const-fn-1-61-0` toolchain since the
-          # `zerocopy-generic-bounds-in-const-fn-1-61-0` feature is unrelated to
+          # `no-zerocopy-diagnostic-on-unimplemented-1-78-0` toolchain since the
+          # `no-zerocopy-diagnostic-on-unimplemented-1-78-0` feature is unrelated to
           # compilation target. This only leaves i686 and x86_64 targets.
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "arm-unknown-linux-gnueabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "aarch64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "powerpc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "powerpc64-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "riscv64gc-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "s390x-unknown-linux-gnu"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "x86_64-pc-windows-msvc"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             target: "thumbv6m-none-eabi"
-          - toolchain: "zerocopy-generic-bounds-in-const-fn-1-61-0"
+          - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
+            target: "wasm32-unknown-unknown"
+          # Exclude most targets targets from the
+          # `no-zerocopy-generic-bounds-in-const-fn-1-61-0` toolchain since the
+          # `no-zerocopy-generic-bounds-in-const-fn-1-61-0` feature is unrelated to
+          # compilation target. This only leaves i686 and x86_64 targets.
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "arm-unknown-linux-gnueabi"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "aarch64-unknown-linux-gnu"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "powerpc-unknown-linux-gnu"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "powerpc64-unknown-linux-gnu"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "riscv64gc-unknown-linux-gnu"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "s390x-unknown-linux-gnu"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "x86_64-pc-windows-msvc"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
+            target: "thumbv6m-none-eabi"
+          - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
             target: "wasm32-unknown-unknown"
           # Exclude `thumbv6m-none-eabi` combined with any feature that implies
           # the `std` feature since `thumbv6m-none-eabi` does not include a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ exclude = [".*"]
 
 [package.metadata.build-rs]
 # These key/value pairs are parsed by `build.rs`. Each entry names a `--cfg`
-# which will be emitted if zerocopy is built with a toolchain version at least
-# as high as the specified version. In the emitted `--cfg`, dashes are replaced
-# by underscores.
+# which will be emitted if zerocopy is built with a toolchain version *lower*
+# than the specified version. In the emitted `--cfg`, dashes are replaced by
+# underscores.
 #
 # Each name is suffixed with the version it corresponds to. This is a convention
 # used in the codebase to make it less likely for us to make mistakes when
@@ -38,28 +38,28 @@ exclude = [".*"]
 
 # From 1.89.0, Rust supports x86 AVX-12 SIMD types (previously gated by the
 # `stdarch_x86_avx512` feature).
-zerocopy-simd-x86-avx12-1-89-0 = "1.89.0"
+no-zerocopy-simd-x86-avx12-1-89-0 = "1.89.0"
 
 # From 1.81.0, Rust supports the `core::error::Error` trait.
-zerocopy-core-error-1-81-0 = "1.81.0"
+no-zerocopy-core-error-1-81-0 = "1.81.0"
 
 # From 1.78.0, Rust supports the `#[diagnostic::on_unimplemented]` attribute.
-zerocopy-diagnostic-on-unimplemented-1-78-0 = "1.78.0"
+no-zerocopy-diagnostic-on-unimplemented-1-78-0 = "1.78.0"
 
 # From 1.61.0, Rust supports generic types with trait bounds in `const fn`.
-zerocopy-generic-bounds-in-const-fn-1-61-0 = "1.61.0"
+no-zerocopy-generic-bounds-in-const-fn-1-61-0 = "1.61.0"
 
 # From 1.60.0, Rust supports `cfg(target_has_atomics)`, which allows us to
 # detect whether a target supports particular sets of atomics.
-zerocopy-target-has-atomics-1-60-0 = "1.60.0"
+no-zerocopy-target-has-atomics-1-60-0 = "1.60.0"
 
 # When the "simd" feature is enabled, include SIMD types from the
 # `core::arch::aarch64` module, which was stabilized in 1.59.0. On earlier Rust
 # versions, these types require the "simd-nightly" feature.
-zerocopy-aarch64-simd-1-59-0 = "1.59.0"
+no-zerocopy-aarch64-simd-1-59-0 = "1.59.0"
 
 # Permit panicking in `const fn`s and calling `Vec::try_reserve`.
-zerocopy-panic-in-const-and-vec-try-reserve-1-57-0 = "1.57.0"
+no-zerocopy-panic-in-const-and-vec-try-reserve-1-57-0 = "1.57.0"
 
 [package.metadata.ci]
 # The versions of the stable and nightly compiler toolchains to use in CI.

--- a/build.rs
+++ b/build.rs
@@ -95,7 +95,7 @@ fn main() {
     }
 
     for version_cfg in version_cfgs {
-        if rustc_version >= version_cfg.version {
+        if rustc_version < version_cfg.version {
             println!("cargo:rustc-cfg={}", version_cfg.cfg_name);
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,14 +115,14 @@
 //!         .map_err(|err| err.to_string())
 //! }).join().unwrap();
 //! ```
-#[cfg(zerocopy_core_error_1_81_0)]
+#[cfg(not(no_zerocopy_core_error_1_81_0))]
 use core::error::Error;
 use core::{
     convert::Infallible,
     fmt::{self, Debug, Write},
     ops::Deref,
 };
-#[cfg(all(not(zerocopy_core_error_1_81_0), any(feature = "std", test)))]
+#[cfg(all(no_zerocopy_core_error_1_81_0, any(feature = "std", test)))]
 use std::error::Error;
 
 use crate::{util::SendSyncPhantomData, KnownLayout, TryFromBytes, Unaligned};
@@ -234,7 +234,7 @@ impl<A: fmt::Display, S: fmt::Display, V: fmt::Display> fmt::Display for Convert
     }
 }
 
-#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg(any(not(no_zerocopy_core_error_1_81_0), feature = "std", test))]
 #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<A, S, V> Error for ConvertError<A, S, V>
 where
@@ -407,7 +407,7 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg(any(not(no_zerocopy_core_error_1_81_0), feature = "std", test))]
 #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for AlignmentError<Src, Dst>
 where
@@ -568,7 +568,7 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg(any(not(no_zerocopy_core_error_1_81_0), feature = "std", test))]
 #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for SizeError<Src, Dst>
 where
@@ -689,7 +689,7 @@ where
     }
 }
 
-#[cfg(any(zerocopy_core_error_1_81_0, feature = "std", test))]
+#[cfg(any(not(no_zerocopy_core_error_1_81_0), feature = "std", test))]
 #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.81.0", feature = "std"))))]
 impl<Src, Dst: ?Sized> Error for ValidityError<Src, Dst> where Dst: KnownLayout + TryFromBytes {}
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -383,7 +383,7 @@ const _: () = unsafe {
 };
 
 #[cfg(all(
-    zerocopy_target_has_atomics_1_60_0,
+    not(no_zerocopy_target_has_atomics_1_60_0),
     any(
         target_has_atomic = "8",
         target_has_atomic = "16",
@@ -1061,7 +1061,7 @@ mod simd {
             #[cfg(target_arch = "x86")]
             x86, x86, __m128, __m128d, __m128i, __m256, __m256d, __m256i
         );
-        #[cfg(zerocopy_simd_x86_avx12_1_89_0)]
+        #[cfg(not(no_zerocopy_simd_x86_avx12_1_89_0))]
         simd_arch_mod!(
             #[cfg(target_arch = "x86")]
             #[cfg_attr(doc_cfg, doc(cfg(rust = "1.89.0")))]
@@ -1071,7 +1071,7 @@ mod simd {
             #[cfg(target_arch = "x86_64")]
             x86_64, x86_64, __m128, __m128d, __m128i, __m256, __m256d, __m256i
         );
-        #[cfg(zerocopy_simd_x86_avx12_1_89_0)]
+        #[cfg(not(no_zerocopy_simd_x86_avx12_1_89_0))]
         simd_arch_mod!(
             #[cfg(target_arch = "x86_64")]
             #[cfg_attr(doc_cfg, doc(cfg(rust = "1.89.0")))]
@@ -1089,7 +1089,7 @@ mod simd {
             #[cfg(all(feature = "simd-nightly", target_arch = "powerpc64"))]
             powerpc64, powerpc64, vector_bool_long, vector_double, vector_signed_long, vector_unsigned_long
         );
-        #[cfg(zerocopy_aarch64_simd_1_59_0)]
+        #[cfg(not(no_zerocopy_aarch64_simd_1_59_0))]
         simd_arch_mod!(
             // NOTE(https://github.com/rust-lang/stdarch/issues/1484): NEON intrinsics are currently
             // broken on big-endian platforms.
@@ -2062,13 +2062,13 @@ mod tests {
             #[cfg(target_arch = "x86")]
             test_simd_arch_mod!(x86, __m128, __m128d, __m128i, __m256, __m256d, __m256i);
 
-            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "x86"))]
+            #[cfg(all(not(no_zerocopy_simd_x86_avx12_1_89_0), target_arch = "x86"))]
             test_simd_arch_mod!(x86, __m512bh, __m512, __m512d, __m512i);
 
             #[cfg(target_arch = "x86_64")]
             test_simd_arch_mod!(x86_64, __m128, __m128d, __m128i, __m256, __m256d, __m256i);
 
-            #[cfg(all(zerocopy_simd_x86_avx12_1_89_0, target_arch = "x86_64"))]
+            #[cfg(all(not(no_zerocopy_simd_x86_avx12_1_89_0), target_arch = "x86_64"))]
             test_simd_arch_mod!(x86_64, __m512bh, __m512, __m512d, __m512i);
 
             #[cfg(target_arch = "wasm32")]
@@ -2091,7 +2091,7 @@ mod tests {
                 vector_signed_long,
                 vector_unsigned_long
             );
-            #[cfg(all(target_arch = "aarch64", zerocopy_aarch64_simd_1_59_0))]
+            #[cfg(all(target_arch = "aarch64", not(no_zerocopy_aarch64_simd_1_59_0)))]
             #[rustfmt::skip]
             test_simd_arch_mod!(
                 aarch64, float32x2_t, float32x4_t, float64x1_t, float64x2_t, int8x8_t, int8x8x2_t,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1246,7 +1246,7 @@ mod tests {
                             layout(size_info, align).validate_cast_and_convert_metadata(addr, bytes_len, cast_type)
                         }).map_err(|d| {
                             let msg = d.downcast::<&'static str>().ok().map(|s| *s.as_ref());
-                            assert!(msg.is_some() || cfg!(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)), "non-string panic messages are not permitted when `--cfg zerocopy_panic_in_const_and_vec_try_reserve` is set");
+                            assert!(msg.is_some() || cfg!(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0), "non-string panic messages are not permitted when usage of panic in const fn is enabled");
                             msg
                         });
                         std::panic::set_hook(previous_hook);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,7 +725,7 @@ use {FromZeros as FromZeroes, IntoBytes as AsBytes, Ref as LayoutVerified};
     doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.KnownLayout.html"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(KnownLayout)]` to `{Self}`")
 )]
 pub unsafe trait KnownLayout {
@@ -1303,7 +1303,7 @@ pub use zerocopy_derive::Immutable;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Immutable.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(Immutable)]` to `{Self}`")
 )]
 pub unsafe trait Immutable {
@@ -1473,7 +1473,7 @@ pub use zerocopy_derive::TryFromBytes;
     doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.TryFromBytes.html"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(TryFromBytes)]` to `{Self}`")
 )]
 pub unsafe trait TryFromBytes {
@@ -3022,7 +3022,7 @@ unsafe fn try_read_from<S, T: TryFromBytes>(
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.FromZeros.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(FromZeros)]` to `{Self}`")
 )]
 pub unsafe trait FromZeros: TryFromBytes {
@@ -3261,7 +3261,7 @@ pub unsafe trait FromZeros: TryFromBytes {
 
     /// Extends a `Vec<Self>` by pushing `additional` new items onto the end of
     /// the vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+    #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.57.0", feature = "alloc"))))]
     #[inline(always)]
@@ -3280,7 +3280,7 @@ pub unsafe trait FromZeros: TryFromBytes {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+    #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
     #[cfg(feature = "alloc")]
     #[cfg_attr(doc_cfg, doc(cfg(all(rust = "1.57.0", feature = "alloc"))))]
     #[inline]
@@ -3537,7 +3537,7 @@ pub use zerocopy_derive::FromBytes;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.FromBytes.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(FromBytes)]` to `{Self}`")
 )]
 pub unsafe trait FromBytes: FromZeros {
@@ -4991,7 +4991,7 @@ pub use zerocopy_derive::IntoBytes;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.IntoBytes.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(IntoBytes)]` to `{Self}`")
 )]
 pub unsafe trait IntoBytes {
@@ -5554,7 +5554,7 @@ pub use zerocopy_derive::Unaligned;
     doc = concat!("[derive-analysis]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.Unaligned.html#analysis"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(Unaligned)]` to `{Self}`")
 )]
 pub unsafe trait Unaligned {
@@ -5657,13 +5657,13 @@ pub use zerocopy_derive::SplitAt;
 
 #[cfg(feature = "alloc")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+#[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
 mod alloc_support {
     use super::*;
 
     /// Extends a `Vec<T>` by pushing `additional` new items onto the end of the
     /// vector. The new items are initialized with zeros.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+    #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5680,7 +5680,7 @@ mod alloc_support {
     /// # Panics
     ///
     /// Panics if `position > v.len()`.
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+    #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
     #[doc(hidden)]
     #[deprecated(since = "0.8.0", note = "moved to `FromZeros`")]
     #[inline(always)]
@@ -5694,7 +5694,7 @@ mod alloc_support {
 }
 
 #[cfg(feature = "alloc")]
-#[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+#[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
 #[doc(hidden)]
 pub use alloc_support::*;
 
@@ -6607,7 +6607,7 @@ mod tests {
     mod alloc {
         use super::*;
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         #[test]
         fn test_extend_vec_zeroed() {
             // Test extending when there is an existing allocation.
@@ -6625,7 +6625,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         #[test]
         fn test_extend_vec_zeroed_zst() {
             // Test extending when there is an existing (fake) allocation.
@@ -6642,7 +6642,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         #[test]
         fn test_insert_vec_zeroed() {
             // Insert at start (no existing allocation).
@@ -6674,7 +6674,7 @@ mod tests {
             drop(v);
         }
 
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         #[test]
         fn test_insert_vec_zeroed_zst() {
             // Insert at start (no existing fake allocation).

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1202,7 +1202,7 @@ mod tests {
 
         // Before 1.61.0, we can't define the `const fn transmute_ref` function
         // that we do on and after 1.61.0.
-        #[cfg(not(zerocopy_generic_bounds_in_const_fn_1_61_0))]
+        #[cfg(no_zerocopy_generic_bounds_in_const_fn_1_61_0)]
         {
             // Test that `transmute_ref!` supports non-`KnownLayout` `Sized`
             // types.
@@ -1212,7 +1212,7 @@ mod tests {
             assert_eq!(*X_NKL, ARRAY_OF_NKL_ARRAYS);
         }
 
-        #[cfg(zerocopy_generic_bounds_in_const_fn_1_61_0)]
+        #[cfg(not(no_zerocopy_generic_bounds_in_const_fn_1_61_0))]
         {
             // Call through a generic function to make sure our autoref
             // specialization trick works even when types are generic.

--- a/src/split_at.rs
+++ b/src/split_at.rs
@@ -51,7 +51,7 @@ use crate::pointer::invariant::{Aligned, Exclusive, Invariants, Shared, Valid};
     doc = concat!("[derive]: https://docs.rs/zerocopy/", env!("CARGO_PKG_VERSION"), "/zerocopy/derive.SplitAt.html"),
 )]
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(SplitAt)]` to `{Self}`")
 )]
 // # Safety

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -50,7 +50,7 @@ pub unsafe trait Field<Index> {
 }
 
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(
         message = "`{T}` has {PADDING_BYTES} total byte(s) of padding",
         label = "types with padding cannot implement `IntoBytes`",
@@ -68,7 +68,7 @@ impl<T: ?Sized> PaddingFree<T, 0> for () {}
 // name) so that we can have more clear error messages.
 
 #[cfg_attr(
-    zerocopy_diagnostic_on_unimplemented_1_78_0,
+    not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(
         message = "`{T}` has one or more padding bytes",
         label = "types with padding cannot implement `IntoBytes`",
@@ -332,7 +332,7 @@ pub type SizeToTag<const SIZE: usize> = <() as size_to_tag::SizeToTag<SIZE>>::Ta
 
 // We put `Sized` in its own module so it can have the same name as the standard
 // library `Sized` without shadowing it in the parent module.
-#[cfg(zerocopy_diagnostic_on_unimplemented_1_78_0)]
+#[cfg(not(no_zerocopy_diagnostic_on_unimplemented_1_78_0))]
 mod __size_of {
     #[diagnostic::on_unimplemented(
         message = "`{Self}` is unsized",
@@ -351,10 +351,10 @@ mod __size_of {
     }
 }
 
-#[cfg(not(zerocopy_diagnostic_on_unimplemented_1_78_0))]
+#[cfg(no_zerocopy_diagnostic_on_unimplemented_1_78_0)]
 pub use core::mem::size_of;
 
-#[cfg(zerocopy_diagnostic_on_unimplemented_1_78_0)]
+#[cfg(not(no_zerocopy_diagnostic_on_unimplemented_1_78_0))]
 pub use __size_of::size_of;
 
 /// How many padding bytes does the struct type `$t` have?

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -548,10 +548,10 @@ macro_rules! maybe_const_trait_bounded_fn {
     // non-method functions. Each `$args` may optionally be followed by `:
     // $arg_tys:ty`, which can be omitted for `self`.
     ($(#[$attr:meta])* $vis:vis const fn $name:ident($($args:ident $(: $arg_tys:ty)?),* $(,)?) $(-> $ret_ty:ty)? $body:block) => {
-        #[cfg(zerocopy_generic_bounds_in_const_fn_1_61_0)]
+        #[cfg(not(no_zerocopy_generic_bounds_in_const_fn_1_61_0))]
         $(#[$attr])* $vis const fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
 
-        #[cfg(not(zerocopy_generic_bounds_in_const_fn_1_61_0))]
+        #[cfg(no_zerocopy_generic_bounds_in_const_fn_1_61_0)]
         $(#[$attr])* $vis fn $name($($args $(: $arg_tys)?),*) $(-> $ret_ty)? $body
     };
 }
@@ -572,9 +572,9 @@ macro_rules! const_panic {
         panic[0]
     }};
     ($($arg:tt)+) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         panic!($($arg)+);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
+        #[cfg(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         const_panic!(@non_panic $($arg)+)
     }};
 }
@@ -585,9 +585,9 @@ macro_rules! const_panic {
 /// accommodate old toolchains.
 macro_rules! const_assert {
     ($e:expr) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         assert!($e);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
+        #[cfg(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         {
             let e = $e;
             if !e {
@@ -596,9 +596,9 @@ macro_rules! const_assert {
         }
     }};
     ($e:expr, $($args:tt)+) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         assert!($e, $($args)+);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
+        #[cfg(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         {
             let e = $e;
             if !e {
@@ -611,9 +611,9 @@ macro_rules! const_assert {
 /// Like `const_assert!`, but relative to `debug_assert!`.
 macro_rules! const_debug_assert {
     ($e:expr $(, $msg:expr)?) => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         debug_assert!($e $(, $msg)?);
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
+        #[cfg(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         {
             // Use this (rather than `#[cfg(debug_assertions)]`) to ensure that
             // `$e` is always compiled even if it will never be evaluated at
@@ -632,10 +632,10 @@ macro_rules! const_debug_assert {
 /// toolchain supports panicking in `const fn`.
 macro_rules! const_unreachable {
     () => {{
-        #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+        #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
         unreachable!();
 
-        #[cfg(not(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
+        #[cfg(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
         loop {}
     }};
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -236,7 +236,7 @@ pub(crate) const fn round_down_to_next_multiple_of_alignment(
     }
 
     let align = align.get();
-    #[cfg(zerocopy_panic_in_const_and_vec_try_reserve_1_57_0)]
+    #[cfg(not(no_zerocopy_panic_in_const_and_vec_try_reserve_1_57_0))]
     debug_assert!(align.is_power_of_two());
 
     // Subtraction can't underflow because `align.get() >= 1`.


### PR DESCRIPTION
Inverts version detection flags to default to enabled on modern compilers. Renames `zerocopy-foo` to `no-zerocopy-foo` in `Cargo.toml`, `build.rs`, source code, and `.github/workflows/ci.yml`. Ensures `check_all_toolchains_tested.sh` passes by syncing CI config. Verified unit tests on all affected toolchains.

Closes #2259

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
