### PR TITLE
Simplify MutationCompatible impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4390,9 +4390,7 @@ pub unsafe trait FromBytes: FromZeros {
         let source = Ptr::from_mut(source);
         let maybe_slf = source.try_cast_into_no_leftover::<_, BecauseImmutable>(Some(count));
         match maybe_slf {
-            Ok(slf) => Ok(slf
-                .recall_validity::<_, (_, (_, (BecauseExclusive, BecauseExclusive)))>()
-                .as_mut()),
+            Ok(slf) => Ok(slf.recall_validity::<_, (_, (_, BecauseExclusive))>().as_mut()),
             Err(err) => Err(err.map_src(|s| s.as_mut())),
         }
     }

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -966,6 +966,9 @@ mod _casts {
         T: 'a + KnownLayout + ?Sized,
         I: Invariants<Validity = Initialized>,
     {
+        // FIXME: Is there any way to teach Rust that, for all `T, A, R`, `T:
+        // Read<A, R>` implies `[u8]: Read<A, R>`?
+
         /// Casts this pointer-to-initialized into a pointer-to-bytes.
         #[allow(clippy::wrong_self_convention)]
         #[must_use]
@@ -973,6 +976,7 @@ mod _casts {
         pub fn as_bytes<R>(self) -> Ptr<'a, [u8], (I::Aliasing, Aligned, Valid)>
         where
             T: Read<I::Aliasing, R>,
+            [u8]: Read<I::Aliasing, R>,
             I::Aliasing: Reference,
         {
             let ptr = self.cast::<_, AsBytesCast, _>();
@@ -1125,6 +1129,7 @@ mod _casts {
         where
             I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
+            [u8]: Read<I::Aliasing, R>,
         {
             // FIXME(#67): Remove this allow. See NonNulSlicelExt for more
             // details.

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -188,11 +188,11 @@ pub unsafe trait MutationCompatible<Src: ?Sized, A: Aliasing, SV, DV, R> {}
 pub enum BecauseRead {}
 
 // SAFETY: `Src: Read<A, _>` and `Dst: Read<A, _>`.
-unsafe impl<Src: ?Sized, Dst: ?Sized, A: Aliasing, SV: Validity, DV: Validity, R, S>
-    MutationCompatible<Src, A, SV, DV, (BecauseRead, (R, S))> for Dst
+unsafe impl<Src: ?Sized, Dst: ?Sized, A: Aliasing, SV: Validity, DV: Validity, R>
+    MutationCompatible<Src, A, SV, DV, (BecauseRead, R)> for Dst
 where
     Src: Read<A, R>,
-    Dst: Read<A, S>,
+    Dst: Read<A, R>,
 {
 }
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -681,7 +681,7 @@ where
                 cast_for_sized::<
                     T,
                     _,
-                    (BecauseRead, (BecauseExclusive, BecauseExclusive)),
+                    (BecauseRead, BecauseExclusive),
                     (BecauseMutationCompatible, BecauseInvariantsEq),
                 >(ptr)
             };
@@ -857,7 +857,7 @@ where
                 cast_for_sized::<
                     T,
                     _,
-                    (BecauseRead, (BecauseExclusive, BecauseExclusive)),
+                    (BecauseRead, BecauseExclusive),
                     (BecauseMutationCompatible, BecauseInvariantsEq),
                 >(ptr)
             };
@@ -876,7 +876,7 @@ where
         let ptr = Ptr::from_mut(b)
             .try_cast_into_no_leftover::<T, BecauseExclusive>(None)
             .expect("zerocopy internal error: DerefMut::deref_mut should be infallible");
-        let ptr = ptr.recall_validity::<_, (_, (_, (BecauseExclusive, BecauseExclusive)))>();
+        let ptr = ptr.recall_validity::<_, (_, (_, BecauseExclusive))>();
         ptr.as_mut()
     }
 }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -220,7 +220,7 @@ macro_rules! impl_for_transmute_from {
         #[inline]
         fn is_bit_valid<A: crate::pointer::invariant::Reference>(candidate: Maybe<'_, Self, A>) -> bool {
             let c: Maybe<'_, Self, crate::pointer::invariant::Exclusive> = candidate.into_exclusive_or_pme();
-            let c: Maybe<'_, $repr, _> = c.transmute::<_, _, (_, (_, (BecauseExclusive, BecauseExclusive)))>();
+            let c: Maybe<'_, $repr, _> = c.transmute::<_, _, (_, (_, BecauseExclusive))>();
             // SAFETY: This macro ensures that `$repr` and `Self` have the same
             // size and bit validity. Thus, a bit-valid instance of `$repr` is
             // also a bit-valid instance of `Self`.

--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -76,7 +76,7 @@ fn two_bad() {
 
     let candidate = {
         use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<_, CastSized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<_, CastSized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
@@ -105,7 +105,7 @@ fn un_sized() {
 
     let candidate = {
         use imp::pointer::{cast::CastUnsized, BecauseExclusive};
-        candidate.cast::<_, CastUnsized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<_, CastUnsized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
@@ -161,8 +161,7 @@ fn test_maybe_from_bytes() {
 
     let candidate = {
         use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate
-            .cast::<MaybeFromBytes<bool>, CastSized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<MaybeFromBytes<bool>, CastSized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `[u8]` consists entirely of initialized bytes.

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -71,7 +71,7 @@ fn two_bad() {
 
     let candidate = {
         use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<Two, CastSized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<Two, CastSized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
@@ -99,7 +99,7 @@ fn bool_and_zst() {
 
     let candidate = {
         use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<BoolAndZst, CastSized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<BoolAndZst, CastSized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `candidate`'s referent is fully initialized.
@@ -127,8 +127,7 @@ fn test_maybe_from_bytes() {
 
     let candidate = {
         use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate
-            .cast::<MaybeFromBytes<bool>, CastSized, (_, (BecauseExclusive, BecauseExclusive))>()
+        candidate.cast::<MaybeFromBytes<bool>, CastSized, (_, BecauseExclusive)>()
     };
 
     // SAFETY: `[u8]` consists entirely of initialized bytes.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Previously, we allowed for `Src: Read<A, R>` and `Dst: Read<A, S>` for
different `R` and `S` "reason" parameters. This is an unnecessary degree
of freedom (two types are only ever `Read<A>` for a particular `A` for
the same reason – either because `A = Exclusive` or because both types
implement `Immutable`). This degree of freedom required more verbose
type annotations by callers.




---

- &#x3000; #2876
- &#x3000; #2875
- &#x3000; #2873
- &#x3000; #2866
- &#x3000; #2872
- 👉 #2877

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3cc35009cf6e17a935df0ae0c3c37dcc389e2f9f", "parent": null, "child": "G57ec07c3841271440bbaf40cab04b942cbdbddb9"}" -->