### PR TITLE
[WIP]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1532,7 +1532,7 @@ pub use zerocopy_derive::TryFromBytes;
     not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(note = "Consider adding `#[derive(TryFromBytes)]` to `{Self}`")
 )]
-pub unsafe trait TryFromBytes {
+pub unsafe trait TryFromBytes: KnownLayout {
     // The `Self: Sized` bound makes it so that `TryFromBytes` is still object
     // safe.
     #[doc(hidden)]
@@ -1562,7 +1562,7 @@ pub unsafe trait TryFromBytes {
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid<A: invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool;
+    fn is_bit_valid(candidate: Maybe<'_, Self>) -> bool;
 
     /// Attempts to interpret the given `source` as a `&Self`.
     ///

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -833,7 +833,13 @@ mod _transitions {
             // This call may panic. If that happens, it doesn't cause any
             // soundness issues, as we have not generated any invalid state
             // which we need to fix before returning.
-            if T::is_bit_valid(self.reborrow().forget_aligned()) {
+            let candidate = unsafe {
+                self.reborrow()
+                    .forget_aligned()
+                    .transmute_unchecked::<crate::wrappers::ReadOnly<T>, _, crate::pointer::cast::CastUnsized>()
+                    .assume_aliasing::<crate::pointer::invariant::Shared>()
+            };
+            if T::is_bit_valid(candidate) {
                 // SAFETY: If `T::is_bit_valid`, code may assume that `self`
                 // contains a bit-valid instance of `T`. By `T:
                 // TryTransmuteFromPtr<T, I::Aliasing, I::Validity, Valid>`, so

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -148,8 +148,14 @@ const _: () = unsafe {
     impl_or_verify!(T => Unaligned for Unalign<T>);
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
-        T: TryFromBytes => TryFromBytes for Unalign<T>;
-        |c| T::is_bit_valid(c.transmute())
+        T: TryFromBytes + KnownLayout => TryFromBytes for Unalign<T>;
+        |c| T::is_bit_valid(unsafe {
+            c.transmute_unchecked::<
+                crate::wrappers::ReadOnly<T>,
+                _,
+                crate::pointer::cast::CastUnsized
+            >()
+        })
     );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
@@ -615,7 +621,7 @@ const _: () = unsafe {
 const _: () = unsafe {
     impl_or_verify!(T: ?Sized + Unaligned => Unaligned for ReadOnly<T>);
     impl_or_verify!(
-        T: ?Sized + TryFromBytes => TryFromBytes for ReadOnly<T>;
+        T: ?Sized + TryFromBytes + KnownLayout => TryFromBytes for ReadOnly<T>;
         |c| T::is_bit_valid(c.transmute::<_, _, BecauseImmutable>())
     );
     impl_or_verify!(T: ?Sized + FromZeros => FromZeros for ReadOnly<T>);

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -879,20 +879,35 @@ fn derive_try_from_bytes_struct(
                 // validity of a struct is just the composition of the bit
                 // validities of its fields, so this is a sound implementation
                 // of `is_bit_valid`.
-                fn is_bit_valid<___ZerocopyAliasing>(
-                    mut candidate: #zerocopy_crate::Maybe<Self, ___ZerocopyAliasing>,
-                ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool
-                where
-                    ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
-                {
+                fn is_bit_valid(
+                    mut candidate: #zerocopy_crate::Maybe<Self>,
+                ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool {
                     use #zerocopy_crate::util::macro_util::core_reexport;
                     use #zerocopy_crate::pointer::PtrInner;
+
+                    // SAFETY: `ReadOnly<Self>` has the same memory layout as `Self`.
+                    let mut candidate = unsafe {
+                        candidate.transmute_unchecked::<
+                            Self,
+                            _,
+                            #zerocopy_crate::pointer::cast::CastUnsized
+                        >()
+                    };
 
                     true #(&& {
                         let field_candidate = candidate.reborrow().project::<
                             _,
                             { #zerocopy_crate::ident_id!(#field_names) }
                         >();
+
+                        // SAFETY: `ReadOnly<T>` has the same memory layout as `T`.
+                        let field_candidate = unsafe {
+                             field_candidate.transmute_unchecked::<
+                                #zerocopy_crate::wrappers::ReadOnly<#field_tys>,
+                                _,
+                                #zerocopy_crate::pointer::cast::CastUnsized
+                             >()
+                        };
 
                         <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
                     })*
@@ -933,14 +948,20 @@ fn derive_try_from_bytes_union(
                 // The bit validity of a union is not yet well defined in Rust,
                 // but it is guaranteed to be no more strict than this
                 // definition. See #696 for a more in-depth discussion.
-                fn is_bit_valid<___ZerocopyAliasing>(
-                    mut candidate: #zerocopy_crate::Maybe<'_, Self,___ZerocopyAliasing>
-                ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool
-                where
-                    ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
-                {
+                fn is_bit_valid(
+                    mut candidate: #zerocopy_crate::Maybe<'_, Self>
+                ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool {
                     use #zerocopy_crate::util::macro_util::core_reexport;
                     use #zerocopy_crate::pointer::PtrInner;
+
+                    // SAFETY: `ReadOnly<Self>` has the same memory layout as `Self`.
+                    let mut candidate = unsafe {
+                        candidate.transmute_unchecked::<
+                            Self,
+                            _,
+                            #zerocopy_crate::pointer::cast::CastUnsized
+                        >()
+                    };
 
                     false #(|| {
                         // SAFETY:
@@ -957,6 +978,15 @@ fn derive_try_from_bytes_union(
                                 _,
                                 #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#field_names) }>
                             >()
+                        };
+
+                        // SAFETY: `ReadOnly<T>` has the same memory layout as `T`.
+                        let field_candidate = unsafe {
+                             field_candidate.transmute_unchecked::<
+                                #zerocopy_crate::wrappers::ReadOnly<#field_tys>,
+                                _,
+                                #zerocopy_crate::pointer::cast::CastUnsized
+                             >()
                         };
 
                         <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
@@ -1040,12 +1070,9 @@ fn try_gen_trivial_is_bit_valid(
     if matches!(top_level, Trait::FromBytes) && ast.generics.params.is_empty() {
         Some(quote!(
             // SAFETY: See inline.
-            fn is_bit_valid<___ZerocopyAliasing>(
-                _candidate: #zerocopy_crate::Maybe<Self, ___ZerocopyAliasing>,
-            ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool
-            where
-                ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
-            {
+            fn is_bit_valid(
+                _candidate: #zerocopy_crate::Maybe<Self>,
+            ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool {
                 if false {
                     fn assert_is_from_bytes<T>()
                     where
@@ -1083,12 +1110,9 @@ unsafe fn gen_trivial_is_bit_valid_unchecked(zerocopy_crate: &Path) -> proc_macr
     quote!(
         // SAFETY: The caller of `gen_trivial_is_bit_valid_unchecked` has
         // promised that all initialized bit patterns are valid for `Self`.
-        fn is_bit_valid<___ZerocopyAliasing>(
-            _candidate: #zerocopy_crate::Maybe<Self, ___ZerocopyAliasing>,
-        ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool
-        where
-            ___ZerocopyAliasing: #zerocopy_crate::pointer::invariant::Reference,
-        {
+        fn is_bit_valid(
+            _candidate: #zerocopy_crate::Maybe<Self>,
+        ) -> #zerocopy_crate::util::macro_util::core_reexport::primitive::bool {
             true
         }
     )


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #2864
- &#x3000; #2863
- &#x3000; #2860


**Latest Update:** v7 — [Compare vs v6](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|
|v7|[vs v6](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs v5](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs v4](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs v3](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs v2](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v7)|
|v6||[vs v5](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|[vs v4](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|[vs v3](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|[vs v2](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v6)|
|v5|||[vs v4](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5)|[vs v3](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5)|[vs v2](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5)|[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v5)|
|v4||||[vs v3](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4)|[vs v2](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4)|[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v4)|
|v3|||||[vs v2](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3)|[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v3)|
|v2||||||[vs v1](/google/zerocopy/compare/gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2)|[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v2)|
|v1|||||||[vs Base](/google/zerocopy/compare/Gb15e30e716a041285c1bf7434ce3163f594526a7..gherrit/G60971ace7acef9cd1c74f74f397cb7c48e5e3f73/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G60971ace7acef9cd1c74f74f397cb7c48e5e3f73", "parent": "Gb15e30e716a041285c1bf7434ce3163f594526a7", "child": null}" -->