### PR TITLE
[derive] Automatically bless output test output

### DIFF
--- a/agent_docs/ui_tests.md
+++ b/agent_docs/ui_tests.md
@@ -6,11 +6,11 @@ license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
 This file may not be copied, modified, or distributed except according to
 those terms. -->
 
-# UI Tests
+# UI & Output Tests
 
 When updating UI test files (`tests/ui-*` or `zerocopy-derive/tests/ui-*`) or
-functionality which could affect compiler error output, run:
-`./tools/update-ui-test-files.sh`.
+functionality which could affect compiler error output or derive output, run:
+`./tools/update-expected-test-output.sh`.
 
 **Note:** We maintain separate UI tests for different toolchains (`ui-msrv`,
 `ui-stable`, `ui-nightly`) because compiler output varies. The script handles
@@ -34,10 +34,10 @@ we use a symlink pattern:
     1.  Create the `.rs` file in `ui-nightly`.
     2.  Create relative symlinks in `ui-stable` and `ui-msrv` pointing to the
         new file in `ui-nightly`.
-    3.  Run `./tools/update-ui-test-files.sh` to generate the `.stderr` files.
+    3.  Run `./tools/update-expected-test-output.sh` to generate the `.stderr` files.
 - **Modifying a Test:**
     1.  Edit the `.rs` file in `ui-nightly`.
-    2.  Run `./tools/update-ui-test-files.sh` to update the `.stderr` files.
+    2.  Run `./tools/update-expected-test-output.sh` to update the `.stderr` files.
 - **Removing a Test:**
     1.  Delete the `.rs` file from `ui-nightly`.
     2.  Delete the symlinks from `ui-stable` and `ui-msrv`.

--- a/tools/update-expected-test-output.sh
+++ b/tools/update-expected-test-output.sh
@@ -12,12 +12,16 @@
 
 set -e
 
-TRYBUILD=overwrite ./cargo.sh +nightly test ui --verbose --test trybuild -p zerocopy --all-features
-TRYBUILD=overwrite ./cargo.sh +stable  test ui --verbose --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
+TRYBUILD=overwrite ./cargo.sh +nightly test ui --test trybuild -p zerocopy --all-features
+TRYBUILD=overwrite ./cargo.sh +stable  test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
 # For developers using Rust Analyzer, it's often the case that Rust Analyzer has
 # chosen versions of dependencies (especially syn) which have an MSRV higher than
 # our own. Doing `rm Cargo.lock` here permits `./cargo.sh +msrv` to choose its own
 # versions of these crates that have a lower MSRV.
-rm Cargo.lock && TRYBUILD=overwrite ./cargo.sh +msrv test ui --verbose --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
+rm Cargo.lock && TRYBUILD=overwrite ./cargo.sh +msrv test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
 
-TRYBUILD=overwrite ./cargo.sh +all test ui --verbose --test trybuild -p zerocopy-derive
+TRYBUILD=overwrite ./cargo.sh +all test ui --test trybuild -p zerocopy-derive
+
+# Update zerocopy-derive's `.expected.rs` files used to validate derive output.
+
+ZEROCOPY_BLESS=1 ./cargo.sh +nightly test -p zerocopy-derive --lib

--- a/zerocopy-derive/src/output_tests/expected/eq.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/eq.expected.rs
@@ -1,4 +1,3 @@
-
 impl<T: Clone> ::zerocopy::util::macro_util::core_reexport::cmp::PartialEq for Foo<T>
 where
     Self: ::zerocopy::IntoBytes + ::zerocopy::Immutable,
@@ -11,11 +10,8 @@ where
         )
     }
 }
-
-
 impl<T: Clone> ::zerocopy::util::macro_util::core_reexport::cmp::Eq for Foo<T>
 where
     Self: ::zerocopy::IntoBytes + ::zerocopy::Immutable,
     Self: Sized,
-{
-}
+{}

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
@@ -12,7 +12,6 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-
         fn is_bit_valid<___ZerocopyAliasing>(
             _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
@@ -24,16 +23,13 @@ const _: () = {
                 where
                     T: ::zerocopy::FromBytes,
                     T: ?::zerocopy::util::macro_util::core_reexport::marker::Sized,
-                {
-                }
+                {}
                 assert_is_from_bytes::<Self>();
             }
-
             true
         }
     }
 };
-
 #[allow(
     deprecated,
     private_bounds,
@@ -50,7 +46,6 @@ const _: () = {
         fn only_derive_is_allowed_to_implement_this_trait() {}
     }
 };
-
 #[allow(
     deprecated,
     private_bounds,

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
@@ -11,28 +11,25 @@
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-
-    fn is_bit_valid<___ZerocopyAliasing>(
-        _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-    where
-        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-    {
-        if false {
-            fn assert_is_from_bytes<T>()
-            where
-                T: ::zerocopy::FromBytes,
-                T: ?::zerocopy::util::macro_util::core_reexport::marker::Sized,
-            {}
-            assert_is_from_bytes::<Self>();
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            if false {
+                fn assert_is_from_bytes<T>()
+                where
+                    T: ::zerocopy::FromBytes,
+                    T: ?::zerocopy::util::macro_util::core_reexport::marker::Sized,
+                {}
+                assert_is_from_bytes::<Self>();
+            }
+            true
         }
-
-        true
     }
-}
 };
-
 #[allow(
     deprecated,
     private_bounds,
@@ -46,10 +43,9 @@ const _: () = {
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
 };
-
 #[allow(
     deprecated,
     private_bounds,
@@ -63,6 +59,6 @@ const _: () = {
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromBytes for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
 };

--- a/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
@@ -11,16 +11,16 @@
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-    fn is_bit_valid<___ZerocopyAliasing>(
-        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-    where
-        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-    {
-        true
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            true
+        }
     }
-}
 };
 #[allow(
     deprecated,
@@ -35,6 +35,6 @@ const _: () = {
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-}
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
 };

--- a/zerocopy-derive/src/output_tests/expected/hash.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/hash.expected.rs
@@ -1,4 +1,3 @@
-
 impl<T: Clone> ::zerocopy::util::macro_util::core_reexport::hash::Hash for Foo<T>
 where
     Self: ::zerocopy::IntoBytes + ::zerocopy::Immutable,
@@ -13,7 +12,6 @@ where
             ::zerocopy::IntoBytes::as_bytes(self),
         )
     }
-
     fn hash_slice<H: ::zerocopy::util::macro_util::core_reexport::hash::Hasher>(
         data: &[Self],
         state: &mut H,

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
@@ -11,15 +11,14 @@
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
-    fn only_derive_is_allowed_to_implement_this_trait() {}
-
-    fn is_bit_valid<___ZerocopyAliasing>(
-        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-    where
-        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-    {
-        true
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            true
+        }
     }
-}
 };

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -1,4 +1,101 @@
 #[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            #[repr(u8)]
+            #[allow(dead_code)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                {
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of::<
+                        ___ZerocopyTag,
+                    >()
+                },
+            >;
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ();
+            type ___ZerocopyInnerTag = ___ZerocopyTag;
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut Self::Type {
+                    slf.as_ptr().cast()
+                }
+            }
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
                 deprecated,
                 private_bounds,
                 non_local_definitions,
@@ -10,1741 +107,1655 @@
             )]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-                for ComplexWithGenerics<'a, { N }, X, Y>
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
                     X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
                     u8: ::zerocopy::TryFromBytes,
                     X: ::zerocopy::TryFromBytes,
                     X::Target: ::zerocopy::TryFromBytes,
                     Y::Target: ::zerocopy::TryFromBytes,
                     [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     fn is_bit_valid<___ZerocopyAliasing>(
-                        candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                     ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
                         ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                     {
-                        
-                        #[repr(u8)]
-                        #[allow(dead_code)]
-                        enum ___ZerocopyTag {
-                            UnitLike,
-                            StructLike,
-                            TupleLike,
-                        }
-                        unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                        }
-                        type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                            { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
-                        >;
-                        const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                            as ___ZerocopyTagPrimitive;
-                        type ___ZerocopyOuterTag = ();
-                        type ___ZerocopyInnerTag = ___ZerocopyTag;
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
                         > ::zerocopy::HasField<
-                            (),
+                            ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyTag;
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
-                                slf.as_ptr().cast()
-                            }
-                        }
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_StructLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            u8,
-                            X,
-                            X::Target,
-                            Y::Target,
-                            [(X, Y); N],
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                u8: ::zerocopy::TryFromBytes,
-                                X: ::zerocopy::TryFromBytes,
-                                X::Target: ::zerocopy::TryFromBytes,
-                                Y::Target: ::zerocopy::TryFromBytes,
-                                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(5) }>();
-                                            <[(
-                                                X,
-                                                Y,
-                                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(6) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
                                 }
                             }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                enum ẕ5 {}
-                                enum ẕ6 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = u8;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ5,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(5) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = [(X, Y); N];
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).5
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ6,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(6) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).6
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_TupleLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            bool,
-                            Y,
-                            PhantomData<&'a [(X, Y); N]>,
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                bool: ::zerocopy::TryFromBytes,
-                                Y: ::zerocopy::TryFromBytes,
-                                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <PhantomData<
-                                                &'a [(X, Y); N],
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                }
-                            }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = bool;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = PhantomData<&'a [(X, Y); N]>;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                            __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            __nonempty: (),
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕ__field_StructLike {}
-                            enum ẕ__field_TupleLike {}
-                            enum ẕ__nonempty {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_StructLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_TupleLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ();
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__nonempty
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    (),
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > {}
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                            tag: ___ZerocopyOuterTag,
-                            variants: ___ZerocopyVariants<'a, N, X, Y>,
-                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
-                        > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-                        for ComplexWithGenerics<'a, N, X, Y>
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                         where
                             X: Deref<Target = &'a [(X, Y); N]>,
-                        {}
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕtag {}
-                            enum ẕvariants {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕtag,
-                                    { ::zerocopy::STRUCT_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(tag) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyOuterTag;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).tag
-                                            )
-                                        }
-                                    }
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = u8;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
                                 }
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕvariants,
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ5,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = [(X, Y); N];
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).5
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ6,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).6
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ0,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = bool;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = PhantomData<&'a [(X, Y); N]>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_StructLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_TupleLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ();
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__nonempty
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        (),
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > {}
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕtag,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyOuterTag;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).tag
+                                )
+                            }
+                        }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕvariants,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).variants
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = u8;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).variants
-                                            )
-                                        }
-                                    }
-                                }
-                            };
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(a) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(b) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(c) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(d) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(4) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(e) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(5) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        let mut raw_enum = candidate
-                            .cast::<
-                                ___ZerocopyRawEnum<'a, N, X, Y>,
-                                ::zerocopy::pointer::cast::CastSized,
-                                ::zerocopy::pointer::BecauseInvariantsEq,
-                            >();
-                        let tag = {
-                            let tag_ptr = raw_enum
-                                .reborrow()
-                                .project::<(), { ::zerocopy::ident_id!(tag) }>()
-                                .cast::<
-                                    ___ZerocopyTagPrimitive,
-                                    ::zerocopy::pointer::cast::CastSized,
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
                                     _,
-                                >();
-                            tag_ptr
-                                .recall_validity::<_, (_, (_, _))>()
-                                .read_unaligned::<::zerocopy::BecauseImmutable>()
-                        };
-                        let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
-                        match tag {
-                            ___ZEROCOPY_TAG_UnitLike => true,
-                            ___ZEROCOPY_TAG_StructLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_StructLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            ___ZEROCOPY_TAG_TupleLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_TupleLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            _ => false,
-                        }
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
                     }
                 }
             };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(4) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = [(X, Y); N];
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(5) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = bool;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = PhantomData<&'a [(X, Y); N]>;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            let mut raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let tag = {
+                let tag_ptr = raw_enum
+                    .reborrow()
+                    .project::<(), { ::zerocopy::ident_id!(tag) }>()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+};

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -1,4 +1,101 @@
 #[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            #[repr(u32)]
+            #[allow(dead_code)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                {
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of::<
+                        ___ZerocopyTag,
+                    >()
+                },
+            >;
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ();
+            type ___ZerocopyInnerTag = ___ZerocopyTag;
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut Self::Type {
+                    slf.as_ptr().cast()
+                }
+            }
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
                 deprecated,
                 private_bounds,
                 non_local_definitions,
@@ -10,1741 +107,1655 @@
             )]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-                for ComplexWithGenerics<'a, { N }, X, Y>
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
                     X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
                     u8: ::zerocopy::TryFromBytes,
                     X: ::zerocopy::TryFromBytes,
                     X::Target: ::zerocopy::TryFromBytes,
                     Y::Target: ::zerocopy::TryFromBytes,
                     [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     fn is_bit_valid<___ZerocopyAliasing>(
-                        candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                     ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
                         ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                     {
-                        
-                        #[repr(u32)]
-                        #[allow(dead_code)]
-                        enum ___ZerocopyTag {
-                            UnitLike,
-                            StructLike,
-                            TupleLike,
-                        }
-                        unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                        }
-                        type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                            { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
-                        >;
-                        const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                            as ___ZerocopyTagPrimitive;
-                        type ___ZerocopyOuterTag = ();
-                        type ___ZerocopyInnerTag = ___ZerocopyTag;
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
                         > ::zerocopy::HasField<
-                            (),
+                            ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyTag;
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
-                                slf.as_ptr().cast()
-                            }
-                        }
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_StructLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            u8,
-                            X,
-                            X::Target,
-                            Y::Target,
-                            [(X, Y); N],
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                u8: ::zerocopy::TryFromBytes,
-                                X: ::zerocopy::TryFromBytes,
-                                X::Target: ::zerocopy::TryFromBytes,
-                                Y::Target: ::zerocopy::TryFromBytes,
-                                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(5) }>();
-                                            <[(
-                                                X,
-                                                Y,
-                                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(6) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
                                 }
                             }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                enum ẕ5 {}
-                                enum ẕ6 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = u8;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ5,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(5) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = [(X, Y); N];
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).5
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ6,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(6) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).6
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_TupleLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            bool,
-                            Y,
-                            PhantomData<&'a [(X, Y); N]>,
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                bool: ::zerocopy::TryFromBytes,
-                                Y: ::zerocopy::TryFromBytes,
-                                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <PhantomData<
-                                                &'a [(X, Y); N],
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                }
-                            }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = bool;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = PhantomData<&'a [(X, Y); N]>;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                            __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            __nonempty: (),
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕ__field_StructLike {}
-                            enum ẕ__field_TupleLike {}
-                            enum ẕ__nonempty {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_StructLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_TupleLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ();
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__nonempty
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    (),
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > {}
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                            tag: ___ZerocopyOuterTag,
-                            variants: ___ZerocopyVariants<'a, N, X, Y>,
-                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
-                        > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-                        for ComplexWithGenerics<'a, N, X, Y>
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                         where
                             X: Deref<Target = &'a [(X, Y); N]>,
-                        {}
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕtag {}
-                            enum ẕvariants {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕtag,
-                                    { ::zerocopy::STRUCT_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(tag) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyOuterTag;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).tag
-                                            )
-                                        }
-                                    }
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = u8;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
                                 }
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕvariants,
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ5,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = [(X, Y); N];
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).5
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ6,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).6
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ0,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = bool;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = PhantomData<&'a [(X, Y); N]>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_StructLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_TupleLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ();
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__nonempty
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        (),
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > {}
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕtag,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyOuterTag;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).tag
+                                )
+                            }
+                        }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕvariants,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).variants
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = u8;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).variants
-                                            )
-                                        }
-                                    }
-                                }
-                            };
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(a) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(b) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(c) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(d) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(4) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(e) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(5) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        let mut raw_enum = candidate
-                            .cast::<
-                                ___ZerocopyRawEnum<'a, N, X, Y>,
-                                ::zerocopy::pointer::cast::CastSized,
-                                ::zerocopy::pointer::BecauseInvariantsEq,
-                            >();
-                        let tag = {
-                            let tag_ptr = raw_enum
-                                .reborrow()
-                                .project::<(), { ::zerocopy::ident_id!(tag) }>()
-                                .cast::<
-                                    ___ZerocopyTagPrimitive,
-                                    ::zerocopy::pointer::cast::CastSized,
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
                                     _,
-                                >();
-                            tag_ptr
-                                .recall_validity::<_, (_, (_, _))>()
-                                .read_unaligned::<::zerocopy::BecauseImmutable>()
-                        };
-                        let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
-                        match tag {
-                            ___ZEROCOPY_TAG_UnitLike => true,
-                            ___ZEROCOPY_TAG_StructLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_StructLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            ___ZEROCOPY_TAG_TupleLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_TupleLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            _ => false,
-                        }
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
                     }
                 }
             };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(4) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = [(X, Y); N];
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(5) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = bool;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = PhantomData<&'a [(X, Y); N]>;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            let mut raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let tag = {
+                let tag_ptr = raw_enum
+                    .reborrow()
+                    .project::<(), { ::zerocopy::ident_id!(tag) }>()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+};

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -1,4 +1,101 @@
 #[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
+    for ComplexWithGenerics<'a, { N }, X, Y>
+    where
+        X: Deref<Target = &'a [(X, Y); N]>,
+        u8: ::zerocopy::TryFromBytes,
+        X: ::zerocopy::TryFromBytes,
+        X::Target: ::zerocopy::TryFromBytes,
+        Y::Target: ::zerocopy::TryFromBytes,
+        [(X, Y); N]: ::zerocopy::TryFromBytes,
+        bool: ::zerocopy::TryFromBytes,
+        Y: ::zerocopy::TryFromBytes,
+        PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+        fn is_bit_valid<___ZerocopyAliasing>(
+            candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+        {
+            #[repr(C)]
+            #[allow(dead_code)]
+            enum ___ZerocopyTag {
+                UnitLike,
+                StructLike,
+                TupleLike,
+            }
+            unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+            }
+            type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+                {
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of::<
+                        ___ZerocopyTag,
+                    >()
+                },
+            >;
+            const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+                as ___ZerocopyTagPrimitive;
+            const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+                as ___ZerocopyTagPrimitive;
+            type ___ZerocopyOuterTag = ___ZerocopyTag;
+            type ___ZerocopyInnerTag = ();
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::HasField<
+                (),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut Self::Type {
+                    slf.as_ptr().cast()
+                }
+            }
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_StructLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                u8,
+                X,
+                X::Target,
+                Y::Target,
+                [(X, Y); N],
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
                 deprecated,
                 private_bounds,
                 non_local_definitions,
@@ -10,1741 +107,1655 @@
             )]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
-                for ComplexWithGenerics<'a, { N }, X, Y>
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                 where
                     X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
                     u8: ::zerocopy::TryFromBytes,
                     X: ::zerocopy::TryFromBytes,
                     X::Target: ::zerocopy::TryFromBytes,
                     Y::Target: ::zerocopy::TryFromBytes,
                     [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     fn is_bit_valid<___ZerocopyAliasing>(
-                        candidate: ::zerocopy::Maybe<'_, Self, ___ZerocopyAliasing>,
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
                     ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
                     where
                         ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
                     {
-                        
-                        #[repr(C)]
-                        #[allow(dead_code)]
-                        enum ___ZerocopyTag {
-                            UnitLike,
-                            StructLike,
-                            TupleLike,
-                        }
-                        unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                        }
-                        type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
-                            { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
-                        >;
-                        const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
-                            as ___ZerocopyTagPrimitive;
-                        const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
-                            as ___ZerocopyTagPrimitive;
-                        type ___ZerocopyOuterTag = ___ZerocopyTag;
-                        type ___ZerocopyInnerTag = ();
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(5) }>();
+                                <[(
+                                    X,
+                                    Y,
+                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(6) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    enum ẕ5 {}
+                    enum ẕ6 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
                         > ::zerocopy::HasField<
-                            (),
+                            ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, N, X, Y> {
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
                             fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ___ZerocopyTag;
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
                             ) -> *mut Self::Type {
-                                slf.as_ptr().cast()
-                            }
-                        }
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_StructLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            u8,
-                            X,
-                            X::Target,
-                            Y::Target,
-                            [(X, Y); N],
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                u8: ::zerocopy::TryFromBytes,
-                                X: ::zerocopy::TryFromBytes,
-                                X::Target: ::zerocopy::TryFromBytes,
-                                Y::Target: ::zerocopy::TryFromBytes,
-                                [(X, Y); N]: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(5) }>();
-                                            <[(
-                                                X,
-                                                Y,
-                                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(6) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
                                 }
                             }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                enum ẕ5 {}
-                                enum ẕ6 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = u8;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = X::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y::Target;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ5,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(5) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = [(X, Y); N];
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).5
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ6,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(6) },
-                                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).6
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyVariantStruct_TupleLike<
-                            'a: 'static,
-                            const N: usize,
-                            X,
-                            Y: Deref,
-                        >(
-                            ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<___ZerocopyInnerTag>,
-                            bool,
-                            Y,
-                            PhantomData<&'a [(X, Y); N]>,
-                            ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<ComplexWithGenerics<'a, N, X, Y>>,
-                        )
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>;
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::TryFromBytes
-                            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                >: ::zerocopy::TryFromBytes,
-                                bool: ::zerocopy::TryFromBytes,
-                                Y: ::zerocopy::TryFromBytes,
-                                PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                >: ::zerocopy::TryFromBytes,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                fn is_bit_valid<___ZerocopyAliasing>(
-                                    mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
-                                ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                                where
-                                    ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
-                                {
-                                    true
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(0) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                                ___ZerocopyInnerTag,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(1) }>();
-                                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(2) }>();
-                                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(3) }>();
-                                            <PhantomData<
-                                                &'a [(X, Y); N],
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                        && {
-                                            let field_candidate = candidate
-                                                .reborrow()
-                                                .project::<_, { ::zerocopy::ident_id!(4) }>();
-                                            <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                                ComplexWithGenerics<'a, N, X, Y>,
-                                            > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                                field_candidate,
-                                            )
-                                        }
-                                }
-                            }
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                enum ẕ0 {}
-                                enum ẕ1 {}
-                                enum ẕ2 {}
-                                enum ẕ3 {}
-                                enum ẕ4 {}
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ0,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(0) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                            ___ZerocopyInnerTag,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).0
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ1,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(1) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = bool;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).1
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ2,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(2) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = Y;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).2
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ3,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(3) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = PhantomData<&'a [(X, Y); N]>;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).3
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                                #[allow(
-                                    deprecated,
-                                    private_bounds,
-                                    non_local_definitions,
-                                    non_camel_case_types,
-                                    non_upper_case_globals,
-                                    non_snake_case,
-                                    non_ascii_idents,
-                                    clippy::missing_inline_in_public_items,
-                                )]
-                                #[automatically_derived]
-                                const _: () = {
-                                    unsafe impl<
-                                        'a: 'static,
-                                        const N: usize,
-                                        X,
-                                        Y: Deref,
-                                    > ::zerocopy::HasField<
-                                        ẕ4,
-                                        { ::zerocopy::STRUCT_VARIANT_ID },
-                                        { ::zerocopy::ident_id!(4) },
-                                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                                    where
-                                        X: Deref<Target = &'a [(X, Y); N]>,
-                                    {
-                                        fn only_derive_is_allowed_to_implement_this_trait() {}
-                                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                            ComplexWithGenerics<'a, N, X, Y>,
-                                        >;
-                                        #[inline(always)]
-                                        fn project(
-                                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                        ) -> *mut Self::Type {
-                                            let slf = slf.as_ptr();
-                                            unsafe {
-                                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                    (* slf).4
-                                                )
-                                            }
-                                        }
-                                    }
-                                };
-                            };
-                        };
-                        #[repr(C)]
-                        union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
-                            __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            __nonempty: (),
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕ__field_StructLike {}
-                            enum ẕ__field_TupleLike {}
-                            enum ẕ__nonempty {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_StructLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_StructLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_StructLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__field_TupleLike
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                    >,
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__field_TupleLike,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__field_TupleLike) },
-                                > {}
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > for ___ZerocopyVariants<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ();
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).__nonempty
-                                            )
-                                        }
-                                    }
-                                }
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::pointer::cast::Cast<
-                                    ___ZerocopyVariants<'a, N, X, Y>,
-                                    (),
-                                >
-                                for ::zerocopy::pointer::cast::Projection<
-                                    ẕ__nonempty,
-                                    { ::zerocopy::UNION_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(__nonempty) },
-                                > {}
-                            };
-                        };
-                        #[repr(C)]
-                        struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
-                            tag: ___ZerocopyOuterTag,
-                            variants: ___ZerocopyVariants<'a, N, X, Y>,
-                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
                         unsafe impl<
                             'a: 'static,
                             const N: usize,
                             X,
                             Y: Deref,
-                        > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-                        for ComplexWithGenerics<'a, N, X, Y>
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
                         where
                             X: Deref<Target = &'a [(X, Y); N]>,
-                        {}
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            enum ẕtag {}
-                            enum ẕvariants {}
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕtag,
-                                    { ::zerocopy::STRUCT_VARIANT_ID },
-                                    { ::zerocopy::ident_id!(tag) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyOuterTag;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).tag
-                                            )
-                                        }
-                                    }
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = u8;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
                                 }
-                            };
-                            #[allow(
-                                deprecated,
-                                private_bounds,
-                                non_local_definitions,
-                                non_camel_case_types,
-                                non_upper_case_globals,
-                                non_snake_case,
-                                non_ascii_idents,
-                                clippy::missing_inline_in_public_items,
-                            )]
-                            #[automatically_derived]
-                            const _: () = {
-                                unsafe impl<
-                                    'a: 'static,
-                                    const N: usize,
-                                    X,
-                                    Y: Deref,
-                                > ::zerocopy::HasField<
-                                    ẕvariants,
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = X::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y::Target;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ5,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = [(X, Y); N];
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).5
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ6,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).6
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyVariantStruct_TupleLike<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            >(
+                ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >,
+                bool,
+                Y,
+                PhantomData<&'a [(X, Y); N]>,
+                ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >,
+            )
+            where
+                X: Deref<Target = &'a [(X, Y); N]>;
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::TryFromBytes
+                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                        ___ZerocopyInnerTag,
+                    >: ::zerocopy::TryFromBytes,
+                    bool: ::zerocopy::TryFromBytes,
+                    Y: ::zerocopy::TryFromBytes,
+                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
+                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                        ComplexWithGenerics<'a, N, X, Y>,
+                    >: ::zerocopy::TryFromBytes,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    fn is_bit_valid<___ZerocopyAliasing>(
+                        mut candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZerocopyAliasing: ::zerocopy::pointer::invariant::Reference,
+                    {
+                        true
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(0) }>();
+                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                    ___ZerocopyInnerTag,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(1) }>();
+                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(2) }>();
+                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(3) }>();
+                                <PhantomData<
+                                    &'a [(X, Y); N],
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                            && {
+                                let field_candidate = candidate
+                                    .reborrow()
+                                    .project::<_, { ::zerocopy::ident_id!(4) }>();
+                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                    ComplexWithGenerics<'a, N, X, Y>,
+                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                    field_candidate,
+                                )
+                            }
+                    }
+                }
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    enum ẕ0 {}
+                    enum ẕ1 {}
+                    enum ẕ2 {}
+                    enum ẕ3 {}
+                    enum ẕ4 {}
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ0,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                                ___ZerocopyInnerTag,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).0
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ1,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = bool;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).1
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ2,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = Y;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).2
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ3,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = PhantomData<&'a [(X, Y); N]>;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).3
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            const N: usize,
+                            X,
+                            Y: Deref,
+                        > ::zerocopy::HasField<
+                            ẕ4,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                                ComplexWithGenerics<'a, N, X, Y>,
+                            >;
+                            #[inline(always)]
+                            fn project(
+                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                            ) -> *mut Self::Type {
+                                let slf = slf.as_ptr();
+                                unsafe {
+                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                        (* slf).4
+                                    )
+                                }
+                            }
+                        }
+                    };
+                };
+            };
+            #[repr(C)]
+            union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+                __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >,
+                __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >,
+                __nonempty: (),
+            }
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕ__field_StructLike {}
+                enum ẕ__field_TupleLike {}
+                enum ẕ__nonempty {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_StructLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_StructLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__field_TupleLike
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                        >,
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__field_TupleLike,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > {}
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ();
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).__nonempty
+                                )
+                            }
+                        }
+                    }
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::pointer::cast::Cast<
+                        ___ZerocopyVariants<'a, N, X, Y>,
+                        (),
+                    >
+                    for ::zerocopy::pointer::cast::Projection<
+                        ẕ__nonempty,
+                        { ::zerocopy::UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > {}
+                };
+            };
+            #[repr(C)]
+            struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+                tag: ___ZerocopyOuterTag,
+                variants: ___ZerocopyVariants<'a, N, X, Y>,
+            }
+            unsafe impl<
+                'a: 'static,
+                const N: usize,
+                X,
+                Y: Deref,
+            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
+            for ComplexWithGenerics<'a, N, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {}
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                enum ẕtag {}
+                enum ẕvariants {}
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕtag,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyOuterTag;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).tag
+                                )
+                            }
+                        }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        const N: usize,
+                        X,
+                        Y: Deref,
+                    > ::zerocopy::HasField<
+                        ẕvariants,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut Self::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).variants
+                                )
+                            }
+                        }
+                    }
+                };
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = u8;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
-                                > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                                    type Type = ___ZerocopyVariants<'a, N, X, Y>;
-                                    #[inline(always)]
-                                    fn project(
-                                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                    ) -> *mut Self::Type {
-                                        let slf = slf.as_ptr();
-                                        unsafe {
-                                            ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                                (* slf).variants
-                                            )
-                                        }
-                                    }
-                                }
-                            };
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(a) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = u8;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(b) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(c) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = X::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(d) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y::Target;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(4) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(StructLike) },
-                                { ::zerocopy::ident_id!(e) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = [(X, Y); N];
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(5) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = bool;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(1) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = Y;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(2) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                const N: usize,
-                                X,
-                                Y: Deref,
-                            > ::zerocopy::HasField<
-                                (),
-                                { ::zerocopy::ident_id!(TupleLike) },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ComplexWithGenerics<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Type = PhantomData<&'a [(X, Y); N]>;
-                                #[inline(always)]
-                                fn project(
-                                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                                ) -> *mut Self::Type {
-                                    use ::zerocopy::pointer::cast::{CastSized, Projection};
-                                    slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(variants) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(value) },
-                                            >,
-                                        >()
-                                        .project::<
-                                            _,
-                                            Projection<
-                                                _,
-                                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(3) },
-                                            >,
-                                        >()
-                                        .as_ptr()
-                                }
-                            }
-                        };
-                        let mut raw_enum = candidate
-                            .cast::<
-                                ___ZerocopyRawEnum<'a, N, X, Y>,
-                                ::zerocopy::pointer::cast::CastSized,
-                                ::zerocopy::pointer::BecauseInvariantsEq,
-                            >();
-                        let tag = {
-                            let tag_ptr = raw_enum
-                                .reborrow()
-                                .project::<(), { ::zerocopy::ident_id!(tag) }>()
-                                .cast::<
-                                    ___ZerocopyTagPrimitive,
-                                    ::zerocopy::pointer::cast::CastSized,
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
                                     _,
-                                >();
-                            tag_ptr
-                                .recall_validity::<_, (_, (_, _))>()
-                                .read_unaligned::<::zerocopy::BecauseImmutable>()
-                        };
-                        let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
-                        match tag {
-                            ___ZEROCOPY_TAG_UnitLike => true,
-                            ___ZEROCOPY_TAG_StructLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_StructLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_StructLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            ___ZEROCOPY_TAG_TupleLike => {
-                                let variant_md = unsafe {
-                                    variants
-                                        .cast_unchecked::<
-                                            ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
-                                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                            >,
-                                            ::zerocopy::pointer::cast::Projection<
-                                                _,
-                                                { ::zerocopy::UNION_VARIANT_ID },
-                                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                                            >,
-                                        >()
-                                };
-                                let variant = variant_md
-                                    .cast::<
-                                        ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                                        ::zerocopy::pointer::cast::CastSized,
-                                        ::zerocopy::pointer::BecauseInvariantsEq,
-                                    >();
-                                <___ZerocopyVariantStruct_TupleLike<
-                                    'a,
-                                    N,
-                                    X,
-                                    Y,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
-                            }
-                            _ => false,
-                        }
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
                     }
                 }
             };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = X::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y::Target;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(4) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = [(X, Y); N];
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(5) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = bool;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(1) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = Y;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(2) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    const N: usize,
+                    X,
+                    Y: Deref,
+                > ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Type = PhantomData<&'a [(X, Y); N]>;
+                    #[inline(always)]
+                    fn project(
+                        slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                    ) -> *mut Self::Type {
+                        use ::zerocopy::pointer::cast::{CastSized, Projection};
+                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(variants) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(value) },
+                                >,
+                            >()
+                            .project::<
+                                _,
+                                Projection<
+                                    _,
+                                    { ::zerocopy::STRUCT_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(3) },
+                                >,
+                            >()
+                            .as_ptr()
+                    }
+                }
+            };
+            let mut raw_enum = candidate
+                .cast::<
+                    ___ZerocopyRawEnum<'a, N, X, Y>,
+                    ::zerocopy::pointer::cast::CastSized,
+                    ::zerocopy::pointer::BecauseInvariantsEq,
+                >();
+            let tag = {
+                let tag_ptr = raw_enum
+                    .reborrow()
+                    .project::<(), { ::zerocopy::ident_id!(tag) }>()
+                    .cast::<
+                        ___ZerocopyTagPrimitive,
+                        ::zerocopy::pointer::cast::CastSized,
+                        _,
+                    >();
+                tag_ptr
+                    .recall_validity::<_, (_, (_, _))>()
+                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+            };
+            let variants = raw_enum.project::<_, { ::zerocopy::ident_id!(variants) }>();
+            match tag {
+                ___ZEROCOPY_TAG_UnitLike => true,
+                ___ZEROCOPY_TAG_StructLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_StructLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_StructLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                ___ZEROCOPY_TAG_TupleLike => {
+                    let variant_md = unsafe {
+                        variants
+                            .cast_unchecked::<
+                                ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                                >,
+                                ::zerocopy::pointer::cast::Projection<
+                                    _,
+                                    { ::zerocopy::UNION_VARIANT_ID },
+                                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                                >,
+                            >()
+                    };
+                    let variant = variant_md
+                        .cast::<
+                            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                            ::zerocopy::pointer::cast::CastSized,
+                            ::zerocopy::pointer::BecauseInvariantsEq,
+                        >();
+                    <___ZerocopyVariantStruct_TupleLike<
+                        'a,
+                        N,
+                        X,
+                        Y,
+                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                }
+                _ => false,
+            }
+        }
+    }
+};

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
@@ -12,7 +12,6 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-
         fn is_bit_valid<___ZerocopyAliasing>(
             _candidate: ::zerocopy::Maybe<Self, ___ZerocopyAliasing>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Closes #2903




---

- 👉 #2905


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v3..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v2..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v1..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v3..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v2..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v1..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v2..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v1..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v1..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/Gd828ec01c10bd743decbefc4946c3ea5db686237/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gd828ec01c10bd743decbefc4946c3ea5db686237", "parent": null, "child": null}" -->