### PR TITLE
[ci] Add MSRV minimality check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,6 +718,19 @@ jobs:
       - name: Check crate versions match
         run: ./ci/check_versions.sh
 
+  check_msrv_is_minimal:
+    needs: generate_cache
+    runs-on: ubuntu-latest
+    name: Check MSRV is minimal
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - name: Populate cache
+        uses: ./.github/actions/cache
+
+      - name: Check MSRV is minimal
+        run: ./ci/check_msrv_is_minimal.sh
+
   generate_cache:
     runs-on: ubuntu-latest
     name: Generate cache
@@ -833,7 +846,7 @@ jobs:
       # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
       if: failure()
       runs-on: ubuntu-latest
-      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_readme, check_versions, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
+      needs: [build_test, kani, check_be_aarch64, check_avr_artmega, check_fmt, check_readme, check_versions, check_msrv_is_minimal, generate_cache, check-all-toolchains-tested, check-job-dependencies, check-todo, run-git-hooks]
       steps:
         - name: Mark the job as failed
           run: exit 1

--- a/ci/check_msrv_is_minimal.sh
+++ b/ci/check_msrv_is_minimal.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -eo pipefail
+
+read -r -d '' PYTHON_SCRIPT <<'EOF' || true
+import sys
+import json
+
+def parse_version(v):
+    """Converts a version string to a tuple of integers."""
+    return tuple(map(int, v.split(".")))
+
+def main():
+    """
+    Checks that the package's MSRV is strictly lower than any version
+    specified in `package.metadata.build-rs`.
+    """
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON from cargo metadata: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Find the zerocopy package
+    try:
+        pkg = next(p for p in data["packages"] if p["name"] == "zerocopy")
+    except StopIteration:
+        print("Error: zerocopy package not found in metadata", file=sys.stderr)
+        sys.exit(1)
+
+    msrv_str = pkg.get("rust_version")
+    if not msrv_str:
+        print("Error: rust-version not found in Cargo.toml", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        msrv = parse_version(msrv_str)
+    except ValueError:
+        print(f"Error: Invalid MSRV format: {msrv_str}", file=sys.stderr)
+        sys.exit(1)
+
+    build_rs_versions = (pkg.get("metadata") or {}).get("build-rs", {})
+
+    failed = False
+    for name, ver_str in build_rs_versions.items():
+        try:
+            ver = parse_version(ver_str)
+        except ValueError:
+            print(f"Warning: Skipping invalid version format for {name}: {ver_str}", file=sys.stderr)
+            continue
+
+        # Check that MSRV < Version (strictly lower)
+        if not (msrv < ver):
+            print(f"Error: MSRV ({msrv_str}) is not strictly lower than {name} ({ver_str})", file=sys.stderr)
+            failed = True
+
+    if failed:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+EOF
+
+cargo metadata --format-version 1 --no-deps | python3 -c "$PYTHON_SCRIPT"

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -20,6 +20,7 @@ echo "Running pre-push git hook: $0"
 ./ci/check_readme.sh                >/dev/null & README_PID=$!
 ./ci/check_todo.sh                  >/dev/null & XODO_PID=$!
 ./ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
+./ci/check_msrv_is_minimal.sh       >/dev/null & MSRV_PID=$!
 
 # `wait <pid>` exits with the same status code as the job it's waiting for.
 # Since we `set -e` above, this will have the effect of causing the entire
@@ -33,6 +34,7 @@ wait $JOB_DEPS_PID
 wait $README_PID
 wait $XODO_PID
 wait $VERSIONS_PID
+wait $MSRV_PID
 
 # Ensure that this script calls all scripts in `ci/*`. This isn't a foolproof
 # check since it just checks for the string in this script (e.g., it could be in


### PR DESCRIPTION
This change adds a new CI script `ci/check_msrv_is_minimal.sh` that verifies that the package's MSRV is strictly lower than any version specified in `package.metadata.build-rs`. This ensures that we don't accidentally bump our MSRV unnecessarily.

The check is added to:
- `.github/workflows/ci.yml` as a new job.
- `githooks/pre-push` to be run locally.

The script implementation uses a Python script embedded via heredoc and a temporary file for better readability and maintainability.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
