### PR TITLE
[zerocopy-derive] Fix panic with raw identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.32"
+version = "0.8.33"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.32", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.32", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # More recent versions of `either` have an MSRV higher than ours.
@@ -142,4 +142,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.32", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.32"
+version = "0.8.33"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -55,8 +55,7 @@ pub(crate) fn generate_tag_enum(repr: &EnumRepr, data: &DataEnum) -> TokenStream
 }
 
 fn tag_ident(variant_ident: &Ident) -> Ident {
-    let variant_ident_str = crate::ext::to_ident_str(variant_ident);
-    Ident::new(&format!("___ZEROCOPY_TAG_{}", variant_ident_str), variant_ident.span())
+    ident!(("___ZEROCOPY_TAG_{}", variant_ident), variant_ident.span())
 }
 
 /// Generates a constant for the tag associated with each variant of the enum.
@@ -103,8 +102,7 @@ fn generate_tag_consts(data: &DataEnum) -> TokenStream {
 }
 
 fn variant_struct_ident(variant_ident: &Ident) -> Ident {
-    let variant_ident_str = crate::ext::to_ident_str(variant_ident);
-    Ident::new(&format!("___ZerocopyVariantStruct_{}", variant_ident_str), variant_ident.span())
+    ident!(("___ZerocopyVariantStruct_{}", variant_ident), variant_ident.span())
 }
 
 /// Generates variant structs for the given enum variant.
@@ -171,10 +169,9 @@ fn generate_variant_structs(
 }
 
 fn variants_union_field_ident(ident: &Ident) -> Ident {
-    let variant_ident_str = crate::ext::to_ident_str(ident);
     // Field names are prefixed with `__field_` to prevent name collision
     // with the `__nonempty` field.
-    Ident::new(&format!("__field_{}", variant_ident_str), ident.span())
+    ident!(("__field_{}", ident), ident.span())
 }
 
 fn generate_variants_union(

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -249,3 +249,11 @@ struct A;
 struct B {
     a: A,
 }
+
+#[derive(imp::TryFromBytes)]
+#[repr(C)]
+struct RawIdent {
+    r#type: u8,
+}
+
+util_assert_impl_all!(RawIdent: imp::TryFromBytes);


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.33.

Applies the same approach as in #2788, but to new lines of code (that
should have used this technique to begin with). Introduces a macro that
makes this pattern less verbose, and also hopefully encourages future
uses to use the correct pattern.




---

- 👉 #2871


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v3..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v3..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v2..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v1..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v2..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v1..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v1..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gc07a814b14897f1beb00786c47a1343e65c9b884/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gc07a814b14897f1beb00786c47a1343e65c9b884", "parent": null, "child": null}" -->