### PR TITLE
Introduce `ReadOnly<T>` which is unconditionally `Immutable`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1447,14 +1447,12 @@ pub use zerocopy_derive::Immutable;
 // # Safety (Internal)
 //
 // If `T: Immutable`, unsafe code *inside of this crate* may assume that, given
-// `t: &T`, `t` does not contain any [`UnsafeCell`]s at any byte location
-// within the byte range addressed by `t`. This includes ranges of length 0
-// (e.g., `UnsafeCell<()>` and `[UnsafeCell<u8>; 0]`). If a type implements
-// `Immutable` which violates this assumptions, it may cause this crate to
-// exhibit [undefined behavior].
+// `t: &T`, `t` does not permit interior mutation of its referent. Because
+// [`UnsafeCell`] is the only type which permits interior mutation, it is
+// sufficient (though not necessary) to guarantee that `T` contains no
+// `UnsafeCell`s.
 //
 // [`UnsafeCell`]: core::cell::UnsafeCell
-// [undefined behavior]: https://raphlinus.github.io/programming/rust/2018/08/17/undefined-behavior.html
 #[cfg_attr(
     feature = "derive",
     doc = "[derive]: zerocopy_derive::Immutable",
@@ -5219,10 +5217,8 @@ pub unsafe trait IntoBytes {
         //   initialized.
         // - Since `slf` is derived from `self`, and `self` is an immutable
         //   reference, the only other references to this memory region that
-        //   could exist are other immutable references, and those don't allow
-        //   mutation. `Self: Immutable` prohibits types which contain
-        //   `UnsafeCell`s, which are the only types for which this rule
-        //   wouldn't be sufficient.
+        //   could exist are other immutable references, which by `Self:
+        //   Immutable` don't permit mutation.
         // - The total size of the resulting slice is no larger than
         //   `isize::MAX` because no allocation produced by safe code can be
         //   larger than `isize::MAX`.
@@ -6333,7 +6329,7 @@ mod tests {
 
     #[test]
     fn test_object_safety() {
-        fn _takes_no_cell(_: &dyn Immutable) {}
+        fn _takes_immutable(_: &dyn Immutable) {}
         fn _takes_unaligned(_: &dyn Unaligned) {}
     }
 

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -456,7 +456,8 @@ mod _conversions {
         ///   subtle soundness requirement that is a function of `T`, `U`,
         ///   `I::Aliasing`, `I::Validity`, and `V`, and may depend upon the
         ///   presence, absence, or specific location of `UnsafeCell`s in `T`
-        ///   and/or `U`. See [`Validity`] for more details.
+        ///   and/or `U`, and on whether interior mutation is ever permitted via
+        ///   those `UnsafeCell`s. See [`Validity`] for more details.
         #[doc(hidden)]
         #[inline(always)]
         #[must_use]

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -82,8 +82,8 @@ use crate::{
 ///   inaccessible so long as `dst` is alive, and no other live `Ptr`s or
 ///   references may reference the same referent.
 /// - If it is `Shared`, then either:
-///   - `Src: Immutable` and `Dst: Immutable`, and so `UnsafeCell`s trivially
-///     cover the same byte ranges in both types.
+///   - `Src: Immutable` and `Dst: Immutable`, and so neither `src` nor `dst`
+///     permit interior mutation.
 ///   - It is explicitly sound for safe code to operate on a `&Src` and a `&Dst`
 ///     pointing to the same byte range at the same time.
 ///
@@ -131,7 +131,7 @@ pub enum BecauseMutationCompatible {}
 //   - `A` is `Exclusive`
 //   - `Src: Immutable` and `Dst: Immutable`
 //   - `Dst: InvariantsEq<Src>`, which guarantees that `Src` and `Dst` have the
-//     same invariants, and have `UnsafeCell`s covering the same byte ranges
+//     same invariants, and permit interior mutation on the same byte ranges
 unsafe impl<Src, Dst, SV, DV, A, R>
     TryTransmuteFromPtr<Src, A, SV, DV, (BecauseMutationCompatible, R)> for Dst
 where

--- a/zerocopy-derive/src/derive/mod.rs
+++ b/zerocopy-derive/src/derive/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     util::{Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait},
 };
 
-pub(crate) fn derive_no_cell(ctx: &Ctx, _top_level: Trait) -> TokenStream {
+pub(crate) fn derive_immutable(ctx: &Ctx, _top_level: Trait) -> TokenStream {
     match &ctx.ast.data {
         Data::Struct(strct) => {
             ImplBlockBuilder::new(ctx, strct, Trait::Immutable, FieldBounds::ALL_SELF).build()

--- a/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -650,8 +650,8 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
                         // SAFETY:
                         // - Since `Self: Immutable` is enforced by
                         //   `self_type_trait_bounds`, neither `*slf` nor the
-                        //   returned pointer's referent contain any
-                        //   `UnsafeCell`s
+                        //   returned pointer's referent permit interior
+                        //   mutation.
                         // - Both source and destination validity are
                         //   `Initialized`, which is always a sound
                         //   transmutation.

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -114,7 +114,7 @@ impl IntoTokenStream for Result<proc_macro2::TokenStream, Error> {
 }
 
 derive!(KnownLayout => derive_known_layout => crate::derive::known_layout::derive);
-derive!(Immutable => derive_no_cell => crate::derive::derive_no_cell);
+derive!(Immutable => derive_immutable => crate::derive::derive_immutable);
 derive!(TryFromBytes => derive_try_from_bytes => crate::derive::try_from_bytes::derive_try_from_bytes);
 derive!(FromZeros => derive_from_zeros => crate::derive::from_bytes::derive_from_zeros);
 derive!(FromBytes => derive_from_bytes => crate::derive::from_bytes::derive_from_bytes);

--- a/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy-derive/src/output_tests/mod.rs
@@ -23,7 +23,7 @@ macro_rules! use_as_trait_name {
 // the trait under test rather than the name of the inner derive function.
 use_as_trait_name!(
     KnownLayout => super::derive::known_layout::derive,
-    Immutable => super::derive::derive_no_cell,
+    Immutable => super::derive::derive_immutable,
     TryFromBytes => super::derive::try_from_bytes::derive_try_from_bytes,
     FromZeros => super::derive::from_bytes::derive_from_zeros,
     FromBytes => super::derive::from_bytes::derive_from_bytes,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

In order to make this sound, we change the safety invariant on
`Immutable` to narrowly ban interior mutation. In other words, the
presence of `UnsafeCell`s is acceptable so long as no interior mutation
is performed in practice.

While we're here, remove the final remaining references to `Immutable`'s
old name, `NoCell`.

Makes progress on #2336
Closes #1760




---

- &#x3000; #2876
- &#x3000; #2873
- &#x3000; #2919
- 👉 #2866


**Latest Update:** v64 — [Compare vs v63](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v63..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v63 | v62 | v61 | v60 | v59 | v58 | v57 | v56 | v55 | v54 | v53 | v52 | v51 | v50 | v49 | v48 | v47 | v46 | v45 | v44 | v43 | v42 | v41 | v40 | v39 | v38 | v37 | v36 | v35 | v34 | v33 | v32 | v31 | v30 | v29 | v28 | v27 | v26 | v25 | v24 | v23 | v22 | v21 | v20 | v19 | v18 | v17 | v16 | v15 | v14 | v13 | v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v64|[v63](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v63..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v62](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v62..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v61](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v61..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v60](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v60..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v59](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v59..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v58](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v58..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v57](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v57..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v56](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v56..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v55](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v55..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v54](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v54..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v53](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v53..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v52](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v52..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v51](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v51..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v50](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v50..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v49](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v49..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v48](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v48..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v47](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v47..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v46](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v46..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v45](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v45..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v44](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v44..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v43](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v43..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v42](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v42..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v41](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v41..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v40](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v40..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v39](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v39..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v38](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v38..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v37](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v37..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v36](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v36..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v35](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v35..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v34](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v34..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v33](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v33..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v32](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v32..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v31](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v31..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v30](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v30..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v29](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v29..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v28](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v28..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v27](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v27..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v26](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v26..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v25](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v25..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v24](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v24..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v23](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v23..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v22](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v22..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v21](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v21..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v20](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v20..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v19](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v19..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v18](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v18..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v17](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v17..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v16](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v16..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v15](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v15..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v14](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v14..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v13](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v13..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v12](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v12..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v11](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v11..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v10](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v10..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v9](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v9..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v8](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v8..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v7](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v7..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v6](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v6..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v5](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v5..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v4](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v4..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v3](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v3..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v2](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v2..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[v1](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v1..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v64)|
|v63||[v62](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v62..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v63)||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v63)|
|v62|||[v61](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v61..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v62)|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v62)|
|v61||||[v60](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v60..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v61)||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v61)|
|v60|||||[v59](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v59..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v60)|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v60)|
|v59||||||[v58](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v58..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v59)||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v59)|
|v58|||||||[v57](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v57..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v58)|||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v58)|
|v57||||||||[v56](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v56..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v57)||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v57)|
|v56|||||||||[v55](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v55..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v56)|||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v56)|
|v55||||||||||[v54](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v54..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v55)||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v55)|
|v54|||||||||||[v53](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v53..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v54)|||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v54)|
|v53||||||||||||[v52](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v52..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v53)||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v53)|
|v52|||||||||||||[v51](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v51..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v52)|||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v52)|
|v51||||||||||||||[v50](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v50..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v51)||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v51)|
|v50|||||||||||||||[v49](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v49..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v50)|||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v50)|
|v49||||||||||||||||[v48](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v48..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v49)||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v49)|
|v48|||||||||||||||||[v47](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v47..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v48)|||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v48)|
|v47||||||||||||||||||[v46](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v46..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v47)||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v47)|
|v46|||||||||||||||||||[v45](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v45..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v46)|||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v46)|
|v45||||||||||||||||||||[v44](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v44..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v45)||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v45)|
|v44|||||||||||||||||||||[v43](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v43..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v44)|||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v44)|
|v43||||||||||||||||||||||[v42](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v42..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v43)||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v43)|
|v42|||||||||||||||||||||||[v41](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v41..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v42)|||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v42)|
|v41||||||||||||||||||||||||[v40](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v40..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v41)||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v41)|
|v40|||||||||||||||||||||||||[v39](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v39..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v40)|||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v40)|
|v39||||||||||||||||||||||||||[v38](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v38..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v39)||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v39)|
|v38|||||||||||||||||||||||||||[v37](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v37..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v38)|||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v38)|
|v37||||||||||||||||||||||||||||[v36](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v36..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v37)||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v37)|
|v36|||||||||||||||||||||||||||||[v35](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v35..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v36)|||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v36)|
|v35||||||||||||||||||||||||||||||[v34](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v34..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v35)||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v35)|
|v34|||||||||||||||||||||||||||||||[v33](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v33..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v34)|||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v34)|
|v33||||||||||||||||||||||||||||||||[v32](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v32..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v33)||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v33)|
|v32|||||||||||||||||||||||||||||||||[v31](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v31..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v32)|||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v32)|
|v31||||||||||||||||||||||||||||||||||[v30](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v30..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v31)||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v31)|
|v30|||||||||||||||||||||||||||||||||||[v29](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v29..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v30)|||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v30)|
|v29||||||||||||||||||||||||||||||||||||[v28](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v28..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v29)||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v29)|
|v28|||||||||||||||||||||||||||||||||||||[v27](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v27..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v28)|||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v28)|
|v27||||||||||||||||||||||||||||||||||||||[v26](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v26..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v27)||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v27)|
|v26|||||||||||||||||||||||||||||||||||||||[v25](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v25..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v26)|||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v26)|
|v25||||||||||||||||||||||||||||||||||||||||[v24](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v24..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v25)||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v25)|
|v24|||||||||||||||||||||||||||||||||||||||||[v23](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v23..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v24)|||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v24)|
|v23||||||||||||||||||||||||||||||||||||||||||[v22](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v22..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v23)||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v23)|
|v22|||||||||||||||||||||||||||||||||||||||||||[v21](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v21..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v22)|||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v22)|
|v21||||||||||||||||||||||||||||||||||||||||||||[v20](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v20..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v21)||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v21)|
|v20|||||||||||||||||||||||||||||||||||||||||||||[v19](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v19..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v20)|||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v20)|
|v19||||||||||||||||||||||||||||||||||||||||||||||[v18](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v18..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v19)||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v19)|
|v18|||||||||||||||||||||||||||||||||||||||||||||||[v17](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v17..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v18)|||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v18)|
|v17||||||||||||||||||||||||||||||||||||||||||||||||[v16](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v16..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v17)||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v17)|
|v16|||||||||||||||||||||||||||||||||||||||||||||||||[v15](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v15..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v16)|||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v16)|
|v15||||||||||||||||||||||||||||||||||||||||||||||||||[v14](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v14..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v15)||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v15)|
|v14|||||||||||||||||||||||||||||||||||||||||||||||||||[v13](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v13..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v14)|||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v14)|
|v13||||||||||||||||||||||||||||||||||||||||||||||||||||[v12](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v12..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v13)||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v13)|
|v12|||||||||||||||||||||||||||||||||||||||||||||||||||||[v11](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v11..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v12)|||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v12)|
|v11||||||||||||||||||||||||||||||||||||||||||||||||||||||[v10](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v10..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v11)||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v11)|
|v10|||||||||||||||||||||||||||||||||||||||||||||||||||||||[v9](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v9..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v10)|||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v10)|
|v9||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v8](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v8..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v9)||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v9)|
|v8|||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v7](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v7..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v8)|||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v8)|
|v7||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v6](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v6..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v7)||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v7)|
|v6|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v5](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v5..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v6)|||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v6)|
|v5||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v4](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v4..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v5)||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v5)|
|v4|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v3](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v3..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v4)|||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v4)|
|v3||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v2](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v2..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v3)||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v3)|
|v2|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[v1](/google/zerocopy/compare/gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v1..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v2)|[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v2)|
|v1||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbe8d7edd150d80731c79815685c596ed88460ae7/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gbe8d7edd150d80731c79815685c596ed88460ae7", "parent": null, "child": "G17f9a0ab1a99ba2147dbc334934cb9e1f3709128"}" -->