### PR TITLE
[tools] Remove now-obsolete `rm Cargo.lock`

### DIFF
--- a/tools/update-expected-test-output.sh
+++ b/tools/update-expected-test-output.sh
@@ -8,20 +8,14 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+set -eo pipefail
+
 # Update the `.stderr` reference files used to validate our UI tests.
-
-set -e
-
 TRYBUILD=overwrite ./cargo.sh +nightly test ui --test trybuild -p zerocopy --all-features
 TRYBUILD=overwrite ./cargo.sh +stable  test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
-# For developers using Rust Analyzer, it's often the case that Rust Analyzer has
-# chosen versions of dependencies (especially syn) which have an MSRV higher than
-# our own. Doing `rm Cargo.lock` here permits `./cargo.sh +msrv` to choose its own
-# versions of these crates that have a lower MSRV.
-rm Cargo.lock && TRYBUILD=overwrite ./cargo.sh +msrv test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
+TRYBUILD=overwrite ./cargo.sh +msrv test ui --test trybuild -p zerocopy --features=__internal_use_only_features_that_work_on_stable
 
 TRYBUILD=overwrite ./cargo.sh +all test ui --test trybuild -p zerocopy-derive
 
 # Update zerocopy-derive's `.expected.rs` files used to validate derive output.
-
 ZEROCOPY_BLESS=1 ./cargo.sh +nightly test -p zerocopy-derive --lib


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This was made obsolete once we started vendoring our dependencies
(#2883).




---

- 👉 #2916

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Ge64eead3ff76fbb4564b48248fcd713b51711573", "parent": null, "child": null}" -->