### PR TITLE
[ci] Add hide-from-release-notes label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    labels:
+      - "hide-from-release-notes"
     commit-message:
       # The trailing space instructs dependabot not to insert a colon between
       # the prefix and the rest of the message.


### PR DESCRIPTION
<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
