### PR TITLE
Generate trait implementations for tuples

### DIFF
--- a/tests/ui-nightly/diagnostic-not-implemented-from-bytes.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-from-bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_from_bytes`
   --> tests/ui-nightly/diagnostic-not-implemented-from-bytes.rs:21:24

--- a/tests/ui-nightly/diagnostic-not-implemented-from-zeros.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-from-zeros.stderr
@@ -12,13 +12,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_from_zeros`
   --> tests/ui-nightly/diagnostic-not-implemented-from-zeros.rs:21:24

--- a/tests/ui-nightly/diagnostic-not-implemented-immutable.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-immutable.stderr
@@ -14,11 +14,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `takes_immutable`
   --> tests/ui-nightly/diagnostic-not-implemented-immutable.rs:21:23

--- a/tests/ui-nightly/diagnostic-not-implemented-try-from-bytes.stderr
+++ b/tests/ui-nightly/diagnostic-not-implemented-try-from-bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_try_from_bytes`
   --> tests/ui-nightly/diagnostic-not-implemented-try-from-bytes.rs:21:28

--- a/tests/ui-nightly/include_value_not_from_bytes.stderr
+++ b/tests/ui-nightly/include_value_not_from_bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy<u32>`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> tests/ui-nightly/include_value_not_from_bytes.rs:19:42

--- a/tests/ui-nightly/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-dst-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> tests/ui-nightly/transmute-dst-not-frombytes.rs:19:41

--- a/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-dst-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-mut-src-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Src`
     = note: Consider adding `#[derive(FromBytes)]` to `Src`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-frombytes.stderr
@@ -15,13 +15,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `Dst`
    = note: Consider adding `#[derive(FromBytes)]` to `Dst`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-nightly/transmute-ref-dst-not-frombytes.rs:23:34

--- a/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-dst-not-nocell.stderr
@@ -17,11 +17,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Dst`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertDstIsImmutable`
   --> tests/ui-nightly/transmute-ref-dst-not-nocell.rs:23:33

--- a/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-nightly/transmute-ref-src-not-nocell.stderr
@@ -17,11 +17,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Src`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34
@@ -46,11 +46,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Src`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-nightly/transmute-ref-src-not-nocell.rs:23:34

--- a/tests/ui-nightly/try_transmute-dst-not-tryfrombytes.stderr
+++ b/tests/ui-nightly/try_transmute-dst-not-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute`
    --> src/util/macro_util.rs
@@ -72,13 +72,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-nightly/try_transmute_mut-dst-not-tryfrombytes.stderr
+++ b/tests/ui-nightly/try_transmute_mut-dst-not-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute_mut`
    --> src/util/macro_util.rs
@@ -104,13 +104,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-nightly/try_transmute_mut-src-not-frombytes.stderr
+++ b/tests/ui-nightly/try_transmute_mut-src-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Src`
     = note: Consider adding `#[derive(FromBytes)]` to `Src`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs
@@ -44,13 +44,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-nightly/try_transmute_mut-src-not-intobytes.stderr
+++ b/tests/ui-nightly/try_transmute_mut-src-not-intobytes.stderr
@@ -44,13 +44,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-nightly/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
+++ b/tests/ui-nightly/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs
@@ -74,11 +74,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
               &T
               &mut T
               ()
-              *const T
-              *mut T
-              AU16
-              Box<T>
-              F32<O>
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs
@@ -104,13 +104,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-nightly/try_transmute_ref-src-not-immutable-intobytes.stderr
+++ b/tests/ui-nightly/try_transmute_ref-src-not-immutable-intobytes.stderr
@@ -46,11 +46,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy<AU16>`
               &T
               &mut T
               ()
-              *const T
-              *mut T
-              AU16
-              Box<T>
-              F32<O>
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs

--- a/tests/ui-stable/diagnostic-not-implemented-from-bytes.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-from-bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_from_bytes`
   --> tests/ui-stable/diagnostic-not-implemented-from-bytes.rs:21:24

--- a/tests/ui-stable/diagnostic-not-implemented-from-zeros.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-from-zeros.stderr
@@ -12,13 +12,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_from_zeros`
   --> tests/ui-stable/diagnostic-not-implemented-from-zeros.rs:21:24

--- a/tests/ui-stable/diagnostic-not-implemented-immutable.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-immutable.stderr
@@ -14,11 +14,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `takes_immutable`
   --> tests/ui-stable/diagnostic-not-implemented-immutable.rs:21:23

--- a/tests/ui-stable/diagnostic-not-implemented-try-from-bytes.stderr
+++ b/tests/ui-stable/diagnostic-not-implemented-try-from-bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `takes_try_from_bytes`
   --> tests/ui-stable/diagnostic-not-implemented-try-from-bytes.rs:21:28

--- a/tests/ui-stable/include_value_not_from_bytes.stderr
+++ b/tests/ui-stable/include_value_not_from_bytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy<u32>`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy<u32>`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> tests/ui-stable/include_value_not_from_bytes.rs:19:42

--- a/tests/ui-stable/transmute-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-dst-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> tests/ui-stable/transmute-dst-not-frombytes.rs:19:41

--- a/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-dst-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-mut-src-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Src`
     = note: Consider adding `#[derive(FromBytes)]` to `Src`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-frombytes.stderr
@@ -15,13 +15,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `Dst`
    = note: Consider adding `#[derive(FromBytes)]` to `Dst`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required by a bound in `AssertDstIsFromBytes`
   --> tests/ui-stable/transmute-ref-dst-not-frombytes.rs:23:34

--- a/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-dst-not-nocell.stderr
@@ -17,11 +17,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Dst`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertDstIsImmutable`
   --> tests/ui-stable/transmute-ref-dst-not-nocell.rs:23:33

--- a/tests/ui-stable/transmute-ref-src-not-nocell.stderr
+++ b/tests/ui-stable/transmute-ref-src-not-nocell.stderr
@@ -17,11 +17,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Src`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34
@@ -46,11 +46,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `Src`
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             Box<T>
-             F32<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
 note: required by a bound in `AssertSrcIsImmutable`
   --> tests/ui-stable/transmute-ref-src-not-nocell.rs:23:34

--- a/tests/ui-stable/try_transmute-dst-not-tryfrombytes.stderr
+++ b/tests/ui-stable/try_transmute-dst-not-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute`
    --> src/util/macro_util.rs
@@ -72,13 +72,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-stable/try_transmute_mut-dst-not-tryfrombytes.stderr
+++ b/tests/ui-stable/try_transmute_mut-dst-not-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute_mut`
    --> src/util/macro_util.rs
@@ -104,13 +104,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-stable/try_transmute_mut-src-not-frombytes.stderr
+++ b/tests/ui-stable/try_transmute_mut-src-not-frombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `FromBytes` is not implemented for `Src`
     = note: Consider adding `#[derive(FromBytes)]` to `Src`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs
@@ -44,13 +44,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-stable/try_transmute_mut-src-not-intobytes.stderr
+++ b/tests/ui-stable/try_transmute_mut-src-not-intobytes.stderr
@@ -44,13 +44,13 @@ help: the trait `FromBytes` is not implemented for `Dst`
     = note: Consider adding `#[derive(FromBytes)]` to `Dst`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs

--- a/tests/ui-stable/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
+++ b/tests/ui-stable/try_transmute_ref-dst-not-immutable-tryfrombytes.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs
@@ -40,13 +40,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs
@@ -74,11 +74,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy`
               &T
               &mut T
               ()
-              *const T
-              *mut T
-              AU16
-              Box<T>
-              F32<O>
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs
@@ -104,13 +104,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
     = help: the following other types implement trait `zerocopy::TryFromBytes`:
               ()
-              *const T
-              *mut T
-              AU16
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required by a bound in `ValidityError`
    --> src/error.rs

--- a/tests/ui-stable/try_transmute_ref-src-not-immutable-intobytes.stderr
+++ b/tests/ui-stable/try_transmute_ref-src-not-immutable-intobytes.stderr
@@ -46,11 +46,11 @@ help: the trait `zerocopy::Immutable` is not implemented for `NotZerocopy<AU16>`
               &T
               &mut T
               ()
-              *const T
-              *mut T
-              AU16
-              Box<T>
-              F32<O>
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
             and $N others
 note: required by a bound in `try_transmute_ref`
    --> src/util/macro_util.rs

--- a/tools/update-ui-test-files.sh
+++ b/tools/update-ui-test-files.sh
@@ -12,12 +12,12 @@
 
 set -e
 
-TRYBUILD=overwrite ./cargo.sh +nightly test ui --test trybuild -p zerocopy --all-features
-TRYBUILD=overwrite ./cargo.sh +stable  test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
+TRYBUILD=overwrite ./cargo.sh +nightly test ui --verbose --test trybuild -p zerocopy --all-features
+TRYBUILD=overwrite ./cargo.sh +stable  test ui --verbose --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
 # For developers using Rust Analyzer, it's often the case that Rust Analyzer has
 # chosen versions of dependencies (especially syn) which have an MSRV higher than
 # our own. Doing `rm Cargo.lock` here permits `./cargo.sh +msrv` to choose its own
 # versions of these crates that have a lower MSRV.
-rm Cargo.lock && TRYBUILD=overwrite ./cargo.sh +msrv    test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
+rm Cargo.lock && TRYBUILD=overwrite ./cargo.sh +msrv test ui --verbose --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
 
-TRYBUILD=overwrite ./cargo.sh +all test ui --test trybuild -p zerocopy-derive
+TRYBUILD=overwrite ./cargo.sh +all test ui --verbose --test trybuild -p zerocopy-derive

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -897,15 +897,11 @@ fn derive_try_from_bytes_struct(
                 where
                     ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
                 {
-                    use #zerocopy_crate::util::macro_util::core_reexport;
-                    use #zerocopy_crate::pointer::PtrInner;
-
                     true #(&& {
                         let field_candidate = candidate.reborrow().project::<
                             _,
                             { #zerocopy_crate::ident_id!(#field_names) }
                         >();
-
                         <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
                     })*
                 }

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -309,8 +309,6 @@ fn test_try_from_bytes() {
                 where
                     ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
-                    use ::zerocopy::util::macro_util::core_reexport;
-                    use ::zerocopy::pointer::PtrInner;
                     true
                 }
             }
@@ -334,8 +332,6 @@ fn test_from_zeros() {
                 where
                     ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
-                    use ::zerocopy::util::macro_util::core_reexport;
-                    use ::zerocopy::pointer::PtrInner;
                     true
                 }
             }
@@ -625,223 +621,871 @@ fn test_try_from_bytes_enum() {
                 TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
             }
         } expands to {
-    #[allow(deprecated, non_local_definitions)]
-    #[automatically_derived]
-    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-    for ComplexWithGenerics<'a, { N }, X, Y>
-    where
-        X: Deref<Target = &'a [(X, Y); N]>,
-        u8: ::zerocopy::TryFromBytes,
-        X: ::zerocopy::TryFromBytes,
-        X::Target: ::zerocopy::TryFromBytes,
-        Y::Target: ::zerocopy::TryFromBytes,
-        [(X, Y); N]: ::zerocopy::TryFromBytes,
-        bool: ::zerocopy::TryFromBytes,
-        Y: ::zerocopy::TryFromBytes,
-        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-    {
-        fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid<___ZerocopyAliasing>(
-            candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-        where
-            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-        {
-            use ::zerocopy::util::macro_util::core_reexport;
-            #[repr(u8)]
-            #[allow(dead_code, non_camel_case_types)]
-            enum ___ZerocopyTag {
-                UnitLike,
-                StructLike,
-                TupleLike,
-            }
-            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-            }
-            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                { core_reexport::mem::size_of::<___ZerocopyTag>() },
-            >;
-            #[allow(non_upper_case_globals)]
-            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                as ___ZerocopyTagPrimitive;
-            #[allow(non_upper_case_globals)]
-            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                as ___ZerocopyTagPrimitive;
-            #[allow(non_upper_case_globals)]
-            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                as ___ZerocopyTagPrimitive;
-            type ___ZerocopyOuterTag = ();
-            type ___ZerocopyInnerTag = ___ZerocopyTag;
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::STRUCT_VARIANT_ID },
-                { ::zerocopy::ident_id!(tag) },
-            > for ___ZerocopyRawEnum<'a, N, X, Y> {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = ___ZerocopyTag;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    slf.as_ptr().cast()
-                }
-            }
-            #[repr(C)]
-            #[allow(non_snake_case)]
-            struct ___ZerocopyVariantStruct_StructLike<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            >(
-                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                u8,
-                X,
-                X::Target,
-                Y::Target,
-                [(X, Y); N],
-                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-            )
-            where
-                X: Deref<Target = &'a [(X, Y); N]>;
             #[allow(deprecated, non_local_definitions)]
             #[automatically_derived]
-            const _: () = {
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                unsafe impl<
-                    'a: 'static,
-                    const N: usize,
-                    X,
-                    Y: Deref,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+            for ComplexWithGenerics<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+                u8: ::zerocopy::TryFromBytes,
+                X: ::zerocopy::TryFromBytes,
+                X::Target: ::zerocopy::TryFromBytes,
+                Y::Target: ::zerocopy::TryFromBytes,
+                [(X, Y); N]: ::zerocopy::TryFromBytes,
+                bool: ::zerocopy::TryFromBytes,
+                Y: ::zerocopy::TryFromBytes,
+                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                fn is_bit_valid<___ZerocopyAliasing>(
+                    candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                 where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    u8: ::zerocopy::TryFromBytes,
-                    X: ::zerocopy::TryFromBytes,
-                    X::Target: ::zerocopy::TryFromBytes,
-                    Y::Target: ::zerocopy::TryFromBytes,
-                    [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
+                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                 {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid<___ZerocopyAliasing>(
-                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                    {
-                        use ::zerocopy::util::macro_util::core_reexport;
-                        use ::zerocopy::pointer::PtrInner;
-                        true
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                <core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(5) }>();
-                                <[(
-                                    X,
-                                    Y,
-                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(6) }>();
-                                <core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                            }
+                    use ::zerocopy::util::macro_util::core_reexport;
+                    #[repr(u8)]
+                    #[allow(dead_code, non_camel_case_types)]
+                    enum ___ZerocopyTag {
+                        UnitLike,
+                        StructLike,
+                        TupleLike,
                     }
-                }
-                #[allow(non_camel_case_types)]
-                const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    enum ẕ5 {}
-                    enum ẕ6 {}
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                    }
+                    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                        { core_reexport::mem::size_of::<___ZerocopyTag>() },
+                    >;
+                    #[allow(non_upper_case_globals)]
+                    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                        as ___ZerocopyTagPrimitive;
+                    #[allow(non_upper_case_globals)]
+                    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                        as ___ZerocopyTagPrimitive;
+                    #[allow(non_upper_case_globals)]
+                    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                        as ___ZerocopyTagPrimitive;
+                    type ___ZerocopyOuterTag = ();
+                    type ___ZerocopyInnerTag = ___ZerocopyTag;
                     unsafe impl<
                         'a: 'static,
                         const N: usize,
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ0,
+                        (),
                         { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(0) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>,
-                    {
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, N, X, Y> {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                        type Type = ___ZerocopyTag;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).0
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            slf.as_ptr().cast()
                         }
                     }
+                    #[repr(C)]
+                    #[allow(non_snake_case)]
+                    struct ___ZerocopyVariantStruct_StructLike<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    >(
+                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                        u8,
+                        X,
+                        X::Target,
+                        Y::Target,
+                        [(X, Y); N],
+                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+                    )
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>;
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    const _: () = {
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::TryFromBytes
+                        for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                            core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >: ::zerocopy::TryFromBytes,
+                            u8: ::zerocopy::TryFromBytes,
+                            X: ::zerocopy::TryFromBytes,
+                            X::Target: ::zerocopy::TryFromBytes,
+                            Y::Target: ::zerocopy::TryFromBytes,
+                            [(X, Y); N]: ::zerocopy::TryFromBytes,
+                            core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >: ::zerocopy::TryFromBytes,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            fn is_bit_valid<___ZerocopyAliasing>(
+                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                            where
+                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                            {
+                                true
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                        <core_reexport::mem::MaybeUninit<
+                                            ___ZerocopyInnerTag,
+                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                        <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                        <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                        <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                        <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(5) }>();
+                                        <[(
+                                            X,
+                                            Y,
+                                        ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(6) }>();
+                                        <core_reexport::marker::PhantomData<
+                                            ComplexWithGenerics<'a, N, X, Y>,
+                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                                    }
+                            }
+                        }
+                        #[allow(non_camel_case_types)]
+                        const _: () = {
+                            enum ẕ0 {}
+                            enum ẕ1 {}
+                            enum ẕ2 {}
+                            enum ẕ3 {}
+                            enum ẕ4 {}
+                            enum ẕ5 {}
+                            enum ẕ6 {}
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = u8;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = X;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = X::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = Y::Target;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ5,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(5) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = [(X, Y); N];
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).5
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ6,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(6) },
+                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).6
+                                        )
+                                    }
+                                }
+                            }
+                        };
+                    };
+                    #[repr(C)]
+                    #[allow(non_snake_case)]
+                    struct ___ZerocopyVariantStruct_TupleLike<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    >(
+                        core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
+                        bool,
+                        Y,
+                        PhantomData<&'a [(X, Y); N]>,
+                        core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
+                    )
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>;
+                    #[allow(deprecated, non_local_definitions)]
+                    #[automatically_derived]
+                    const _: () = {
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::TryFromBytes
+                        for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                            core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >: ::zerocopy::TryFromBytes,
+                            bool: ::zerocopy::TryFromBytes,
+                            Y: ::zerocopy::TryFromBytes,
+                            PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                            core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >: ::zerocopy::TryFromBytes,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            fn is_bit_valid<___ZerocopyAliasing>(
+                                mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                            ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                            where
+                                ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                            {
+                                true
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                        <core_reexport::mem::MaybeUninit<
+                                            ___ZerocopyInnerTag,
+                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                        <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                        <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                            field_candidate,
+                                        )
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                        <PhantomData<
+                                            &'a [(X, Y); N],
+                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                                    }
+                                    && {
+                                        let field_candidate = candidate
+                                            .reborrow()
+                                            .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                        <core_reexport::marker::PhantomData<
+                                            ComplexWithGenerics<'a, N, X, Y>,
+                                        > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                                    }
+                            }
+                        }
+                        #[allow(non_camel_case_types)]
+                        const _: () = {
+                            enum ẕ0 {}
+                            enum ẕ1 {}
+                            enum ẕ2 {}
+                            enum ẕ3 {}
+                            enum ẕ4 {}
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).0
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = bool;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).1
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = Y;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).2
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = PhantomData<&'a [(X, Y); N]>;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).3
+                                        )
+                                    }
+                                }
+                            }
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                            where
+                                X: Deref<Target = &'a [(X, Y); N]>,
+                            {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).4
+                                        )
+                                    }
+                                }
+                            }
+                        };
+                    };
+                    #[repr(C)]
+                    #[allow(non_snake_case)]
+                    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                        __field_StructLike: core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >,
+                        __field_TupleLike: core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >,
+                        __nonempty: (),
+                    }
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕ__field_StructLike {}
+                        enum ẕ__field_TupleLike {}
+                        enum ẕ__nonempty {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        const _: () = {
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ__field_StructLike,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__field_StructLike) },
+                            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).__field_StructLike
+                                        )
+                                    }
+                                }
+                            }
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::pointer::cast::Cast<
+                                ___ZerocopyVariants<'a, N, X, Y>,
+                                core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                >,
+                            >
+                            for ::zerocopy::pointer::cast::Projection<
+                                ẕ__field_StructLike,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__field_StructLike) },
+                            > {}
+                        };
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        const _: () = {
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ__field_TupleLike,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__field_TupleLike) },
+                            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                >;
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).__field_TupleLike
+                                        )
+                                    }
+                                }
+                            }
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::pointer::cast::Cast<
+                                ___ZerocopyVariants<'a, N, X, Y>,
+                                core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                >,
+                            >
+                            for ::zerocopy::pointer::cast::Projection<
+                                ẕ__field_TupleLike,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__field_TupleLike) },
+                            > {}
+                        };
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        const _: () = {
+                            #[allow(deprecated, non_local_definitions)]
+                            #[automatically_derived]
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::HasField<
+                                ẕ__nonempty,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__nonempty) },
+                            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                                fn only_derive_is_allowed_to_implement_this_trait() {}
+                                type Type = ();
+                                #[inline(always)]
+                                fn project(
+                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                                ) -> *mut Self::Type {
+                                    let slf = slf.as_ptr();
+                                    unsafe {
+                                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                            (* slf).__nonempty
+                                        )
+                                    }
+                                }
+                            }
+                            unsafe impl<
+                                'a: 'static,
+                                const N: usize,
+                                X,
+                                Y: Deref,
+                            > ::zerocopy::pointer::cast::Cast<___ZerocopyVariants<'a, N, X, Y>, ()>
+                            for ::zerocopy::pointer::cast::Projection<
+                                ẕ__nonempty,
+                                { ::zerocopy::UNION_VARIANT_ID },
+                                { ::zerocopy::ident_id!(__nonempty) },
+                            > {}
+                        };
+                    };
+                    #[repr(C)]
+                    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                        tag: ___ZerocopyOuterTag,
+                        variants: ___ZerocopyVariants<'a, N, X, Y>,
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+                    for ComplexWithGenerics<'a, N, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {}
+                    #[allow(non_camel_case_types)]
+                    const _: () = {
+                        enum ẕtag {}
+                        enum ẕvariants {}
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(tag) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyOuterTag;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).tag
+                                    )
+                                }
+                            }
+                        }
+                        #[allow(deprecated, non_local_definitions)]
+                        #[automatically_derived]
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).variants
+                                    )
+                                }
+                            }
+                        }
+                    };
                     #[allow(deprecated, non_local_definitions)]
                     #[automatically_derived]
                     unsafe impl<
@@ -850,25 +1494,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ1,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(1) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(a) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = u8;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).1
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_StructLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(1) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -879,25 +1550,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ2,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(2) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(b) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).2
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_StructLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(2) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -908,25 +1606,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ3,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(3) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(c) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = X::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).3
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_StructLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(3) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -937,25 +1662,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ4,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(4) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(d) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y::Target;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).4
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_StructLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(4) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -966,25 +1718,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ5,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(5) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(e) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = [(X, Y); N];
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).5
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_StructLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(5) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -995,186 +1774,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ6,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(6) },
-                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>,
-                    {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::marker::PhantomData<
-                            ComplexWithGenerics<'a, N, X, Y>,
-                        >;
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).6
-                                )
-                            }
-                        }
-                    }
-                };
-            };
-            #[repr(C)]
-            #[allow(non_snake_case)]
-            struct ___ZerocopyVariantStruct_TupleLike<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            >(
-                core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                bool,
-                Y,
-                PhantomData<&'a [(X, Y); N]>,
-                core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-            )
-            where
-                X: Deref<Target = &'a [(X, Y); N]>;
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            const _: () = {
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                unsafe impl<
-                    'a: 'static,
-                    const N: usize,
-                    X,
-                    Y: Deref,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                    core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid<___ZerocopyAliasing>(
-                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                    {
-                        use ::zerocopy::util::macro_util::core_reexport;
-                        use ::zerocopy::pointer::PtrInner;
-                        true
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                <core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                <PhantomData<
-                                    &'a [(X, Y); N],
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                            }
-                            && {
-                                let field_candidate = candidate
-                                    .reborrow()
-                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                <core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
-                            }
-                    }
-                }
-                #[allow(non_camel_case_types)]
-                const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ0,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(0) },
-                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>,
-                    {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>;
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).0
-                                )
-                            }
-                        }
-                    }
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ1,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(1) },
-                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = bool;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).1
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(1) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1185,25 +1830,52 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ2,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(2) },
-                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = Y;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).2
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(2) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
                     #[allow(deprecated, non_local_definitions)]
@@ -1214,815 +1886,135 @@ fn test_try_from_bytes_enum() {
                         X,
                         Y: Deref,
                     > ::zerocopy::HasField<
-                        ẕ3,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(3) },
-                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ComplexWithGenerics<'a, { N }, X, Y>
                     where
                         X: Deref<Target = &'a [(X, Y); N]>,
                     {
                         fn only_derive_is_allowed_to_implement_this_trait() {}
                         type Type = PhantomData<&'a [(X, Y); N]>;
                         #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).3
-                                )
-                            }
+                        fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                            use ::zerocopy::pointer::cast::{CastSized, Projection};
+                            slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(variants) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::UNION_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(value) },
+                                    >,
+                                >()
+                                .project::<
+                                    _,
+                                    Projection<
+                                        _,
+                                        { ::zerocopy::STRUCT_VARIANT_ID },
+                                        { ::zerocopy::ident_id!(3) },
+                                    >,
+                                >()
+                                .as_ptr()
                         }
                     }
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ4,
-                        { ::zerocopy::STRUCT_VARIANT_ID },
-                        { ::zerocopy::ident_id!(4) },
-                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                    where
-                        X: Deref<Target = &'a [(X, Y); N]>,
-                    {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::marker::PhantomData<
-                            ComplexWithGenerics<'a, N, X, Y>,
-                        >;
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).4
-                                )
-                            }
-                        }
-                    }
-                };
-            };
-            #[repr(C)]
-            #[allow(non_snake_case)]
-            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                __field_StructLike: core_reexport::mem::ManuallyDrop<
-                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                >,
-                __field_TupleLike: core_reexport::mem::ManuallyDrop<
-                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                >,
-                __nonempty: (),
-            }
-            #[allow(non_camel_case_types)]
-            const _: () = {
-                enum ẕ__field_StructLike {}
-                enum ẕ__field_TupleLike {}
-                enum ẕ__nonempty {}
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                const _: () = {
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ__field_StructLike,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__field_StructLike) },
-                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                        >;
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).__field_StructLike
-                                )
-                            }
-                        }
-                    }
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::pointer::cast::Cast<
-                        ___ZerocopyVariants<'a, N, X, Y>,
-                        core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                        >,
-                    >
-                    for ::zerocopy::pointer::cast::Projection<
-                        ẕ__field_StructLike,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__field_StructLike) },
-                    > {}
-                };
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                const _: () = {
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ__field_TupleLike,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__field_TupleLike) },
-                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                        >;
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).__field_TupleLike
-                                )
-                            }
-                        }
-                    }
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::pointer::cast::Cast<
-                        ___ZerocopyVariants<'a, N, X, Y>,
-                        core_reexport::mem::ManuallyDrop<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                        >,
-                    >
-                    for ::zerocopy::pointer::cast::Projection<
-                        ẕ__field_TupleLike,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__field_TupleLike) },
-                    > {}
-                };
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                const _: () = {
-                    #[allow(deprecated, non_local_definitions)]
-                    #[automatically_derived]
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::HasField<
-                        ẕ__nonempty,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__nonempty) },
-                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                        type Type = ();
-                        #[inline(always)]
-                        fn project(
-                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
-                            let slf = slf.as_ptr();
-                            unsafe {
-                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                    (* slf).__nonempty
-                                )
-                            }
-                        }
-                    }
-                    unsafe impl<
-                        'a: 'static,
-                        const N: usize,
-                        X,
-                        Y: Deref,
-                    > ::zerocopy::pointer::cast::Cast<___ZerocopyVariants<'a, N, X, Y>, ()>
-                    for ::zerocopy::pointer::cast::Projection<
-                        ẕ__nonempty,
-                        { ::zerocopy::UNION_VARIANT_ID },
-                        { ::zerocopy::ident_id!(__nonempty) },
-                    > {}
-                };
-            };
-            #[repr(C)]
-            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                tag: ___ZerocopyOuterTag,
-                variants: ___ZerocopyVariants<'a, N, X, Y>,
-            }
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-            for ComplexWithGenerics<'a, N, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {}
-            #[allow(non_camel_case_types)]
-            const _: () = {
-                enum ẕtag {}
-                enum ẕvariants {}
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                unsafe impl<
-                    'a: 'static,
-                    const N: usize,
-                    X,
-                    Y: Deref,
-                > ::zerocopy::HasField<
-                    ẕtag,
-                    { ::zerocopy::STRUCT_VARIANT_ID },
-                    { ::zerocopy::ident_id!(tag) },
-                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    type Type = ___ZerocopyOuterTag;
-                    #[inline(always)]
-                    fn project(
-                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
-                        let slf = slf.as_ptr();
-                        unsafe {
-                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                (* slf).tag
-                            )
-                        }
-                    }
-                }
-                #[allow(deprecated, non_local_definitions)]
-                #[automatically_derived]
-                unsafe impl<
-                    'a: 'static,
-                    const N: usize,
-                    X,
-                    Y: Deref,
-                > ::zerocopy::HasField<
-                    ẕvariants,
-                    { ::zerocopy::STRUCT_VARIANT_ID },
-                    { ::zerocopy::ident_id!(variants) },
-                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                    #[inline(always)]
-                    fn project(
-                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
-                        let slf = slf.as_ptr();
-                        unsafe {
-                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                (* slf).variants
-                            )
-                        }
-                    }
-                }
-            };
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(StructLike) },
-                { ::zerocopy::ident_id!(a) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = u8;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
+                    let mut raw_enum = candidate
+                        .cast::<
+                            ___ZerocopyRawEnum<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    let tag = {
+                        let tag_ptr = raw_enum
+                            .reborrow()
+                            .project::<(), { ::zerocopy::ident_id!(tag) }>()
+                            .cast::<
+                                ___ZerocopyTagPrimitive,
+                                ::zerocopy::pointer::cast::CastSized,
                                 _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(StructLike) },
-                { ::zerocopy::ident_id!(b) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = X;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(StructLike) },
-                { ::zerocopy::ident_id!(c) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = X::Target;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(StructLike) },
-                { ::zerocopy::ident_id!(d) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = Y::Target;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(StructLike) },
-                { ::zerocopy::ident_id!(e) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = [(X, Y); N];
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(TupleLike) },
-                { ::zerocopy::ident_id!(0) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = bool;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(TupleLike) },
-                { ::zerocopy::ident_id!(1) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = Y;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            #[allow(deprecated, non_local_definitions)]
-            #[automatically_derived]
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::HasField<
-                (),
-                { ::zerocopy::ident_id!(TupleLike) },
-                { ::zerocopy::ident_id!(2) },
-            > for ComplexWithGenerics<'a, { N }, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {
-                fn only_derive_is_allowed_to_implement_this_trait() {}
-                type Type = PhantomData<&'a [(X, Y); N]>;
-                #[inline(always)]
-                fn project(slf: ::zerocopy::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
-                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(variants) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(value) },
-                            >,
-                        >()
-                        .project::<
-                            _,
-                            Projection<
-                                _,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >,
-                        >()
-                        .as_ptr()
-                }
-            }
-            let mut raw_enum = candidate
-                .cast::<
-                    ___ZerocopyRawEnum<'a, N, X, Y>,
-                    ::zerocopy::pointer::cast::CastSized,
-                    ::zerocopy::pointer::BecauseInvariantsEq,
-                >();
-            let tag = {
-                let tag_ptr = raw_enum
-                    .reborrow()
-                    .project::<(), { ::zerocopy::ident_id!(tag) }>()
-                    .cast::<
-                        ___ZerocopyTagPrimitive,
-                        ::zerocopy::pointer::cast::CastSized,
-                        _,
-                    >();
-                tag_ptr
-                    .recall_validity::<_, (_, (_, _))>()
-                    .read_unaligned::<::zerocopy::BecauseImmutable>()
-            };
-            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
-            #[allow(non_upper_case_globals)]
-            match tag {
-                ___ZEROCOPY_TAG_UnitLike => true,
-                ___ZEROCOPY_TAG_StructLike => {
-                    let variant_md = unsafe {
-                        variants
-                            .cast_unchecked::<
-                                core_reexport::mem::ManuallyDrop<
+                            >();
+                        tag_ptr
+                            .recall_validity::<_, (_, (_, _))>()
+                            .read_unaligned::<::zerocopy::BecauseImmutable>()
+                    };
+                    let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+                    #[allow(non_upper_case_globals)]
+                    match tag {
+                        ___ZEROCOPY_TAG_UnitLike => true,
+                        ___ZEROCOPY_TAG_StructLike => {
+                            let variant_md = unsafe {
+                                variants
+                                    .cast_unchecked::<
+                                        core_reexport::mem::ManuallyDrop<
+                                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                        >,
+                                        ::zerocopy::pointer::cast::Projection<
+                                            _,
+                                            { ::zerocopy::UNION_VARIANT_ID },
+                                            { ::zerocopy::ident_id!(__field_StructLike) },
+                                        >,
+                                    >()
+                            };
+                            let variant = variant_md
+                                .cast::<
                                     ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                >,
-                                ::zerocopy::pointer::cast::Projection<
-                                    _,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                >,
-                            >()
-                    };
-                    let variant = variant_md
-                        .cast::<
-                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            ::zerocopy::pointer::cast::CastSized,
-                            ::zerocopy::pointer::BecauseInvariantsEq,
-                        >();
-                    <___ZerocopyVariantStruct_StructLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                }
-                ___ZEROCOPY_TAG_TupleLike => {
-                    let variant_md = unsafe {
-                        variants
-                            .cast_unchecked::<
-                                core_reexport::mem::ManuallyDrop<
+                                    ::zerocopy::pointer::cast::CastSized,
+                                    ::zerocopy::pointer::BecauseInvariantsEq,
+                                >();
+                            <___ZerocopyVariantStruct_StructLike<
+                                'a,
+                                N,
+                                X,
+                                Y,
+                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                        }
+                        ___ZEROCOPY_TAG_TupleLike => {
+                            let variant_md = unsafe {
+                                variants
+                                    .cast_unchecked::<
+                                        core_reexport::mem::ManuallyDrop<
+                                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                        >,
+                                        ::zerocopy::pointer::cast::Projection<
+                                            _,
+                                            { ::zerocopy::UNION_VARIANT_ID },
+                                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                                        >,
+                                    >()
+                            };
+                            let variant = variant_md
+                                .cast::<
                                     ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                >,
-                                ::zerocopy::pointer::cast::Projection<
-                                    _,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                >,
-                            >()
-                    };
-                    let variant = variant_md
-                        .cast::<
-                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            ::zerocopy::pointer::cast::CastSized,
-                            ::zerocopy::pointer::BecauseInvariantsEq,
-                        >();
-                    <___ZerocopyVariantStruct_TupleLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                                    ::zerocopy::pointer::cast::CastSized,
+                                    ::zerocopy::pointer::BecauseInvariantsEq,
+                                >();
+                            <___ZerocopyVariantStruct_TupleLike<
+                                'a,
+                                N,
+                                X,
+                                Y,
+                            > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                        }
+                        _ => false,
+                    }
                 }
-                _ => false,
             }
-        }
-    }
         } no_build
     }
 
@@ -2153,8 +2145,6 @@ fn test_try_from_bytes_enum() {
                             where
                                 ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                             {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
                                         let field_candidate = candidate
@@ -2480,8 +2470,6 @@ fn test_try_from_bytes_enum() {
                             where
                                 ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                             {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
                                         let field_candidate = candidate
@@ -3436,7 +3424,6 @@ fn test_try_from_bytes_enum() {
                     }
                 }
             }
-
         } no_build
     }
 
@@ -3567,8 +3554,6 @@ fn test_try_from_bytes_enum() {
                             where
                                 ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                             {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
                                         let field_candidate = candidate
@@ -3894,8 +3879,6 @@ fn test_try_from_bytes_enum() {
                             where
                                 ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                             {
-                                use ::zerocopy::util::macro_util::core_reexport;
-                                use ::zerocopy::pointer::PtrInner;
                                 true
                                     && {
                                         let field_candidate = candidate
@@ -4850,7 +4833,6 @@ fn test_try_from_bytes_enum() {
                     }
                 }
             }
-
         } no_build
     }
 }

--- a/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-nightly/derive_transparent.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:21
@@ -51,13 +51,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-nightly/derive_transparent.rs:24:21
@@ -90,13 +90,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::FromBytes`
   --> tests/ui-nightly/derive_transparent.rs:24:21

--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -313,11 +313,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
-             <IntoBytes1 as IntoBytes>::{constant#0}::___ZerocopyTag
-             <IntoBytes2 as IntoBytes>::{constant#0}::___ZerocopyTag
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -337,11 +337,11 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
-             <IntoBytes1 as IntoBytes>::{constant#0}::___ZerocopyTag
-             <IntoBytes2 as IntoBytes>::{constant#0}::___ZerocopyTag
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -364,13 +364,13 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
    = help: the following other types implement trait `TryFromBytes`:
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-             AtomicBool
-             AtomicI16
-             AtomicI32
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -393,13 +393,13 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
     = help: the following other types implement trait `TryFromBytes`:
               ()
-              *const T
-              *mut T
-              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              AtomicBool
-              AtomicI16
-              AtomicI32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -422,13 +422,13 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
     = note: Consider adding `#[derive(FromZeros)]` to `NotFromZeros`
     = help: the following other types implement trait `FromZeros`:
               ()
-              *const T
-              *mut T
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -446,13 +446,13 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -549,13 +549,13 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required for `FooU8` to implement `FromBytes`
    --> tests/ui-nightly/enum.rs:191:10

--- a/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-nightly/late_compile_pass.stderr
@@ -20,13 +20,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -49,13 +49,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -78,13 +78,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -107,13 +107,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -136,13 +136,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -165,13 +165,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -310,13 +310,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `FromBytes1` to implement `zerocopy::FromBytes`
   --> tests/ui-nightly/late_compile_pass.rs:47:10

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -196,11 +196,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -220,11 +220,11 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::Immutable`
    = help: see issue #48214

--- a/zerocopy-derive/tests/ui-nightly/union.stderr
+++ b/zerocopy-derive/tests/ui-nightly/union.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::Immutable`
    = help: see issue #48214

--- a/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
+++ b/zerocopy-derive/tests/ui-stable/derive_transparent.stderr
@@ -12,13 +12,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::TryFromBytes`
   --> tests/ui-stable/derive_transparent.rs:24:21
@@ -46,13 +46,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> tests/ui-stable/derive_transparent.rs:24:21
@@ -80,13 +80,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy::FromBytes`
   --> tests/ui-stable/derive_transparent.rs:24:21

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -299,11 +299,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
-             <IntoBytes1 as IntoBytes>::{constant#0}::___ZerocopyTag
-             <IntoBytes2 as IntoBytes>::{constant#0}::___ZerocopyTag
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -319,11 +319,11 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyTag
-             <IntoBytes1 as IntoBytes>::{constant#0}::___ZerocopyTag
-             <IntoBytes2 as IntoBytes>::{constant#0}::___ZerocopyTag
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -342,13 +342,13 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
    = help: the following other types implement trait `TryFromBytes`:
              ()
-             *const T
-             *mut T
-             <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-             <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-             AtomicBool
-             AtomicI16
-             AtomicI32
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -367,13 +367,13 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
     = help: the following other types implement trait `TryFromBytes`:
               ()
-              *const T
-              *mut T
-              <FromZeros6 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              <TryFromBytes3 as TryFromBytes>::is_bit_valid::___ZerocopyVariantStruct_A
-              AtomicBool
-              AtomicI16
-              AtomicI32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -392,13 +392,13 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
     = note: Consider adding `#[derive(FromZeros)]` to `NotFromZeros`
     = help: the following other types implement trait `FromZeros`:
               ()
-              *const T
-              *mut T
-              AtomicBool
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -412,13 +412,13 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -487,13 +487,13 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
     = help: the following other types implement trait `FromBytes`:
               ()
-              AtomicI16
-              AtomicI32
-              AtomicI64
-              AtomicI8
-              AtomicIsize
-              AtomicU16
-              AtomicU32
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
             and $N others
 note: required for `FooU8` to implement `FromBytes`
    --> tests/ui-stable/enum.rs:191:10

--- a/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
+++ b/zerocopy-derive/tests/ui-stable/late_compile_pass.stderr
@@ -20,13 +20,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -45,13 +45,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -70,13 +70,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -95,13 +95,13 @@ help: the trait `zerocopy::TryFromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(TryFromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::TryFromBytes`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -120,13 +120,13 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromZeros)]` to `NotZerocopy`
    = help: the following other types implement trait `FromZeros`:
              ()
-             *const T
-             *mut T
-             AU16
-             AtomicBool
-             AtomicI16
-             AtomicI32
-             AtomicI64
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -145,13 +145,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -270,13 +270,13 @@ help: the trait `zerocopy::FromBytes` is not implemented for `NotZerocopy`
    = note: Consider adding `#[derive(FromBytes)]` to `NotZerocopy`
    = help: the following other types implement trait `zerocopy::FromBytes`:
              ()
-             AU16
-             AtomicI16
-             AtomicI32
-             AtomicI64
-             AtomicI8
-             AtomicIsize
-             AtomicU16
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
+             (A, B, C, D, E, F, G)
+             (A, B, C, D, E, F, G, H)
            and $N others
 note: required for `FromBytes1` to implement `zerocopy::FromBytes`
   --> tests/ui-stable/late_compile_pass.rs:47:10

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -177,11 +177,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -197,11 +197,11 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy::Immutable`
    = help: see issue #48214

--- a/zerocopy-derive/tests/ui-stable/union.stderr
+++ b/zerocopy-derive/tests/ui-stable/union.stderr
@@ -87,11 +87,11 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy::Immutable` is not satis
              &T
              &mut T
              ()
-             *const T
-             *mut T
-             AU16
-             F32<O>
-             F64<O>
+             (A, B)
+             (A, B, C)
+             (A, B, C, D)
+             (A, B, C, D, E)
+             (A, B, C, D, E, F)
            and $N others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy::Immutable`
    = help: see issue #48214


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Emit implementations of `HasField`, `Immutable`, `TryFromBytes`,
`FromZeros`, and `FromBytes` for tuples of length up to 26.

Closes #274




---

- #2862


**Latest Update:** v7 — [Compare vs v6](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 | v6 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v7 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v5](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) | [vs v6](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v7) |
| v6 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | [vs v5](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v6) | |
| v5 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v5) | | |
| v4 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v4) | | | |
| v3 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v3) | | | | |
| v2 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v2) | | | | | |
| v1 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G992a50c1ccf344487e1cd764afe0b17e566bc620/v1) | | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G992a50c1ccf344487e1cd764afe0b17e566bc620", "parent": null, "child": null} -->