### PR TITLE
Introduce `HasField::project_inner`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1145,6 +1145,41 @@ pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
     /// The returned pointer refers to a non-strict subset of the bytes of
     /// `slf`'s referent, and has the same provenance as `slf`.
     fn project_raw(slf: PtrInner<'_, Self>) -> *mut Self::Type;
+
+    /// Projects from `slf` to the field.
+    ///
+    /// # Safety
+    ///
+    /// The returned pointer refers to a non-strict subset of the bytes of
+    /// `slf`'s referent, and has the same provenance as `slf`.
+    #[must_use]
+    #[inline(always)]
+    fn project_inner(slf: PtrInner<'_, Self>) -> PtrInner<'_, Self::Type> {
+        let projected_raw = Self::project_raw(slf);
+        // SAFETY: `slf`'s referent lives at a `NonNull` address, and is either
+        // zero-sized or lives in an allocation. In either case, it does not
+        // wrap around the address space [1], and so none of the addresses
+        // contained in it or one-past-the-end of it are null.
+        //
+        // By invariant on `project_raw`, `project_raw` is a
+        // provenance-preserving projection which preserves or shrinks the set
+        // of referent bytes, so `projected_raw` references a subset of `slf`'s
+        // referent, and so it cannot be null.
+        //
+        // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
+        let projected_non_null = unsafe { NonNull::new_unchecked(projected_raw) };
+        // SAFETY: As described in the preceding safety comment,
+        // `projected_raw`, and thus `projected_non_null`, addresses a subset of
+        // `slf`'s referent. Thus, `projected_non_null` either:
+        // - Addresses zero bytes or,
+        // - Addresses a subset of the referent of `slf`. In this case, `slf`
+        //   has provenance for its referent, which lives in an allocation.
+        //   Since `projected_non_null` was constructed using a sequence of
+        //   provenance-preserving operations, it also has provenance for its
+        //   referent and that referent lives in an allocation. By invariant on
+        //   `slf`, that allocation lives for `'a`.
+        unsafe { PtrInner::new(projected_non_null) }
+    }
 }
 
 /// Analyzes whether a type is [`FromZeros`].


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- #2886
- #2885


**Latest Update:** v6 — [Compare vs v5](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

| Version | Base | v1 | v2 | v3 | v4 | v5 |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| v6 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) | [vs v5](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v6) |
| v5 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5) | [vs v4](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v5) | |
| v4 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4) | [vs v3](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v4) | | |
| v3 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3) | [vs v2](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v3) | | | |
| v2 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2) | [vs v1](https://github.com/google/zerocopy/compare/gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v2) | | | | |
| v1 | [vs Base](https://github.com/google/zerocopy/compare/main..gherrit/G90165d85418ed6203ef3caaa77662dd3b313e030/v1) | | | | | |

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. -->
<!-- gherrit-meta: {"id": "G90165d85418ed6203ef3caaa77662dd3b313e030", "parent": null, "child": "Gb6fa34cec5080caffa0980ed1d3e1ae273550f44"} -->