### PR TITLE
Simplify projection methods

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -814,7 +814,7 @@ const _: () = {
         }
 
         #[inline(always)]
-        fn project_raw(slf: PtrInner<'_, Self>) -> *mut T {
+        fn project(slf: PtrInner<'_, Self>) -> *mut T {
             // SAFETY: `ManuallyDrop<T>` has the same layout and bit validity as
             // `T` [1].
             //
@@ -1084,7 +1084,7 @@ mod tuples {
                 type Type = $CurrT;
 
                 #[inline(always)]
-                fn project_raw(slf: crate::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project(slf: crate::PtrInner<'_, Self>) -> *mut Self::Type {
                     let slf = slf.as_non_null().as_ptr();
                     // SAFETY: `PtrInner` promises it references either a zero-sized
                     // byte range, or else will reference a byte range that is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1140,46 +1140,15 @@ pub unsafe trait HasField<Field, const VARIANT_ID: i128, const FIELD_ID: i128> {
 
     /// Projects from `slf` to the field.
     ///
-    /// # Safety
-    ///
-    /// The returned pointer refers to a non-strict subset of the bytes of
-    /// `slf`'s referent, and has the same provenance as `slf`.
-    fn project_raw(slf: PtrInner<'_, Self>) -> *mut Self::Type;
-
-    /// Projects from `slf` to the field.
+    /// Users should generally not call `project` directly, and instead should
+    /// use high-level APIs like [`PtrInner::project`] or [`Ptr::project`].
     ///
     /// # Safety
     ///
     /// The returned pointer refers to a non-strict subset of the bytes of
     /// `slf`'s referent, and has the same provenance as `slf`.
     #[must_use]
-    #[inline(always)]
-    fn project_inner(slf: PtrInner<'_, Self>) -> PtrInner<'_, Self::Type> {
-        let projected_raw = Self::project_raw(slf);
-        // SAFETY: `slf`'s referent lives at a `NonNull` address, and is either
-        // zero-sized or lives in an allocation. In either case, it does not
-        // wrap around the address space [1], and so none of the addresses
-        // contained in it or one-past-the-end of it are null.
-        //
-        // By invariant on `project_raw`, `project_raw` is a
-        // provenance-preserving projection which preserves or shrinks the set
-        // of referent bytes, so `projected_raw` references a subset of `slf`'s
-        // referent, and so it cannot be null.
-        //
-        // [1] https://doc.rust-lang.org/1.92.0/std/ptr/index.html#allocation
-        let projected_non_null = unsafe { NonNull::new_unchecked(projected_raw) };
-        // SAFETY: As described in the preceding safety comment,
-        // `projected_raw`, and thus `projected_non_null`, addresses a subset of
-        // `slf`'s referent. Thus, `projected_non_null` either:
-        // - Addresses zero bytes or,
-        // - Addresses a subset of the referent of `slf`. In this case, `slf`
-        //   has provenance for its referent, which lives in an allocation.
-        //   Since `projected_non_null` was constructed using a sequence of
-        //   provenance-preserving operations, it also has provenance for its
-        //   referent and that referent lives in an allocation. By invariant on
-        //   `slf`, that allocation lives for `'a`.
-        unsafe { PtrInner::new(projected_non_null) }
-    }
+    fn project(slf: PtrInner<'_, Self>) -> *mut Self::Type;
 }
 
 /// Analyzes whether a type is [`FromZeros`].

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -56,6 +56,12 @@ pub mod cast {
     pub unsafe trait Project<Src: ?Sized, Dst: ?Sized> {
         /// Projects a pointer from `Src` to `Dst`.
         ///
+        /// Users should generally not call `project` directly, and instead
+        /// should use high-level APIs like [`PtrInner::project`] or
+        /// [`Ptr::project`].
+        ///
+        /// [`Ptr::project`]: crate::pointer::Ptr::project
+        ///
         /// # Safety
         ///
         /// The returned pointer refers to a non-strict subset of the bytes of
@@ -173,7 +179,7 @@ pub mod cast {
     /// A field projection
     ///
     /// A `Projection` is a [`Project`] which implements projection by
-    /// delegating to an implementation of [`HasField::project_raw`].
+    /// delegating to an implementation of [`HasField::project`].
     #[allow(missing_debug_implementations, missing_copy_implementations)]
     pub struct Projection<F: ?Sized, const VARIANT_ID: i128, const FIELD_ID: i128> {
         _never: core::convert::Infallible,
@@ -189,7 +195,7 @@ pub mod cast {
     {
         #[inline(always)]
         fn project(src: PtrInner<'_, T>) -> *mut T::Type {
-            T::project_raw(src)
+            T::project(src)
         }
     }
 

--- a/zerocopy-derive/src/enum.rs
+++ b/zerocopy-derive/src/enum.rs
@@ -297,7 +297,7 @@ pub(crate) fn derive_is_bit_valid(
                 type Type = #ty;
 
                 #[inline(always)]
-                fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                     use #zerocopy_crate::pointer::cast::{CastSized, Projection};
 
                     slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
@@ -410,7 +410,7 @@ pub(crate) fn derive_is_bit_valid(
                 type Type = ___ZerocopyTag;
 
                 #[inline(always)]
-                fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                     slf.as_ptr().cast()
                 }
             }

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -784,7 +784,7 @@ fn derive_has_field_struct_union(
             type Type = #ty;
 
             #[inline(always)]
-            fn project_raw(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
+            fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut Self::Type {
                 let slf = slf.as_ptr();
                 // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
                 // pointer whose referent is zero-sized or lives in a valid

--- a/zerocopy-derive/src/output_tests.rs
+++ b/zerocopy-derive/src/output_tests.rs
@@ -548,7 +548,7 @@ fn test_from_bytes_union() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = u8;
                             #[inline(always)]
-                            fn project_raw(
+                            fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 let slf = slf.as_ptr();
@@ -889,7 +889,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project_raw(
+                            fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -1067,7 +1067,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1107,7 +1107,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1147,7 +1147,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1187,7 +1187,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1227,7 +1227,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1267,7 +1267,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1309,7 +1309,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1472,7 +1472,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1512,7 +1512,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1552,7 +1552,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1592,7 +1592,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1634,7 +1634,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -1700,7 +1700,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1755,7 +1755,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1808,7 +1808,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1889,7 +1889,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1926,7 +1926,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -1967,7 +1967,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2036,7 +2036,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2105,7 +2105,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2174,7 +2174,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2243,7 +2243,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2312,7 +2312,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2381,7 +2381,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2450,7 +2450,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -2654,7 +2654,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project_raw(
+                            fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -2832,7 +2832,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2872,7 +2872,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2912,7 +2912,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2952,7 +2952,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -2992,7 +2992,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3032,7 +3032,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3074,7 +3074,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3237,7 +3237,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3277,7 +3277,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3317,7 +3317,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3357,7 +3357,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3399,7 +3399,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -3465,7 +3465,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3520,7 +3520,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3573,7 +3573,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3654,7 +3654,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3691,7 +3691,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -3732,7 +3732,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3801,7 +3801,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3870,7 +3870,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -3939,7 +3939,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4008,7 +4008,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4077,7 +4077,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4146,7 +4146,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4215,7 +4215,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -4419,7 +4419,7 @@ fn test_try_from_bytes_enum() {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
                             type Type = ___ZerocopyTag;
                             #[inline(always)]
-                            fn project_raw(
+                            fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
                                 slf.as_ptr().cast()
@@ -4597,7 +4597,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4637,7 +4637,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = u8;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4677,7 +4677,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4717,7 +4717,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = X::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4757,7 +4757,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y::Target;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4797,7 +4797,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = [(X, Y); N];
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -4839,7 +4839,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5002,7 +5002,7 @@ fn test_try_from_bytes_enum() {
                                             ___ZerocopyInnerTag,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5042,7 +5042,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = bool;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5082,7 +5082,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = Y;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5122,7 +5122,7 @@ fn test_try_from_bytes_enum() {
                                         fn only_derive_is_allowed_to_implement_this_trait() {}
                                         type Type = PhantomData<&'a [(X, Y); N]>;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5164,7 +5164,7 @@ fn test_try_from_bytes_enum() {
                                             ComplexWithGenerics<'a, N, X, Y>,
                                         >;
                                         #[inline(always)]
-                                        fn project_raw(
+                                        fn project(
                                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                         ) -> *mut Self::Type {
                                             let slf = slf.as_ptr();
@@ -5230,7 +5230,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5285,7 +5285,7 @@ fn test_try_from_bytes_enum() {
                                         ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
                                     >;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5338,7 +5338,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ();
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5419,7 +5419,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyOuterTag;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5456,7 +5456,7 @@ fn test_try_from_bytes_enum() {
                                     fn only_derive_is_allowed_to_implement_this_trait() {}
                                     type Type = ___ZerocopyVariants<'a, N, X, Y>;
                                     #[inline(always)]
-                                    fn project_raw(
+                                    fn project(
                                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                     ) -> *mut Self::Type {
                                         let slf = slf.as_ptr();
@@ -5497,7 +5497,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = u8;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5566,7 +5566,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5635,7 +5635,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = X::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5704,7 +5704,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y::Target;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5773,7 +5773,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = [(X, Y); N];
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5842,7 +5842,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = bool;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5911,7 +5911,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = Y;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};
@@ -5980,7 +5980,7 @@ fn test_try_from_bytes_enum() {
                                 fn only_derive_is_allowed_to_implement_this_trait() {}
                                 type Type = PhantomData<&'a [(X, Y); N]>;
                                 #[inline(always)]
-                                fn project_raw(
+                                fn project(
                                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                                 ) -> *mut Self::Type {
                                     use ::zerocopy::pointer::cast::{CastSized, Projection};


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Remove high-level `HasField::project_inner`, and rename
`HasField::project_raw` to `HasField::project`.

The new plan is for `pointer::cast::Project` and `HasField` to only have
`project` methods which project from `PtrInner<Src>` to `*mut Dst`, and
for callers who want `PtrInner -> PtrInner` or `Ptr -> Ptr` to use
inherent methods on `PtrInner` and `Ptr`. Compared to a default-impl'd
method on `HasField`, this reduces indirection and reduces pressure on
the optimizer.

Reverts #2884, #2885




---

- &#x3000; #2878
- &#x3000; #2876
- &#x3000; #2873
- &#x3000; #2866
- &#x3000; #2872
- 👉 #2895


**Latest Update:** v9 — [Compare vs v8](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v9|[v8](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v7](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v6](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v5](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v4](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v9)|
|v8||[v7](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v6](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v5](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v4](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v8)|
|v7|||[v6](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[v5](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[v4](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v7)|
|v6||||[v5](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|[v4](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v6)|
|v5|||||[v4](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5)|[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v5)|
|v4||||||[v3](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4)|[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v4)|
|v3|||||||[v2](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3)|[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v3)|
|v2||||||||[v1](/google/zerocopy/compare/gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2)|[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v2)|
|v1|||||||||[Base](/google/zerocopy/compare/main..gherrit/G481927cb6e9ca76c1531c05465f608e1b2607a62/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G481927cb6e9ca76c1531c05465f608e1b2607a62", "parent": null, "child": "G57ec07c3841271440bbaf40cab04b942cbdbddb9"}" -->