### PR TITLE
[derive] Refactor is_bit_valid tests

### DIFF
--- a/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -17,16 +17,10 @@ include!("include.rs");
 
 #[test]
 fn zst() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let candidate = ::zerocopy::Ptr::from_ref(&());
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&()` trivially consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <() as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(is_bit_valid);
+    crate::util::test_is_bit_valid::<(), _>((), true);
 }
 
-#[derive(imp::TryFromBytes)]
+#[derive(imp::TryFromBytes, imp::Immutable, imp::IntoBytes)]
 #[repr(C)]
 struct One {
     a: u8,
@@ -36,16 +30,11 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&One` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <One as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(is_bit_valid);
+    crate::util::test_is_bit_valid::<One, _>(One { a: 42 }, true);
+    crate::util::test_is_bit_valid::<One, _>(One { a: 43 }, true);
 }
 
-#[derive(imp::TryFromBytes)]
+#[derive(imp::TryFromBytes, imp::Immutable, imp::IntoBytes)]
 #[repr(C)]
 struct Two {
     a: bool,
@@ -56,34 +45,9 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let candidate = ::zerocopy::Ptr::from_ref(&Two { a: false, b: () });
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&Two` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(is_bit_valid);
-}
-
-#[test]
-fn two_bad() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let mut buf = [2u8; 1];
-    let candidate = ::zerocopy::Ptr::from_mut(&mut buf);
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&Two` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let candidate = {
-        use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<_, CastSized, (_, BecauseExclusive)>()
-    };
-
-    // SAFETY: `candidate`'s referent is as-initialized as `Two`.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(!is_bit_valid);
+    crate::util::test_is_bit_valid::<Two, _>(Two { a: false, b: () }, true);
+    crate::util::test_is_bit_valid::<Two, _>(Two { a: true, b: () }, true);
+    crate::util::test_is_bit_valid::<Two, _>([2u8], false);
 }
 
 #[derive(imp::KnownLayout, imp::TryFromBytes)]
@@ -99,11 +63,10 @@ fn un_sized() {
     // FIXME(#5): Use `try_transmute` in this test once it's available.
     let mut buf = [16u8, 12, 42];
     let candidate = ::zerocopy::Ptr::from_mut(&mut buf[..]);
-    let candidate = candidate.forget_aligned();
     // SAFETY: `&Unsized` consists entirely of initialized bytes.
     let candidate = unsafe { candidate.assume_initialized() };
 
-    let candidate = {
+    let mut candidate = {
         use imp::pointer::{cast::CastUnsized, BecauseExclusive};
         candidate.cast::<_, CastUnsized, (_, BecauseExclusive)>()
     };
@@ -145,7 +108,7 @@ where
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::TryFromBytes);
 
-#[derive(imp::FromBytes)]
+#[derive(imp::FromBytes, imp::IntoBytes)]
 #[repr(C)]
 struct MaybeFromBytes<T>(T);
 
@@ -155,19 +118,9 @@ fn test_maybe_from_bytes() {
     // trivial `is_bit_valid` impl that always returns true. This test confirms
     // that we *don't* spuriously do that when generic parameters are present.
 
-    let mut buf = [2u8];
-    let candidate = ::zerocopy::Ptr::from_mut(&mut buf);
-    let candidate = candidate.bikeshed_recall_initialized_from_bytes();
-
-    let candidate = {
-        use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<MaybeFromBytes<bool>, CastSized, (_, BecauseExclusive)>()
-    };
-
-    // SAFETY: `[u8]` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <MaybeFromBytes<bool> as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(!is_bit_valid);
+    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>(MaybeFromBytes(false), true);
+    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>(MaybeFromBytes(true), true);
+    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>([2u8], false);
 }
 
 #[derive(Debug, PartialEq, Eq, imp::TryFromBytes, imp::Immutable, imp::KnownLayout)]

--- a/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -24,16 +24,11 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let candidate = ::zerocopy::Ptr::from_ref(&One { a: 42 });
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&One` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <One as imp::TryFromBytes>::is_bit_valid(candidate);
-    assert!(is_bit_valid);
+    crate::util::test_is_bit_valid::<One, _>([42u8], true);
+    crate::util::test_is_bit_valid::<One, _>([43u8], true);
 }
 
-#[derive(imp::Immutable, imp::TryFromBytes)]
+#[derive(imp::Immutable, imp::TryFromBytes, imp::IntoBytes)]
 #[repr(C)]
 union Two {
     a: bool,
@@ -44,41 +39,9 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let candidate_a = ::zerocopy::Ptr::from_ref(&Two { a: false });
-    let candidate_a = candidate_a.forget_aligned();
-    // SAFETY: `&Two` consists entirely of initialized bytes.
-    let candidate_a = unsafe { candidate_a.assume_initialized() };
-    let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate_a);
-    assert!(is_bit_valid);
-
-    let candidate_b = ::zerocopy::Ptr::from_ref(&Two { b: true });
-    let candidate_b = candidate_b.forget_aligned();
-    // SAFETY: `&Two` consists entirely of initialized bytes.
-    let candidate_b = unsafe { candidate_b.assume_initialized() };
-    let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate_b);
-    assert!(is_bit_valid);
-}
-
-#[test]
-fn two_bad() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let mut buf = [2u8];
-    let candidate = ::zerocopy::Ptr::from_mut(&mut buf);
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&[u8]` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let candidate = {
-        use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<Two, CastSized, (_, BecauseExclusive)>()
-    };
-
-    // SAFETY: `candidate`'s referent is as-initialized as `Two`.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let is_bit_valid = <Two as imp::TryFromBytes>::is_bit_valid(candidate);
-    assert!(!is_bit_valid);
+    crate::util::test_is_bit_valid::<Two, _>(Two { a: false }, true);
+    crate::util::test_is_bit_valid::<Two, _>(Two { b: true }, true);
+    crate::util::test_is_bit_valid::<Two, _>([2u8], false);
 }
 
 #[derive(imp::Immutable, imp::TryFromBytes)]
@@ -90,23 +53,9 @@ union BoolAndZst {
 
 #[test]
 fn bool_and_zst() {
-    // FIXME(#5): Use `try_transmute` in this test once it's available.
-    let mut buf = [2u8];
-    let candidate = ::zerocopy::Ptr::from_mut(&mut buf);
-    let candidate = candidate.forget_aligned();
-    // SAFETY: `&[u8]` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let candidate = {
-        use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<BoolAndZst, CastSized, (_, BecauseExclusive)>()
-    };
-
-    // SAFETY: `candidate`'s referent is fully initialized.
-    let candidate = unsafe { candidate.assume_initialized() };
-
-    let is_bit_valid = <BoolAndZst as imp::TryFromBytes>::is_bit_valid(candidate);
-    assert!(is_bit_valid);
+    crate::util::test_is_bit_valid::<BoolAndZst, _>([0u8], true);
+    crate::util::test_is_bit_valid::<BoolAndZst, _>([1u8], true);
+    crate::util::test_is_bit_valid::<BoolAndZst, _>([2u8], true);
 }
 
 #[derive(imp::FromBytes)]
@@ -121,19 +70,7 @@ fn test_maybe_from_bytes() {
     // trivial `is_bit_valid` impl that always returns true. This test confirms
     // that we *don't* spuriously do that when generic parameters are present.
 
-    let mut buf = [2u8];
-    let candidate = ::zerocopy::Ptr::from_mut(&mut buf);
-    let candidate = candidate.bikeshed_recall_initialized_from_bytes();
-
-    let candidate = {
-        use imp::pointer::{cast::CastSized, BecauseExclusive};
-        candidate.cast::<MaybeFromBytes<bool>, CastSized, (_, BecauseExclusive)>()
-    };
-
-    // SAFETY: `[u8]` consists entirely of initialized bytes.
-    let candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <MaybeFromBytes<bool> as imp::TryFromBytes>::is_bit_valid(candidate);
-    imp::assert!(!is_bit_valid);
+    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>([2u8], false);
 }
 
 #[derive(imp::Immutable, imp::TryFromBytes)]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- &#x3000; #2876
- &#x3000; #2873
- &#x3000; #2866
- &#x3000; #2872
- 👉 #2879


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v3..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v3..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v4)|[vs v2](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v2..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v4)|[vs v1](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v1..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v2..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v3)|[vs v1](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v1..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v1..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/G3eff65bc88b62c899bbd054028b3ff9306fe2167/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3eff65bc88b62c899bbd054028b3ff9306fe2167", "parent": null, "child": "G57ec07c3841271440bbaf40cab04b942cbdbddb9"}" -->