### PR TITLE
[cast] Add Project::pointer_inner

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -771,7 +771,7 @@ mod cast_from {
         /// implement soundly.
         //
         // FIXME(#1817): Support Sized->Unsized and Unsized->Sized casts
-        fn project(src: PtrInner<'_, Src>) -> *mut Dst {
+        fn project_raw(src: PtrInner<'_, Src>) -> *mut Dst {
             // At compile time (specifically, post-monomorphization time), we
             // need to compute two things:
             // - Whether, given *any* `*Src`, it is possible to construct a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1145,41 +1145,6 @@ pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
     /// The returned pointer refers to a non-strict subset of the bytes of
     /// `slf`'s referent, and has the same provenance as `slf`.
     fn project_raw(slf: PtrInner<'_, Self>) -> *mut Self::Type;
-
-    /// Projects from `slf` to the field.
-    ///
-    /// # Safety
-    ///
-    /// The returned pointer refers to a non-strict subset of the bytes of
-    /// `slf`'s referent, and has the same provenance as `slf`.
-    #[must_use]
-    #[inline(always)]
-    fn project_inner(slf: PtrInner<'_, Self>) -> PtrInner<'_, Self::Type> {
-        let projected_raw = Self::project_raw(slf);
-        // SAFETY: `slf`'s referent lives at a `NonNull` address, and is either
-        // zero-sized or lives in an allocation. In either case, it does not
-        // wrap around the address space [1], and so none of the addresses
-        // contained in it or one-past-the-end of it are null.
-        //
-        // By invariant on `project_raw`, `project_raw` is a
-        // provenance-preserving projection which preserves or shrinks the set
-        // of referent bytes, so `projected_raw` references a subset of `slf`'s
-        // referent, and so it cannot be null.
-        //
-        // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
-        let projected_non_null = unsafe { NonNull::new_unchecked(projected_raw) };
-        // SAFETY: As described in the preceding safety comment,
-        // `projected_raw`, and thus `projected_non_null`, addresses a subset of
-        // `slf`'s referent. Thus, `projected_non_null` either:
-        // - Addresses zero bytes or,
-        // - Addresses a subset of the referent of `slf`. In this case, `slf`
-        //   has provenance for its referent, which lives in an allocation.
-        //   Since `projected_non_null` was constructed using a sequence of
-        //   provenance-preserving operations, it also has provenance for its
-        //   referent and that referent lives in an allocation. By invariant on
-        //   `slf`, that allocation lives for `'a`.
-        unsafe { PtrInner::new(projected_non_null) }
-    }
 }
 
 /// Analyzes whether a type is [`FromZeros`].

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -60,7 +60,44 @@ pub mod cast {
         ///
         /// The returned pointer refers to a non-strict subset of the bytes of
         /// `src`'s referent, and has the same provenance as `src`.
-        fn project(src: PtrInner<'_, Src>) -> *mut Dst;
+        fn project_raw(src: PtrInner<'_, Src>) -> *mut Dst;
+
+        /// Projects a [`PtrInner`] from `Src` to `Dst`.
+        ///
+        /// # Safety
+        ///
+        /// The caller may assume that the resulting `PtrInner` addresses a
+        /// subset of the bytes of `src`'s referent.
+        #[must_use]
+        #[inline(always)]
+        fn project_inner(src: PtrInner<'_, Src>) -> PtrInner<'_, Dst> {
+            let projected_raw = Self::project_raw(src);
+
+            // SAFETY: `src`'s referent lives at a `NonNull` address, and is
+            // either zero-sized or lives in an allocation. In either case, it
+            // does not wrap around the address space [1], and so none of the
+            // addresses contained in it or one-past-the-end of it are null.
+            //
+            // By invariant on `Self: Project`, `Self::project` is a
+            // provenance-preserving projection which preserves or shrinks the
+            // set of referent bytes, so `projected_raw` references a subset of
+            // `src`'s referent, and so it cannot be null.
+            //
+            // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
+            let projected_non_null = unsafe { core::ptr::NonNull::new_unchecked(projected_raw) };
+
+            // SAFETY: As described in the preceding safety comment, `projected_raw`,
+            // and thus `projected_non_null`, addresses a subset of `src`'s
+            // referent. Thus, `projected_non_null` either:
+            // - Addresses zero bytes or,
+            // - Addresses a subset of the referent of `src`. In this case, `src`
+            //   has provenance for its referent, which lives in an allocation.
+            //   Since `projected_non_null` was constructed using a sequence of
+            //   provenance-preserving operations, it also has provenance for its
+            //   referent and that referent lives in an allocation. By invariant on
+            //   `src`, that allocation lives for `'a`.
+            unsafe { PtrInner::new(projected_non_null) }
+        }
     }
 
     /// A [`Project`] which preserves the address of the referent – a pointer
@@ -82,7 +119,7 @@ pub mod cast {
     // bytes.
     unsafe impl<T: ?Sized> Project<T, T> for IdCast {
         #[inline(always)]
-        fn project(src: PtrInner<'_, T>) -> *mut T {
+        fn project_raw(src: PtrInner<'_, T>) -> *mut T {
             src.as_ptr()
         }
     }
@@ -107,7 +144,7 @@ pub mod cast {
     // operations preserve provenance.
     unsafe impl<Src, Dst> Project<Src, Dst> for CastSized {
         #[inline(always)]
-        fn project(src: PtrInner<'_, Src>) -> *mut Dst {
+        fn project_raw(src: PtrInner<'_, Src>) -> *mut Dst {
             static_assert!(Src, Dst => mem::size_of::<Src>() >= mem::size_of::<Dst>());
             src.as_ptr().cast::<Dst>()
         }
@@ -142,7 +179,7 @@ pub mod cast {
         Dst: ?Sized + KnownLayout<PointerMetadata = Src::PointerMetadata>,
     {
         #[inline(always)]
-        fn project(src: PtrInner<'_, Src>) -> *mut Dst {
+        fn project_raw(src: PtrInner<'_, Src>) -> *mut Dst {
             // FIXME: Do we want this to support shrinking casts as well?
             static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {
                 let src = <Src as KnownLayout>::LAYOUT;
@@ -188,7 +225,7 @@ pub mod cast {
         T: HasField<F, VARIANT_ID, FIELD_ID>,
     {
         #[inline(always)]
-        fn project(src: PtrInner<'_, T>) -> *mut T::Type {
+        fn project_raw(src: PtrInner<'_, T>) -> *mut T::Type {
             T::project_raw(src)
         }
     }
@@ -221,7 +258,7 @@ pub mod cast {
         UV: Project<U, V>,
     {
         #[inline(always)]
-        fn project(t: PtrInner<'_, T>) -> *mut V {
+        fn project_raw(t: PtrInner<'_, T>) -> *mut V {
             t.project::<_, TU>().project::<_, UV>().as_ptr()
         }
     }
@@ -251,7 +288,7 @@ pub mod cast {
     // true of other proofs in this codebase). Is this guaranteed anywhere?
     unsafe impl<T: ?Sized + KnownLayout> Project<T, [u8]> for AsBytesCast {
         #[inline(always)]
-        fn project(src: PtrInner<'_, T>) -> *mut [u8] {
+        fn project_raw(src: PtrInner<'_, T>) -> *mut [u8] {
             let bytes = match T::size_of_val_raw(src.as_non_null()) {
                 Some(bytes) => bytes,
                 // SAFETY: `KnownLayout::size_of_val_raw` promises to always

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -479,8 +479,9 @@ mod tests {
     use crate::pointer::cast::Project as _;
 
     fn test_size_eq<Src, Dst: SizeEq<Src>>(mut src: Src) {
-        let _: *mut Dst =
-            <Dst as SizeEq<Src>>::CastFrom::project(crate::pointer::PtrInner::from_mut(&mut src));
+        let _: *mut Dst = <Dst as SizeEq<Src>>::CastFrom::project_raw(
+            crate::pointer::PtrInner::from_mut(&mut src),
+        );
     }
 
     #[test]

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -972,7 +972,7 @@ where
     // provenance.
     unsafe impl<T: ?Sized + KnownLayout> Project<[u8], T> for CastForSized {
         #[inline(always)]
-        fn project(src: PtrInner<'_, [u8]>) -> *mut T {
+        fn project_raw(src: PtrInner<'_, [u8]>) -> *mut T {
             T::raw_from_ptr_len(
                 src.as_non_null().cast(),
                 <T::PointerMetadata as crate::PointerMetadata>::from_elem_count(0),

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -716,7 +716,7 @@ macro_rules! define_cast {
         // preserving or size-shrinking cast. All operations preserve
         // provenance.
         unsafe impl $(<$tyvar $(: ?$optbound)?>)? $crate::pointer::cast::Project<$src, $dst> for $name {
-            fn project(src: $crate::pointer::PtrInner<'_, $src>) -> *mut $dst {
+            fn project_raw(src: $crate::pointer::PtrInner<'_, $src>) -> *mut $dst {
                 #[allow(clippy::as_conversions)]
                 return src.as_ptr() as *mut $dst;
             }
@@ -878,7 +878,7 @@ macro_rules! unsafe_with_size_eq {
             // SAFETY: This call is never executed.
             #[allow(unused_unsafe, clippy::missing_transmute_annotations)]
             let ptr = unsafe { core::mem::transmute(ptr) };
-            let _ = <$dst<$u> as SizeEq<$src<$t>>>::CastFrom::project(ptr);
+            let _ = <$dst<$u> as SizeEq<$src<$t>>>::CastFrom::project_inner(ptr);
         }
 
         impl_for_transmute_from!(T: ?Sized + TryFromBytes => TryFromBytes for $src<T>[<T>]);


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Rename `Project::project` to `project_raw`, and add a new
`project_inner` which returns a `PtrInner` instead of a raw pointer.

Remove `HasField::project_inner` since we can use
`Project::project_inner` instead.




---

- &#x3000; #2878
- &#x3000; #2876
- &#x3000; #2873
- &#x3000; #2866
- &#x3000; #2872
- 👉 #2894
- &#x3000; #2887


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v1..gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v1..gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v2)|[vs Base](/google/zerocopy/compare/G2eb58496ed1e3c61421020abbbb694d970d43c1c..gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v2)|
|v1||[vs Base](/google/zerocopy/compare/G2eb58496ed1e3c61421020abbbb694d970d43c1c..gherrit/G82a7bac1fdbde51b23d1760bfc7881a3bf862452/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G82a7bac1fdbde51b23d1760bfc7881a3bf862452", "parent": "G2eb58496ed1e3c61421020abbbb694d970d43c1c", "child": "G57ec07c3841271440bbaf40cab04b942cbdbddb9"}" -->