### PR TITLE
[ci] In check_todo.sh, permit disabling check

### DIFF
--- a/ci/check_todo.sh
+++ b/ci/check_todo.sh
@@ -24,7 +24,7 @@ rg --version >/dev/null
 # -n: Print line number
 # -w: Match whole words
 # Match TODO, TODO-check-disable, and TODO-check-enable
-output=$(rg -H -n -w --no-ignore "$KEYWORD|$KEYWORD-check-disable|$KEYWORD-check-enable" "$@" || true)
+output=$(rg -H -n -w "$KEYWORD|$KEYWORD-check-disable|$KEYWORD-check-enable" "$@" || true)
 
 if [ -z "$output" ]; then
   exit 0


### PR DESCRIPTION
Support `TODO-check-disable` and `TODO-check-enable` to toggle the check within a particular file.

gherrit-pr-id: I0ca32fb0b6e87d3be51ff69487a4f221c0a9ee45

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
