### PR TITLE
[cast] Fix safety comment bug for CastUnsized

### DIFF
--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -139,9 +139,10 @@ pub mod cast {
     // - Both sized and equal in size
     // - Both slice DSTs with the same trailing slice offset and element size
     //   and with align_of::<Src>() >= align_of::<Dst>(). These ensure that any
-    //   given pointer metadata encodes the same size for both `Src` and `Dst`
-    //   (note that the alignment is required as it affects the amount of
-    //   trailing padding).
+    //   given pointer metadata encodes the same size or more size for `Src`
+    //   than for `Dst` (note that the alignment is required as it affects the
+    //   amount of trailing padding). Thus, `project` preserves or shrinks the
+    //   set of referent bytes.
     unsafe impl<Src, Dst> Project<Src, Dst> for CastUnsized
     where
         Src: ?Sized + KnownLayout,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The decorated `unsafe impl` block is still sound, but the proof
previously proved too much (namely, that the cast preserves referent
size, when in fact it may shrink referent size).




---

- &#x3000; #2907
- &#x3000; #2909
- 👉 #2908


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v3..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v2..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v1..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v3..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v2..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v1..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v2..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v1..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v1..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/Gba34c175d9c27344e336de4ed088eb0754d87f30/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gba34c175d9c27344e336de4ed088eb0754d87f30", "parent": null, "child": "G31f38f3a71e4f8e878e91a9e0d53fd34b4f4d8cb"}" -->