### PR TITLE
Add more safety comments to `FromZeros::new_box_zeroed`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3168,14 +3168,21 @@ pub unsafe trait FromZeros: TryFromBytes {
             return Ok(unsafe { Box::from_raw(NonNull::dangling().as_ptr()) });
         }
 
-        // FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
-        #[allow(clippy::undocumented_unsafe_blocks)]
+        // SAFETY: `alloc::alloc_zeroed` has the same safety requirements as
+        // `GlobalAlloc::alloc_zeroed`, which just requires that the given layout has non-zero size.
+        // Above, we returned early if `layout.size() == 0`, so the size must be non-zero.
         let ptr = unsafe { alloc::alloc::alloc_zeroed(layout).cast::<Self>() };
         if ptr.is_null() {
             return Err(AllocError);
         }
-        // FIXME(#429): Add a "SAFETY" comment and remove this `allow`.
-        #[allow(clippy::undocumented_unsafe_blocks)]
+        // SAFETY:
+        // - Per the documentation on `alloc::alloc_zeroed`, so long as no specific allocator is
+        //   registered with `#[global_allocator]`, `ptr` will be allocated using the `std` crate's
+        //   default `Global` allocator as required for `Box::from_raw`.
+        // - As the layout used to get the allocation was taken from `Layout::new()`,
+        //   it is suitable for holding a `T`, and the resulting `ptr` will be sufficiently
+        //   aligned & non-null.
+        // - Since `T` implements `FromZeros`, all zeros is a valid value of `T`.
         Ok(unsafe { Box::from_raw(ptr) })
     }
 


### PR DESCRIPTION
Adds safety comments to two of the undocumented unsafe blocks in `FromZeros::new_box_zeroed`.

I tried to base their structure off of existing comments and am happy to do modifications if you have feedback!

Is it alright to trust that the `std` crate's default allocator will return an allocation of the right size and alignment for the given layout? I was looking through documentation to support this, but the `std::alloc` module [says](https://doc.rust-lang.org/std/alloc/index.html) that the default global allocator is unspecified in most cases.

Towards #429
