### PR TITLE
Exclude various files from the published packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
 rust-version = "1.56.0"
 
-exclude = [".*"]
+include = ["README.md", "LICENSE-MIT", "LICENSE-BSD", "LICENSE-APACHE", "Cargo.toml", "CHANGELOG.md", "build.rs", "src/**/*.rs"]
 
 [package.metadata.build-rs]
 # These key/value pairs are parsed by `build.rs`. Each entry names a `--cfg`


### PR DESCRIPTION
During a dependency review we noticed that the zerocopy crate includes various development scripts and also test output for the compile tests in the published packages. Neither of that content is required for building zerocopy as dependency. Especially the development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of `cargo deny`.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
