### PR TITLE
Add serde optional feature to serialize primitive types

### DIFF
--- a/tools/generate-readme/src/main.rs
+++ b/tools/generate-readme/src/main.rs
@@ -50,15 +50,23 @@ fn main() {
 
     let readme = String::from_utf8(output.stdout).unwrap();
 
-    // This regex is used to strip code links like:
+    // This regex is used to strip code links without url after, like:
     //
     //   /// Here is a link to [`Vec`].
     //
     // These links don't work in a Markdown file, and so we remove the `[` and `]`
     // characters to convert them to non-link code snippets.
-    let body = Regex::new(r"\[(`[^`]*`)\]")
-        .unwrap()
-        .replace_all(&readme, |caps: &Captures| caps[1].to_string());
+    let re = Regex::new(r"\[(`[^`]*`)\](\([^)]*\))?").unwrap();
+
+    let body = re.replace_all(&readme, |caps: &Captures| {
+        if caps.get(2).is_some() {
+            // There is a following `(...)`: keep the whole original text
+            caps[0].to_string()
+        } else {
+            // No `(...)`: strip the surrounding [ ]
+            caps[1].to_string()
+        }
+    });
 
     println!("{}\n\n{}\n{}", COPYRIGHT_HEADER, body, DISCLAIMER_FOOTER);
 }

--- a/zerocopy/Cargo.lock
+++ b/zerocopy/Cargo.lock
@@ -419,6 +419,8 @@ dependencies = [
  "rand",
  "regex",
  "rustversion",
+ "serde",
+ "serde_json",
  "static_assertions",
  "testutil",
  "zerocopy-derive",

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -94,13 +94,19 @@ pinned-nightly = "nightly-2026-01-25"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition", "--extend-css", "rustdoc/style.css"]
+rustdoc-args = [
+    "--cfg",
+    "doc_cfg",
+    "--generate-link-to-definition",
+    "--extend-css",
+    "rustdoc/style.css",
+]
 targets = [
     "x86_64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
     "i686-unknown-linux-gnu",
-    "i686-pc-windows-msvc"
+    "i686-pc-windows-msvc",
 ]
 
 [package.metadata.playground]
@@ -119,11 +125,13 @@ std = ["alloc"]
 __internal_use_only_features_that_work_on_stable = [
     "alloc",
     "derive",
+    "serde",
     "simd",
     "std",
 ]
 
 [dependencies]
+serde = { version = "1.0.144", default-features = false, optional = true }
 zerocopy-derive = { version = "=0.8.52", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
@@ -141,5 +149,6 @@ regex = "1.0"
 rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
+serde_json = "1.0.143"
 # In tests, unlike in production, zerocopy-derive is not optional
 zerocopy-derive = { version = "=0.8.52", path = "zerocopy-derive" }

--- a/zerocopy/README.md
+++ b/zerocopy/README.md
@@ -121,6 +121,10 @@ for network parsing.
   derives as `use zerocopy_derive::*` rather than by name (e.g., `use
   zerocopy_derive::FromBytes`).
 
+- **`serde`**
+  Provides [`serde`](https://github.com/serde-rs/serde) `Serialize` and `Deserialize` impls for
+  the `byteorder` numeric wrappers by delegating to their underlying primitive types.
+
 - **`simd`**
   When the `simd` feature is enabled, `FromZeros`, `FromBytes`, and
   `IntoBytes` impls are emitted for all stable SIMD types which exist on the

--- a/zerocopy/src/byteorder.rs
+++ b/zerocopy/src/byteorder.rs
@@ -652,6 +652,36 @@ example of how it can be used for parsing UDP packets.
             }
         }
 
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
+        #[cfg(feature = "serde")]
+        impl<O: ByteOrder> serde::Serialize for $name<O>
+        where
+            $native: serde::Serialize,
+        {
+            #[inline(always)]
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                $native::serialize(&self.get(), serializer)
+            }
+        }
+
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
+        #[cfg(feature = "serde")]
+        impl<'de, O: ByteOrder> serde::Deserialize<'de> for $name<O>
+        where
+            $native: serde::Deserialize<'de>,
+        {
+            #[inline(always)]
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                $native::deserialize(deserializer).map(Self::from)
+            }
+        }
+
         $(
             impl<O: ByteOrder> From<$name<O>> for $larger_native {
                 #[inline(always)]
@@ -1591,5 +1621,106 @@ mod tests {
         assert_eq!(val_be_i16.get(), 1);
         assert_eq!(format!("{:?}", val_be_i16), "I16(1)");
         assert_eq!(val_be_i16.cmp(&val_be_i16), core::cmp::Ordering::Equal);
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod serialization_tests {
+    use core::fmt::Debug;
+
+    use serde::{Deserialize, Serialize};
+
+    use crate::{
+        byteorder::{Isize, Usize, F32, F64, I128, I16, I32, I64, U128, U16, U32, U64},
+        BigEndian, LittleEndian,
+    };
+
+    fn assert_roundtrip<PrimitiveType, WrapperType>(
+        to_serialize: WrapperType,
+        primitive_value: Option<PrimitiveType>,
+    ) where
+        WrapperType: Serialize + for<'de> Deserialize<'de> + PartialEq + Debug,
+        PrimitiveType: Serialize + for<'de> Deserialize<'de> + PartialEq + Debug,
+    {
+        let serialized_value =
+            serde_json::to_string(&to_serialize).expect("Serialization to json should succeed");
+        let deserialized_wrapper = serde_json::from_str(&serialized_value)
+            .expect("Deserialization from json to wrapper type should succeed");
+        assert_eq!(to_serialize, deserialized_wrapper);
+
+        if let Some(primitive_value) = primitive_value {
+            let deserialized_primitive = serde_json::from_str(&serialized_value)
+                .expect("Deserialization from json to primitive type should succeed");
+            assert_eq!(primitive_value, deserialized_primitive);
+        }
+    }
+
+    macro_rules! assert_serialization_roundtrip {
+        ($prim:ty, $wrapper:ident, $value:expr) => {{
+            let primitive_value: $prim = $value;
+            assert_roundtrip($wrapper::<BigEndian>::new(primitive_value), Some(primitive_value));
+            assert_roundtrip($wrapper::<LittleEndian>::new(primitive_value), Some(primitive_value));
+        }};
+    }
+
+    #[test]
+    fn serialize_native_primitives() {
+        assert_serialization_roundtrip!(u16, U16, 0xABCDu16);
+        assert_serialization_roundtrip!(i16, I16, -123i16);
+        assert_serialization_roundtrip!(u32, U32, 0x89AB_CDEFu32);
+        assert_serialization_roundtrip!(i32, I32, -0x1234_5678i32);
+        assert_serialization_roundtrip!(u64, U64, 0x0123_4567_89AB_CDEFu64);
+        assert_serialization_roundtrip!(i64, I64, -0x0123_4567_89AB_CDEFi64);
+        assert_serialization_roundtrip!(u128, U128, 0x1234u128);
+        assert_serialization_roundtrip!(i128, I128, -0x1234i128);
+        assert_serialization_roundtrip!(usize, Usize, 0xBEEFusize);
+        assert_serialization_roundtrip!(isize, Isize, -12isize);
+        assert_serialization_roundtrip!(f32, F32, 1.25f32);
+        assert_serialization_roundtrip!(f64, F64, -0.75f64);
+    }
+
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct SerializableStruct<WrapperTypeA, WrapperTypeB>
+    where
+        WrapperTypeA: PartialEq + Debug,
+        WrapperTypeB: PartialEq + Debug,
+    {
+        value_a: WrapperTypeA,
+        value_b: [WrapperTypeB; 2],
+        value_c: (WrapperTypeA, WrapperTypeB),
+    }
+
+    macro_rules! assert_struct_serialization_roundtrip {
+        ($prim:ty, $wrapper:ident, $value:expr) => {{
+            let primitive_value: $prim = $value;
+            let test_struct = SerializableStruct {
+                value_a: $wrapper::<BigEndian>::new(primitive_value),
+                value_b: [
+                    $wrapper::<LittleEndian>::new(primitive_value),
+                    $wrapper::<LittleEndian>::new(primitive_value),
+                ],
+                value_c: (
+                    $wrapper::<BigEndian>::new(primitive_value),
+                    $wrapper::<LittleEndian>::new(primitive_value),
+                ),
+            };
+            assert_roundtrip(test_struct, None::<$prim>);
+        }};
+    }
+
+    #[test]
+    fn serialize_struct() {
+        assert_struct_serialization_roundtrip!(u16, U16, 0xABCDu16);
+        assert_struct_serialization_roundtrip!(i16, I16, -123i16);
+        assert_struct_serialization_roundtrip!(u32, U32, 0x89AB_CDEFu32);
+        assert_struct_serialization_roundtrip!(i32, I32, -0x1234_5678i32);
+        assert_struct_serialization_roundtrip!(u64, U64, 0x0123_4567_89AB_CDEFu64);
+        assert_struct_serialization_roundtrip!(i64, I64, -0x0123_4567_89AB_CDEFi64);
+        assert_struct_serialization_roundtrip!(u128, U128, 0x1234u128);
+        assert_struct_serialization_roundtrip!(i128, I128, -0x1234i128);
+        assert_struct_serialization_roundtrip!(usize, Usize, 0xBEEFusize);
+        assert_struct_serialization_roundtrip!(isize, Isize, -12isize);
+        assert_struct_serialization_roundtrip!(f32, F32, 1.25f32);
+        assert_struct_serialization_roundtrip!(f64, F64, -0.75f64);
     }
 }

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -123,9 +123,13 @@
 //!   derives as `use zerocopy_derive::*` rather than by name (e.g., `use
 //!   zerocopy_derive::FromBytes`).
 //!
+//! - **`serde`**
+//!   Provides [`serde`](https://github.com/serde-rs/serde) `Serialize` and `Deserialize` impls for
+//!   the `byteorder` numeric wrappers by delegating to their underlying primitive types.
+//!
 //! - **`simd`**
-//!   When the `simd` feature is enabled, `FromZeros`, `FromBytes`, and
-//!   `IntoBytes` impls are emitted for all stable SIMD types which exist on the
+//!   When the `simd` feature is enabled, [`FromZeros`], [`FromBytes`], and
+//!   [`IntoBytes`] impls are emitted for all stable SIMD types which exist on the
 //!   target platform. Note that the layout of SIMD types is not yet stabilized,
 //!   so these impls may be removed in the future if layout changes make them
 //!   invalid. For more information, see the Unsafe Code Guidelines Reference

--- a/zerocopy/src/pointer/ptr.rs
+++ b/zerocopy/src/pointer/ptr.rs
@@ -1529,10 +1529,10 @@ mod tests {
         }
 
         test!(ZstDst, 8, 0, Some(0));
-        test!(ZstDst, 7, 0, None);
+        test!(ZstDst, 7, 0, None::<usize>);
 
         test!(ZstDst, 8, usize::MAX, Some(usize::MAX));
-        test!(ZstDst, 7, usize::MAX, None);
+        test!(ZstDst, 7, usize::MAX, None::<usize>);
 
         #[derive(KnownLayout, Immutable)]
         #[repr(C)]
@@ -1542,15 +1542,15 @@ mod tests {
         }
 
         test!(Dst, 8, 0, Some(0));
-        test!(Dst, 7, 0, None);
+        test!(Dst, 7, 0, None::<usize>);
 
         test!(Dst, 9, 1, Some(1));
-        test!(Dst, 8, 1, None);
+        test!(Dst, 8, 1, None::<usize>);
 
         // If we didn't properly check for overflow, this would cause the
         // metadata to overflow to 0, and thus the cast would spuriously
         // succeed.
-        test!(Dst, 8, usize::MAX - 8 + 1, None);
+        test!(Dst, 8, usize::MAX - 8 + 1, None::<usize>);
     }
 
     #[test]


### PR DESCRIPTION
This pull request add a feature named `serde` to enable serializing and deserializing the `byteorder` numeric  wrappers using [serde](https://github.com/serde-rs/serde) derives.

# Why 
The reason for adding this is that I need to be able to convert a struct to either:
- a raw binary blob in the most performance efficient way (using `zerocopy` on my struct)
- a serialized format like `CSV` or `json` which doesn't need to be as fast (using `serde` on my struct)

Instead of having to manually write the [`serde:Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html) and [`serde:Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) traits every time for my structs and calling the `get()`/`from()` function to get the inner type, e.g. `f64` for an `F64`, it would have been easier to use the `Serialize` and `Deserialize` [derives](https://serde.rs/derive.html) provided by the serde crate.

# How

This simply update the `define_type!()` macro to add the `Serialize` and `Deserialize` trait implementations using the `get()`/`from()` function to get the inner type when the `serde` feature is enabled.

---

Thank you for your work in maintaining this project.