### PR TITLE
Fix stale comments

### DIFF
--- a/src/byte_slice.rs
+++ b/src/byte_slice.rs
@@ -211,7 +211,7 @@ unsafe impl SplitByteSlice for &[u8] {
     #[inline]
     unsafe fn split_at_unchecked(self, mid: usize) -> (Self, Self) {
         // SAFETY: By contract on caller, `mid` is not greater than
-        // `bytes.len()`.
+        // `self.len()`.
         #[allow(clippy::multiple_unsafe_ops_per_block)]
         unsafe {
             (<[u8]>::get_unchecked(self, ..mid), <[u8]>::get_unchecked(self, mid..))

--- a/src/byteorder.rs
+++ b/src/byteorder.rs
@@ -1372,7 +1372,6 @@ mod tests {
             FNT: Fn(T::Native, T) -> T,
             FNN: Fn(T::Native, T::Native) -> T::Native,
             FNNChecked: Fn(T::Native, T::Native) -> Option<T::Native>,
-
             FATT: Fn(&mut T, T),
             FATN: Fn(&mut T, T::Native),
             FANT: Fn(&mut T::Native, T),

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -168,7 +168,7 @@ const _: () = unsafe { unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unalig
 // `Maybe<str>` refers to a valid `str`. `str::from_utf8` guarantees that it
 // returns `Err` if its input is not a valid `str` [1].
 //
-// [2] Per https://doc.rust-lang.org/core/str/fn.from_utf8.html#errors:
+// [1] Per https://doc.rust-lang.org/core/str/fn.from_utf8.html#errors:
 //
 //   Returns `Err` if the slice is not UTF-8.
 const _: () = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4362,8 +4362,8 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// Since an explicit `count` is provided, this method supports types with
-    /// zero-sized trailing slice elements. Methods such as [`mut_from`] which
-    /// do not take an explicit count do not support such types.
+    /// zero-sized trailing slice elements. Methods such as [`mut_from_bytes`]
+    /// which do not take an explicit count do not support such types.
     ///
     /// ```
     /// use zerocopy::*;
@@ -4381,7 +4381,7 @@ pub unsafe trait FromBytes: FromZeros {
     /// assert_eq!(zsty.trailing_dst.len(), 42);
     /// ```
     ///
-    /// [`mut_from`]: FromBytes::mut_from
+    /// [`mut_from_bytes`]: FromBytes::mut_from_bytes
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_bytes_with_elems(
@@ -6449,10 +6449,10 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_from_mut_from() {
-        // Test `FromBytes::{ref_from, mut_from}{,_prefix,Suffix}` success cases
-        // Exhaustive coverage for these methods is covered by the `Ref` tests above,
-        // which these helper methods defer to.
+    fn test_ref_from_mut_from_bytes() {
+        // Test `FromBytes::{ref_from_bytes, mut_from_bytes}{,_prefix,Suffix}`
+        // success cases. Exhaustive coverage for these methods is covered by
+        // the `Ref` tests above, which these helper methods defer to.
 
         let mut buf =
             Align::<[u8; 16], AU64>::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
@@ -6484,8 +6484,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ref_from_mut_from_error() {
-        // Test `FromBytes::{ref_from, mut_from}{,_prefix,Suffix}` error cases.
+    fn test_ref_from_mut_from_bytes_error() {
+        // Test `FromBytes::{ref_from_bytes, mut_from_bytes}{,_prefix,Suffix}`
+        // error cases.
 
         // Fail because the buffer is too large.
         let mut buf = Align::<[u8; 16], AU64>::default();

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -517,8 +517,8 @@ impl<'a, T, const N: usize> PtrInner<'a, [T; N]> {
         //    operations, it has provenance for its entire referent.
         // 1. By the above lemma, if `slice`'s referent is not zero sized, then
         //    `A` is guaranteed to live for at least `'a`, because it is derived
-        //    from the same allocation as `self`, which, by invariant on `Ptr`,
-        //    lives for at least `'a`.
+        //    from the same allocation as `self`, which, by invariant on
+        //    `PtrInner`, lives for at least `'a`.
         unsafe { PtrInner::new(slice) }
     }
 }

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1131,8 +1131,7 @@ mod _casts {
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
             [u8]: Read<I::Aliasing, R>,
         {
-            // FIXME(#67): Remove this allow. See NonNulSlicelExt for more
-            // details.
+            // FIXME(#67): Remove this allow. See NonNullExt for more details.
             #[allow(unstable_name_collisions)]
             match self.try_cast_into(CastType::Prefix, meta) {
                 Ok((slf, remainder)) => {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #2896


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v1..gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v1..gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G13169e447339730a2f697b60aa0eedc6f11ed647/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G13169e447339730a2f697b60aa0eedc6f11ed647", "parent": null, "child": null}" -->