### PR TITLE
[ci] Integrate zizmor static analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: github-actions
+  - package-ecosystem: github-actions # zizmor: ignore[dependabot-cooldown] (Dependabot cooldown not desired)
     directory: /
     schedule:
       interval: daily

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -18,10 +18,17 @@ on:
         required: true
         default: 'main'
 
-permissions: read-all
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:
+    permissions:
+      contents: write # Need to write to repo to cherry-pick
+      pull-requests: write # zizmor: ignore[excessive-permissions] (Needed to create pull requests)
     runs-on: ubuntu-latest
     name: Backport PR
     steps:
@@ -35,16 +42,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Cherry-pick commit
+        env:
+          COMMIT: ${{ github.event.inputs.commit }}
         run: |
           set -eo pipefail
 
-          AUTHOR_NAME="$(git log -1 --pretty='%an' ${{ github.event.inputs.commit }})"
-          AUTHOR_EMAIL="$(git log -1 --pretty='%ae' ${{ github.event.inputs.commit }})"
+          AUTHOR_NAME="$(git log -1 --pretty='%an' "$COMMIT")"
+          AUTHOR_EMAIL="$(git log -1 --pretty='%ae' "$COMMIT")"
 
           git config --global user.name "$AUTHOR_NAME"
           git config --global user.email "$AUTHOR_EMAIL"
 
-          git cherry-pick ${{ github.event.inputs.commit }}
+          git cherry-pick "$COMMIT"
 
           PR_TITLE="$(git log -1 --pretty=%s)"
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ on:
   pull_request:
   merge_group:
 
-permissions: read-all
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -251,6 +256,7 @@ jobs:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         fetch-depth: 2
+        persist-credentials: false
 
     - name: Populate cache
       uses: ./.github/actions/cache
@@ -269,6 +275,8 @@ jobs:
         cargo add -p zerocopy-derive 'syn@=2.0.46'
 
     - name: Configure environment variables
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
       run: |
         set -eo pipefail
 
@@ -285,11 +293,11 @@ jobs:
         # ...to:
         #
         #   toolchain: $ {{ ./cargo.sh --version matrix.toolchain }} # hypothetical syntax
-        ZC_TOOLCHAIN="$(./cargo.sh --version ${{ matrix.toolchain }})"
-        echo "Found that the '${{ matrix.toolchain }}' toolchain is $ZC_TOOLCHAIN" | tee -a $GITHUB_STEP_SUMMARY
+        ZC_TOOLCHAIN="$(./cargo.sh --version $TOOLCHAIN)"
+        echo "Found that the '$TOOLCHAIN' toolchain is $ZC_TOOLCHAIN" | tee -a $GITHUB_STEP_SUMMARY
         echo "ZC_TOOLCHAIN=$ZC_TOOLCHAIN" >> $GITHUB_ENV
 
-        if [[ '${{ matrix.toolchain }}' == 'nightly' ]]; then
+        if [[ "$TOOLCHAIN" == 'nightly' ]]; then
           RUSTFLAGS="$RUSTFLAGS $ZC_NIGHTLY_RUSTFLAGS"
           MIRIFLAGS="$MIRIFLAGS $ZC_NIGHTLY_MIRIFLAGS"
           echo "Using nightly toolchain; setting RUSTFLAGS='$RUSTFLAGS' and MIRIFLAGS='$MIRIFLAGS'" | tee -a $GITHUB_STEP_SUMMARY
@@ -306,12 +314,12 @@ jobs:
     # (more recent) stable toolchain to be installed. As of this writing, this
     # toolchain is not used for anything else.
     - name: Install stable Rust for use in 'cargo.sh'
-      uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
         toolchain: stable
 
     - name: Install Rust with ${{ matrix.toolchain }} toolchain (${{ env.ZC_TOOLCHAIN }}) and target ${{ matrix.target }}
-      uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
           toolchain: ${{ env.ZC_TOOLCHAIN }}
           targets: ${{ matrix.target }}
@@ -335,15 +343,30 @@ jobs:
     # On the `thumbv6m-none-eabi` target, we can't run `cargo check --tests` due
     # to the `memchr` crate, so we just do `cargo check` instead.
     - name: Check
-      run: ./cargo.sh +${{ matrix.toolchain }} check --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
+      run: ./cargo.sh +$TOOLCHAIN check --package $CRATE --target $TARGET $FEATURES --verbose
       if: matrix.target == 'thumbv6m-none-eabi'
 
     - name: Check tests
-      run: ./cargo.sh +${{ matrix.toolchain }} check --tests --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
+      run: ./cargo.sh +$TOOLCHAIN check --tests --package $CRATE --target $TARGET $FEATURES --verbose
       if: matrix.target != 'thumbv6m-none-eabi'
 
     - name: Build
-      run: ./cargo.sh +${{ matrix.toolchain }} build --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
+      run: ./cargo.sh +$TOOLCHAIN build --package $CRATE --target $TARGET $FEATURES --verbose
       if: matrix.target != 'thumbv6m-none-eabi'
 
     # When building tests for the i686 target, we need certain libraries which
@@ -362,11 +385,16 @@ jobs:
       if: contains(matrix.target, 'i686')
 
     - name: Run tests
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
       run: |
-        ./cargo.sh +${{ matrix.toolchain }} test \
-          --package ${{ matrix.crate }} \
-          --target ${{ matrix.target }} \
-          ${{ matrix.features }} \
+        ./cargo.sh +$TOOLCHAIN test \
+          --package $CRATE \
+          --target $TARGET \
+          $FEATURES \
           --verbose \
           -- \
           --skip ui
@@ -379,6 +407,11 @@ jobs:
       if: contains(matrix.target, 'linux') && (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686'))
 
     - name: Run UI tests
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
       run: |
         # Run UI tests separately, treating warnings as warnings (rather than
         # as errors, as we do everywhere else in our CI tests). This allows
@@ -389,10 +422,10 @@ jobs:
         #
         # TODO(#560), TODO(#187): Once we migrate to the ui-test crate, we
         # likely won't have to special-case the UI tests like this.
-        RUSTFLAGS="$RUSTFLAGS -Wwarnings" ./cargo.sh +${{ matrix.toolchain }} test \
-          --package ${{ matrix.crate }} \
-          --target ${{ matrix.target }} \
-          ${{ matrix.features }} \
+        RUSTFLAGS="$RUSTFLAGS -Wwarnings" ./cargo.sh +$TOOLCHAIN test \
+          --package $CRATE \
+          --target $TARGET \
+          $FEATURES \
           --verbose \
           ui
 
@@ -419,11 +452,16 @@ jobs:
           (matrix.toolchain == 'msrv' || matrix.toolchain == 'stable' || matrix.toolchain == 'nightly')
 
     - name: Run tests under Miri
+      env:
+        TARGET: ${{ matrix.target }}
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        FEATURES: ${{ matrix.features }}
       run: |
         set -eo pipefail
 
         # Work around https://github.com/rust-lang/miri/issues/3125
-        [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ] && cargo clean
+        [ "$TARGET" == "aarch64-unknown-linux-gnu" ] && cargo clean
 
         # Spawn twice the number of workers as there are CPU cores.
         THREADS=$(echo "$(nproc) * 2" | bc)
@@ -434,12 +472,12 @@ jobs:
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
-          MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +${{ matrix.toolchain }} \
+          MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +$TOOLCHAIN \
             miri nextest run \
             --test-threads "$THREADS" \
-            --package ${{ matrix.crate }} \
-            --target ${{ matrix.target }} \
-            ${{ matrix.features }}
+            --package $CRATE \
+            --target $TARGET \
+            $FEATURES
         done
       # Only nightly has a working Miri, so we skip installing on all other
       # toolchains.
@@ -463,11 +501,21 @@ jobs:
     # On the `thumbv6m-none-eabi` target, we can't run `cargo clippy --tests`
     # due to the `memchr` crate, so we just do `cargo clippy` instead.
     - name: Clippy
-      run: ./cargo.sh +${{ matrix.toolchain }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --verbose
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
+      run: ./cargo.sh +$TOOLCHAIN clippy --package $CRATE --target $TARGET $FEATURES --verbose
       if: matrix.toolchain == 'nightly' && matrix.target == 'thumbv6m-none-eabi'
 
     - name: Clippy tests
-      run: ./cargo.sh +${{ matrix.toolchain }} clippy --package ${{ matrix.crate }} --target ${{ matrix.target }} ${{ matrix.features }} --tests --verbose
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
+      run: ./cargo.sh +$TOOLCHAIN clippy --package $CRATE --target $TARGET $FEATURES --tests --verbose
       # Clippy improves the accuracy of lints over time, and fixes bugs. Only
       # running Clippy on nightly allows us to avoid having to write code which
       # is compatible with older versions of Clippy, which sometimes requires
@@ -480,27 +528,38 @@ jobs:
       # make those items public/non-hidden more painless. Note that 
       # --document-hidden-items is unstable; if a future release breaks or removes it,
       # we can just update CI to no longer pass that flag.
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        FEATURES: ${{ matrix.features }}
+        NIGHTLY_FLAG: ${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }}
       run: |
         # Include arguments passed during docs.rs deployments to make sure those
         # work properly.
         set -eo pipefail
         METADATA_DOCS_RS_RUSTDOC_ARGS="$(cargo metadata --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
-        export RUSTDOCFLAGS="${{ matrix.toolchain == 'nightly' && '-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS'|| '' }} $RUSTDOCFLAGS"
-        ./cargo.sh +${{ matrix.toolchain }} doc --document-private-items --package ${{ matrix.crate }} ${{ matrix.features }}
+        if [[ "$TOOLCHAIN" == "nightly" ]]; then
+          export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS $RUSTDOCFLAGS"
+        fi
+        ./cargo.sh +$TOOLCHAIN doc --document-private-items --package $CRATE $FEATURES
 
     # If the commit message contains the line `SKIP_CARGO_SEMVER_CHECKS=1`, then
     # skip the cargo-semver-checks step.
     - name: Check whether to skip cargo-semver-checks
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        SHA: ${{ github.sha }}
       run: |
         set -eo pipefail
 
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
+        if [ "$EVENT_NAME" == "pull_request" ]; then
           # Invoked from a PR - get the PR body directly
-          MESSAGE="$(git log -1 --pretty=%B ${{ github.event.pull_request.head.sha }})"
+          MESSAGE="$(git log -1 --pretty=%B $HEAD_SHA)"
         else
           # Invoked from the merge queue - get the commit message
-          MESSAGE="$(git log -1 --pretty=%B ${{ github.sha }})"
+          MESSAGE="$(git log -1 --pretty=%B $SHA)"
         fi
 
         if echo "$MESSAGE" | grep '^\s*SKIP_CARGO_SEMVER_CHECKS=1\s*$' > /dev/null; then
@@ -549,14 +608,19 @@ jobs:
     # - Support multiple matrix combinations (which we intend to do as part of
     #   #453 eventually anyway) so that this location is justified
     - name: Generate code coverage
+      env:
+        TOOLCHAIN: ${{ matrix.toolchain }}
+        CRATE: ${{ matrix.crate }}
+        TARGET: ${{ matrix.target }}
+        FEATURES: ${{ matrix.features }}
       run: |
         set -eo pipefail
         ./cargo.sh +nightly install cargo-llvm-cov
 
-        ./cargo.sh +${{ matrix.toolchain }} llvm-cov \
-          --package ${{ matrix.crate }}              \
-          --target ${{ matrix.target }}              \
-          ${{ matrix.features }}                     \
+        ./cargo.sh +$TOOLCHAIN llvm-cov \
+          --package $CRATE              \
+          --target $TARGET              \
+          $FEATURES                     \
           --doctests                                 \
           --lcov                                     \
           --output-path lcov.info                    \
@@ -570,7 +634,7 @@ jobs:
         matrix.target == 'x86_64-unknown-linux-gnu'
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: lcov.info
@@ -585,6 +649,8 @@ jobs:
     name: 'Run tests under Kani'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           # Use `--features __internal_use_only_features_that_work_on_stable`
@@ -613,6 +679,8 @@ jobs:
     name: Build (zerocopy / nightly / --simd / aarch64_be-unknown-linux-gnu)
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Configure environment variables
         run: |
           set -eo pipefail
@@ -625,11 +693,11 @@ jobs:
         with:
           key: aarch64_be-unknown-linux-gnu
       - name: Install stable Rust for use in 'cargo.sh'
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - name: Install Rust with nightly toolchain (${{ env.ZC_TOOLCHAIN }}) and target aarch64_be-unknown-linux-gnu
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
             toolchain: ${{ env.ZC_TOOLCHAIN }}
             components: clippy, rust-src
@@ -643,6 +711,8 @@ jobs:
     name: Build (zerocopy / nightly / --simd / avr-none)
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Configure environment variables
         run: |
           set -eo pipefail
@@ -655,11 +725,11 @@ jobs:
         with:
           key: avr-none
       - name: Install stable Rust for use in 'cargo.sh'
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - name: Install Rust with nightly toolchain (${{ env.ZC_TOOLCHAIN }})
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
             toolchain: ${{ env.ZC_TOOLCHAIN }}
             components: clippy, rust-src
@@ -680,6 +750,8 @@ jobs:
     name: Check Rust formatting
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Check Rust formatting
         run: |
           set -eo pipefail
@@ -695,6 +767,8 @@ jobs:
     name: Check GitHub Actions
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: Populate cache
         uses: ./.github/actions/cache
@@ -708,6 +782,8 @@ jobs:
     name: Check README.md
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: Populate cache
         uses: ./.github/actions/cache
@@ -721,6 +797,8 @@ jobs:
     name: Check crate versions match
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - name: Populate cache
         uses: ./.github/actions/cache
@@ -738,6 +816,8 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
+        with:
+          persist-credentials: false
       - name: Populate cache
         uses: ./.github/actions/cache
 
@@ -749,6 +829,8 @@ jobs:
     name: Generate cache
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
 
       - id: populate-cache
         uses: ./.github/actions/cache
@@ -799,6 +881,8 @@ jobs:
       - name: Install yq (for YAML parsing)
         run: go install github.com/mikefarah/yq/v4@latest
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Run check
         run: ./ci/check_all_toolchains_tested.sh
 
@@ -809,6 +893,8 @@ jobs:
       - name: Install yq (for YAML parsing)
         run: go install github.com/mikefarah/yq/v4@latest
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Run dependency check
         run: ./ci/check_job_dependencies.sh
 
@@ -821,6 +907,8 @@ jobs:
          sudo apt-get update
          sudo apt-get install ripgrep
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Run todo check
         run: ./ci/check_todo.sh
 
@@ -835,6 +923,8 @@ jobs:
          sudo apt-get update
          sudo apt-get install ripgrep
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Run dependency check
         # Ensure that Git hooks execute successfully.
         #
@@ -850,6 +940,22 @@ jobs:
 
           for hook in ./githooks/*; do $hook; done
 
+  zizmor:
+    runs-on: ubuntu-latest
+    name: zizmor
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+        with:
+          # We don't want to use GitHub Advanced Security because we want to
+          # block the merge on zizmor failure, and the only way to do that
+          # (without manually configuring a ruleset) is to fail the job, which
+          # the action only does if advanced-security is false.
+          advanced-security: false
+          persona: pedantic
+
   # Used to signal to branch protections that all other jobs have succeeded.
   all-jobs-succeed:
       name: All checks succeeded
@@ -860,7 +966,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_actions, check_readme, check_versions, check_msrv_is_minimal, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
+      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_actions, check_readme, check_versions, check_msrv_is_minimal, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks, zizmor]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,19 +17,27 @@
 name: 'Dependency Review'
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
 
       - name: 'Checkout Repository'
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,8 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
+
 concurrency:
   group: deploy
   cancel-in-progress: false
@@ -26,8 +24,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          persist-credentials: false
       - name: Configure environment variables
         run: |
           set -eo pipefail
@@ -57,7 +59,7 @@ jobs:
       # (more recent) stable toolchain to be installed. As of this writing, this
       # toolchain is not used for anything else.
       - name: Install stable Rust for use in 'cargo.sh'
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           # This isn't actually required to build docs, but `cargo.sh` checks
@@ -66,7 +68,7 @@ jobs:
           components: rust-src
   
       - name: Install Rust with nightly toolchain (${{ env.ZC_NIGHTLY_TOOLCHAIN }})
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
             toolchain: ${{ env.ZC_NIGHTLY_TOOLCHAIN }}
             targets: "x86_64-unknown-linux-gnu"
@@ -92,7 +94,7 @@ jobs:
             export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS"
 
             # TODO: Use `./cargo.sh` instead once we've debugged why it won't work.
-            cargo +${{ env.ZC_NIGHTLY_TOOLCHAIN }} doc --document-private-items --package zerocopy --all-features
+            cargo +$ZC_NIGHTLY_TOOLCHAIN doc --document-private-items --package zerocopy --all-features
 
       - name: Add HTML redirect to doc root
         # By default, Rustdoc doesn't redirect to the documentation root, so we
@@ -110,6 +112,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write # zizmor: ignore[excessive-permissions] (Required for Pages deployment)
+      id-token: write # zizmor: ignore[excessive-permissions] (Required for Pages deployment)
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-crate-version.yml
+++ b/.github/workflows/release-crate-version.yml
@@ -18,12 +18,17 @@ on:
         required: true
         default: 'main'
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:
+    permissions:
+      contents: read
+      pull-requests: write # zizmor: ignore[excessive-permissions] (Needed to create pull requests)
     runs-on: ubuntu-latest
     name: Release new crate versions
     steps:
@@ -33,7 +38,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
       - name: Overwrite Cargo.toml files
-        run: ./ci/release_crate_version.sh ${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./ci/release_crate_version.sh "$VERSION"
 
       - name: Submit PR
         id: submit-pr
@@ -49,6 +56,7 @@ jobs:
 
       - name: Add labels
         if: steps.submit-pr.outputs.pull-request-operation == 'created'
-        run: gh pr edit "${{ steps.submit-pr.outputs.pull-request-number }}" --add-label "hide-from-release-notes"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.submit-pr.outputs.pull-request-number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "hide-from-release-notes"

--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -22,13 +22,18 @@ on:
     - cron: '29 09 * * 1'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   roll_rust:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # zizmor: ignore[excessive-permissions] (Needed to create pull requests)
     strategy:
       # By default, this is set to `true`, which means that a single CI job
       # failure will cause all outstanding jobs to be canceled. This means that
@@ -46,8 +51,10 @@ jobs:
           ref: ${{ matrix.branch }}
           persist-credentials: false
       - name: Calculate target version
+        env:
+          TOOLCHAIN: ${{ matrix.toolchain }}
         run: |
-          if [ "${{ matrix.toolchain }}" == stable ]; then
+          if [ "$TOOLCHAIN" == stable ]; then
             # Install whatever the latest stable release is. This has the side
             # effect of determining the latest stable release so that we can
             # update `Cargo.toml`.
@@ -59,7 +66,7 @@ jobs:
             echo "ZC_TARGET_TOOLCHAIN=nightly-$(date -d '-1 day' +%Y-%m-%d)" >> $GITHUB_ENV
           fi
       - name: Install Rust with ${{ env.ZC_TARGET_TOOLCHAIN }} toolchain
-        uses: dtolnay/rust-toolchain@00b49be78f40fba4e87296b2ead62868750bdd83 # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
             toolchain: ${{ env.ZC_TARGET_TOOLCHAIN }}
             # We require the `rust-src` component to ensure that the compiler
@@ -68,6 +75,8 @@ jobs:
             # https://github.com/rust-lang/rust/issues/116433.
             components: rust-src
       - name: Update files
+        env:
+          TOOLCHAIN: ${{ matrix.toolchain }}
         run: |
           set -eo pipefail
 
@@ -121,7 +130,7 @@ jobs:
             TRYBUILD=overwrite cargo "+$VERSION_FOR_CARGO" test --package file:///home/runner/work/zerocopy/zerocopy/zerocopy-derive
           }
 
-          if [ "${{ matrix.toolchain }}" == stable ]; then
+          if [ "$TOOLCHAIN" == stable ]; then
             STABLE_VERSION="$(cargo +stable version | sed -e 's/^cargo \([0-9\.]*\) .*/\1/')"
             update-pinned-version stable "$STABLE_VERSION" stable '--features __internal_use_only_features_that_work_on_stable'
 
@@ -147,12 +156,16 @@ jobs:
 
       - name: Add labels
         if: steps.submit-pr.outputs.pull-request-operation == 'created'
-        run: gh pr edit "${{ steps.submit-pr.outputs.pull-request-number }}" --add-label "hide-from-release-notes"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.submit-pr.outputs.pull-request-number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "hide-from-release-notes"
           
   roll_kani:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # zizmor: ignore[excessive-permissions] (Needed to create pull requests)
     strategy:
       matrix:
         branch: ["main", "v0.7.x"]
@@ -188,6 +201,7 @@ jobs:
 
       - name: Add labels
         if: steps.submit-pr.outputs.pull-request-operation == 'created'
-        run: gh pr edit "${{ steps.submit-pr.outputs.pull-request-number }}" --add-label "hide-from-release-notes"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.submit-pr.outputs.pull-request-number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "hide-from-release-notes"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,11 @@ on:
     branches: [ "main" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analysis:
@@ -31,9 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
-      security-events: write
+      security-events: write # zizmor: ignore[undocumented-permissions] (Required by Scorecard)
       # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      id-token: write # zizmor: ignore[undocumented-permissions] (Required by Scorecard)
+      # Needed for actions/checkout
+      contents: read
 
     steps:
       - name: "Checkout code"
@@ -66,6 +72,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c36620d31ac7c881962c3d9dd939c40ec9434f2b # v3.26.12
+        uses: github/codeql-action/upload-sarif@c3d42c5d08633d8b33635fbd94b000a0e2585b3c # v3.31.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Integrates the zizmor static analysis tool into the CI pipeline to enforce security best practices for GitHub Actions.

- Added a zizmor job to ci.yml with persona: pedantic to enforce strict checking.
- Configured the job to fail the build on findings, blocking merges.
- Refactored run scripts in all workflows to use environment variables instead of inline interpolation, preventing potential template injection vulnerabilities.
- Pinned action versions and tightened permissions across all workflows.
- Added concurrency groups to all workflows to manage parallel runs.
- Suppressed false positives and necessary write permissions where appropriate.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
