### PR TITLE
Rename `HasField::project` to `HasField::project_raw`

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -814,7 +814,7 @@ const _: () = {
         }
 
         #[inline(always)]
-        fn project(slf: PtrInner<'_, Self>) -> *mut T {
+        fn project_raw(slf: PtrInner<'_, Self>) -> *mut T {
             // SAFETY: `ManuallyDrop<T>` has the same layout and bit validity as
             // `T` [1].
             //
@@ -1084,7 +1084,7 @@ mod tuples {
                 type Type = $CurrT;
 
                 #[inline(always)]
-                fn project(slf: crate::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project_raw(slf: crate::PtrInner<'_, Self>) -> *mut Self::Type {
                     let slf = slf.as_non_null().as_ptr();
                     // SAFETY: `PtrInner` promises it references either a zero-sized
                     // byte range, or else will reference a byte range that is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,7 +1144,7 @@ pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
     ///
     /// The returned pointer refers to a non-strict subset of the bytes of
     /// `slf`'s referent, and has the same provenance as `slf`.
-    fn project(slf: PtrInner<'_, Self>) -> *mut Self::Type;
+    fn project_raw(slf: PtrInner<'_, Self>) -> *mut Self::Type;
 }
 
 /// Analyzes whether a type is [`FromZeros`].

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -173,7 +173,7 @@ pub mod cast {
     /// A field projection
     ///
     /// A `Projection` is a [`Project`] which implements projection by
-    /// delegating to an implementation of [`HasField::project`].
+    /// delegating to an implementation of [`HasField::project_raw`].
     #[allow(missing_debug_implementations, missing_copy_implementations)]
     pub struct Projection<F: ?Sized, const VARIANT_ID: i128, const FIELD_ID: i128> {
         _never: core::convert::Infallible,
@@ -189,7 +189,7 @@ pub mod cast {
     {
         #[inline(always)]
         fn project(src: PtrInner<'_, T>) -> *mut T::Type {
-            T::project(src)
+            T::project_raw(src)
         }
     }
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -297,7 +297,7 @@ pub(crate) fn derive_is_bit_valid(
                 type Type = #ty;
 
                 #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                     use #zerocopy_crate::pointer::cast::{CastSized, Projection};
 
                     slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
@@ -410,7 +410,7 @@ pub(crate) fn derive_is_bit_valid(
                 type Type = ___ZerocopyTag;
 
                 #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                     slf.as_ptr().cast()
                 }
             }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -784,7 +784,7 @@ fn derive_has_field_struct_union(
             type Type = #ty;
 
             #[inline(always)]
-            fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+            fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                 let slf = slf.as_ptr();
                 // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
                 // pointer whose referent is zero-sized or lives in a valid

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -94,7 +94,7 @@ diff (expected vs got):
 ```
 {}
 ```\n",
-            res, diff
+            res, "diff"
         );
     }
 }
@@ -548,7 +548,7 @@ fn test_from_bytes_union() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = u8;
                             #[inline(always)]
-                            fn project(
+                            fn project_raw(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 let slf = slf.as_ptr();
@@ -889,7 +889,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project(
+                            fn project_raw(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -1067,7 +1067,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1107,7 +1107,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1147,7 +1147,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1187,7 +1187,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1227,7 +1227,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1267,7 +1267,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1309,7 +1309,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1472,7 +1472,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1512,7 +1512,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1552,7 +1552,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1592,7 +1592,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1634,7 +1634,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1700,7 +1700,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1755,7 +1755,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1808,7 +1808,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1889,7 +1889,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1926,7 +1926,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1967,7 +1967,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2036,7 +2036,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2105,7 +2105,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2174,7 +2174,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2243,7 +2243,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2312,7 +2312,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2381,7 +2381,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2450,7 +2450,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2654,7 +2654,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project(
+                            fn project_raw(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -2832,7 +2832,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2872,7 +2872,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2912,7 +2912,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2952,7 +2952,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2992,7 +2992,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3032,7 +3032,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3074,7 +3074,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3237,7 +3237,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3277,7 +3277,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3317,7 +3317,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3357,7 +3357,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3399,7 +3399,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3465,7 +3465,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3520,7 +3520,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3573,7 +3573,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3654,7 +3654,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3691,7 +3691,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3732,7 +3732,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3801,7 +3801,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3870,7 +3870,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3939,7 +3939,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4008,7 +4008,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4077,7 +4077,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4146,7 +4146,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4215,7 +4215,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4337,7 +4337,6 @@ fn test_try_from_bytes_enum() {
                     }
                 }
             };
-
         } no_build
     }
 
@@ -4420,7 +4419,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project(
+                            fn project_raw(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -4598,7 +4597,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4638,7 +4637,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4678,7 +4677,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4718,7 +4717,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4758,7 +4757,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4798,7 +4797,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4840,7 +4839,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5003,7 +5002,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5043,7 +5042,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5083,7 +5082,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5123,7 +5122,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5165,7 +5164,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project(
+                                        fn project_raw(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5231,7 +5230,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5286,7 +5285,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5339,7 +5338,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5420,7 +5419,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5457,7 +5456,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project(
+                                    fn project_raw(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5498,7 +5497,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5567,7 +5566,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5636,7 +5635,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5705,7 +5704,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5774,7 +5773,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5843,7 +5842,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5912,7 +5911,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5981,7 +5980,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project(
+                                fn project_raw(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #2886
- #2885
- #2884


**Latest Update:** v5 — [Compare vs v4](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 |
| :--- | :--- | :--- | :--- | :--- | :--- |
| v5 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v1..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v2..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v3..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v5) |
| v4 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v1..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v2..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v3..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v4) | |
| v3 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v3) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v1..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v3) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v2..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v3) | | |
| v2 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v2) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v1..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v2) | | | |
| v1 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/Gb943ae3571a06b4a5c727268ae1829579e6350dc/v1) | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "Gb943ae3571a06b4a5c727268ae1829579e6350dc", "parent": null, "child": "G90165d85418ed6203ef3caaa77662dd3b313e030"} -->