### PR TITLE
[ci] Integrate action-validator into CI and pre-push hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,6 +689,19 @@ jobs:
 
           ./ci/check_fmt.sh
 
+  check_actions:
+    needs: generate_cache
+    runs-on: ubuntu-latest
+    name: Check GitHub Actions
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Populate cache
+        uses: ./.github/actions/cache
+
+      - name: Check Actions
+        run: ./ci/check_actions.sh
+
   check_readme:
     needs: generate_cache
     runs-on: ubuntu-latest
@@ -769,12 +782,13 @@ jobs:
           # maybe remove it.
           cargo add -p zerocopy-derive 'syn@=2.0.46' &> /dev/null
 
-          cargo check --workspace --tests            &> /dev/null &
-          cargo metadata                             &> /dev/null &
-          cargo install cargo-readme --version 3.2.0 &> /dev/null &
-          cargo install --locked kani-verifier       &> /dev/null &
-          cargo install cargo-nextest                &> /dev/null &
-          cargo kani setup                           &> /dev/null &
+          cargo check --workspace --tests                         &> /dev/null &
+          cargo metadata                                          &> /dev/null &
+          cargo install cargo-readme --version 3.2.0              &> /dev/null &
+          cargo install --locked action-validator --version 0.8.0 &> /dev/null &
+          cargo install --locked kani-verifier                    &> /dev/null &
+          cargo install cargo-nextest                             &> /dev/null &
+          cargo kani setup                                        &> /dev/null &
 
           wait
 
@@ -846,7 +860,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_readme, check_versions, check_msrv_is_minimal, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
+      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_actions, check_readme, check_versions, check_msrv_is_minimal, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/ci/check_actions.sh
+++ b/ci/check_actions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -eo pipefail
+
+script_name="ci/check_actions.sh"
+
+# Ensure action-validator is installed
+if [ ! -x "$HOME/.cargo/bin/action-validator" ]; then
+    echo "$script_name: action-validator not found, installing..." >&2
+    # Install specific version to ensure reproducibility
+    cargo install -q action-validator --version 0.8.0 --locked
+fi
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Files to exclude from validation (e.g., because they are not Actions/Workflows)
+# Use relative paths matching `find .github` output
+EXCLUDE_FILES=(
+    "./.github/dependabot.yml"
+    "./.github/release.yml"
+)
+
+failed=0
+
+# Use process substitution and while loop to handle filenames with spaces robustly
+while IFS= read -r -d '' file; do
+    # Check if file is in exclusion list
+    for exclude in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$file" == "$exclude" ]]; then
+            continue 2
+        fi
+    done
+
+    if ! output=$(action-validator "$file" 2>&1); then
+        echo "$script_name: ❌ Validation failed for $file" >&2
+        echo "$output" | sed "s|^|$script_name:   |" >&2
+        failed=1
+    fi
+done < <(find ./.github -type f \( -iname '*.yml' -o -iname '*.yaml' \) -print0)
+
+if [[ $failed -ne 0 ]]; then
+    echo "$script_name: One or more files failed validation." >&2
+    exit 1
+fi

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -14,6 +14,7 @@ echo "Running pre-push git hook: $0"
 # `cargo fmt` is useful (and the good stuff is not delivered by stderr).
 #
 # Background all jobs and wait for them so they can run in parallel.
+./ci/check_actions.sh                          & ACTIONS_PID=$!
 ./ci/check_fmt.sh                              & FMT_PID=$!
 ./ci/check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_PID=$!
 ./ci/check_job_dependencies.sh      >/dev/null & JOB_DEPS_PID=$!
@@ -28,6 +29,7 @@ echo "Running pre-push git hook: $0"
 # Note that, while `wait` (with no PID argument) waits for all backgrounded
 # jobs, it exits with code 0 even if one of the backgrounded jobs does not, so
 # we can't use it here.
+wait $ACTIONS_PID
 wait $FMT_PID
 wait $TOOLCHAINS_PID
 wait $JOB_DEPS_PID


### PR DESCRIPTION
Integrate the `action-validator` tool into our CI pipeline and pre-push hooks. This tool validates GitHub Actions workflow files to ensure they are syntactically correct and follow best practices.

This change adds a new script, `ci/check_actions.sh`, which runs `action-validator` on all YAML files in `.github/`. It also updates the pre-push hook to run this check.

Includes a fix for path matching in the exclusion list, ensuring that excluded files are correctly identified by prefixing them with `./`.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
