### PR TITLE
Add `HasField::project`; simplify `is_bit_valid`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,8 @@ glob = "=0.3.2"
 itertools = "0.11"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = "1.0"
+# More recent versions of `ryu` have an MSRV higher than ours.
+ryu = "=1.0.20"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # Pinned to a specific version so that the version used for local development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,8 @@ use core::{
 use std::io;
 
 use crate::pointer::invariant::{self, BecauseExclusive};
+#[doc(hidden)]
+pub use crate::pointer::PtrInner;
 pub use crate::{
     byte_slice::*,
     byteorder::*,
@@ -1109,6 +1111,9 @@ pub unsafe trait HasField<Field, const VARIANT_ID: u128, const FIELD_ID: u128> {
 
     /// The type of the field.
     type Type: ?Sized;
+
+    /// Projects from `slf` to the field.
+    fn project(slf: PtrInner<'_, Self>) -> PtrInner<'_, Self::Type>;
 }
 
 /// Analyzes whether a type is [`FromZeros`].

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -15,7 +15,7 @@ use crate::util::polyfills::NumExt as _;
 use crate::{
     layout::{CastType, MetadataCastError},
     util::AsAddress,
-    AlignmentError, CastError, KnownLayout, MetadataOf, SizeError, SplitAt,
+    AlignmentError, CastError, HasField, KnownLayout, MetadataOf, SizeError, SplitAt,
 };
 
 mod _def {
@@ -195,6 +195,16 @@ impl<'a, T: ?Sized> PtrInner<'a, T> {
         // 1. By invariant on `self`, if `self`'s referent is not zero sized,
         //    then `A` is guaranteed to live for at least `'a`.
         unsafe { PtrInner::new(ptr) }
+    }
+
+    /// Projects a field.
+    #[must_use]
+    #[inline(always)]
+    pub fn project<F, const VARIANT_ID: u128, const FIELD_ID: u128>(self) -> PtrInner<'a, T::Type>
+    where
+        T: HasField<F, VARIANT_ID, FIELD_ID>,
+    {
+        <T as HasField<F, VARIANT_ID, FIELD_ID>>::project(self)
     }
 }
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -9,11 +9,13 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse_quote, spanned::Spanned as _, DataEnum, DeriveInput, Error, Fields, Generics, Ident, Path,
+    parse_quote, spanned::Spanned as _, DataEnum, DeriveInput, Error, Fields, Generics, Ident,
+    Index, Path,
 };
 
 use crate::{
-    derive_try_from_bytes_inner, repr::EnumRepr, DataExt, FieldBounds, ImplBlockBuilder, Trait,
+    derive_has_field_struct_union, derive_try_from_bytes_inner, repr::EnumRepr, DataExt,
+    FieldBounds, ImplBlockBuilder, Trait,
 };
 
 /// Generates a tag enum for the given enum. This generates an enum with the
@@ -162,7 +164,18 @@ fn generate_variant_structs(
     }
 }
 
-fn generate_variants_union(generics: &Generics, data: &DataEnum) -> TokenStream {
+fn variants_union_field_ident(ident: &Ident) -> Ident {
+    let variant_ident_str = crate::ext::to_ident_str(ident);
+    // Field names are prefixed with `__field_` to prevent name collision
+    // with the `__nonempty` field.
+    Ident::new(&format!("__field_{}", variant_ident_str), ident.span())
+}
+
+fn generate_variants_union(
+    generics: &Generics,
+    data: &DataEnum,
+    zerocopy_crate: &Path,
+) -> TokenStream {
     let (_, ty_generics, _) = generics.split_for_impl();
 
     let fields = data.variants.iter().filter_map(|variant| {
@@ -172,10 +185,7 @@ fn generate_variants_union(generics: &Generics, data: &DataEnum) -> TokenStream 
             return None;
         }
 
-        // Field names are prefixed with `__field_` to prevent name collision
-        // with the `__nonempty` field.
-        let field_name_str = crate::ext::to_ident_str(&variant.ident);
-        let field_name = Ident::new(&format!("__field_{}", field_name_str), variant.ident.span());
+        let field_name = variants_union_field_ident(&variant.ident);
         let variant_struct_ident = variant_struct_ident(&variant.ident);
 
         Some(quote! {
@@ -185,7 +195,7 @@ fn generate_variants_union(generics: &Generics, data: &DataEnum) -> TokenStream 
         })
     });
 
-    quote! {
+    let variants_union = parse_quote! {
         #[repr(C)]
         #[allow(non_snake_case)]
         union ___ZerocopyVariants #generics {
@@ -197,6 +207,14 @@ fn generate_variants_union(generics: &Generics, data: &DataEnum) -> TokenStream 
             // affect the layout.
             __nonempty: (),
         }
+    };
+
+    let has_field =
+        derive_has_field_struct_union(&variants_union, &variants_union.data, zerocopy_crate);
+
+    quote! {
+        #variants_union
+        #has_field
     }
 }
 
@@ -246,18 +264,20 @@ pub(crate) fn derive_is_bit_valid(
     };
 
     let variant_structs = generate_variant_structs(enum_ident, generics, data, zerocopy_crate);
-    let variants_union = generate_variants_union(generics, data);
+    let variants_union = generate_variants_union(generics, data, zerocopy_crate);
 
-    let (_, ty_generics, _) = generics.split_for_impl();
+    let (_, ref ty_generics, _) = generics.split_for_impl();
 
     let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
         let variant_ident = &variant.unwrap().ident;
+        let variants_union_field_ident = variants_union_field_ident(variant_ident);
         let field: Box<syn::Type> = parse_quote!(());
-        fields.into_iter().map(move |(vis, ident, ty)| {
+        fields.into_iter().enumerate().map(move |(idx, (vis, ident, ty))| {
             // Rust does not presently support explicit visibility modifiers on
             // enum fields, but we guard against the possibility to ensure this
             // derive remains sound.
             assert!(matches!(vis, syn::Visibility::Inherited));
+            let variant_struct_field_index = Index::from(idx + 1);
             ImplBlockBuilder::new(
                 ast,
                 data,
@@ -274,6 +294,18 @@ pub(crate) fn derive_is_bit_valid(
             )
             .inner_extras(quote! {
                 type Type = #ty;
+
+                #[inline(always)]
+                fn project(slf: #zerocopy_crate::PtrInner<'_, Self>) -> #zerocopy_crate::PtrInner<'_, Self::Type> {
+                    // SAFETY: By invariant on `___ZerocopyRawEnum`,
+                    // `___ZerocopyRawEnum` has the same layout as `Self`.
+                    let slf = unsafe { slf.cast::<___ZerocopyRawEnum #ty_generics>() };
+
+                    slf.project::<_, 0, { #zerocopy_crate::ident_id!(variants) }>()
+                        .project::<_, 0, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>()
+                        .project::<_, 0, { #zerocopy_crate::ident_id!(value) }>()
+                        .project::<_, 0, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>()
+                }
             })
             .build()
         })
@@ -323,6 +355,22 @@ pub(crate) fn derive_is_bit_valid(
         }
     });
 
+    let raw_enum = parse_quote! {
+        #[repr(C)]
+        struct ___ZerocopyRawEnum #generics {
+            tag: ___ZerocopyOuterTag,
+            variants: ___ZerocopyVariants #ty_generics,
+        }
+    };
+
+    let raw_enum_projections =
+        derive_has_field_struct_union(&raw_enum, &raw_enum.data, zerocopy_crate);
+
+    let raw_enum = quote! {
+        #raw_enum
+        #raw_enum_projections
+    };
+
     Ok(quote! {
         // SAFETY: We use `is_bit_valid` to validate that the bit pattern of the
         // enum's tag corresponds to one of the enum's discriminants. Then, we
@@ -351,11 +399,7 @@ pub(crate) fn derive_is_bit_valid(
 
             #variants_union
 
-            #[repr(C)]
-            struct ___ZerocopyRawEnum #generics {
-                tag: ___ZerocopyOuterTag,
-                variants: ___ZerocopyVariants #ty_generics,
-            }
+            #raw_enum
 
             #(#has_fields)*
 
@@ -399,26 +443,23 @@ pub(crate) fn derive_is_bit_valid(
             // invariant from `p`, so we re-assert that all of the bytes are
             // initialized.
             let raw_enum = unsafe { raw_enum.assume_initialized() };
+
             // SAFETY:
-            // - This projection returns a subfield of `this` using
-            //   `addr_of_mut!`.
-            // - Because the subfield pointer is derived from `this`, it has the
-            //   same provenance.
+            // - This projection returns a subfield of `raw_enum` using
+            //   `project`.
+            // - Because the subfield pointer is derived from `raw_enum`, it has
+            //   the same provenance.
             // - The locations of `UnsafeCell`s in the subfield match the
-            //   locations of `UnsafeCell`s in `this`. This is because the
+            //   locations of `UnsafeCell`s in `raw_enum`. This is because the
             //   subfield pointer just points to a smaller portion of the
             //   overall struct.
+            let project = #zerocopy_crate::pointer::PtrInner::project::<
+                _,
+                0,
+                { #zerocopy_crate::ident_id!(variants) }
+            >;
             let variants = unsafe {
-                use #zerocopy_crate::pointer::PtrInner;
-                raw_enum.cast_unsized_unchecked(|p: PtrInner<'_, ___ZerocopyRawEnum #ty_generics>| {
-                    let p = p.as_non_null().as_ptr();
-                    let ptr = core_reexport::ptr::addr_of_mut!((*p).variants);
-                    // SAFETY: `ptr` is a projection into `p`, which is
-                    // `NonNull`, and guaranteed not to wrap around the address
-                    // space. Thus, `ptr` cannot be null.
-                    let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) };
-                    unsafe { PtrInner::new(ptr) }
-                })
+                raw_enum.cast_unsized_unchecked(project)
             };
 
             #[allow(non_upper_case_globals)]

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -436,6 +436,23 @@ fn test_from_bytes_union() {
                     > for Foo {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = slf.as_non_null().as_ptr();
+                            let field = unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).a
+                                )
+                            };
+                            let ptr = unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                    field,
+                                )
+                            };
+                            unsafe { ::zerocopy::PtrInner::new(ptr) }
+                        }
                     }
                 };
             };
@@ -708,15 +725,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -724,15 +738,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -740,15 +751,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -756,15 +764,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -772,15 +777,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -788,15 +790,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(5) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).5);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <[(
@@ -807,15 +806,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(6) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).6);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -850,6 +846,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -868,6 +881,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -886,6 +916,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -904,6 +951,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -922,6 +986,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -940,6 +1021,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).5
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -960,6 +1058,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).6
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -1012,15 +1127,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -1028,15 +1140,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1044,15 +1153,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1060,15 +1166,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <PhantomData<
@@ -1076,15 +1179,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -1117,6 +1217,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1135,6 +1252,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1153,6 +1287,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1171,6 +1322,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1191,6 +1359,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -1205,11 +1390,186 @@ fn test_try_from_bytes_enum() {
                         >,
                         __nonempty: (),
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕ__field_StructLike {}
+                        enum ẕ__field_TupleLike {}
+                        enum ẕ__nonempty {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_StructLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_TupleLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ();
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__nonempty
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[repr(C)]
                     struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                         tag: ___ZerocopyOuterTag,
                         variants: ___ZerocopyVariants<'a, N, X, Y>,
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕtag {}
+                        enum ẕvariants {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(tag) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyOuterTag;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).tag
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(variants) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).variants
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -1227,6 +1587,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1245,6 +1615,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1263,6 +1643,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1281,6 +1671,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(4) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1299,6 +1699,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(5) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1317,6 +1727,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1335,6 +1755,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -1353,6 +1783,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     let tag = {
                         let tag_ptr = unsafe {
@@ -1374,18 +1814,12 @@ fn test_try_from_bytes_enum() {
                             })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let variants = unsafe {
-                        use ::zerocopy::pointer::PtrInner;
-                        raw_enum
-                            .cast_unsized_unchecked(|
-                                p: PtrInner<'_, ___ZerocopyRawEnum<'a, N, X, Y>>|
-                            {
-                                let p = p.as_non_null().as_ptr();
-                                let ptr = core_reexport::ptr::addr_of_mut!((* p).variants);
-                                let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) };
-                                unsafe { PtrInner::new(ptr) }
-                            })
-                    };
+                    let project = ::zerocopy::pointer::PtrInner::project::<
+                        _,
+                        0,
+                        { ::zerocopy::ident_id!(variants) },
+                    >;
+                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
                     #[allow(non_upper_case_globals)]
                     match tag {
                         ___ZEROCOPY_TAG_UnitLike => true,
@@ -1549,15 +1983,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -1565,15 +1996,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1581,15 +2009,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1597,15 +2022,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1613,15 +2035,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1629,15 +2048,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(5) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).5);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <[(
@@ -1648,15 +2064,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(6) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).6);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -1691,6 +2104,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1709,6 +2139,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1727,6 +2174,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1745,6 +2209,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1763,6 +2244,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1781,6 +2279,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).5
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1801,6 +2316,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).6
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -1853,15 +2385,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -1869,15 +2398,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1885,15 +2411,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -1901,15 +2424,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <PhantomData<
@@ -1917,15 +2437,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -1958,6 +2475,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1976,6 +2510,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -1994,6 +2545,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2012,6 +2580,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2032,6 +2617,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -2046,11 +2648,186 @@ fn test_try_from_bytes_enum() {
                         >,
                         __nonempty: (),
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕ__field_StructLike {}
+                        enum ẕ__field_TupleLike {}
+                        enum ẕ__nonempty {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_StructLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_TupleLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ();
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__nonempty
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[repr(C)]
                     struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                         tag: ___ZerocopyOuterTag,
                         variants: ___ZerocopyVariants<'a, N, X, Y>,
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕtag {}
+                        enum ẕvariants {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(tag) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyOuterTag;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).tag
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(variants) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).variants
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -2068,6 +2845,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2086,6 +2873,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2104,6 +2901,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2122,6 +2929,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(4) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2140,6 +2957,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(5) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2158,6 +2985,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2176,6 +3013,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2194,6 +3041,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     let tag = {
                         let tag_ptr = unsafe {
@@ -2215,18 +3072,12 @@ fn test_try_from_bytes_enum() {
                             })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let variants = unsafe {
-                        use ::zerocopy::pointer::PtrInner;
-                        raw_enum
-                            .cast_unsized_unchecked(|
-                                p: PtrInner<'_, ___ZerocopyRawEnum<'a, N, X, Y>>|
-                            {
-                                let p = p.as_non_null().as_ptr();
-                                let ptr = core_reexport::ptr::addr_of_mut!((* p).variants);
-                                let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) };
-                                unsafe { PtrInner::new(ptr) }
-                            })
-                    };
+                    let project = ::zerocopy::pointer::PtrInner::project::<
+                        _,
+                        0,
+                        { ::zerocopy::ident_id!(variants) },
+                    >;
+                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
                     #[allow(non_upper_case_globals)]
                     match tag {
                         ___ZEROCOPY_TAG_UnitLike => true,
@@ -2390,15 +3241,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -2406,15 +3254,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2422,15 +3267,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2438,15 +3280,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2454,15 +3293,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2470,15 +3306,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(5) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).5);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <[(
@@ -2489,15 +3322,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(6) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).6);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -2532,6 +3362,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2550,6 +3397,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2568,6 +3432,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2586,6 +3467,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2604,6 +3502,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2622,6 +3537,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).5
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2642,6 +3574,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).6
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -2694,15 +3643,12 @@ fn test_try_from_bytes_enum() {
                                 use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(0) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).0);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::mem::MaybeUninit<
@@ -2710,15 +3656,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(1) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).1);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2726,15 +3669,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(2) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).2);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
@@ -2742,15 +3682,12 @@ fn test_try_from_bytes_enum() {
                                         )
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(3) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).3);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <PhantomData<
@@ -2758,15 +3695,12 @@ fn test_try_from_bytes_enum() {
                                         > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                                     }
                                     && {
+                                        let project = <Self as ::zerocopy::HasField<
+                                            _,
+                                            0,
+                                            { ::zerocopy::ident_id!(4) },
+                                        >>::project;
                                         let field_candidate = unsafe {
-                                            let project = |slf: PtrInner<'_, Self>| {
-                                                let slf = slf.as_non_null().as_ptr();
-                                                let field = core_reexport::ptr::addr_of_mut!((* slf).4);
-                                                let ptr = unsafe {
-                                                    core_reexport::ptr::NonNull::new_unchecked(field)
-                                                };
-                                                unsafe { PtrInner::new(ptr) }
-                                            };
                                             candidate.reborrow().cast_unsized_unchecked(project)
                                         };
                                         <core_reexport::marker::PhantomData<
@@ -2799,6 +3733,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2817,6 +3768,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2835,6 +3803,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2853,6 +3838,23 @@ fn test_try_from_bytes_enum() {
                             {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                             #[allow(deprecated, non_local_definitions)]
                             #[automatically_derived]
@@ -2873,6 +3875,23 @@ fn test_try_from_bytes_enum() {
                                 type Type = core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
                                 >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::PtrInner<'_, Self>,
+                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                    let slf = slf.as_non_null().as_ptr();
+                                    let field = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    };
+                                    let ptr = unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                            field,
+                                        )
+                                    };
+                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
+                                }
                             }
                         };
                     };
@@ -2887,11 +3906,186 @@ fn test_try_from_bytes_enum() {
                         >,
                         __nonempty: (),
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕ__field_StructLike {}
+                        enum ẕ__field_TupleLike {}
+                        enum ẕ__nonempty {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_StructLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = core_reexport::mem::ManuallyDrop<
+                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__field_TupleLike
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ();
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).__nonempty
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[repr(C)]
                     struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                         tag: ___ZerocopyOuterTag,
                         variants: ___ZerocopyVariants<'a, N, X, Y>,
                     }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕtag {}
+                        enum ẕvariants {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(tag) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyOuterTag;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).tag
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::ident_id!(0) },
+                            { ::zerocopy::ident_id!(variants) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::PtrInner<'_, Self>,
+                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                                let slf = slf.as_non_null().as_ptr();
+                                let field = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).variants
+                                    )
+                                };
+                                let ptr = unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
+                                        field,
+                                    )
+                                };
+                                unsafe { ::zerocopy::PtrInner::new(ptr) }
+                            }
+                        }
+                    };
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -2909,6 +4103,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2927,6 +4131,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2945,6 +4159,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2963,6 +4187,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(4) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2981,6 +4215,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_StructLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(5) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -2999,6 +4243,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(1) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -3017,6 +4271,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(2) }>()
+                        }
                     }
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
@@ -3035,6 +4299,16 @@ fn test_try_from_bytes_enum() {
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::PtrInner<'_, Self>,
+                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
+                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
+                            slf.project::<_, 0, { ::zerocopy::ident_id!(variants) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(__field_TupleLike) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(value) }>()
+                                .project::<_, 0, { ::zerocopy::ident_id!(3) }>()
+                        }
                     }
                     let tag = {
                         let tag_ptr = unsafe {
@@ -3056,18 +4330,12 @@ fn test_try_from_bytes_enum() {
                             })
                     };
                     let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let variants = unsafe {
-                        use ::zerocopy::pointer::PtrInner;
-                        raw_enum
-                            .cast_unsized_unchecked(|
-                                p: PtrInner<'_, ___ZerocopyRawEnum<'a, N, X, Y>>|
-                            {
-                                let p = p.as_non_null().as_ptr();
-                                let ptr = core_reexport::ptr::addr_of_mut!((* p).variants);
-                                let ptr = unsafe { core_reexport::ptr::NonNull::new_unchecked(ptr) };
-                                unsafe { PtrInner::new(ptr) }
-                            })
-                    };
+                    let project = ::zerocopy::pointer::PtrInner::project::<
+                        _,
+                        0,
+                        { ::zerocopy::ident_id!(variants) },
+                    >;
+                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
                     #[allow(non_upper_case_globals)]
                     match tag {
                         ___ZEROCOPY_TAG_UnitLike => true,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This method projects from `PtrInner<_, Self>` to a `PtrInner` of a field
of `Self`. In this commit, we use `HasField::project` to considerably
simplify `is_bit_valid` implementations.




---

- #2854
- #2843


**Latest Update:** v19 — [Compare vs v18](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 | v7 | v8 | v9 | v10 | v11 | v12 | v13 | v14 | v15 | v16 | v17 | v18 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v19 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v14](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v15](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v16](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v17](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) | [v18](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v19) |
| v18 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v14](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v15](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v16](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | [v17](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v18) | |
| v17 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v14](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v15](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | [v16](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v17) | | |
| v16 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v14](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | [v15](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v16) | | | |
| v15 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | [v14](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v15) | | | | |
| v14 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | [v13](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v14) | | | | | |
| v13 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | [v12](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v13) | | | | | | |
| v12 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | [v11](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v12) | | | | | | | |
| v11 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | [v10](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v11) | | | | | | | | |
| v10 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | [v9](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v10) | | | | | | | | | |
| v9 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | [v8](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v9) | | | | | | | | | | |
| v8 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | [v7](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v8) | | | | | | | | | | | |
| v7 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | [v6](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v7) | | | | | | | | | | | | |
| v6 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | [v5](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v6) | | | | | | | | | | | | | |
| v5 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5) | [v4](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v5) | | | | | | | | | | | | | | |
| v4 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4) | [v3](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v4) | | | | | | | | | | | | | | | |
| v3 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3) | [v2](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v3) | | | | | | | | | | | | | | | | |
| v2 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2) | [v1](https://github.com/google/zerocopy/pull/2843/compare/gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v2) | | | | | | | | | | | | | | | | | |
| v1 | [Base](https://github.com/google/zerocopy/pull/2843/compare/main..gherrit/G9e7039c715e1ec53e6d860909bb0d618898fd46b/v1) | | | | | | | | | | | | | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G9e7039c715e1ec53e6d860909bb0d618898fd46b", "parent": null, "child": "G57b42ad4ff767a765f9b4ac149aa1c19d3796711"} -->