### PR TITLE
[derive] Move find_zero_variant to enum module

### DIFF
--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -9,8 +9,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse_quote, spanned::Spanned as _, DataEnum, DeriveInput, Error, Fields, Generics, Ident,
-    Index, Path,
+    parse_quote, spanned::Spanned as _, DataEnum, DeriveInput, Error, Expr, ExprLit, ExprUnary,
+    Fields, Generics, Ident, Index, Lit, Path, UnOp,
 };
 
 use crate::{
@@ -449,4 +449,82 @@ pub(crate) fn derive_is_bit_valid(
             }
         }
     })
+}
+
+/// Returns `Ok(index)` if variant `index` of the enum has a discriminant of
+/// zero. If `Err(bool)` is returned, the boolean is true if the enum has
+/// unknown discriminants (e.g. discriminants set to const expressions which we
+/// can't evaluate in a proc macro). If the enum has unknown discriminants, then
+/// it might have a zero variant that we just can't detect.
+pub(crate) fn find_zero_variant(enm: &DataEnum) -> Result<usize, bool> {
+    // Discriminants can be anywhere in the range [i128::MIN, u128::MAX] because
+    // the discriminant type may be signed or unsigned. Since we only care about
+    // tracking the discriminant when it's less than or equal to zero, we can
+    // avoid u128 -> i128 conversions and bounds checking by making the "next
+    // discriminant" value implicitly negative.
+    // Technically 64 bits is enough, but 128 is better for future compatibility
+    // with https://github.com/rust-lang/rust/issues/56071
+    let mut next_negative_discriminant = Some(0);
+
+    // Sometimes we encounter explicit discriminants that we can't know the
+    // value of (e.g. a constant expression that requires evaluation). These
+    // could evaluate to zero or a negative number, but we can't assume that
+    // they do (no false positives allowed!). So we treat them like strictly-
+    // positive values that can't result in any zero variants, and track whether
+    // we've encountered any unknown discriminants.
+    let mut has_unknown_discriminants = false;
+
+    for (i, v) in enm.variants.iter().enumerate() {
+        match v.discriminant.as_ref() {
+            // Implicit discriminant
+            None => {
+                match next_negative_discriminant.as_mut() {
+                    Some(0) => return Ok(i),
+                    // n is nonzero so subtraction is always safe
+                    Some(n) => *n -= 1,
+                    None => (),
+                }
+            }
+            // Explicit positive discriminant
+            Some((_, Expr::Lit(ExprLit { lit: Lit::Int(int), .. }))) => {
+                match int.base10_parse::<u128>().ok() {
+                    Some(0) => return Ok(i),
+                    Some(_) => next_negative_discriminant = None,
+                    None => {
+                        // Numbers should never fail to parse, but just in case:
+                        has_unknown_discriminants = true;
+                        next_negative_discriminant = None;
+                    }
+                }
+            }
+            // Explicit negative discriminant
+            Some((_, Expr::Unary(ExprUnary { op: UnOp::Neg(_), expr, .. }))) => match &**expr {
+                Expr::Lit(ExprLit { lit: Lit::Int(int), .. }) => {
+                    match int.base10_parse::<u128>().ok() {
+                        Some(0) => return Ok(i),
+                        // x is nonzero so subtraction is always safe
+                        Some(x) => next_negative_discriminant = Some(x - 1),
+                        None => {
+                            // Numbers should never fail to parse, but just in
+                            // case:
+                            has_unknown_discriminants = true;
+                            next_negative_discriminant = None;
+                        }
+                    }
+                }
+                // Unknown negative discriminant (e.g. const repr)
+                _ => {
+                    has_unknown_discriminants = true;
+                    next_negative_discriminant = None;
+                }
+            },
+            // Unknown discriminant (e.g. const expr)
+            _ => {
+                has_unknown_discriminants = true;
+                next_negative_discriminant = None;
+            }
+        }
+    }
+
+    Err(has_unknown_discriminants)
 }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -53,8 +53,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
     parse_quote, spanned::Spanned as _, Attribute, Data, DataEnum, DataStruct, DataUnion,
-    DeriveInput, Error, Expr, ExprLit, ExprUnary, GenericParam, Ident, Lit, Meta, Path, Type, UnOp,
-    WherePredicate,
+    DeriveInput, Error, Expr, ExprLit, GenericParam, Ident, Lit, Meta, Path, Type, WherePredicate,
 };
 
 use crate::{repr::*, util::*};
@@ -1100,84 +1099,6 @@ fn derive_from_zeros_struct(
         .build()
 }
 
-/// Returns `Ok(index)` if variant `index` of the enum has a discriminant of
-/// zero. If `Err(bool)` is returned, the boolean is true if the enum has
-/// unknown discriminants (e.g. discriminants set to const expressions which we
-/// can't evaluate in a proc macro). If the enum has unknown discriminants, then
-/// it might have a zero variant that we just can't detect.
-fn find_zero_variant(enm: &DataEnum) -> Result<usize, bool> {
-    // Discriminants can be anywhere in the range [i128::MIN, u128::MAX] because
-    // the discriminant type may be signed or unsigned. Since we only care about
-    // tracking the discriminant when it's less than or equal to zero, we can
-    // avoid u128 -> i128 conversions and bounds checking by making the "next
-    // discriminant" value implicitly negative.
-    // Technically 64 bits is enough, but 128 is better for future compatibility
-    // with https://github.com/rust-lang/rust/issues/56071
-    let mut next_negative_discriminant = Some(0);
-
-    // Sometimes we encounter explicit discriminants that we can't know the
-    // value of (e.g. a constant expression that requires evaluation). These
-    // could evaluate to zero or a negative number, but we can't assume that
-    // they do (no false positives allowed!). So we treat them like strictly-
-    // positive values that can't result in any zero variants, and track whether
-    // we've encountered any unknown discriminants.
-    let mut has_unknown_discriminants = false;
-
-    for (i, v) in enm.variants.iter().enumerate() {
-        match v.discriminant.as_ref() {
-            // Implicit discriminant
-            None => {
-                match next_negative_discriminant.as_mut() {
-                    Some(0) => return Ok(i),
-                    // n is nonzero so subtraction is always safe
-                    Some(n) => *n -= 1,
-                    None => (),
-                }
-            }
-            // Explicit positive discriminant
-            Some((_, Expr::Lit(ExprLit { lit: Lit::Int(int), .. }))) => {
-                match int.base10_parse::<u128>().ok() {
-                    Some(0) => return Ok(i),
-                    Some(_) => next_negative_discriminant = None,
-                    None => {
-                        // Numbers should never fail to parse, but just in case:
-                        has_unknown_discriminants = true;
-                        next_negative_discriminant = None;
-                    }
-                }
-            }
-            // Explicit negative discriminant
-            Some((_, Expr::Unary(ExprUnary { op: UnOp::Neg(_), expr, .. }))) => match &**expr {
-                Expr::Lit(ExprLit { lit: Lit::Int(int), .. }) => {
-                    match int.base10_parse::<u128>().ok() {
-                        Some(0) => return Ok(i),
-                        // x is nonzero so subtraction is always safe
-                        Some(x) => next_negative_discriminant = Some(x - 1),
-                        None => {
-                            // Numbers should never fail to parse, but just in
-                            // case:
-                            has_unknown_discriminants = true;
-                            next_negative_discriminant = None;
-                        }
-                    }
-                }
-                // Unknown negative discriminant (e.g. const repr)
-                _ => {
-                    has_unknown_discriminants = true;
-                    next_negative_discriminant = None;
-                }
-            },
-            // Unknown discriminant (e.g. const expr)
-            _ => {
-                has_unknown_discriminants = true;
-                next_negative_discriminant = None;
-            }
-        }
-    }
-
-    Err(has_unknown_discriminants)
-}
-
 /// An enum is `FromZeros` if:
 /// - one of the variants has a discriminant of `0`
 /// - that variant's fields are all `FromZeros`
@@ -1199,7 +1120,7 @@ fn derive_from_zeros_enum(
         | Repr::Compound(Spanned { t: CompoundRepr::Rust, span: _ }, _) => return Err(Error::new(Span::call_site(), "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout")),
     }
 
-    let zero_variant = match find_zero_variant(enm) {
+    let zero_variant = match r#enum::find_zero_variant(enm) {
         Ok(index) => enm.variants.iter().nth(index).unwrap(),
         // Has unknown variants
         Err(true) => {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- &#x3000; #2893
- &#x3000; #2890
- 👉 #2889
- &#x3000; #2888


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)|[vs v3](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v3..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)|[vs v2](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v2..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)|[vs v1](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v1..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)|[vs Base](/google/zerocopy/compare/G5b19f4ff3c98f2a068b4270232da1b337d1f2d61..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v3..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4)|[vs v2](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v2..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4)|[vs v1](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v1..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4)|[vs Base](/google/zerocopy/compare/G5b19f4ff3c98f2a068b4270232da1b337d1f2d61..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v2..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v3)|[vs v1](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v1..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v3)|[vs Base](/google/zerocopy/compare/G5b19f4ff3c98f2a068b4270232da1b337d1f2d61..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v1..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v2)|[vs Base](/google/zerocopy/compare/G5b19f4ff3c98f2a068b4270232da1b337d1f2d61..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/G5b19f4ff3c98f2a068b4270232da1b337d1f2d61..gherrit/G3cfee091c2de68a64a643bafaf57c57427dd4914/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3cfee091c2de68a64a643bafaf57c57427dd4914", "parent": "G5b19f4ff3c98f2a068b4270232da1b337d1f2d61", "child": "G0662505d5901f5c3cd21b16c314b9f3f8dc817a6"}" -->