### PR TITLE
Tighten impl of CastUnsized

### DIFF
--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -129,9 +129,13 @@ pub mod cast {
     #[allow(missing_debug_implementations, missing_copy_implementations)]
     pub enum CastUnsized {}
 
-    // SAFETY: The `static_assert!` ensures that `Src` and `Dst` have the same
-    // `SizeInfo`. Thus, casting preserves the set of referent bytes. All
-    // operations are provenance-preserving.
+    // SAFETY: By the `static_assert!`, `Src` and `Dst` are either:
+    // - Both sized and equal in size
+    // - Both slice DSTs with the same trailing slice offset and element size
+    //   and with align_of::<Src>() >= align_of::<Dst>(). These ensure that any
+    //   given pointer metadata encodes the same size for both `Src` and `Dst`
+    //   (note that the alignment is required as it affects the amount of
+    //   trailing padding).
     unsafe impl<Src, Dst> Project<Src, Dst> for CastUnsized
     where
         Src: ?Sized + KnownLayout,
@@ -139,20 +143,16 @@ pub mod cast {
     {
         #[inline(always)]
         fn project(src: PtrInner<'_, Src>) -> *mut Dst {
-            // FIXME:
-            // - Is the alignment check necessary for soundness? It's not
-            //   necessary for the soundness of the `Project` impl, but what
-            //   about the soundness of particular use sites?
-            // - Do we want this to support shrinking casts as well?
+            // FIXME: Do we want this to support shrinking casts as well?
             static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {
-                let t = <Src as KnownLayout>::LAYOUT;
-                let u = <Dst as KnownLayout>::LAYOUT;
-                t.align.get() >= u.align.get() && match (t.size_info, u.size_info) {
-                    (SizeInfo::Sized { size: t }, SizeInfo::Sized { size: u }) => t == u,
+                let src = <Src as KnownLayout>::LAYOUT;
+                let dst = <Dst as KnownLayout>::LAYOUT;
+                match (src.size_info, dst.size_info) {
+                    (SizeInfo::Sized { size: src_size }, SizeInfo::Sized { size: dst_size }) => src_size == dst_size,
                     (
-                        SizeInfo::SliceDst(TrailingSliceLayout { offset: t_offset, elem_size: t_elem_size }),
-                        SizeInfo::SliceDst(TrailingSliceLayout { offset: u_offset, elem_size: u_elem_size })
-                    ) => t_offset == u_offset && t_elem_size == u_elem_size,
+                        SizeInfo::SliceDst(TrailingSliceLayout { offset: src_offset, elem_size: src_elem_size }),
+                        SizeInfo::SliceDst(TrailingSliceLayout { offset: dst_offset, elem_size: dst_elem_size })
+                    ) => src.align.get() >= dst.align.get() && src_offset == dst_offset && src_elem_size == dst_elem_size,
                     _ => false,
                 }
             });


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Migrate alignment check from unconditional to only applying to the slice
DST case. Improve detail of safety proof.




---

- &#x3000; #2878
- &#x3000; #2876
- &#x3000; #2873
- &#x3000; #2866
- &#x3000; #2872
- &#x3000; #2895
- 👉 #2887


**Latest Update:** v17 — [Compare vs v16](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v16 | v15 | v14 | v13 | v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v17|[v16](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v15](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v14](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v13](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v12](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v17)|
|v16||[v15](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v14](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v13](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v12](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v16)|
|v15|||[v14](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v13](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v12](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v15)|
|v14||||[v13](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v12](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v14)|
|v13|||||[v12](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v13)|
|v12||||||[v11](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v12)|
|v11|||||||[v10](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v11)|
|v10||||||||[v9](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v10)|
|v9|||||||||[v8](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v9)|
|v8||||||||||[v7](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v8)|
|v7|||||||||||[v6](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v7)|
|v6||||||||||||[v5](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v6)|
|v5|||||||||||||[v4](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5)|[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v5)|
|v4||||||||||||||[v3](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4)|[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v4)|
|v3|||||||||||||||[v2](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3)|[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v3)|
|v2||||||||||||||||[v1](/google/zerocopy/compare/gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2)|[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v2)|
|v1|||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/G2eb58496ed1e3c61421020abbbb694d970d43c1c/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2eb58496ed1e3c61421020abbbb694d970d43c1c", "parent": null, "child": "G481927cb6e9ca76c1531c05465f608e1b2607a62"}" -->