### PR TITLE
[ci] Various performance improvements

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -23,8 +23,7 @@ runs:
       uses: actions/cache@v4
       id: cache
       with:
-        path: |
-          ~/.cargo/
+        path: ~/.cargo/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-
@@ -58,7 +57,5 @@ runs:
       if: inputs.mode == 'generate' && steps.check.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: |
-          ~/.cargo/
-          ~/.rustup/
+        path: ~/.cargo/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,10 +608,6 @@ jobs:
           persist-credentials: false
       - name: Populate cache
         uses: ./.github/actions/cache
-      - name: Install nightly toolchain
-        run: |
-          TOOLCHAIN=$(./cargo.sh --version nightly)
-          rustup toolchain install $TOOLCHAIN -c rust-src
       - name: Generate code coverage
         run: |
           set -eo pipefail

--- a/cargo.sh
+++ b/cargo.sh
@@ -8,7 +8,8 @@
 
 set -eo pipefail
 
-# Build `cargo-zerocopy` without any RUSTFLAGS set in the environment
-env -u RUSTFLAGS cargo +stable build --manifest-path tools/Cargo.toml -p cargo-zerocopy -q
+# Build `cargo-zerocopy` without any RUSTFLAGS or CARGO_TARGET_DIR set in the
+# environment
+env -u RUSTFLAGS -u CARGO_TARGET_DIR cargo +stable build --manifest-path tools/Cargo.toml -p cargo-zerocopy -q
 # Thin wrapper around the `cargo-zerocopy` binary in `tools/cargo-zerocopy`
 ./tools/target/debug/cargo-zerocopy $@


### PR DESCRIPTION
Supersedes #2822, factoring out most of its optimizations while avoiding the ones that turned out to be overly complex without much performance benefit.

Brings the execution time to [3m20s](https://github.com/google/zerocopy/actions/runs/19679434572) when there's a cache hit.