### PR TITLE
[pointer] Add generic projection/cast framework

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -426,7 +426,7 @@ mod atomics {
             crate::util::macros::__unsafe();
 
             use core::cell::UnsafeCell;
-            use crate::pointer::{PtrInner, SizeEq, TransmuteFrom, invariant::Valid};
+            use crate::pointer::{SizeEq, TransmuteFrom, invariant::Valid};
 
             $(
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
@@ -439,21 +439,11 @@ mod atomics {
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
                 // the same size.
                 unsafe impl<$($tyvar)?> SizeEq<$atomic> for $prim {
-                    #[inline]
-                    fn cast_from_raw(a: PtrInner<'_, $atomic>) -> PtrInner<'_, $prim> {
-                        // SAFETY: The caller promised that `$atomic` and
-                        // `$prim` have the same size. Thus, this cast preserves
-                        // address, referent size, and provenance.
-                        unsafe { cast!(a) }
-                    }
+                    type CastFrom = $crate::pointer::cast::CastSized;
                 }
                 // SAFETY: See previous safety comment.
                 unsafe impl<$($tyvar)?> SizeEq<$prim> for $atomic {
-                    #[inline]
-                    fn cast_from_raw(p: PtrInner<'_, $prim>) -> PtrInner<'_, $atomic> {
-                        // SAFETY: See previous safety comment.
-                        unsafe { cast!(p) }
-                    }
+                    type CastFrom = $crate::pointer::cast::CastSized;
                 }
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
                 // the same size. `UnsafeCell<T>` has the same size as `T` [1].
@@ -464,19 +454,11 @@ mod atomics {
                 //   its inner type `T`. A consequence of this guarantee is that
                 //   it is possible to convert between `T` and `UnsafeCell<T>`.
                 unsafe impl<$($tyvar)?> SizeEq<$atomic> for UnsafeCell<$prim> {
-                    #[inline]
-                    fn cast_from_raw(a: PtrInner<'_, $atomic>) -> PtrInner<'_, UnsafeCell<$prim>> {
-                        // SAFETY: See previous safety comment.
-                        unsafe { cast!(a) }
-                    }
+                    type CastFrom = $crate::pointer::cast::CastSized;
                 }
                 // SAFETY: See previous safety comment.
                 unsafe impl<$($tyvar)?> SizeEq<UnsafeCell<$prim>> for $atomic {
-                    #[inline]
-                    fn cast_from_raw(p: PtrInner<'_, UnsafeCell<$prim>>) -> PtrInner<'_, $atomic> {
-                        // SAFETY: See previous safety comment.
-                        unsafe { cast!(p) }
-                    }
+                    type CastFrom = $crate::pointer::cast::CastSized;
                 }
 
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
@@ -818,7 +800,8 @@ const _: () = {
     // private field, and because it is the name it is referred to in the public
     // documentation of `ManuallyDrop::new`, `ManuallyDrop::into_inner`,
     // `ManuallyDrop::take` and `ManuallyDrop::drop`.
-    unsafe impl<T> HasField<value, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!(value) }>
+    unsafe impl<T: ?Sized>
+        HasField<value, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!(value) }>
         for ManuallyDrop<T>
     {
         type Type = T;
@@ -831,7 +814,7 @@ const _: () = {
         }
 
         #[inline(always)]
-        fn project(slf: PtrInner<'_, Self>) -> PtrInner<'_, T> {
+        unsafe fn project(slf: *mut Self) -> *mut T {
             // SAFETY: `ManuallyDrop<T>` has the same layout and bit validity as
             // `T` [1].
             //
@@ -839,7 +822,8 @@ const _: () = {
             //
             //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit
             //   validity as `T`
-            unsafe { slf.cast() }
+            #[allow(clippy::as_conversions)]
+            return slf as *mut T;
         }
     }
 };

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -738,213 +738,233 @@ impl DstLayout {
     }
 }
 
-pub(crate) use cast_from_raw::cast_from_raw;
+pub(crate) use cast_from_raw::CastFromRaw;
 mod cast_from_raw {
-    use crate::{pointer::PtrInner, *};
+    use crate::*;
 
-    /// Implements [`<Dst as SizeEq<Src>>::cast_from_raw`][cast_from_raw].
-    ///
-    /// # PME
-    ///
-    /// Generates a post-monomorphization error if it is not possible to satisfy
-    /// the soundness conditions of [`SizeEq::cast_from_raw`][cast_from_raw]
-    /// for `Src` and `Dst`.
-    ///
-    /// [cast_from_raw]: crate::pointer::SizeEq::cast_from_raw
-    //
-    // FIXME(#1817): Support Sized->Unsized and Unsized->Sized casts
-    pub(crate) fn cast_from_raw<Src, Dst>(src: PtrInner<'_, Src>) -> PtrInner<'_, Dst>
+    pub(crate) struct CastFromRaw<Dst: ?Sized> {
+        _never: core::convert::Infallible,
+        _marker: PhantomData<Dst>,
+    }
+
+    // SAFETY: The implementation of `Project::project` preserves the address
+    // of the referent – it only modifies pointer metadata.
+    unsafe impl<Src, Dst> crate::pointer::cast::Cast<Src, Dst> for CastFromRaw<Dst>
     where
         Src: KnownLayout<PointerMetadata = usize> + ?Sized,
         Dst: KnownLayout<PointerMetadata = usize> + ?Sized,
     {
-        // At compile time (specifically, post-monomorphization time), we need
-        // to compute two things:
-        // - Whether, given *any* `*Src`, it is possible to construct a `*Dst`
-        //   which addresses the same number of bytes (ie, whether, for any
-        //   `Src` pointer metadata, there exists `Dst` pointer metadata that
-        //   addresses the same number of bytes)
-        // - If this is possible, any information necessary to perform the
-        //   `Src`->`Dst` metadata conversion at runtime.
-        //
-        // Assume that `Src` and `Dst` are slice DSTs, and define:
-        // - `S_OFF = Src::LAYOUT.size_info.offset`
-        // - `S_ELEM = Src::LAYOUT.size_info.elem_size`
-        // - `D_OFF = Dst::LAYOUT.size_info.offset`
-        // - `D_ELEM = Dst::LAYOUT.size_info.elem_size`
-        //
-        // We are trying to solve the following equation:
-        //
-        //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
-        //
-        // At runtime, we will be attempting to compute `d_meta`, given `s_meta`
-        // (a runtime value) and all other parameters (which are compile-time
-        // values). We can solve like so:
-        //
-        //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
-        //
-        //   d_meta * D_ELEM = S_OFF - D_OFF + s_meta * S_ELEM
-        //
-        //   d_meta = (S_OFF - D_OFF + s_meta * S_ELEM)/D_ELEM
-        //
-        // Since `d_meta` will be a `usize`, we need the right-hand side to be
-        // an integer, and this needs to hold for *any* value of `s_meta` (in
-        // order for our conversion to be infallible - ie, to not have to reject
-        // certain values of `s_meta` at runtime). This means that:
-        // - `s_meta * S_ELEM` must be a multiple of `D_ELEM`
-        // - Since this must hold for any value of `s_meta`, `S_ELEM` must be a
-        //   multiple of `D_ELEM`
-        // - `S_OFF - D_OFF` must be a multiple of `D_ELEM`
-        //
-        // Thus, let `OFFSET_DELTA_ELEMS = (S_OFF - D_OFF)/D_ELEM` and
-        // `ELEM_MULTIPLE = S_ELEM/D_ELEM`. We can rewrite the above expression
-        // as:
-        //
-        //   d_meta = (S_OFF - D_OFF + s_meta * S_ELEM)/D_ELEM
-        //
-        //   d_meta = OFFSET_DELTA_ELEMS + s_meta * ELEM_MULTIPLE
-        //
-        // Thus, we just need to compute the following and confirm that they
-        // have integer solutions in order to both a) determine whether
-        // infallible `Src` -> `Dst` casts are possible and, b) pre-compute the
-        // parameters necessary to perform those casts at runtime. These
-        // parameters are encapsulated in `CastParams`, which acts as a witness
-        // that such infallible casts are possible.
+    }
 
-        /// The parameters required in order to perform a pointer cast from
-        /// `Src` to `Dst` as described above.
+    // SAFETY: `project` produces a pointer which refers to the same referent
+    // bytes as its input, or to a subset of them (see inline comments for a
+    // more detailed proof of this). It does this using provenance-preserving
+    // operations.
+    unsafe impl<Src, Dst> crate::pointer::cast::Project<Src, Dst> for CastFromRaw<Dst>
+    where
+        Src: KnownLayout<PointerMetadata = usize> + ?Sized,
+        Dst: KnownLayout<PointerMetadata = usize> + ?Sized,
+    {
+        /// # PME
         ///
-        /// These are a compile-time function of the layouts of `Src` and `Dst`.
-        ///
-        /// # Safety
-        ///
-        /// `offset_delta_elems` and `elem_multiple` must be valid as described
-        /// above.
-        ///
-        /// `Src`'s alignment must not be smaller than `Dst`'s alignment.
-        #[derive(Copy, Clone)]
-        struct CastParams {
-            offset_delta_elems: usize,
-            elem_multiple: usize,
-        }
+        /// Generates a post-monomorphization error if it is not possible to
+        /// implement soundly.
+        //
+        // FIXME(#1817): Support Sized->Unsized and Unsized->Sized casts
+        unsafe fn project(src: *mut Src) -> *mut Dst {
+            // At compile time (specifically, post-monomorphization time), we
+            // need to compute two things:
+            // - Whether, given *any* `*Src`, it is possible to construct a
+            //   `*Dst` which addresses the same number of bytes (ie, whether,
+            //   for any `Src` pointer metadata, there exists `Dst` pointer
+            //   metadata that addresses the same number of bytes)
+            // - If this is possible, any information necessary to perform the
+            //   `Src`->`Dst` metadata conversion at runtime.
+            //
+            // Assume that `Src` and `Dst` are slice DSTs, and define:
+            // - `S_OFF = Src::LAYOUT.size_info.offset`
+            // - `S_ELEM = Src::LAYOUT.size_info.elem_size`
+            // - `D_OFF = Dst::LAYOUT.size_info.offset`
+            // - `D_ELEM = Dst::LAYOUT.size_info.elem_size`
+            //
+            // We are trying to solve the following equation:
+            //
+            //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
+            //
+            // At runtime, we will be attempting to compute `d_meta`, given
+            // `s_meta` (a runtime value) and all other parameters (which are
+            // compile-time values). We can solve like so:
+            //
+            //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
+            //
+            //   d_meta * D_ELEM = S_OFF - D_OFF + s_meta * S_ELEM
+            //
+            //   d_meta = (S_OFF - D_OFF + s_meta * S_ELEM)/D_ELEM
+            //
+            // Since `d_meta` will be a `usize`, we need the right-hand side to
+            // be an integer, and this needs to hold for *any* value of `s_meta`
+            // (in order for our conversion to be infallible - ie, to not have
+            // to reject certain values of `s_meta` at runtime). This means
+            // that:
+            // - `s_meta * S_ELEM` must be a multiple of `D_ELEM`
+            // - Since this must hold for any value of `s_meta`, `S_ELEM` must
+            //   be a multiple of `D_ELEM`
+            // - `S_OFF - D_OFF` must be a multiple of `D_ELEM`
+            //
+            // Thus, let `OFFSET_DELTA_ELEMS = (S_OFF - D_OFF)/D_ELEM` and
+            // `ELEM_MULTIPLE = S_ELEM/D_ELEM`. We can rewrite the above
+            // expression as:
+            //
+            //   d_meta = (S_OFF - D_OFF + s_meta * S_ELEM)/D_ELEM
+            //
+            //   d_meta = OFFSET_DELTA_ELEMS + s_meta * ELEM_MULTIPLE
+            //
+            // Thus, we just need to compute the following and confirm that they
+            // have integer solutions in order to both a) determine whether
+            // infallible `Src` -> `Dst` casts are possible and, b) pre-compute
+            // the parameters necessary to perform those casts at runtime. These
+            // parameters are encapsulated in `CastParams`, which acts as a
+            // witness that such infallible casts are possible.
 
-        impl CastParams {
-            const fn try_compute(src: &DstLayout, dst: &DstLayout) -> Option<CastParams> {
-                if src.align.get() < dst.align.get() {
-                    return None;
-                }
-
-                let (src, dst) = if let (SizeInfo::SliceDst(src), SizeInfo::SliceDst(dst)) =
-                    (src.size_info, dst.size_info)
-                {
-                    (src, dst)
-                } else {
-                    return None;
-                };
-
-                let offset_delta = if let Some(od) = src.offset.checked_sub(dst.offset) {
-                    od
-                } else {
-                    return None;
-                };
-
-                let dst_elem_size = if let Some(e) = NonZeroUsize::new(dst.elem_size) {
-                    e
-                } else {
-                    return None;
-                };
-
-                // PANICS: `dst_elem_size: NonZeroUsize`, so this won't div by zero.
-                #[allow(clippy::arithmetic_side_effects)]
-                let delta_mod_other_elem = offset_delta % dst_elem_size.get();
-
-                // PANICS: `dst_elem_size: NonZeroUsize`, so this won't div by zero.
-                #[allow(clippy::arithmetic_side_effects)]
-                let elem_remainder = src.elem_size % dst_elem_size.get();
-
-                if delta_mod_other_elem != 0 || src.elem_size < dst.elem_size || elem_remainder != 0
-                {
-                    return None;
-                }
-
-                // PANICS: `dst_elem_size: NonZeroUsize`, so this won't div by zero.
-                #[allow(clippy::arithmetic_side_effects)]
-                let offset_delta_elems = offset_delta / dst_elem_size.get();
-
-                // PANICS: `dst_elem_size: NonZeroUsize`, so this won't div by zero.
-                #[allow(clippy::arithmetic_side_effects)]
-                let elem_multiple = src.elem_size / dst_elem_size.get();
-
-                // SAFETY: We checked above that `src.align >= dst.align`.
-                Some(CastParams {
-                    // SAFETY: We checked above that this is an exact ratio.
-                    offset_delta_elems,
-                    // SAFETY: We checked above that this is an exact ratio.
-                    elem_multiple,
-                })
-            }
-
+            /// The parameters required in order to perform a pointer cast from
+            /// `Src` to `Dst` as described above.
+            ///
+            /// These are a compile-time function of the layouts of `Src` and
+            /// `Dst`.
+            ///
             /// # Safety
             ///
-            /// `src_meta` describes a `Src` whose size is no larger than
-            /// `isize::MAX`.
+            /// `offset_delta_elems` and `elem_multiple` must be valid as
+            /// described above.
             ///
-            /// The returned metadata describes a `Dst` of the same size as the
-            /// original `Src`.
-            unsafe fn cast_metadata(self, src_meta: usize) -> usize {
-                #[allow(unused)]
-                use crate::util::polyfills::*;
+            /// `Src`'s alignment must not be smaller than `Dst`'s alignment.
+            #[derive(Copy, Clone)]
+            struct CastParams {
+                offset_delta_elems: usize,
+                elem_multiple: usize,
+            }
 
-                // SAFETY: `self` is a witness that the following equation
-                // holds:
-                //
-                //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
-                //
-                // Since the caller promises that `src_meta` is valid `Src`
-                // metadata, this math will not overflow, and the returned value
-                // will describe a `Dst` of the same size.
-                #[allow(unstable_name_collisions, clippy::multiple_unsafe_ops_per_block)]
-                unsafe {
-                    self.offset_delta_elems
-                        .unchecked_add(src_meta.unchecked_mul(self.elem_multiple))
+            impl CastParams {
+                const fn try_compute(src: &DstLayout, dst: &DstLayout) -> Option<CastParams> {
+                    if src.align.get() < dst.align.get() {
+                        return None;
+                    }
+
+                    let (src, dst) = if let (SizeInfo::SliceDst(src), SizeInfo::SliceDst(dst)) =
+                        (src.size_info, dst.size_info)
+                    {
+                        (src, dst)
+                    } else {
+                        return None;
+                    };
+
+                    let offset_delta = if let Some(od) = src.offset.checked_sub(dst.offset) {
+                        od
+                    } else {
+                        return None;
+                    };
+
+                    let dst_elem_size = if let Some(e) = NonZeroUsize::new(dst.elem_size) {
+                        e
+                    } else {
+                        return None;
+                    };
+
+                    // PANICS: `dst_elem_size: NonZeroUsize`, so this won't
+                    // divide by zero.
+                    #[allow(clippy::arithmetic_side_effects)]
+                    let delta_mod_other_elem = offset_delta % dst_elem_size.get();
+
+                    // PANICS: `dst_elem_size: NonZeroUsize`, so this won't
+                    // divide by zero.
+                    #[allow(clippy::arithmetic_side_effects)]
+                    let elem_remainder = src.elem_size % dst_elem_size.get();
+
+                    if delta_mod_other_elem != 0
+                        || src.elem_size < dst.elem_size
+                        || elem_remainder != 0
+                    {
+                        return None;
+                    }
+
+                    // PANICS: `dst_elem_size: NonZeroUsize`, so this won't
+                    // divide by zero.
+                    #[allow(clippy::arithmetic_side_effects)]
+                    let offset_delta_elems = offset_delta / dst_elem_size.get();
+
+                    // PANICS: `dst_elem_size: NonZeroUsize`, so this won't
+                    // divide by zero.
+                    #[allow(clippy::arithmetic_side_effects)]
+                    let elem_multiple = src.elem_size / dst_elem_size.get();
+
+                    // SAFETY: We checked above that `src.align >= dst.align`.
+                    Some(CastParams {
+                        // SAFETY: We checked above that this is an exact ratio.
+                        offset_delta_elems,
+                        // SAFETY: We checked above that this is an exact ratio.
+                        elem_multiple,
+                    })
+                }
+
+                /// # Safety
+                ///
+                /// `src_meta` describes a `Src` whose size is no larger than
+                /// `isize::MAX`.
+                ///
+                /// The returned metadata describes a `Dst` of the same size as
+                /// the original `Src`.
+                unsafe fn cast_metadata(self, src_meta: usize) -> usize {
+                    #[allow(unused)]
+                    use crate::util::polyfills::*;
+
+                    // SAFETY: `self` is a witness that the following equation
+                    // holds:
+                    //
+                    //   D_OFF + d_meta * D_ELEM = S_OFF + s_meta * S_ELEM
+                    //
+                    // Since the caller promises that `src_meta` is valid `Src`
+                    // metadata, this math will not overflow, and the returned
+                    // value will describe a `Dst` of the same size.
+                    #[allow(unstable_name_collisions, clippy::multiple_unsafe_ops_per_block)]
+                    unsafe {
+                        self.offset_delta_elems
+                            .unchecked_add(src_meta.unchecked_mul(self.elem_multiple))
+                    }
                 }
             }
-        }
 
-        trait Params<Src: ?Sized> {
-            const CAST_PARAMS: CastParams;
-        }
+            trait Params<Src: ?Sized> {
+                const CAST_PARAMS: CastParams;
+            }
 
-        impl<Src, Dst> Params<Src> for Dst
-        where
-            Src: KnownLayout + ?Sized,
-            Dst: KnownLayout<PointerMetadata = usize> + ?Sized,
-        {
-            const CAST_PARAMS: CastParams =
-                match CastParams::try_compute(&Src::LAYOUT, &Dst::LAYOUT) {
-                    Some(params) => params,
-                    None => const_panic!(
+            impl<Src, Dst> Params<Src> for Dst
+            where
+                Src: KnownLayout + ?Sized,
+                Dst: KnownLayout<PointerMetadata = usize> + ?Sized,
+            {
+                const CAST_PARAMS: CastParams =
+                    match CastParams::try_compute(&Src::LAYOUT, &Dst::LAYOUT) {
+                        Some(params) => params,
+                        None => const_panic!(
                         "cannot `transmute_ref!` or `transmute_mut!` between incompatible types"
                     ),
-                };
+                    };
+            }
+
+            let src_meta = <Src as KnownLayout>::pointer_to_metadata(src);
+            let params = <Dst as Params<Src>>::CAST_PARAMS;
+
+            // SAFETY: The caller promises `src`'s referent is zero bytes or
+            // lives in a single allocation, which means that it is no larger
+            // than `isize::MAX` bytes [1].
+            //
+            // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
+            let dst_meta = unsafe { params.cast_metadata(src_meta) };
+
+            // SAFETY: The caller promises that `src` is non-null.
+            let src = unsafe { NonNull::new_unchecked(src) };
+            <Dst as KnownLayout>::raw_from_ptr_len(src.cast(), dst_meta).as_ptr()
         }
-
-        let src_meta = <Src as KnownLayout>::pointer_to_metadata(src.as_non_null().as_ptr());
-        let params = <Dst as Params<Src>>::CAST_PARAMS;
-
-        // SAFETY: `src: PtrInner`, and so by invariant on `PtrInner`, `src`'s
-        // referent is no larger than `isize::MAX`.
-        let dst_meta = unsafe { params.cast_metadata(src_meta) };
-
-        let dst = <Dst as KnownLayout>::raw_from_ptr_len(src.as_non_null().cast(), dst_meta);
-
-        // SAFETY: By post-condition on `params.cast_metadata`, `dst` addresses
-        // the same number of bytes as `src`. Since `src: PtrInner`, `src` has
-        // provenance for its entire referent, which lives inside of a single
-        // allocation. Since `dst` has the same address as `src` and was
-        // constructed using provenance-preserving operations, it addresses a
-        // subset of those bytes, and has provenance for those bytes.
-        unsafe { PtrInner::new(dst) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1118,8 +1118,11 @@ pub const UNION_VARIANT_ID: i128 = -2;
 ///   if `f` is at index `i`, `FIELD_ID` is `zerocopy::ident_id!(i)`.
 /// - `Field` is a type with the same visibility as `f`.
 /// - `Type` has the same type as `f`.
+///
+/// The implementation of `project` must preserve or shrink the set of bytes in
+/// the referent of its argument, and must preserve provenance.
 #[doc(hidden)]
-pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
+pub unsafe trait HasField<Field: ?Sized, const VARIANT_ID: i128, const FIELD_ID: i128> {
     fn only_derive_is_allowed_to_implement_this_trait()
     where
         Self: Sized;
@@ -1128,7 +1131,12 @@ pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
     type Type: ?Sized;
 
     /// Projects from `slf` to the field.
-    fn project(slf: PtrInner<'_, Self>) -> PtrInner<'_, Self::Type>;
+    ///
+    /// # Safety
+    ///
+    /// `slf` must be a non-null pointer, and its referent must be zero bytes in
+    /// size or live in a single allocation.
+    unsafe fn project(slf: *mut Self) -> *mut Self::Type;
 }
 
 /// Analyzes whether a type is [`FromZeros`].

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -6,7 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-use core::{marker::PhantomData, mem, ops::Range, ptr::NonNull};
+use core::{marker::PhantomData, ops::Range, ptr::NonNull};
 
 pub use _def::PtrInner;
 
@@ -14,8 +14,9 @@ pub use _def::PtrInner;
 use crate::util::polyfills::NumExt as _;
 use crate::{
     layout::{CastType, MetadataCastError},
+    pointer::cast,
     util::AsAddress,
-    AlignmentError, CastError, HasField, KnownLayout, MetadataOf, SizeError, SplitAt,
+    AlignmentError, CastError, KnownLayout, MetadataOf, SizeError, SplitAt,
 };
 
 mod _def {
@@ -166,45 +167,39 @@ impl<'a, T: ?Sized> PtrInner<'a, T> {
 
     #[must_use]
     #[inline(always)]
-    pub fn cast_sized<U>(self) -> PtrInner<'a, U>
-    where
-        T: Sized,
-    {
-        static_assert!(T, U => mem::size_of::<T>() >= mem::size_of::<U>());
-        // SAFETY: By the preceding assert, `U` is no larger than `T`, which is
-        // the size of `self`'s referent.
-        unsafe { self.cast() }
-    }
+    pub fn project<U: ?Sized, C: cast::Project<T, U>>(self) -> PtrInner<'a, U> {
+        let non_null = self.as_non_null();
+        let raw = non_null.as_ptr();
 
-    /// # Safety
-    ///
-    /// `U` must not be larger than the size of `self`'s referent.
-    #[must_use]
-    #[inline(always)]
-    pub unsafe fn cast<U>(self) -> PtrInner<'a, U> {
-        let ptr = self.as_non_null().cast::<U>();
+        // SAFETY: `raw` is derived from a `NonNull` pointer, and so is
+        // non-null. By invariant on `self`, `raw`'s referent is zero-sized
+        // or lives in a single allocation.
+        let projected_raw = unsafe { C::project(raw) };
 
-        // SAFETY: The caller promises that `U` is no larger than `self`'s
-        // referent. Thus, `ptr` addresses a subset of the bytes addressed by
-        // `self`.
+        // SAFETY: `self`'s referent lives at a `NonNull` address, and is either
+        // zero-sized or lives in an allocation. In either case, it does not
+        // wrap around the address space [1], and so none of the addresses
+        // contained in it or one-past-the-end of it are null.
         //
-        // 0. By invariant on `self`, if `self`'s referent is not zero sized,
-        //    then `self` has valid provenance for its referent, which is
-        //    entirely contained in some Rust allocation, `A`. Thus, the same
-        //    holds of `ptr`.
-        // 1. By invariant on `self`, if `self`'s referent is not zero sized,
-        //    then `A` is guaranteed to live for at least `'a`.
-        unsafe { PtrInner::new(ptr) }
-    }
+        // By invariant on `C: Project`, `C::project` is a provenance-preserving
+        // projection which preserves or shrinks the set of referent bytes, so
+        // `projected_raw` references a subset of `self`'s referent, and so it
+        // cannot be null.
+        //
+        // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
+        let projected_non_null = unsafe { NonNull::new_unchecked(projected_raw) };
 
-    /// Projects a field.
-    #[must_use]
-    #[inline(always)]
-    pub fn project<F, const VARIANT_ID: i128, const FIELD_ID: i128>(self) -> PtrInner<'a, T::Type>
-    where
-        T: HasField<F, VARIANT_ID, FIELD_ID>,
-    {
-        <T as HasField<F, VARIANT_ID, FIELD_ID>>::project(self)
+        // SAFETY: As described in the preceding safety comment, `projected_raw`,
+        // and thus `projected_non_null`, addresses a subset of `self`'s
+        // referent. Thus, `projected_non_null` either:
+        // - Addresses zero bytes or,
+        // - Addresses a subset of the referent of `self`. In this case, `self`
+        //   has provenance for its referent, which lives in an allocation.
+        //   Since `projected_non_null` was constructed using a sequence of
+        //   provenance-preserving operations, it also has provenance for its
+        //   referent and that referent lives in an allocation. By invariant on
+        //   `self`, that allocation lives for `'a`.
+        unsafe { PtrInner::new(projected_non_null) }
     }
 }
 
@@ -261,37 +256,6 @@ where
         // 5. Per Lemma 0 and by invariant on `self`, if `ptr`'s referent is not
         //    zero sized, then `A` is guaranteed to live for at least `'a`.
         unsafe { PtrInner::new(raw) }
-    }
-
-    pub(crate) fn as_bytes(self) -> PtrInner<'a, [u8]> {
-        let ptr = self.as_non_null();
-        let bytes = match T::size_of_val_raw(ptr) {
-            Some(bytes) => bytes,
-            // SAFETY: `KnownLayout::size_of_val_raw` promises to always
-            // return `Some` so long as the resulting size fits in a
-            // `usize`. By invariant on `PtrInner`, `self` refers to a range
-            // of bytes whose size fits in an `isize`, which implies that it
-            // also fits in a `usize`.
-            None => unsafe { core::hint::unreachable_unchecked() },
-        };
-
-        let ptr = core::ptr::slice_from_raw_parts_mut(ptr.cast::<u8>().as_ptr(), bytes);
-
-        // SAFETY: `ptr` has the same address as `ptr = self.as_non_null()`,
-        // which is non-null by construction.
-        let ptr = unsafe { NonNull::new_unchecked(ptr) };
-
-        // SAFETY: `ptr` points to `bytes` `u8`s starting at the same address as
-        // `self`'s referent. Since `bytes` is the length of `self`'s referent,
-        // `ptr` addresses the same byte range as `self`. Thus, by invariant on
-        // `self` (as a `PtrInner`):
-        //
-        // 0. If `ptr`'s referent is not zero sized, then `ptr` has valid
-        //    provenance for its referent, which is entirely contained in some
-        //    Rust allocation, `A`.
-        // 1. If `ptr`'s referent is not zero sized, `A` is guaranteed to live
-        //    for at least `'a`.
-        unsafe { PtrInner::new(ptr) }
     }
 }
 

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -38,3 +38,267 @@ where
 {
     ptr.as_bytes::<BecauseImmutable>().as_ref().iter().all(|&byte| byte == 0)
 }
+
+#[doc(hidden)]
+pub mod cast {
+    use core::{marker::PhantomData, mem, ptr::NonNull};
+
+    use crate::{
+        layout::{SizeInfo, TrailingSliceLayout},
+        HasField, KnownLayout,
+    };
+
+    /// A pointer cast or projection.
+    ///
+    /// # Safety
+    ///
+    /// `project` must be a provenance-preserving operation which preserves or
+    /// shrinks the set of referent bytes.
+    pub unsafe trait Project<Src: ?Sized, Dst: ?Sized> {
+        /// Projects a pointer from `Src` to `Dst`.
+        ///
+        /// # Safety
+        ///
+        /// `src` must be a non-null pointer which has provenance for its entire
+        /// referent. Its referent must be zero-sized or live in a single
+        /// allocation.
+        unsafe fn project(src: *mut Src) -> *mut Dst;
+    }
+
+    /// A [`Project`] which preserves the address of the referent – a pointer
+    /// cast.
+    ///
+    /// # Safety
+    ///
+    /// A `Cast` projection must preserve the address of the referent. It may
+    /// shrink the set of referent bytes, and it may change the referent's type.
+    pub unsafe trait Cast<Src: ?Sized, Dst: ?Sized>: Project<Src, Dst> {}
+
+    /// A no-op pointer cast.
+    #[derive(Default, Copy, Clone)]
+    #[allow(missing_debug_implementations)]
+    pub struct IdCast;
+
+    // SAFETY: `project` returns its argument unchanged, and so it is a
+    // provenance-preserving projection which preserves the set of referent
+    // bytes.
+    unsafe impl<T: ?Sized> Project<T, T> for IdCast {
+        #[inline(always)]
+        unsafe fn project(src: *mut T) -> *mut T {
+            src
+        }
+    }
+
+    // SAFETY: The `Project::project` impl preserves referent address.
+    unsafe impl<T: ?Sized> Cast<T, T> for IdCast {}
+
+    /// A pointer cast which preserves or shrinks the set of referent bytes of
+    /// a statically-sized referent.
+    ///
+    /// # Safety
+    ///
+    /// The implementation of [`Project`] uses a compile-time assertion to
+    /// guarantee that `Dst` is no larger than `Src`. Thus, `CastSized` has a
+    /// sound implementation of [`Project`] for all `Src` and `Dst` – the caller
+    /// may pass any `Src` and `Dst` without being responsible for soundness.
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
+    pub enum CastSized {}
+
+    // SAFETY: By the `static_assert!`, `Dst` is no larger than `Src`,
+    // and `<*mut Src>::project` is a provenance-preserving cast.
+    unsafe impl<Src, Dst> Project<Src, Dst> for CastSized {
+        #[inline(always)]
+        unsafe fn project(src: *mut Src) -> *mut Dst {
+            static_assert!(Src, Dst => mem::size_of::<Src>() >= mem::size_of::<Dst>());
+            src.cast::<Dst>()
+        }
+    }
+
+    // SAFETY: The `Project::project` impl preserves referent address.
+    unsafe impl<Src, Dst> Cast<Src, Dst> for CastSized {}
+
+    /// A pointer cast which preserves or shrinks the set of referent bytes of
+    /// a dynamically-sized referent.
+    ///
+    /// # Safety
+    ///
+    /// The implementation of [`Project`] uses a compile-time assertion to
+    /// guarantee that the cast preserves the set of referent bytes. Thus,
+    /// `CastUnsized` has a sound implementation of [`Project`] for all `Src`
+    /// and `Dst` – the caller may pass any `Src` and `Dst` without being
+    /// responsible for soundness.
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
+    pub enum CastUnsized {}
+
+    // SAFETY: The `static_assert!` ensures that `Src` and `Dst` have the same
+    // `SizeInfo`. Thus, casting preserves the set of referent bytes. All
+    // operations are provenance-preserving.
+    unsafe impl<Src, Dst> Project<Src, Dst> for CastUnsized
+    where
+        Src: ?Sized + KnownLayout,
+        Dst: ?Sized + KnownLayout<PointerMetadata = Src::PointerMetadata>,
+    {
+        #[inline(always)]
+        unsafe fn project(src: *mut Src) -> *mut Dst {
+            // FIXME:
+            // - Is the alignment check necessary for soundness? It's not
+            //   necessary for the soundness of the `Project` impl, but what
+            //   about the soundness of particular use sites?
+            // - Do we want this to support shrinking casts as well?
+            static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {
+                let t = <Src as KnownLayout>::LAYOUT;
+                let u = <Dst as KnownLayout>::LAYOUT;
+                t.align.get() >= u.align.get() && match (t.size_info, u.size_info) {
+                    (SizeInfo::Sized { size: t }, SizeInfo::Sized { size: u }) => t == u,
+                    (
+                        SizeInfo::SliceDst(TrailingSliceLayout { offset: t_offset, elem_size: t_elem_size }),
+                        SizeInfo::SliceDst(TrailingSliceLayout { offset: u_offset, elem_size: u_elem_size })
+                    ) => t_offset == u_offset && t_elem_size == u_elem_size,
+                    _ => false,
+                }
+            });
+
+            let metadata = Src::pointer_to_metadata(src);
+            // SAFETY: The caller promises that `src` is non-null.
+            let src = unsafe { NonNull::new_unchecked(src) };
+            Dst::raw_from_ptr_len(src.cast::<u8>(), metadata).as_ptr()
+        }
+    }
+
+    // SAFETY: The `Project::project` impl preserves referent address.
+    unsafe impl<Src, Dst> Cast<Src, Dst> for CastUnsized
+    where
+        Src: ?Sized + KnownLayout,
+        Dst: ?Sized + KnownLayout<PointerMetadata = Src::PointerMetadata>,
+    {
+    }
+
+    /// A field projection
+    ///
+    /// A `Projection` is a [`Project`] which implements projection by
+    /// delegating to an implementation of [`HasField::project`].
+    #[allow(missing_debug_implementations, missing_copy_implementations)]
+    pub struct Projection<F: ?Sized, const VARIANT_ID: i128, const FIELD_ID: i128> {
+        _never: core::convert::Infallible,
+        _phantom: PhantomData<F>,
+    }
+
+    // SAFETY: `HasField::project` has the same safety post-conditions as
+    // `Project::project`.
+    unsafe impl<T: ?Sized, F, const VARIANT_ID: i128, const FIELD_ID: i128> Project<T, T::Type>
+        for Projection<F, VARIANT_ID, FIELD_ID>
+    where
+        T: HasField<F, VARIANT_ID, FIELD_ID>,
+    {
+        #[inline(always)]
+        unsafe fn project(src: *mut T) -> *mut T::Type {
+            // SAFETY: The caller promises that `src` is a non-null pointer
+            // whose referent is zero bytes or live in a single allocation.
+            unsafe { T::project(src) }
+        }
+    }
+
+    // SAFETY: All union fields exist at offset 0 within the union, and so any
+    // union projection is actually a cast (ie, preserves address).
+    //
+    // TODO: Is this actually true, even for repr(rust) unions?
+    unsafe impl<T: ?Sized, F, const FIELD_ID: i128> Cast<T, T::Type>
+        for Projection<F, { crate::UNION_VARIANT_ID }, FIELD_ID>
+    where
+        T: HasField<F, { crate::UNION_VARIANT_ID }, FIELD_ID>,
+    {
+    }
+
+    /// A transitive sequence of projections.
+    ///
+    /// Given `TU: Project` and `UV: Project`, `TransitiveProject<_, TU, UV>` is
+    /// a [`Project`] which projects by applying `TU` followed by `UV`.
+    ///
+    /// If `TU: Cast` and `UV: Cast`, then `TransitiveProject<_, TU, UV>: Cast`.
+    #[allow(missing_debug_implementations)]
+    pub struct TransitiveProject<U: ?Sized, TU, UV> {
+        _never: core::convert::Infallible,
+        _projections: PhantomData<(TU, UV)>,
+        // On our MSRV (1.56), the debuginfo for a tuple containing both an
+        // uninhabited type and a DST causes an ICE. We split `U` from `TU` and
+        // `UV` to avoid this situation.
+        _u: PhantomData<U>,
+    }
+
+    // SAFETY: Since `TU::project` and `UV::project` are each
+    // provenance-preserving operations which preserve or shrink the set of
+    // referent bytes, so is their composition.
+    unsafe impl<T, U, V, TU, UV> Project<T, V> for TransitiveProject<U, TU, UV>
+    where
+        T: ?Sized,
+        U: ?Sized,
+        V: ?Sized,
+        TU: Project<T, U>,
+        UV: Project<U, V>,
+    {
+        #[inline(always)]
+        unsafe fn project(t: *mut T) -> *mut V {
+            // SAFETY: The caller promises that `t` is a non-null pointer whose
+            // referent is zero-sized or lives in a single allocation.
+            let u = unsafe { TU::project(t) };
+            // SAFETY: By invariant on `TU::project`, `u` addresses a subset of
+            // the bytes of `*t`, and has provenance for all of those bytes.
+            // Thus, its referent is either zero-sized or lives in a single
+            // allocation. The first byte of the referent (its lowest address)
+            // lives in or one-past-the-end of `*t`. There are two cases:
+            // - `*t` is zero-sized, in which case `u` has the same address as
+            //   `t`, which is guaranteed by the caller to be non-null, or
+            // - `*t` lives in a single allocation, in which case none of its
+            //   bytes (nor the byte one past the end of it) live at the null
+            //   address [1].
+            //
+            // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
+            unsafe { UV::project(u) }
+        }
+    }
+
+    // SAFETY: Since the `Project::project` impl delegates to `TU::project` and
+    // `UV::project`, and since `TU` and `UV` are `Cast`, the `Project::project`
+    // impl preserves the address of the referent.
+    unsafe impl<T, U, V, TU, UV> Cast<T, V> for TransitiveProject<U, TU, UV>
+    where
+        T: ?Sized,
+        U: ?Sized,
+        V: ?Sized,
+        TU: Cast<T, U>,
+        UV: Cast<U, V>,
+    {
+    }
+
+    /// A cast from `T` to `[u8]`.
+    pub(crate) struct AsBytesCast;
+
+    // SAFETY: `project` constructs a pointer with the same address as `src`
+    // and with a referent of the same size as `*src`. It does this using
+    // provenance-preserving operations.
+    //
+    // FIXME(https://github.com/rust-lang/unsafe-code-guidelines/issues/594):
+    // Technically, this proof assumes that `*src` is contiguous (the same is
+    // true of other proofs in this codebase). Is this guaranteed anywhere?
+    unsafe impl<T: ?Sized + KnownLayout> Project<T, [u8]> for AsBytesCast {
+        #[inline(always)]
+        unsafe fn project(src: *mut T) -> *mut [u8] {
+            // SAFETY: The caller promises that `src` is non-null.
+            let src = unsafe { NonNull::new_unchecked(src) };
+            let bytes = match T::size_of_val_raw(src) {
+                Some(bytes) => bytes,
+                // SAFETY: `KnownLayout::size_of_val_raw` promises to always
+                // return `Some` so long as the resulting size fits in a
+                // `usize`. By invariant on `PtrInner`, `self` refers to a range
+                // of bytes whose size fits in an `isize`, which implies that it
+                // also fits in a `usize`.
+                None => unsafe { core::hint::unreachable_unchecked() },
+            };
+
+            core::ptr::slice_from_raw_parts_mut(src.cast::<u8>().as_ptr(), bytes)
+        }
+    }
+
+    // SAFETY: The `Project::project` impl preserves referent address.
+    unsafe impl<T: ?Sized + KnownLayout> Cast<T, [u8]> for AsBytesCast {}
+}

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -160,6 +160,7 @@ mod _external {
 /// Methods for converting to and from `Ptr` and Rust's safe reference types.
 mod _conversions {
     use super::*;
+    use crate::pointer::cast::CastSized;
 
     /// `&'a T` → `Ptr<'a, T>`
     impl<'a, T> Ptr<'a, T, (Shared, Aligned, Valid)>
@@ -393,7 +394,7 @@ mod _conversions {
             //     operate on these references simultaneously
             // - By `U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
-            unsafe { self.transmute_unchecked(SizeEq::cast_from_raw) }
+            unsafe { self.transmute_unchecked::<_, _, <U as SizeEq<T>>::CastFrom>() }
         }
 
         #[doc(hidden)]
@@ -411,29 +412,26 @@ mod _conversions {
             //   same referent simultaneously
             // - By `T: TransmuteFromPtr<T, I::Aliasing, I::Validity, V>`, it is
             //   sound to perform this transmute.
-            let ptr = unsafe { self.transmute_unchecked(SizeEq::cast_from_raw) };
+            let ptr = unsafe { self.transmute_unchecked::<_, _, <T as SizeEq<T>>::CastFrom>() };
             // SAFETY: `self` and `ptr` have the same address and referent type.
             // Therefore, if `self` satisfies `I::Alignment`, then so does
             // `ptr`.
             unsafe { ptr.assume_alignment::<I::Alignment>() }
         }
 
-        /// Casts to a different (unsized) target type without checking interior
-        /// mutability.
+        /// Casts to a different (unsized) referent type without checking
+        /// interior mutability.
         ///
-        /// Callers should prefer [`cast_unsized`] where possible.
+        /// Callers should prefer [`cast`] where possible.
         ///
-        /// [`cast_unsized`]: Ptr::cast_unsized
+        /// [`cast`]: Ptr::cast
         ///
         /// # Safety
         ///
-        /// The caller promises that `u = cast(p)` is a pointer cast with the
-        /// following properties:
-        /// - `u` addresses a subset of the bytes addressed by `p`
-        /// - `u` has the same provenance as `p`
+        /// The caller promises that:
         /// - If `I::Aliasing` is [`Shared`], it must not be possible for safe
         ///   code, operating on a `&T` and `&U` with the same referent
-        ///   simultaneously, to cause undefined behavior
+        ///   simultaneously, to cause undefined behavior.
         /// - It is sound to transmute a pointer of type `T` with aliasing
         ///   `I::Aliasing` and validity `I::Validity` to a pointer of type `U`
         ///   with aliasing `I::Aliasing` and validity `V`. This is a subtle
@@ -442,21 +440,22 @@ mod _conversions {
         ///   presence, absence, or specific location of `UnsafeCell`s in `T`
         ///   and/or `U`. See [`Validity`] for more details.
         #[doc(hidden)]
-        #[inline]
-        pub unsafe fn transmute_unchecked<U: ?Sized, V, F>(
+        #[inline(always)]
+        #[must_use]
+        pub unsafe fn transmute_unchecked<U: ?Sized, V, C>(
             self,
-            cast: F,
         ) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
             V: Validity,
-            F: FnOnce(PtrInner<'a, T>) -> PtrInner<'a, U>,
+            C: crate::pointer::cast::Cast<T, U>,
         {
-            let ptr = cast(self.as_inner());
+            let ptr = self.as_inner().project::<_, C>();
 
             // SAFETY:
             //
-            // The following safety arguments rely on the fact that the caller
-            // promises that `cast` returns a `PtrInner` which addresses a
+            // The following safety arguments rely on the fact that `C: Cast`
+            // guarantees that `C` is an address-preserving and
+            // referent-preserving or -shrinking cast. Thus, `ptr` addresses a
             // prefix of the bytes of `*self`, and so properties that hold of
             // `*self` also hold of `*ptr`.
             //
@@ -511,7 +510,7 @@ mod _conversions {
             //   and the returned `Ptr` permit the same set of bit patterns in
             //   their referents, and so neither can be used to violate the
             //   validity of the other.
-            let ptr = unsafe { self.transmute_unchecked(PtrInner::cast_sized) };
+            let ptr = unsafe { self.transmute_unchecked::<_, _, CastSized>() };
             ptr.bikeshed_recall_aligned()
         }
     }
@@ -854,52 +853,44 @@ mod _transitions {
 
 /// Casts of the referent type.
 mod _casts {
+    use core::cell::UnsafeCell;
+
     use super::*;
+    use crate::{
+        pointer::cast::{AsBytesCast, Cast},
+        HasField,
+    };
 
     impl<'a, T, I> Ptr<'a, T, I>
     where
         T: 'a + ?Sized,
         I: Invariants,
     {
-        /// Casts to a different (unsized) target type without checking interior
+        /// Casts to a different referent type without checking interior
         /// mutability.
         ///
-        /// Callers should prefer [`cast_unsized`] where possible.
-        ///
-        /// [`cast_unsized`]: Ptr::cast_unsized
+        /// Callers should prefer [`cast`][Ptr::cast] where possible.
         ///
         /// # Safety
         ///
-        /// The caller promises that `u = cast(p)` is a pointer cast with the
-        /// following properties:
-        /// - `u` addresses a subset of the bytes addressed by `p`
-        /// - `u` has the same provenance as `p`
-        /// - If `I::Aliasing` is [`Shared`], it must not be possible for safe
-        ///   code, operating on a `&T` and `&U` with the same referent
-        ///   simultaneously, to cause undefined behavior
-        ///
-        /// `cast_unsized_unchecked` guarantees that the pointer passed to
-        /// `cast` will reference a byte sequence which is either contained
-        /// inside a single allocated object or is zero sized. In either case,
-        /// this means that its size will fit in an `isize` and it will not wrap
-        /// around the address space.
+        /// `I::Aliasing` is [`Shared`], it must not be possible for safe code,
+        /// operating on a `&T` and `&U` with the same referent simultaneously,
+        /// to cause undefined behavior.
         #[doc(hidden)]
-        #[inline]
-        pub unsafe fn cast_unsized_unchecked<U, F: FnOnce(PtrInner<'a, T>) -> PtrInner<'a, U>>(
+        #[inline(always)]
+        #[must_use]
+        pub unsafe fn cast_unchecked<U, C: Cast<T, U>>(
             self,
-            cast: F,
         ) -> Ptr<'a, U, (I::Aliasing, Unaligned, I::Validity)>
         where
             U: 'a + CastableFrom<T, I::Validity, I::Validity> + ?Sized,
         {
             // SAFETY:
-            // - The caller promises that `u = cast(p)` is a pointer which
-            //   satisfies:
-            //   - `u` addresses a subset of the bytes addressed by `p`
-            //   - `u` has the same provenance as `p`
-            //   - If `I::Aliasing` is [`Shared`], it must not be possible for
-            //     safe code, operating on a `&T` and `&U` with the same
-            //     referent simultaneously, to cause undefined behavior
+            // - By `C: Cast`, `C` preserves the address of the referent.
+            // - If `I::Aliasing` is [`Shared`], the caller promises that it
+            //   is not possible for safe code, operating on a `&T` and `&U`
+            //   with the same referent simultaneously, to cause undefined
+            //   behavior.
             // - By `U: CastableFrom<T, I::Validity, I::Validity>`,
             //   `I::Validity` is either `Uninit` or `Initialized`. In both
             //   cases, the bit validity `I::Validity` has the same semantics
@@ -908,35 +899,18 @@ mod _casts {
             //   (_, _, I::Validity)>` are identical. As a consequence, neither
             //   `self` nor the returned `Ptr` can be used to write values which
             //   are invalid for the other.
-            //
-            // `transmute_unchecked` guarantees that it will only pass pointers
-            // to `cast` which either reference a zero-sized byte range or
-            // reference a byte range which is entirely contained inside of an
-            // allocated object.
-            #[allow(clippy::multiple_unsafe_ops_per_block)]
-            unsafe {
-                self.transmute_unchecked(cast)
-            }
+            unsafe { self.transmute_unchecked::<_, _, C>() }
         }
 
-        /// Casts to a different (unsized) target type.
-        ///
-        /// # Safety
-        ///
-        /// The caller promises that `u = cast(p)` is a pointer cast with the
-        /// following properties:
-        /// - `u` addresses a subset of the bytes addressed by `p`
-        /// - `u` has the same provenance as `p`
+        /// Casts to a different referent type.
         #[doc(hidden)]
-        #[inline]
-        pub unsafe fn cast_unsized<U, F, R>(
-            self,
-            cast: F,
-        ) -> Ptr<'a, U, (I::Aliasing, Unaligned, I::Validity)>
+        #[inline(always)]
+        #[must_use]
+        pub fn cast<U, C, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, I::Validity)>
         where
             T: MutationCompatible<U, I::Aliasing, I::Validity, I::Validity, R>,
             U: 'a + ?Sized + CastableFrom<T, I::Validity, I::Validity>,
-            F: FnOnce(PtrInner<'a, T>) -> PtrInner<'a, U>,
+            C: Cast<T, U>,
         {
             // SAFETY: Because `T: MutationCompatible<U, I::Aliasing, R>`, one
             // of the following holds:
@@ -945,10 +919,29 @@ mod _casts {
             //   - `I::Aliasing` is `Exclusive`
             //   - `T` and `U` are both `Immutable`
             // - It is sound for safe code to operate on `&T` and `&U` with the
-            //   same referent simultaneously
-            //
-            // The caller promises all other safety preconditions.
-            unsafe { self.cast_unsized_unchecked(cast) }
+            //   same referent simultaneously.
+            unsafe { self.cast_unchecked::<_, C>() }
+        }
+
+        // FIXME(#196): Support all validity invariants (not just those that are
+        // `CastableFrom`).
+        #[must_use]
+        #[inline(always)]
+        pub fn project<F, const FIELD_ID: i128>(
+            self,
+        ) -> Ptr<'a, T::Type, (I::Aliasing, Unaligned, I::Validity)>
+        where
+            T: HasField<F, { crate::STRUCT_VARIANT_ID }, FIELD_ID>,
+            T::Type: 'a + CastableFrom<T, I::Validity, I::Validity>,
+        {
+            let ptr = self.as_inner().project::<_, crate::pointer::cast::Projection<
+                F,
+                { crate::STRUCT_VARIANT_ID },
+                FIELD_ID,
+            >>();
+
+            // SAFETY: TODO
+            unsafe { Ptr::from_inner(ptr) }
         }
     }
 
@@ -966,10 +959,7 @@ mod _casts {
             T: Read<I::Aliasing, R>,
             I::Aliasing: Reference,
         {
-            // SAFETY: `PtrInner::as_bytes` returns a pointer which addresses
-            // the same byte range as its argument, and which has the same
-            // provenance.
-            let ptr = unsafe { self.cast_unsized(PtrInner::as_bytes) };
+            let ptr = self.cast::<_, AsBytesCast, _>();
             ptr.bikeshed_recall_aligned().recall_validity::<Valid, (_, (_, _))>()
         }
     }
@@ -1149,7 +1139,7 @@ mod _casts {
         }
     }
 
-    impl<'a, T, I> Ptr<'a, core::cell::UnsafeCell<T>, I>
+    impl<'a, T, I> Ptr<'a, UnsafeCell<T>, I>
     where
         T: 'a + ?Sized,
         I: Invariants<Aliasing = Exclusive>,
@@ -1165,6 +1155,11 @@ mod _casts {
         #[must_use]
         #[inline(always)]
         pub fn get_mut(self) -> Ptr<'a, T, I> {
+            // SAFETY: As described below, `UnsafeCell<T>` has the same size
+            // as `T: ?Sized` (same static size or same DST layout). Thus,
+            // `*const UnsafeCell<T> as *const T` is a size-preserving cast.
+            define_cast!(unsafe { Cast<T: ?Sized> = UnsafeCell<T> => T });
+
             // SAFETY:
             // - The closure uses an `as` cast, which preserves address range
             //   and provenance.
@@ -1188,9 +1183,7 @@ mod _casts {
             //   `UnsafeCell<T>` has the same in-memory representation as its
             //   inner type `T`. A consequence of this guarantee is that it is
             //   possible to convert between `T` and `UnsafeCell<T>`.
-            #[allow(clippy::as_conversions)]
-            #[allow(clippy::multiple_unsafe_ops_per_block)]
-            let ptr = unsafe { self.transmute_unchecked(|ptr| cast!(ptr)) };
+            let ptr = unsafe { self.transmute_unchecked::<_, _, Cast>() };
 
             // SAFETY: `UnsafeCell<T>` has the same alignment as `T` [1],
             // and so if `self` is guaranteed to be aligned, then so is the

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -13,7 +13,7 @@ use core::{
 };
 
 use crate::{
-    pointer::{invariant::*, PtrInner},
+    pointer::{cast, invariant::*},
     FromBytes, Immutable, IntoBytes, Unalign,
 };
 
@@ -218,7 +218,9 @@ where
 {
 }
 
-pub(crate) enum BecauseInvariantsEq {}
+#[allow(missing_debug_implementations, missing_copy_implementations)]
+#[doc(hidden)]
+pub enum BecauseInvariantsEq {}
 
 macro_rules! unsafe_impl_invariants_eq {
     ($tyvar:ident => $t:ty, $u:ty) => {{
@@ -297,17 +299,14 @@ pub unsafe trait TransmuteFrom<Src: ?Sized, SV, DV> {}
 ///   the case that `cast_from_raw` modifies the pointer's metadata in order to
 ///   preserve referent size, which an `as` cast does not do.*
 pub unsafe trait SizeEq<T: ?Sized> {
-    fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, Self>;
+    type CastFrom: cast::Cast<T, Self>;
 }
 
 // SAFETY: `T` trivially has the same size and vtable kind as `T`, and since
 // pointer `*mut T -> *mut T` pointer casts are no-ops, this cast trivially
 // preserves referent size (when `T: ?Sized`).
 unsafe impl<T: ?Sized> SizeEq<T> for T {
-    #[inline(always)]
-    fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, T> {
-        t
-    }
+    type CastFrom = cast::IdCast;
 }
 
 // SAFETY: Since `Src: IntoBytes`, the set of valid `Src`'s is the set of
@@ -366,13 +365,13 @@ where
 //   `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
 //   `T`
 #[allow(clippy::multiple_unsafe_ops_per_block)]
-const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T: ?Sized => ManuallyDrop<T>) };
+const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(pub T: ?Sized => ManuallyDrop<T>) };
 
 // SAFETY:
 // - `Unalign<T>` promises to have the same size as `T`.
 // - `Unalign<T>` promises to have the same validity as `T`.
 #[allow(clippy::multiple_unsafe_ops_per_block)]
-const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T => Unalign<T>) };
+const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(pub T => Unalign<T>) };
 // SAFETY: `Unalign<T>` promises to have the same size and validity as `T`.
 // Given `u: &Unalign<T>`, it is already possible to obtain `let t =
 // u.try_deref().unwrap()`. Because `Unalign<T>` has the same size as `T`, the
@@ -405,7 +404,7 @@ const _: () = unsafe { unsafe_impl_invariants_eq!(T => T, Unalign<T>) };
 //   pub struct Wrapping<T>(pub T);
 //   ```
 #[allow(clippy::multiple_unsafe_ops_per_block)]
-const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T => Wrapping<T>) };
+const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(pub T => Wrapping<T>) };
 
 // SAFETY: By the preceding safety proof, `Wrapping<T>` and `T` have the same
 // layout and bit validity. Since a `Wrapping<T>`'s `T` field is `pub`, given
@@ -427,7 +426,7 @@ const _: () = unsafe { unsafe_impl_invariants_eq!(T => T, Wrapping<T>) };
 //   `T`. A consequence of this guarantee is that it is possible to convert
 //   between `T` and `UnsafeCell<T>`.
 #[allow(clippy::multiple_unsafe_ops_per_block)]
-const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T: ?Sized => UnsafeCell<T>) };
+const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(pub T: ?Sized => UnsafeCell<T>) };
 
 // SAFETY:
 // - `Cell<T>` has the same size as `T` [1].
@@ -449,7 +448,7 @@ const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T: ?Sized => UnsafeC
 //   `T`. A consequence of this guarantee is that it is possible to convert
 //   between `T` and `UnsafeCell<T>`.
 #[allow(clippy::multiple_unsafe_ops_per_block)]
-const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(T: ?Sized => Cell<T>) };
+const _: () = unsafe { unsafe_impl_for_transparent_wrapper!(pub T: ?Sized => Cell<T>) };
 
 impl_transitive_transmute_from!(T: ?Sized => Cell<T> => T => UnsafeCell<T>);
 impl_transitive_transmute_from!(T: ?Sized => UnsafeCell<T> => T => Cell<T>);
@@ -467,74 +466,46 @@ unsafe impl<T> TransmuteFrom<T, Uninit, Valid> for MaybeUninit<T> {}
 //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and ABI as
 //   `T`
 unsafe impl<T> SizeEq<T> for MaybeUninit<T> {
-    #[inline(always)]
-    fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, MaybeUninit<T>> {
-        // SAFETY: Per preceding safety comment, `MaybeUninit<T>` and `T` have
-        // the same size, and so this cast preserves referent size.
-        #[allow(clippy::multiple_unsafe_ops_per_block)]
-        unsafe {
-            cast!(t)
-        }
-    }
+    type CastFrom = cast::CastSized;
 }
 
 // SAFETY: See previous safety comment.
 unsafe impl<T> SizeEq<MaybeUninit<T>> for T {
-    #[inline(always)]
-    fn cast_from_raw(t: PtrInner<'_, MaybeUninit<T>>) -> PtrInner<'_, T> {
-        // SAFETY: Per preceding safety comment, `MaybeUninit<T>` and `T` have
-        // the same size, and so this cast preserves referent size.
-        #[allow(clippy::multiple_unsafe_ops_per_block)]
-        unsafe {
-            cast!(t)
-        }
-    }
+    type CastFrom = cast::CastSized;
 }
 
 #[cfg(test)]
 mod tests {
-    use core::ptr::NonNull;
-
     use super::*;
+    use crate::pointer::cast::Project as _;
+
+    fn test_size_eq<Src, Dst: SizeEq<Src>>(mut src: Src) {
+        // SAFETY: By invariant on `&mut T`, `&mut src` is a non-null reference
+        // which has provenance for its referent, and its referent lives in a
+        // single allocation.
+        let _: *mut Dst = unsafe { <Dst as SizeEq<Src>>::CastFrom::project(&mut src) };
+    }
 
     #[test]
     fn test_transmute_coverage() {
         // SizeEq<T> for MaybeUninit<T>
-        let mut t = 0u8;
-        // SAFETY: `ptr` is valid for `t`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut t)) };
-        <MaybeUninit<u8> as SizeEq<u8>>::cast_from_raw(ptr);
+        test_size_eq::<u8, MaybeUninit<u8>>(0u8);
 
         // SizeEq<MaybeUninit<T>> for T
-        let mut mu = MaybeUninit::<u8>::new(0);
-        // SAFETY: `ptr` is valid for `mu`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut mu)) };
-        <u8 as SizeEq<MaybeUninit<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<MaybeUninit<u8>, u8>(MaybeUninit::<u8>::new(0));
 
         // Transitive: MaybeUninit<T> -> Wrapping<T>
         // T => MaybeUninit<T> => T => Wrapping<T>
-        let mut mu = MaybeUninit::<u8>::new(0);
-        // SAFETY: `ptr` is valid for `mu`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut mu)) };
-        <Wrapping<u8> as SizeEq<MaybeUninit<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<u8, Wrapping<u8>>(0u8);
 
         // T => Wrapping<T> => T => MaybeUninit<T>
-        let mut w = Wrapping(0u8);
-        // SAFETY: `ptr` is valid for `w`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut w)) };
-        <MaybeUninit<u8> as SizeEq<Wrapping<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<Wrapping<u8>, MaybeUninit<u8>>(Wrapping(0u8));
 
         // T: ?Sized => Cell<T> => T => UnsafeCell<T>
-        let mut c = Cell::new(0u8);
-        // SAFETY: `ptr` is valid for `c`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut c)) };
-        <UnsafeCell<u8> as SizeEq<Cell<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<Cell<u8>, UnsafeCell<u8>>(Cell::new(0u8));
 
         // T: ?Sized => UnsafeCell<T> => T => Cell<T>
-        let mut uc = UnsafeCell::new(0u8);
-        // SAFETY: `ptr` is valid for `uc`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut uc)) };
-        <Cell<u8> as SizeEq<UnsafeCell<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<UnsafeCell<u8>, Cell<u8>>(UnsafeCell::new(0u8));
     }
 
     #[cfg(not(no_zerocopy_target_has_atomics_1_60_0))]
@@ -544,27 +515,15 @@ mod tests {
         use core::sync::atomic::AtomicU8;
 
         // 1. Atomic -> Prim (SizeEq<Atomic> for Prim)
-        let mut a = AtomicU8::new(0);
-        // SAFETY: `ptr` is valid for `a`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut a)) };
-        <u8 as SizeEq<AtomicU8>>::cast_from_raw(ptr);
+        test_size_eq::<AtomicU8, u8>(AtomicU8::new(0));
 
         // 2. Prim -> Atomic (SizeEq<Prim> for Atomic)
-        let mut p = 0u8;
-        // SAFETY: `ptr` is valid for `p`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut p)) };
-        <AtomicU8 as SizeEq<u8>>::cast_from_raw(ptr);
+        test_size_eq::<u8, AtomicU8>(0u8);
 
         // 3. Atomic -> UnsafeCell<Prim> (SizeEq<Atomic> for UnsafeCell<Prim>)
-        let mut a = AtomicU8::new(0);
-        // SAFETY: `ptr` is valid for `a`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut a)) };
-        <UnsafeCell<u8> as SizeEq<AtomicU8>>::cast_from_raw(ptr);
+        test_size_eq::<AtomicU8, UnsafeCell<u8>>(AtomicU8::new(0));
 
         // 4. UnsafeCell<Prim> -> Atomic (SizeEq<UnsafeCell<Prim>> for Atomic)
-        let mut uc = UnsafeCell::new(0u8);
-        // SAFETY: `ptr` is valid for `uc`, which lives for the duration of this block.
-        let ptr = unsafe { PtrInner::new(NonNull::from(&mut uc)) };
-        <AtomicU8 as SizeEq<UnsafeCell<u8>>>::cast_from_raw(ptr);
+        test_size_eq::<UnsafeCell<u8>, AtomicU8>(UnsafeCell::new(0u8));
     }
 }

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -629,27 +629,14 @@ where
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());
 
-    // SAFETY: This is a pointer cast, satisfying the following properties:
-    // - `p as *mut Dst` addresses a subset of the `bytes` addressed by `src`,
-    //   because we assert above that the size of `Dst` equal to the size of
-    //   `Src`.
-    // - `p as *mut Dst` is a provenance-preserving cast
-    #[allow(clippy::multiple_unsafe_ops_per_block)]
-    let c_ptr = unsafe { src.cast_unsized(|p| cast!(p)) };
+    let c_ptr = src.cast::<_, crate::pointer::cast::CastSized, _>();
 
     match c_ptr.try_into_valid() {
         Ok(ptr) => Ok(ptr),
         Err(err) => {
             // Re-cast `Ptr<Dst>` to `Ptr<Src>`.
             let ptr = err.into_src();
-            // SAFETY: This is a pointer cast, satisfying the following
-            // properties:
-            // - `p as *mut Src` addresses a subset of the `bytes` addressed by
-            //   `ptr`, because we assert above that the size of `Dst` is equal
-            //   to the size of `Src`.
-            // - `p as *mut Src` is a provenance-preserving cast
-            #[allow(clippy::multiple_unsafe_ops_per_block)]
-            let ptr = unsafe { ptr.cast_unsized(|p| cast!(p)) };
+            let ptr = ptr.cast::<_, crate::pointer::cast::CastSized, _>();
             // SAFETY: `ptr` is `src`, and has the same alignment invariant.
             let ptr = unsafe { ptr.assume_alignment::<I::Alignment>() };
             // SAFETY: `ptr` is `src` and has the same validity invariant.
@@ -695,18 +682,7 @@ where
     // initialized.
     let ptr = unsafe { ptr.assume_validity::<invariant::Initialized>() };
 
-    // SAFETY: `MaybeUninit<T>` and `T` have the same size [1], so this cast
-    // preserves the referent's size. This cast preserves provenance.
-    //
-    // [1] Per https://doc.rust-lang.org/1.81.0/std/mem/union.MaybeUninit.html#layout-1:
-    //
-    //   `MaybeUninit<T>` is guaranteed to have the same size, alignment, and
-    //   ABI as `T`
-    let ptr: Ptr<'_, Dst, _> = unsafe {
-        ptr.cast_unsized(|ptr: crate::pointer::PtrInner<'_, mem::MaybeUninit<Dst>>| {
-            ptr.cast_sized()
-        })
-    };
+    let ptr: Ptr<'_, Dst, _> = ptr.cast::<_, crate::pointer::cast::CastSized, _>();
 
     if Dst::is_bit_valid(ptr.forget_aligned()) {
         // SAFETY: Since `Dst::is_bit_valid`, we know that `ptr`'s referent is

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -693,29 +693,37 @@ macro_rules! static_assert_dst_is_not_zst {
     }}
 }
 
+/// Defines a named [`Cast`] implementation.
+///
 /// # Safety
 ///
-/// The caller must ensure that the cast does not grow the size of the referent.
-/// Preserving or shrinking the size of the referent are both acceptable.
-macro_rules! cast {
-    ($p:expr) => {{
-        let ptr: crate::pointer::PtrInner<'_, _> = $p;
-        let ptr = ptr.as_non_null();
-        let ptr = ptr.as_ptr();
-        #[allow(clippy::as_conversions)]
-        let ptr = ptr as *mut _;
-        #[allow(unused_unsafe)]
-        // SAFETY: `NonNull::as_ptr` returns a non-null pointer, so the argument
-        // to `NonNull::new_unchecked` is also non-null.
-        let ptr = unsafe { core::ptr::NonNull::new_unchecked(ptr) };
-        // SAFETY: The caller promises that the cast preserves or shrinks
-        // referent size. By invariant on `$p: PtrInner` (guaranteed by type
-        // annotation above), `$p` refers to a byte range entirely contained
-        // inside of a single allocation, has provenance for that whole byte
-        // range, and will not outlive the allocation. All of these conditions
-        // are preserved when preserving or shrinking referent size.
-        crate::pointer::PtrInner::new(ptr)
-    }};
+/// The caller must ensure that, given `src: *mut $src`, `src as *mut $dst` is a
+/// size-preserving or size-shrinking cast.
+///
+/// [`Cast`]: crate::pointer::cast::Cast
+#[macro_export]
+#[doc(hidden)]
+macro_rules! define_cast {
+    // We require the caller to provide an `unsafe` block as part of the input
+    // syntax since a call to `define_cast!` is useless inside of an `unsafe`
+    // block (since it would introduce a type which can't be named outside of
+    // the context of that block).
+    (unsafe { $vis:vis $name:ident $(<$tyvar:ident $(: ?$optbound:ident)?>)? = $src:ty => $dst:ty }) => {
+        #[allow(missing_debug_implementations, missing_copy_implementations, unreachable_pub)]
+        $vis enum $name {}
+
+        // SAFETY: The caller promises that `src: *mut $src` is a
+        // size-preserving or size-shrinking cast.
+        unsafe impl $(<$tyvar $(: ?$optbound)?>)? $crate::pointer::cast::Project<$src, $dst> for $name {
+            unsafe fn project(src: *mut $src) -> *mut $dst {
+                #[allow(clippy::as_conversions)]
+                return src as *mut $dst;
+            }
+        }
+
+        // SAFETY: The impl of `Project::project` preserves referent address.
+        unsafe impl $(<$tyvar $(: ?$optbound)?>)? $crate::pointer::cast::Cast<$src, $dst> for $name {}
+    };
 }
 
 /// Implements `TransmuteFrom` and `SizeEq` for `T` and `$wrapper<T>`.
@@ -725,32 +733,26 @@ macro_rules! cast {
 /// `T` and `$wrapper<T>` must have the same bit validity, and must have the
 /// same size in the sense of `SizeEq`.
 macro_rules! unsafe_impl_for_transparent_wrapper {
-    (T $(: ?$optbound:ident)? => $wrapper:ident<T>) => {{
+    ($vis:vis T $(: ?$optbound:ident)? => $wrapper:ident<T>) => {{
         crate::util::macros::__unsafe();
 
-        use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+        use crate::pointer::{TransmuteFrom, SizeEq, invariant::Valid};
 
         // SAFETY: The caller promises that `T` and `$wrapper<T>` have the same
         // bit validity.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<T, Valid, Valid> for $wrapper<T> {}
         // SAFETY: See previous safety comment.
         unsafe impl<T $(: ?$optbound)?> TransmuteFrom<$wrapper<T>, Valid, Valid> for T {}
+        define_cast!(unsafe { $vis CastA<T $(: ?$optbound)? > = T => $wrapper<T> });
         // SAFETY: The caller promises that `T` and `$wrapper<T>` satisfy
         // `SizeEq`.
         unsafe impl<T $(: ?$optbound)?> SizeEq<T> for $wrapper<T> {
-            #[inline(always)]
-            fn cast_from_raw(t: PtrInner<'_, T>) -> PtrInner<'_, $wrapper<T>> {
-                // SAFETY: See previous safety comment.
-                unsafe { cast!(t) }
-            }
+            type CastFrom = CastA;
         }
+        define_cast!(unsafe { $vis CastB<T $(: ?$optbound)? > = $wrapper<T> => T });
         // SAFETY: See previous safety comment.
         unsafe impl<T $(: ?$optbound)?> SizeEq<$wrapper<T>> for T {
-            #[inline(always)]
-            fn cast_from_raw(t: PtrInner<'_, $wrapper<T>>) -> PtrInner<'_, T> {
-                // SAFETY: See previous safety comment.
-                unsafe { cast!(t) }
-            }
+            type CastFrom = CastB;
         }
     }};
 }
@@ -758,7 +760,7 @@ macro_rules! unsafe_impl_for_transparent_wrapper {
 macro_rules! impl_transitive_transmute_from {
     ($($tyvar:ident $(: ?$optbound:ident)?)? => $t:ty => $u:ty => $v:ty) => {
         const _: () = {
-            use crate::pointer::{TransmuteFrom, PtrInner, SizeEq, invariant::Valid};
+            use crate::pointer::{TransmuteFrom, SizeEq, invariant::Valid};
 
             // SAFETY: Since `$u: SizeEq<$t>` and `$v: SizeEq<U>`, this impl is
             // transitively sound.
@@ -767,11 +769,11 @@ macro_rules! impl_transitive_transmute_from {
                 $u: SizeEq<$t>,
                 $v: SizeEq<$u>,
             {
-                #[inline(always)]
-                fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $v> {
-                    let u = <$u as SizeEq<_>>::cast_from_raw(t);
-                    <$v as SizeEq<_>>::cast_from_raw(u)
-                }
+                type CastFrom = cast::TransitiveProject<
+                    $u,
+                    <$u as SizeEq<$t>>::CastFrom,
+                    <$v as SizeEq<$u>>::CastFrom
+                >;
             }
 
             // SAFETY: Since `$u: TransmuteFrom<$t, Valid, Valid>`, it is sound
@@ -791,41 +793,15 @@ macro_rules! impl_transitive_transmute_from {
 macro_rules! impl_size_eq {
     ($t:ty, $u:ty) => {
         const _: () = {
-            use crate::{KnownLayout, pointer::{PtrInner, SizeEq}};
-
-            static_assert!(=> {
-                let t = <$t as KnownLayout>::LAYOUT;
-                let u = <$u as KnownLayout>::LAYOUT;
-                t.align.get() >= u.align.get() && match (t.size_info, u.size_info) {
-                    (SizeInfo::Sized { size: t }, SizeInfo::Sized { size: u }) => t == u,
-                    (
-                        SizeInfo::SliceDst(TrailingSliceLayout { offset: t_offset, elem_size: t_elem_size }),
-                        SizeInfo::SliceDst(TrailingSliceLayout { offset: u_offset, elem_size: u_elem_size })
-                    ) => t_offset == u_offset && t_elem_size == u_elem_size,
-                    _ => false,
-                }
-            });
+            use $crate::{pointer::{cast::CastUnsized, SizeEq}};
 
             // SAFETY: See inline.
             unsafe impl SizeEq<$t> for $u {
-                #[inline(always)]
-                fn cast_from_raw(t: PtrInner<'_, $t>) -> PtrInner<'_, $u> {
-                    // SAFETY: We've asserted that their
-                    // `KnownLayout::LAYOUT.size_info`s are equal, and so this
-                    // cast is guaranteed to preserve address and referent size.
-                    // It trivially preserves provenance.
-                    #[allow(clippy::multiple_unsafe_ops_per_block)]
-                    unsafe { cast!(t) }
-                }
+                type CastFrom = CastUnsized;
             }
             // SAFETY: See previous safety comment.
             unsafe impl SizeEq<$u> for $t {
-                #[inline(always)]
-                fn cast_from_raw(u: PtrInner<'_, $u>) -> PtrInner<'_, $t> {
-                    // SAFETY: See previous safety comment.
-                    #[allow(clippy::multiple_unsafe_ops_per_block)]
-                    unsafe { cast!(u) }
-                }
+                type CastFrom = CastUnsized;
             }
         };
     };
@@ -846,7 +822,7 @@ macro_rules! unsafe_with_size_eq {
     (<$src:ident<$t:ident>, $dst:ident<$u:ident>> $blk:expr) => {{
         crate::util::macros::__unsafe();
 
-        use crate::{KnownLayout, pointer::PtrInner};
+        use crate::{KnownLayout, pointer::cast::TransitiveProject};
 
         #[repr(transparent)]
         struct $src<T: ?Sized>(T);
@@ -870,6 +846,9 @@ macro_rules! unsafe_with_size_eq {
         // no added semantics.
         unsafe impl<T: ?Sized> InvariantsEq<$dst<T>> for T {}
 
+        define_cast!(unsafe { SrcCast<T: ?Sized> = $src<T> => T });
+        define_cast!(unsafe { DstCast<U: ?Sized> = U => $dst<U> });
+
         // SAFETY: See inline for the soundness of this impl when
         // `cast_from_raw` is actually instantiated (otherwise, PMEs may not be
         // triggered).
@@ -882,41 +861,23 @@ macro_rules! unsafe_with_size_eq {
             T: KnownLayout<PointerMetadata = usize>,
             U: KnownLayout<PointerMetadata = usize>,
         {
-            fn cast_from_raw(src: PtrInner<'_, $src<T>>) -> PtrInner<'_, Self> {
-                // SAFETY: `crate::layout::cast_from_raw` promises to satisfy
-                // the safety invariants of `SizeEq::cast_from_raw`, or to
-                // generate a PME. Since `$src<T>` and `$dst<U>` are
-                // `#[repr(transparent)]` wrappers around `T` and `U`
-                // respectively, a `cast_from_raw` impl which satisfies the
-                // conditions for casting from `NonNull<T>` to `NonNull<U>` also
-                // satisfies the conditions for casting from `NonNull<$src<T>>`
-                // to `NonNull<$dst<U>>`.
-
-                // SAFETY: By the preceding safety comment, this cast preserves
-                // referent size.
-                #[allow(clippy::multiple_unsafe_ops_per_block)]
-                let src: PtrInner<'_, T> = unsafe { cast!(src) };
-                let dst: PtrInner<'_, U> = crate::layout::cast_from_raw(src);
-                // SAFETY: By the preceding safety comment, this cast preserves
-                // referent size.
-                #[allow(clippy::multiple_unsafe_ops_per_block)]
-                unsafe { cast!(dst) }
-            }
+            type CastFrom = TransitiveProject<U, TransitiveProject<
+                T,
+                SrcCast,
+                crate::layout::CastFromRaw<U>,
+            >, DstCast>;
         }
 
         // See safety comment on the preceding `unsafe impl` block for an
         // explanation of why we need this block.
         if 1 == 0 {
+            use crate::pointer::cast::Project as _;
+
             let ptr = <$t as KnownLayout>::raw_dangling();
-            #[allow(unused_unsafe)]
             // SAFETY: This call is never executed.
-            #[allow(clippy::multiple_unsafe_ops_per_block)]
-            let ptr = unsafe { crate::pointer::PtrInner::new(ptr) };
-            #[allow(unused_unsafe)]
-            // SAFETY: This call is never executed.
-            #[allow(clippy::multiple_unsafe_ops_per_block)]
-            let ptr = unsafe { cast!(ptr) };
-            let _ = <$dst<$u> as SizeEq<$src<$t>>>::cast_from_raw(ptr);
+            #[allow(unused_unsafe, clippy::missing_transmute_annotations)]
+            let ptr = unsafe { core::mem::transmute(ptr) };
+            let _ = <$dst<$u> as SizeEq<$src<$t>>>::CastFrom::project(ptr);
         }
 
         impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for $src<T>[<T>]);
@@ -945,4 +906,5 @@ macro_rules! unsafe_with_size_eq {
 ///
 /// Calling this function in a macro expansion ensures that the macro's caller
 /// must wrap the call in `unsafe { ... }`.
+#[inline(always)]
 pub(crate) const unsafe fn __unsafe() {}

--- a/tests/ui-nightly/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-nightly/invalid-impls/invalid-impls.stderr
@@ -1,3 +1,19 @@
+warning: ambiguous glob re-exports
+ --> tests/ui-nightly/invalid-impls/../../../src/util/macros.rs
+  |
+  | / macro_rules! define_cast {
+... |
+  | |     };
+  | | }
+  | |_^ the name `define_cast` in the macro namespace is first re-exported here
+  |
+ ::: tests/ui-nightly/invalid-impls/invalid-impls.rs:17:5
+  |
+ 17 |   use zerocopy::*;
+    |       ----------- but the name `define_cast` in the macro namespace is also re-exported here
+    |
+    = note: `#[warn(ambiguous_glob_reexports)]` on by default
+
 error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
  --> tests/ui-nightly/invalid-impls/invalid-impls.rs:27:43
   |

--- a/tests/ui-stable/invalid-impls/invalid-impls.stderr
+++ b/tests/ui-stable/invalid-impls/invalid-impls.stderr
@@ -1,3 +1,19 @@
+warning: ambiguous glob re-exports
+ --> tests/ui-stable/invalid-impls/../../../src/util/macros.rs
+  |
+  | / macro_rules! define_cast {
+... |
+  | |     };
+  | | }
+  | |_^ the name `define_cast` in the macro namespace is first re-exported here
+  |
+ ::: tests/ui-stable/invalid-impls/invalid-impls.rs:17:5
+  |
+ 17 |   use zerocopy::*;
+    |       ----------- but the name `define_cast` in the macro namespace is also re-exported here
+    |
+    = note: `#[warn(ambiguous_glob_reexports)]` on by default
+
 error[E0277]: the trait bound `T: zerocopy::TryFromBytes` is not satisfied
  --> tests/ui-stable/invalid-impls/invalid-impls.rs:27:43
   |

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -147,6 +147,11 @@ fn generate_variant_structs(
             ) #where_clause;
         };
 
+        let invariants_eq_impl: TokenStream = parse_quote! {
+            // SAFETY: TODO
+            unsafe impl #impl_generics #zerocopy_crate::pointer::InvariantsEq<#variant_struct_ident #ty_generics> for ___ZerocopyVariants #ty_generics #where_clause {}
+        };
+
         // We do this rather than emitting `#[derive(::zerocopy::TryFromBytes)]`
         // because that is not hygienic, and this is also more performant.
         let try_from_bytes_impl =
@@ -156,6 +161,7 @@ fn generate_variant_structs(
         Some(quote! {
             #variant_struct
             #try_from_bytes_impl
+            #invariants_eq_impl
         })
     });
 
@@ -266,7 +272,7 @@ pub(crate) fn derive_is_bit_valid(
     let variant_structs = generate_variant_structs(enum_ident, generics, data, zerocopy_crate);
     let variants_union = generate_variants_union(generics, data, zerocopy_crate);
 
-    let (_, ref ty_generics, _) = generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
         let variant_ident = &variant.unwrap().ident;
@@ -278,6 +284,7 @@ pub(crate) fn derive_is_bit_valid(
             // derive remains sound.
             assert!(matches!(vis, syn::Visibility::Inherited));
             let variant_struct_field_index = Index::from(idx + 1);
+            let (_, ty_generics, _) = generics.split_for_impl();
             ImplBlockBuilder::new(
                 ast,
                 data,
@@ -296,15 +303,17 @@ pub(crate) fn derive_is_bit_valid(
                 type Type = #ty;
 
                 #[inline(always)]
-                fn project(slf: #zerocopy_crate::PtrInner<'_, Self>) -> #zerocopy_crate::PtrInner<'_, Self::Type> {
-                    // SAFETY: By invariant on `___ZerocopyRawEnum`,
-                    // `___ZerocopyRawEnum` has the same layout as `Self`.
-                    let slf = unsafe { slf.cast::<___ZerocopyRawEnum #ty_generics>() };
-
-                    slf.project::<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>()
-                        .project::<_, { #zerocopy_crate::UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>()
-                        .project::<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>()
-                        .project::<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>()
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum #ty_generics;
+                    // FIXME(#196): Does it make sense to keep `HasField` impls
+                    // which are really casts, or can we replace them with
+                    // `Cast`s? This would allow us to emit fewer `HasField`
+                    // impls.
+                    let slf = <___ZerocopyRawEnum #ty_generics as #zerocopy_crate::HasField<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>::project(slf);
+                    let slf = <_ as #zerocopy_crate::HasField<_, { #zerocopy_crate::UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>>::project(slf);
+                    let slf = <_ as #zerocopy_crate::HasField<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>::project(slf);
+                    let slf = <_ as #zerocopy_crate::HasField<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>::project(slf);
+                    slf
                 }
             })
             .build()
@@ -324,29 +333,11 @@ pub(crate) fn derive_is_bit_valid(
         } else {
             quote! {
                 #tag_ident => {
-                    // SAFETY:
-                    // - This cast is from a `repr(C)` union which has a field
-                    //   of type `variant_struct_ident` to that variant struct
-                    //   type itself. This addresses a subset of the bytes
-                    //   addressed by `variants`.
-                    // - The returned pointer is cast from `p`, and so has the
-                    //   same provenance as `p`.
-                    // - We checked that the tag of the enum matched the
-                    //   constant for this variant, so this cast preserves
-                    //   types and locations of all fields. Therefore, any
-                    //   `UnsafeCell`s will have the same location as in the
-                    //   original type.
-                    let variant = unsafe {
-                        variants.cast_unsized_unchecked(
-                            |p: #zerocopy_crate::pointer::PtrInner<'_, ___ZerocopyVariants #ty_generics>| {
-                                p.cast_sized::<#variant_struct_ident #ty_generics>()
-                            }
-                        )
-                    };
-                    // SAFETY: `cast_unsized_unchecked` removes the
-                    // initialization invariant from `p`, so we re-assert that
-                    // all of the bytes are initialized.
-                    let variant = unsafe { variant.assume_initialized() };
+                    let variant = variants.cast::<
+                        #variant_struct_ident #ty_generics,
+                        #zerocopy_crate::pointer::cast::CastSized,
+                        #zerocopy_crate::pointer::BecauseInvariantsEq
+                    >();
                     <
                         #variant_struct_ident #ty_generics as #trait_path
                     >::is_bit_valid(variant)
@@ -355,7 +346,7 @@ pub(crate) fn derive_is_bit_valid(
         }
     });
 
-    let raw_enum = parse_quote! {
+    let raw_enum: DeriveInput = parse_quote! {
         #[repr(C)]
         struct ___ZerocopyRawEnum #generics {
             tag: ___ZerocopyOuterTag,
@@ -363,11 +354,18 @@ pub(crate) fn derive_is_bit_valid(
         }
     };
 
+    let self_ident = &ast.ident;
+    let invariants_eq_impl = quote! {
+        // SAFETY: TODO
+        unsafe impl #impl_generics #zerocopy_crate::pointer::InvariantsEq<___ZerocopyRawEnum #ty_generics> for #self_ident #ty_generics #where_clause {}
+    };
+
     let raw_enum_projections =
         derive_has_field_struct_union(&raw_enum, &raw_enum.data, zerocopy_crate);
 
     let raw_enum = quote! {
         #raw_enum
+        #invariants_eq_impl
         #raw_enum_projections
     };
 
@@ -386,9 +384,17 @@ pub(crate) fn derive_is_bit_valid(
 
             #tag_enum
 
+            // SAFETY: TODO
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+
             type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
                 { core_reexport::mem::size_of::<___ZerocopyTag>() },
             >;
+
+            // SAFETY: TODO
+            unsafe impl #impl_generics #zerocopy_crate::pointer::InvariantsEq<___ZerocopyTag> for #self_ident #ty_generics #where_clause {}
 
             #tag_consts
 
@@ -404,63 +410,25 @@ pub(crate) fn derive_is_bit_valid(
             #(#has_fields)*
 
             let tag = {
-                // SAFETY:
-                // - The provided cast addresses a subset of the bytes addressed
-                //   by `candidate` because it addresses the starting tag of the
-                //   enum.
-                // - Because the pointer is cast from `candidate`, it has the
-                //   same provenance as it.
-                // - There are no `UnsafeCell`s in the tag because it is a
-                //   primitive integer.
-                let tag_ptr = unsafe {
-                    candidate.reborrow().cast_unsized_unchecked(|p: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
-                        p.cast_sized::<___ZerocopyTagPrimitive>()
-                    })
-                };
-                // SAFETY: `tag_ptr` is casted from `candidate`, whose referent
-                // is `Initialized`. Since we have not written uninitialized
-                // bytes into the referent, `tag_ptr` is also `Initialized`.
-                let tag_ptr = unsafe { tag_ptr.assume_initialized() };
+                let tag_ptr = candidate.reborrow().cast::<
+                    ___ZerocopyTag,
+                    #zerocopy_crate::pointer::cast::CastSized,
+                    #zerocopy_crate::pointer::BecauseInvariantsEq
+                >().cast::<
+                    ___ZerocopyTagPrimitive,
+                    #zerocopy_crate::pointer::cast::CastSized,
+                    _
+                >();
                 tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
             };
 
-            // SAFETY:
-            // - The raw enum has the same fields in the same locations as the
-            //   input enum, and may have a lower alignment. This guarantees
-            //   that it addresses a subset of the bytes addressed by
-            //   `candidate`.
-            // - The returned pointer is cast from `p`, and so has the same
-            //   provenance as `p`.
-            // - The raw enum has the same types at the same locations as the
-            //   original enum, and so preserves the locations of any
-            //   `UnsafeCell`s.
-            let raw_enum = unsafe {
-                candidate.cast_unsized_unchecked(|p: #zerocopy_crate::pointer::PtrInner<'_, Self>| {
-                    p.cast_sized::<___ZerocopyRawEnum #ty_generics>()
-                })
-            };
-            // SAFETY: `cast_unsized_unchecked` removes the initialization
-            // invariant from `p`, so we re-assert that all of the bytes are
-            // initialized.
-            let raw_enum = unsafe { raw_enum.assume_initialized() };
+            let raw_enum = candidate.cast::<
+                ___ZerocopyRawEnum #ty_generics,
+                #zerocopy_crate::pointer::cast::CastSized,
+                #zerocopy_crate::pointer::BecauseInvariantsEq
+            >();
 
-            // SAFETY:
-            // - This projection returns a subfield of `raw_enum` using
-            //   `project`.
-            // - Because the subfield pointer is derived from `raw_enum`, it has
-            //   the same provenance.
-            // - The locations of `UnsafeCell`s in the subfield match the
-            //   locations of `UnsafeCell`s in `raw_enum`. This is because the
-            //   subfield pointer just points to a smaller portion of the
-            //   overall struct.
-            let project = #zerocopy_crate::pointer::PtrInner::project::<
-                _,
-                { #zerocopy_crate::STRUCT_VARIANT_ID },
-                { #zerocopy_crate::ident_id!(variants) }
-            >;
-            let variants = unsafe {
-                raw_enum.cast_unsized_unchecked(project)
-            };
+            let variants = raw_enum.project::<_, { #zerocopy_crate::ident_id!(variants) }>();
 
             #[allow(non_upper_case_globals)]
             match tag {

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -781,31 +781,13 @@ fn derive_has_field_struct_union(
             type Type = #ty;
 
             #[inline(always)]
-            fn project(slf: #zerocopy_crate::PtrInner<'_, Self>) -> #zerocopy_crate::PtrInner<'_, Self::Type> {
-                let slf = slf.as_non_null().as_ptr();
-                // SAFETY: `PtrInner` promises it references either a zero-sized
-                // byte range, or else will reference a byte range that is
-                // entirely contained within an allocated object. In either
-                // case, this guarantees that `(*slf).#ident` is in-bounds of
-                // `slf`.
-                let field = unsafe { #zerocopy_crate::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).#ident) };
-                // SAFETY: `PtrInner` promises it references either a zero-sized
-                // byte range, or else will reference a byte range that is
-                // entirely contained within an allocated object. In either
-                // case, this guarantees that field projection will not wrap
-                // around the address space, and so `field` will be non-null.
-                let ptr = unsafe { #zerocopy_crate::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(field) };
-                // SAFETY:
-                // 0. `ptr` addresses a subset of the bytes of
-                //    `slf`, so by invariant on `slf: PtrInner`,
-                //    if `ptr`'s referent is not zero sized,
-                //    then `ptr` has valid provenance for its
-                //    referent, which is entirely contained in
-                //    some Rust allocation, `A`.
-                // 1. By invariant on `slf: PtrInner`, if
-                //    `ptr`'s referent is not zero sized, `A` is
-                //    guaranteed to live for at least `'a`.
-                unsafe { #zerocopy_crate::PtrInner::new(ptr) }
+            unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                // SAFETY: The caller promises that `slf` is a non-null pointer
+                // whose referent is zero-sized or lives in a valid allocation.
+                // Since `#ident` is a struct or union field of `Self`, this
+                // projection preserves or shrinks the referent size, and so the
+                // resulting referent also fits in the same allocation.
+                unsafe { #zerocopy_crate::util::macro_util::core_reexport::ptr::addr_of_mut!((*slf).#ident) }
             }
         })
         .build()
@@ -849,21 +831,10 @@ fn derive_try_from_bytes_struct(
                     use #zerocopy_crate::pointer::PtrInner;
 
                     true #(&& {
-                        let project = <Self as #zerocopy_crate::HasField<
+                        let field_candidate = candidate.reborrow().project::<
                             _,
-                            { #zerocopy_crate::STRUCT_VARIANT_ID },
                             { #zerocopy_crate::ident_id!(#field_names) }
-                        >>::project;
-                        // SAFETY:
-                        // - `project` is a field projection, and so it
-                        //   addresses a subset of the bytes addressed by `slf`
-                        // - ..., and so it preserves provenance
-                        // - ..., and `*slf` is a struct, so `UnsafeCell`s exist
-                        //   at the same byte ranges in the returned pointer's
-                        //   referent as they do in `*slf`
-                        let field_candidate = unsafe {
-                            candidate.reborrow().cast_unsized_unchecked(project)
-                        };
+                        >();
 
                         <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
                     })*
@@ -914,11 +885,6 @@ fn derive_try_from_bytes_union(
                     use #zerocopy_crate::pointer::PtrInner;
 
                     false #(|| {
-                        let project = <Self as #zerocopy_crate::HasField<
-                            _,
-                            { #zerocopy_crate::UNION_VARIANT_ID },
-                            { #zerocopy_crate::ident_id!(#field_names) }
-                        >>::project;
                         // SAFETY:
                         // - `project` is a field projection, and so it
                         //   addresses a subset of the bytes addressed by `slf`
@@ -928,7 +894,11 @@ fn derive_try_from_bytes_union(
                         //   returned pointer's referent contain any
                         //   `UnsafeCell`s
                         let field_candidate = unsafe {
-                            candidate.reborrow().cast_unsized_unchecked(project)
+                            candidate.reborrow().transmute_unchecked::<
+                                _,
+                                _,
+                                #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#field_names) }>
+                            >()
                         };
 
                         <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -437,21 +437,13 @@ fn test_from_bytes_union() {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = slf.as_non_null().as_ptr();
-                            let field = unsafe {
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
                                     (* slf).a
                                 )
-                            };
-                            let ptr = unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                    field,
-                                )
-                            };
-                            unsafe { ::zerocopy::PtrInner::new(ptr) }
+
+                            }
                         }
                     }
                 };
@@ -628,948 +620,171 @@ fn test_try_from_bytes_enum() {
                 TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
             }
         } expands to {
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-            for ComplexWithGenerics<'a, { N }, X, Y>
+    #[allow(deprecated, non_local_definitions)]
+    #[automatically_derived]
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            use ::zerocopy::util::macro_util::core_reexport;
+            #[repr(u8)]
+            #[allow(dead_code, non_camel_case_types)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                { core_reexport::mem::size_of::<___ZerocopyTag>() },
+            >;
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyTag>
+            for ComplexWithGenerics<'a, N, X, Y>
             where
                 X: Deref<Target = &'a [(X, Y); N]>,
-                u8: ::zerocopy::TryFromBytes,
-                X: ::zerocopy::TryFromBytes,
-                X::Target: ::zerocopy::TryFromBytes,
-                Y::Target: ::zerocopy::TryFromBytes,
-                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                bool: ::zerocopy::TryFromBytes,
-                Y: ::zerocopy::TryFromBytes,
-                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<___ZerocopyAliasing>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
-                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+            {}
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ();
+            type ___ZerocopyInnerTag = ___ZerocopyTag;
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    u8: ::zerocopy::TryFromBytes,
+                    X: ::zerocopy::TryFromBytes,
+                    X::Target: ::zerocopy::TryFromBytes,
+                    Y::Target: ::zerocopy::TryFromBytes,
+                    [(X, Y); N]: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
-                    use ::zerocopy::util::macro_util::core_reexport;
-                    #[repr(u8)]
-                    #[allow(dead_code, non_camel_case_types)]
-                    enum ___ZerocopyTag {
-                        UnitLike,
-                        StructLike,
-                        TupleLike,
-                    }
-                    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                        { core_reexport::mem::size_of::<___ZerocopyTag>() },
-                    >;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                        as ___ZerocopyTagPrimitive;
-                    type ___ZerocopyOuterTag = ();
-                    type ___ZerocopyInnerTag = ___ZerocopyTag;
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_StructLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        u8,
-                        X,
-                        X::Target,
-                        Y::Target,
-                        [(X, Y); N],
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            u8: ::zerocopy::TryFromBytes,
-                            X: ::zerocopy::TryFromBytes,
-                            X::Target: ::zerocopy::TryFromBytes,
-                            Y::Target: ::zerocopy::TryFromBytes,
-                            [(X, Y); N]: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(5) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <[(
-                                            X,
-                                            Y,
-                                        ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(6) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            enum ẕ5 {}
-                            enum ẕ6 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).5
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).6
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_TupleLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        bool,
-                        Y,
-                        PhantomData<&'a [(X, Y); N]>,
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            bool: ::zerocopy::TryFromBytes,
-                            Y: ::zerocopy::TryFromBytes,
-                            PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <PhantomData<
-                                            &'a [(X, Y); N],
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                            }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                        __field_StructLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                        >,
-                        __field_TupleLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                        >,
-                        __nonempty: (),
                     }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕ__field_StructLike {}
-                        enum ẕ__field_TupleLike {}
-                        enum ẕ__nonempty {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_StructLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_StructLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_StructLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_TupleLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_TupleLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_TupleLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__nonempty,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__nonempty) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ();
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__nonempty
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
-                    #[repr(C)]
-                    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                        tag: ___ZerocopyOuterTag,
-                        variants: ___ZerocopyVariants<'a, N, X, Y>,
-                    }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕtag {}
-                        enum ẕvariants {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕtag,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyOuterTag;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).tag
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕvariants,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).variants
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -1578,24 +793,48 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(a) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1606,24 +845,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(b) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1634,24 +871,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(c) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1662,24 +897,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(d) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1690,24 +923,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(e) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1718,24 +949,176 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                    }
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1746,24 +1129,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(1) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1774,103 +1155,665 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(2) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
-                    let tag = {
-                        let tag_ptr = unsafe {
-                            candidate
-                                .reborrow()
-                                .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                    p.cast_sized::<___ZerocopyTagPrimitive>()
-                                })
-                        };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr
-                            .recall_validity::<_, (_, (_, _))>()
-                            .read_unaligned::<::zerocopy::BecauseImmutable>()
-                    };
-                    let raw_enum = unsafe {
-                        candidate
-                            .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>>()
-                            })
-                    };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let project = ::zerocopy::pointer::PtrInner::project::<
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_StructLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_StructLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_TupleLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__nonempty,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ();
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__nonempty
+                            )
+                        }
+                    }
+                }
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyOuterTag;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).tag
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).variants
+                            )
+                        }
+                    }
+                }
+            };
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
                         _,
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
-                    >;
-                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
-                    #[allow(non_upper_case_globals)]
-                    match tag {
-                        ___ZEROCOPY_TAG_UnitLike => true,
-                        ___ZEROCOPY_TAG_StructLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_StructLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        ___ZEROCOPY_TAG_TupleLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_TupleLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        _ => false,
-                    }
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
                 }
             }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            let tag = {
+                let tag_ptr = candidate
+                    .reborrow()
+                    .cast::<
+                        ___ZerocopyTag,
+                        ::zerocopy::pointer::cast::CastSized,
+                        ::zerocopy::pointer::BecauseInvariantsEq,
+                    >()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            #[allow(non_upper_case_globals)]
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+
         } no_build
     }
 
@@ -1886,948 +1829,171 @@ fn test_try_from_bytes_enum() {
                 TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
             }
         } expands to {
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-            for ComplexWithGenerics<'a, { N }, X, Y>
+    #[allow(deprecated, non_local_definitions)]
+    #[automatically_derived]
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            use ::zerocopy::util::macro_util::core_reexport;
+            #[repr(u32)]
+            #[allow(dead_code, non_camel_case_types)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                { core_reexport::mem::size_of::<___ZerocopyTag>() },
+            >;
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyTag>
+            for ComplexWithGenerics<'a, N, X, Y>
             where
                 X: Deref<Target = &'a [(X, Y); N]>,
-                u8: ::zerocopy::TryFromBytes,
-                X: ::zerocopy::TryFromBytes,
-                X::Target: ::zerocopy::TryFromBytes,
-                Y::Target: ::zerocopy::TryFromBytes,
-                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                bool: ::zerocopy::TryFromBytes,
-                Y: ::zerocopy::TryFromBytes,
-                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<___ZerocopyAliasing>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
-                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+            {}
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ();
+            type ___ZerocopyInnerTag = ___ZerocopyTag;
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    u8: ::zerocopy::TryFromBytes,
+                    X: ::zerocopy::TryFromBytes,
+                    X::Target: ::zerocopy::TryFromBytes,
+                    Y::Target: ::zerocopy::TryFromBytes,
+                    [(X, Y); N]: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
-                    use ::zerocopy::util::macro_util::core_reexport;
-                    #[repr(u32)]
-                    #[allow(dead_code, non_camel_case_types)]
-                    enum ___ZerocopyTag {
-                        UnitLike,
-                        StructLike,
-                        TupleLike,
-                    }
-                    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                        { core_reexport::mem::size_of::<___ZerocopyTag>() },
-                    >;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                        as ___ZerocopyTagPrimitive;
-                    type ___ZerocopyOuterTag = ();
-                    type ___ZerocopyInnerTag = ___ZerocopyTag;
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_StructLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        u8,
-                        X,
-                        X::Target,
-                        Y::Target,
-                        [(X, Y); N],
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            u8: ::zerocopy::TryFromBytes,
-                            X: ::zerocopy::TryFromBytes,
-                            X::Target: ::zerocopy::TryFromBytes,
-                            Y::Target: ::zerocopy::TryFromBytes,
-                            [(X, Y); N]: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(5) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <[(
-                                            X,
-                                            Y,
-                                        ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(6) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            enum ẕ5 {}
-                            enum ẕ6 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).5
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).6
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_TupleLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        bool,
-                        Y,
-                        PhantomData<&'a [(X, Y); N]>,
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            bool: ::zerocopy::TryFromBytes,
-                            Y: ::zerocopy::TryFromBytes,
-                            PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <PhantomData<
-                                            &'a [(X, Y); N],
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                            }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                        __field_StructLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                        >,
-                        __field_TupleLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                        >,
-                        __nonempty: (),
                     }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕ__field_StructLike {}
-                        enum ẕ__field_TupleLike {}
-                        enum ẕ__nonempty {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_StructLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_StructLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_StructLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_TupleLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_TupleLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_TupleLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__nonempty,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__nonempty) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ();
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__nonempty
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
-                    #[repr(C)]
-                    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                        tag: ___ZerocopyOuterTag,
-                        variants: ___ZerocopyVariants<'a, N, X, Y>,
-                    }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕtag {}
-                        enum ẕvariants {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕtag,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyOuterTag;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).tag
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕvariants,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).variants
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -2836,24 +2002,48 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(a) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -2864,24 +2054,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(b) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -2892,24 +2080,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(c) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -2920,24 +2106,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(d) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -2948,24 +2132,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(e) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -2976,24 +2158,176 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                    }
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -3004,24 +2338,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(1) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -3032,103 +2364,665 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(2) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
-                    let tag = {
-                        let tag_ptr = unsafe {
-                            candidate
-                                .reborrow()
-                                .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                    p.cast_sized::<___ZerocopyTagPrimitive>()
-                                })
-                        };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr
-                            .recall_validity::<_, (_, (_, _))>()
-                            .read_unaligned::<::zerocopy::BecauseImmutable>()
-                    };
-                    let raw_enum = unsafe {
-                        candidate
-                            .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>>()
-                            })
-                    };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let project = ::zerocopy::pointer::PtrInner::project::<
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_StructLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_StructLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_TupleLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__nonempty,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ();
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__nonempty
+                            )
+                        }
+                    }
+                }
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyOuterTag;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).tag
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).variants
+                            )
+                        }
+                    }
+                }
+            };
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
                         _,
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
-                    >;
-                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
-                    #[allow(non_upper_case_globals)]
-                    match tag {
-                        ___ZEROCOPY_TAG_UnitLike => true,
-                        ___ZEROCOPY_TAG_StructLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_StructLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        ___ZEROCOPY_TAG_TupleLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_TupleLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        _ => false,
-                    }
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
                 }
             }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            let tag = {
+                let tag_ptr = candidate
+                    .reborrow()
+                    .cast::<
+                        ___ZerocopyTag,
+                        ::zerocopy::pointer::cast::CastSized,
+                        ::zerocopy::pointer::BecauseInvariantsEq,
+                    >()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            #[allow(non_upper_case_globals)]
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+
         } no_build
     }
 
@@ -3144,948 +3038,171 @@ fn test_try_from_bytes_enum() {
                 TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
             }
         } expands to {
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-            for ComplexWithGenerics<'a, { N }, X, Y>
+    #[allow(deprecated, non_local_definitions)]
+    #[automatically_derived]
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            use ::zerocopy::util::macro_util::core_reexport;
+            #[repr(C)]
+            #[allow(dead_code, non_camel_case_types)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                { core_reexport::mem::size_of::<___ZerocopyTag>() },
+            >;
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyTag>
+            for ComplexWithGenerics<'a, N, X, Y>
             where
                 X: Deref<Target = &'a [(X, Y); N]>,
-                u8: ::zerocopy::TryFromBytes,
-                X: ::zerocopy::TryFromBytes,
-                X::Target: ::zerocopy::TryFromBytes,
-                Y::Target: ::zerocopy::TryFromBytes,
-                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                bool: ::zerocopy::TryFromBytes,
-                Y: ::zerocopy::TryFromBytes,
-                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                fn is_bit_valid<___ZerocopyAliasing>(
-                    mut candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
-                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+            {}
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            #[allow(non_upper_case_globals)]
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ___ZerocopyTag;
+            type ___ZerocopyInnerTag = ();
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
-                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    u8: ::zerocopy::TryFromBytes,
+                    X: ::zerocopy::TryFromBytes,
+                    X::Target: ::zerocopy::TryFromBytes,
+                    Y::Target: ::zerocopy::TryFromBytes,
+                    [(X, Y); N]: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
-                    use ::zerocopy::util::macro_util::core_reexport;
-                    #[repr(C)]
-                    #[allow(dead_code, non_camel_case_types)]
-                    enum ___ZerocopyTag {
-                        UnitLike,
-                        StructLike,
-                        TupleLike,
-                    }
-                    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                        { core_reexport::mem::size_of::<___ZerocopyTag>() },
-                    >;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                        as ___ZerocopyTagPrimitive;
-                    #[allow(non_upper_case_globals)]
-                    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                        as ___ZerocopyTagPrimitive;
-                    type ___ZerocopyOuterTag = ___ZerocopyTag;
-                    type ___ZerocopyInnerTag = ();
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_StructLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        u8,
-                        X,
-                        X::Target,
-                        Y::Target,
-                        [(X, Y); N],
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            u8: ::zerocopy::TryFromBytes,
-                            X: ::zerocopy::TryFromBytes,
-                            X::Target: ::zerocopy::TryFromBytes,
-                            Y::Target: ::zerocopy::TryFromBytes,
-                            [(X, Y); N]: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(5) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <[(
-                                            X,
-                                            Y,
-                                        ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(6) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            enum ẕ5 {}
-                            enum ẕ6 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
                             }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).5
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <core_reexport::marker::PhantomData<
                                     ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).6
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
                             }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    struct ___ZerocopyVariantStruct_TupleLike<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    >(
-                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                        bool,
-                        Y,
-                        PhantomData<&'a [(X, Y); N]>,
-                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                    )
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>;
-                    const _: () = {
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::TryFromBytes
-                        for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                            core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >: ::zerocopy::TryFromBytes,
-                            bool: ::zerocopy::TryFromBytes,
-                            Y: ::zerocopy::TryFromBytes,
-                            PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                            core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >: ::zerocopy::TryFromBytes,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            fn is_bit_valid<___ZerocopyAliasing>(
-                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                            where
-                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                            {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
-                                true
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(0) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(1) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(2) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                            field_candidate,
-                                        )
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(3) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <PhantomData<
-                                            &'a [(X, Y); N],
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                                    && {
-                                        let project = <Self as ::zerocopy::HasField<
-                                            _,
-                                            { ::zerocopy::STRUCT_VARIANT_ID },
-                                            { ::zerocopy::ident_id!(4) },
-                                        >>::project;
-                                        let field_candidate = unsafe {
-                                            candidate.reborrow().cast_unsized_unchecked(project)
-                                        };
-                                        <core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                                    }
-                            }
-                        }
-                        #[allow(non_camel_case_types)]
-                        const _: () = {
-                            enum ẕ0 {}
-                            enum ẕ1 {}
-                            enum ẕ2 {}
-                            enum ẕ3 {}
-                            enum ẕ4 {}
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).0
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).1
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).2
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).3
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                            #[allow(deprecated, non_local_definitions)]
-                            #[automatically_derived]
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::PtrInner<'_, Self>,
-                                ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                    let slf = slf.as_non_null().as_ptr();
-                                    let field = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                            (* slf).4
-                                        )
-                                    };
-                                    let ptr = unsafe {
-                                        ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                            field,
-                                        )
-                                    };
-                                    unsafe { ::zerocopy::PtrInner::new(ptr) }
-                                }
-                            }
-                        };
-                    };
-                    #[repr(C)]
-                    #[allow(non_snake_case)]
-                    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                        __field_StructLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                        >,
-                        __field_TupleLike: core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                        >,
-                        __nonempty: (),
                     }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕ__field_StructLike {}
-                        enum ẕ__field_TupleLike {}
-                        enum ẕ__nonempty {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_StructLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_StructLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_StructLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__field_TupleLike,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__field_TupleLike) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__field_TupleLike
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕ__nonempty,
-                            { ::zerocopy::UNION_VARIANT_ID },
-                            { ::zerocopy::ident_id!(__nonempty) },
-                        > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ();
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).__nonempty
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
-                    #[repr(C)]
-                    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                        tag: ___ZerocopyOuterTag,
-                        variants: ___ZerocopyVariants<'a, N, X, Y>,
-                    }
-                    #[allow(non_camel_case_types)]
-                    const _: () = {
-                        enum ẕtag {}
-                        enum ẕvariants {}
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕtag,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyOuterTag;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).tag
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                        #[allow(deprecated, non_local_definitions)]
-                        #[automatically_derived]
-                        unsafe impl<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        > ::zerocopy::HasField<
-                            ẕvariants,
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::PtrInner<'_, Self>,
-                            ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                                let slf = slf.as_non_null().as_ptr();
-                                let field = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).variants
-                                    )
-                                };
-                                let ptr = unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::NonNull::new_unchecked(
-                                        field,
-                                    )
-                                };
-                                unsafe { ::zerocopy::PtrInner::new(ptr) }
-                            }
-                        }
-                    };
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -4094,24 +3211,48 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(a) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4122,24 +3263,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(b) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4150,24 +3289,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(c) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4178,24 +3315,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(d) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4206,24 +3341,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(StructLike) },
-                        { ::zerocopy::ident_id!(e) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_StructLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4234,24 +3367,176 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            const _: () = {
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        use ::zerocopy::util::macro_util::core_reexport;
+                        use ::zerocopy::pointer::PtrInner;
+                        true
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                            && {
+                                let field_candidate = candidate.reborrow().project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            }
+                    }
+                }
+                #[allow(non_camel_case_types)]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
+                            }
+                        }
+                    }
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4262,24 +3547,22 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(1) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
+                            }
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -4290,103 +3573,665 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        (),
-                        { ::zerocopy::ident_id!(TupleLike) },
-                        { ::zerocopy::ident_id!(2) },
-                    > for ComplexWithGenerics<'a, { N }, X, Y>
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::PtrInner<'_, Self>,
-                        ) -> ::zerocopy::PtrInner<'_, Self::Type> {
-                            let slf = unsafe { slf.cast::<___ZerocopyRawEnum<'a, N, X, Y>>() };
-                            slf.project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) }>()
-                                .project::<_, { ::zerocopy::UNION_VARIANT_ID }, { ::zerocopy::ident_id!(__field_TupleLike) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(value) }>()
-                                .project::<_, { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3) }>()
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
+                            }
                         }
                     }
-                    let tag = {
-                        let tag_ptr = unsafe {
-                            candidate
-                                .reborrow()
-                                .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                    p.cast_sized::<___ZerocopyTagPrimitive>()
-                                })
-                        };
-                        let tag_ptr = unsafe { tag_ptr.assume_initialized() };
-                        tag_ptr
-                            .recall_validity::<_, (_, (_, _))>()
-                            .read_unaligned::<::zerocopy::BecauseImmutable>()
-                    };
-                    let raw_enum = unsafe {
-                        candidate
-                            .cast_unsized_unchecked(|p: ::zerocopy::pointer::PtrInner<'_, Self>| {
-                                p.cast_sized::<___ZerocopyRawEnum<'a, N, X, Y>>()
-                            })
-                    };
-                    let raw_enum = unsafe { raw_enum.assume_initialized() };
-                    let project = ::zerocopy::pointer::PtrInner::project::<
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<
+                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+            > for ___ZerocopyVariants<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[repr(C)]
+            #[allow(non_snake_case)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_StructLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_StructLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = core_reexport::mem::ManuallyDrop<
+                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                    >;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__field_TupleLike
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕ__nonempty,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ();
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).__nonempty
+                            )
+                        }
+                    }
+                }
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(non_camel_case_types)]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyOuterTag;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).tag
+                            )
+                        }
+                    }
+                }
+                #[allow(deprecated, non_local_definitions)]
+                #[automatically_derived]
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                    #[inline(always)]
+                    unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                        unsafe {
+                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                (* slf).variants
+                            )
+                        }
+                    }
+                }
+            };
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
                         _,
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
-                    >;
-                    let variants = unsafe { raw_enum.cast_unsized_unchecked(project) };
-                    #[allow(non_upper_case_globals)]
-                    match tag {
-                        ___ZEROCOPY_TAG_UnitLike => true,
-                        ___ZEROCOPY_TAG_StructLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_StructLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        ___ZEROCOPY_TAG_TupleLike => {
-                            let variant = unsafe {
-                                variants
-                                    .cast_unsized_unchecked(|
-                                        p: ::zerocopy::pointer::PtrInner<
-                                            '_,
-                                            ___ZerocopyVariants<'a, N, X, Y>,
-                                        >|
-                                    {
-                                        p.cast_sized::<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >()
-                                    })
-                            };
-                            let variant = unsafe { variant.assume_initialized() };
-                            <___ZerocopyVariantStruct_TupleLike<
-                                'a,
-                                N,
-                                X,
-                                Y,
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                        }
-                        _ => false,
-                    }
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
                 }
             }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            #[allow(deprecated, non_local_definitions)]
+            #[automatically_derived]
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            > for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                unsafe fn project(slf: *mut Self) -> *mut Self::Type {
+                    let slf = slf as *mut ___ZerocopyRawEnum<'a, N, X, Y>;
+                    let slf = <___ZerocopyRawEnum<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(value) },
+                    >>::project(slf);
+                    let slf = <_ as ::zerocopy::HasField<
+                        _,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    >>::project(slf);
+                    slf
+                }
+            }
+            let tag = {
+                let tag_ptr = candidate
+                    .reborrow()
+                    .cast::<
+                        ___ZerocopyTag,
+                        ::zerocopy::pointer::cast::CastSized,
+                        ::zerocopy::pointer::BecauseInvariantsEq,
+                    >()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            #[allow(non_upper_case_globals)]
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant = variants
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+
         } no_build
     }
 }

--- a/zerocopy-derive/tests/include.rs
+++ b/zerocopy-derive/tests/include.rs
@@ -123,7 +123,8 @@ pub mod util {
 
         // SAFETY: `T` and `MaybeUninit<T>` have the same layout, so this is a
         // size-preserving cast. It is also a provenance-preserving cast.
-        let ptr = unsafe { ptr.cast_unsized_unchecked(|p| p.cast_sized()) };
+        let ptr =
+            unsafe { ptr.transmute_unchecked::<_, _, ::zerocopy::pointer::cast::CastSized>() };
         assert!(<T as super::imp::TryFromBytes>::is_bit_valid(ptr));
     }
 }

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -315,9 +315,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              ()
              *const T
              *mut T
+             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
+             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyTag
              F32<O>
-             F64<O>
-             I128<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -339,9 +339,9 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              ()
              *const T
              *mut T
+             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
+             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyTag
              F32<O>
-             F64<O>
-             I128<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -367,12 +367,14 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
              *const T
              *mut T
              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+             ___ZerocopyVariantStruct_A
              AtomicBool
              AtomicI16
              AtomicI32
            and $N others
    = help: see issue #48214
+   = note: the full name for the type has been written to '$DIR/target/by-toolchain/nightly/tests/trybuild/x86_64-unknown-linux-gnu/debug/deps/$CRATE-bdab6aa76df77861.long-type-3677111104590332862.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -396,12 +398,14 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               *const T
               *mut T
               <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
+              ___ZerocopyVariantStruct_A
               AtomicBool
               AtomicI16
               AtomicI32
             and $N others
     = help: see issue #48214
+    = note: the full name for the type has been written to '$DIR/target/by-toolchain/nightly/tests/trybuild/x86_64-unknown-linux-gnu/debug/deps/$CRATE-bdab6aa76df77861.long-type-3677111104590332862.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -301,9 +301,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              ()
              *const T
              *mut T
+             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
+             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyTag
              F32<O>
-             F64<O>
-             I128<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -321,9 +321,9 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              ()
              *const T
              *mut T
+             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
+             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyTag
              F32<O>
-             F64<O>
-             I128<O>
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -73,7 +73,13 @@ fn two_bad() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p.cast::<Two>()) };
+    let candidate = {
+        ::zerocopy::define_cast!(unsafe { CastToTwo = [u8] => Two });
+        unsafe {
+            candidate
+                .transmute_unchecked::<Two, ::zerocopy::pointer::invariant::Uninit, CastToTwo>()
+        }
+    };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -102,7 +108,12 @@ fn bool_and_zst() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate = unsafe { candidate.cast_unsized_unchecked(|p| p.cast::<BoolAndZst>()) };
+    let candidate = {
+        ::zerocopy::define_cast!(unsafe { CastToBoolAndZst = [u8] => BoolAndZst });
+        unsafe {
+            candidate.transmute_unchecked::<BoolAndZst, ::zerocopy::pointer::invariant::Uninit, CastToBoolAndZst>()
+        }
+    };
 
     // SAFETY: `candidate`'s referent is fully initialized.
     let candidate = unsafe { candidate.assume_initialized() };
@@ -131,8 +142,12 @@ fn test_maybe_from_bytes() {
     //   the same bytes as `c`.
     // - The cast preserves provenance.
     // - Neither the input nor output types contain any `UnsafeCell`s.
-    let candidate =
-        unsafe { candidate.cast_unsized_unchecked(|p| p.cast::<MaybeFromBytes<bool>>()) };
+    let candidate = {
+        ::zerocopy::define_cast!(unsafe { CastToMaybeFromBytes = [u8] => MaybeFromBytes<bool> });
+        unsafe {
+            candidate.transmute_unchecked::<MaybeFromBytes<bool>, ::zerocopy::pointer::invariant::Uninit, CastToMaybeFromBytes>()
+        }
+    };
 
     // SAFETY: `[u8]` consists entirely of initialized bytes.
     let candidate = unsafe { candidate.assume_initialized() };


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Add `unsafe trait Project` and `unsafe trait Cast: Project`. `Cast` is
implemented for any address-preserving cast, while `Project` generalizes
to conversions which may not preserve the address of the referent (ie,
field projections). Use these (mostly `Cast`, but some `Project`) to
unify `PtrInner`/`Ptr` casts, field projections, and `SizeEq` casts.
Replace a good amount of unsafe derive-generated code with uses of this
machinery.

Makes progress on #196
Closes #2856




---

- #2854


**Latest Update:** v54 — [Compare vs v53](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 | v7 | v8 | v9 | v10 | v11 | v12 | v13 | v14 | v15 | v16 | v17 | v18 | v19 | v20 | v21 | v22 | v23 | v24 | v25 | v26 | v27 | v28 | v29 | v30 | v31 | v32 | v33 | v34 | v35 | v36 | v37 | v38 | v39 | v40 | v41 | v42 | v43 | v44 | v45 | v46 | v47 | v48 | v49 | v50 | v51 | v52 | v53 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v54 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v49](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v50](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v51](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v52](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) | [v53](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v54) |
| v53 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v49](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v50](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v51](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | [v52](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v53) | |
| v52 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v49](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v50](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | [v51](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v52) | | |
| v51 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v49](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | [v50](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v51) | | | |
| v50 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | [v49](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v50) | | | | |
| v49 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | [v48](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v49) | | | | | |
| v48 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | [v47](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v48) | | | | | | |
| v47 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | [v46](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v47) | | | | | | | |
| v46 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | [v45](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v46) | | | | | | | | |
| v45 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | [v44](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v45) | | | | | | | | | |
| v44 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | [v43](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v44) | | | | | | | | | | |
| v43 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | [v42](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v43) | | | | | | | | | | | |
| v42 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | [v41](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v42) | | | | | | | | | | | | |
| v41 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | [v40](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v41) | | | | | | | | | | | | | |
| v40 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | [v39](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v40) | | | | | | | | | | | | | | |
| v39 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | [v38](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v39) | | | | | | | | | | | | | | | |
| v38 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | [v37](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v38) | | | | | | | | | | | | | | | | |
| v37 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | [v36](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v37) | | | | | | | | | | | | | | | | | |
| v36 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | [v35](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v36) | | | | | | | | | | | | | | | | | | |
| v35 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | [v34](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v35) | | | | | | | | | | | | | | | | | | | |
| v34 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | [v33](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v34) | | | | | | | | | | | | | | | | | | | | |
| v33 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | [v32](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v33) | | | | | | | | | | | | | | | | | | | | | |
| v32 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | [v31](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v32) | | | | | | | | | | | | | | | | | | | | | | |
| v31 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | [v30](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v31) | | | | | | | | | | | | | | | | | | | | | | | |
| v30 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | [v29](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v30) | | | | | | | | | | | | | | | | | | | | | | | | |
| v29 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | [v28](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v29) | | | | | | | | | | | | | | | | | | | | | | | | | |
| v28 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | [v27](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v28) | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v27 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | [v26](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v27) | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v26 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | [v25](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v26) | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v25 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | [v24](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v25) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v24 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | [v23](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v24) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v23 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | [v22](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v23) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v22 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | [v21](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v22) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v21 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | [v20](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v21) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v20 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | [v19](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v20) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v19 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | [v18](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v19) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v18 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | [v17](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v18) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v17 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | [v16](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v17) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v16 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | [v15](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v16) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v15 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | [v14](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v15) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v14 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | [v13](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v14) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v13 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | [v12](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v13) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v12 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | [v11](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v12) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v11 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | [v10](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v11) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v10 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | [v9](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v10) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v9 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | [v8](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v9) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v8 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | [v7](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v8) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v7 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | [v6](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v7) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v6 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | [v5](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v6) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v5 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5) | [v4](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v5) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v4 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4) | [v3](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v4) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v3 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3) | [v2](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v3) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v2 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2) | [v1](https://github.com/google/zerocopy/pull/2854/compare/gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v2) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |
| v1 | [Base](https://github.com/google/zerocopy/pull/2854/compare/main..gherrit/G57b42ad4ff767a765f9b4ac149aa1c19d3796711/v1) | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G57b42ad4ff767a765f9b4ac149aa1c19d3796711", "parent": null, "child": null} -->