### PR TITLE
[derive] Avoid ambiguities referring to associated items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.34"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.34", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.34", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -134,4 +134,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.33", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.34", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.34"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy-derive/src/derive/known_layout.rs
@@ -69,7 +69,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
             #[inline(always)]
             fn raw_from_ptr_len(
                 bytes: #core::ptr::NonNull<u8>,
-                meta: Self::PointerMetadata,
+                meta: <Self as #zerocopy_crate::KnownLayout>::PointerMetadata,
             ) -> #core::ptr::NonNull<Self> {
                 let trailing = <#trailing_field_ty as #zerocopy_crate::KnownLayout>::raw_from_ptr_len(bytes, meta);
                 let slf = trailing.as_ptr() as *mut Self;
@@ -78,7 +78,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
             }
 
             #[inline(always)]
-            fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+            fn pointer_to_metadata(ptr: *mut Self) -> <Self as #zerocopy_crate::KnownLayout>::PointerMetadata {
                 <#trailing_field_ty>::pointer_to_metadata(ptr as *mut _)
             }
         }

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
@@ -40,6 +41,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo {
@@ -56,6 +58,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
@@ -40,6 +41,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo {
@@ -56,6 +58,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo
@@ -42,6 +43,7 @@ const _: () = {
         non_ascii_idents,
         clippy::missing_inline_in_public_items,
     )]
+    #[deny(ambiguous_associated_items)]
     #[automatically_derived]
     const _: () = {
         enum ẕa {}
@@ -55,6 +57,7 @@ const _: () = {
             non_ascii_idents,
             clippy::missing_inline_in_public_items,
         )]
+        #[deny(ambiguous_associated_items)]
         #[automatically_derived]
         const _: () = {
             unsafe impl ::zerocopy::HasField<
@@ -67,7 +70,11 @@ const _: () = {
                 #[inline(always)]
                 fn project(
                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                ) -> *mut Self::Type {
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ẕa,
+                    { ::zerocopy::UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(a) },
+                >>::Type {
                     let slf = slf.as_ptr();
                     unsafe {
                         ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -89,6 +96,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo
@@ -108,6 +116,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromBytes for Foo

--- a/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
@@ -32,6 +33,7 @@ const _: () = {
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::FromZeros for Foo {

--- a/zerocopy-derive/src/output_tests/expected/immutable.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/immutable.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::Immutable for Foo {

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_enum.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::IntoBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_basic.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_basic.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::IntoBytes for Foo

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_empty.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_empty.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::IntoBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_trailing.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_trailing.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::IntoBytes for Foo

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_trailing_generic.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_trailing_generic.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<Trailing> ::zerocopy::IntoBytes for Foo<Trailing>

--- a/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<T, U> ::zerocopy::KnownLayout for Foo<T, U>
@@ -30,7 +31,7 @@ const _: () = {
         #[inline(always)]
         fn raw_from_ptr_len(
             bytes: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<u8>,
-            meta: Self::PointerMetadata,
+            meta: <Self as ::zerocopy::KnownLayout>::PointerMetadata,
         ) -> ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self> {
             let trailing = <U as ::zerocopy::KnownLayout>::raw_from_ptr_len(bytes, meta);
             let slf = trailing.as_ptr() as *mut Self;
@@ -41,7 +42,9 @@ const _: () = {
             }
         }
         #[inline(always)]
-        fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+        fn pointer_to_metadata(
+            ptr: *mut Self,
+        ) -> <Self as ::zerocopy::KnownLayout>::PointerMetadata {
             <U>::pointer_to_metadata(ptr as *mut _)
         }
     }
@@ -97,7 +100,7 @@ const _: () = {
         #[inline(always)]
         fn raw_from_ptr_len(
             bytes: ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<u8>,
-            meta: Self::PointerMetadata,
+            meta: <Self as ::zerocopy::KnownLayout>::PointerMetadata,
         ) -> ::zerocopy::util::macro_util::core_reexport::ptr::NonNull<Self> {
             let trailing = <<<Foo<
                 T,
@@ -116,7 +119,9 @@ const _: () = {
             }
         }
         #[inline(always)]
-        fn pointer_to_metadata(ptr: *mut Self) -> Self::PointerMetadata {
+        fn pointer_to_metadata(
+            ptr: *mut Self,
+        ) -> <Self as ::zerocopy::KnownLayout>::PointerMetadata {
             <<<Foo<
                 T,
                 U,

--- a/zerocopy-derive/src/output_tests/expected/known_layout_struct.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/known_layout_struct.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::KnownLayout for Foo

--- a/zerocopy-derive/src/output_tests/expected/split_at_repr_c.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/split_at_repr_c.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<T: ?Sized + Copy> ::zerocopy::SplitAt for Foo<T>

--- a/zerocopy-derive/src/output_tests/expected/split_at_repr_transparent.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/split_at_repr_transparent.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<T: ?Sized + Copy> ::zerocopy::SplitAt for Foo<T>

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
@@ -70,7 +71,11 @@ const _: () = {
                 #[inline(always)]
                 fn project(
                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                ) -> *mut Self::Type {
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
                     slf.as_ptr().cast()
                 }
             }
@@ -105,6 +110,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -211,6 +217,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -230,6 +237,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -252,7 +260,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -272,6 +284,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -292,7 +305,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -312,6 +329,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -332,7 +350,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -352,6 +374,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -372,7 +395,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -392,6 +419,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -412,7 +440,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -432,6 +464,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -452,7 +485,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ5,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(5) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -472,6 +509,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -494,7 +532,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ6,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(6) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -535,6 +577,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -622,6 +665,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -639,6 +683,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -661,7 +706,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -681,6 +730,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -701,7 +751,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -721,6 +775,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -741,7 +796,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -761,6 +820,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -781,7 +841,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -801,6 +865,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -823,7 +888,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -855,6 +924,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕ__field_StructLike {}
@@ -870,6 +940,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -889,7 +960,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -925,6 +1000,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -944,7 +1020,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -980,6 +1060,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -997,7 +1078,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1047,6 +1132,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕtag {}
@@ -1061,6 +1147,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1078,7 +1165,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(tag) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1098,6 +1189,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1115,7 +1207,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1136,6 +1232,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1156,7 +1253,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(a) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1205,6 +1306,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1225,7 +1327,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(b) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1274,6 +1380,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1294,7 +1401,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(c) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1343,6 +1454,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1363,7 +1475,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(d) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1412,6 +1528,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1432,7 +1549,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(e) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1481,6 +1602,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1501,7 +1623,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(0) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1550,6 +1676,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1570,7 +1697,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1619,6 +1750,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1639,7 +1771,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
@@ -70,7 +71,11 @@ const _: () = {
                 #[inline(always)]
                 fn project(
                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                ) -> *mut Self::Type {
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
                     slf.as_ptr().cast()
                 }
             }
@@ -105,6 +110,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -211,6 +217,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -230,6 +237,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -252,7 +260,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -272,6 +284,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -292,7 +305,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -312,6 +329,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -332,7 +350,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -352,6 +374,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -372,7 +395,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -392,6 +419,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -412,7 +440,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -432,6 +464,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -452,7 +485,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ5,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(5) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -472,6 +509,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -494,7 +532,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ6,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(6) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -535,6 +577,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -622,6 +665,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -639,6 +683,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -661,7 +706,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -681,6 +730,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -701,7 +751,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -721,6 +775,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -741,7 +796,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -761,6 +820,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -781,7 +841,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -801,6 +865,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -823,7 +888,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -855,6 +924,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕ__field_StructLike {}
@@ -870,6 +940,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -889,7 +960,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -925,6 +1000,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -944,7 +1020,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -980,6 +1060,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -997,7 +1078,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1047,6 +1132,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕtag {}
@@ -1061,6 +1147,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1078,7 +1165,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(tag) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1098,6 +1189,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1115,7 +1207,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1136,6 +1232,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1156,7 +1253,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(a) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1205,6 +1306,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1225,7 +1327,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(b) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1274,6 +1380,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1294,7 +1401,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(c) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1343,6 +1454,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1363,7 +1475,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(d) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1412,6 +1528,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1432,7 +1549,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(e) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1481,6 +1602,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1501,7 +1623,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(0) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1550,6 +1676,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1570,7 +1697,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1619,6 +1750,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1639,7 +1771,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl<'a: 'static, const N: usize, X, Y: Deref> ::zerocopy::TryFromBytes
@@ -70,7 +71,11 @@ const _: () = {
                 #[inline(always)]
                 fn project(
                     slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                ) -> *mut Self::Type {
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    (),
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
                     slf.as_ptr().cast()
                 }
             }
@@ -105,6 +110,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -211,6 +217,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -230,6 +237,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -252,7 +260,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -272,6 +284,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -292,7 +305,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -312,6 +329,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -332,7 +350,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -352,6 +374,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -372,7 +395,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -392,6 +419,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -412,7 +440,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -432,6 +464,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -452,7 +485,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ5,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(5) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -472,6 +509,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -494,7 +532,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ6,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(6) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -535,6 +577,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -622,6 +665,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     enum ẕ0 {}
@@ -639,6 +683,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -661,7 +706,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ0,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(0) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -681,6 +730,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -701,7 +751,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ1,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(1) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -721,6 +775,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -741,7 +796,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ2,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(2) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -761,6 +820,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -781,7 +841,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ3,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(3) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -801,6 +865,7 @@ const _: () = {
                         non_ascii_idents,
                         clippy::missing_inline_in_public_items,
                     )]
+                    #[deny(ambiguous_associated_items)]
                     #[automatically_derived]
                     const _: () = {
                         unsafe impl<
@@ -823,7 +888,11 @@ const _: () = {
                             #[inline(always)]
                             fn project(
                                 slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut Self::Type {
+                            ) -> *mut <Self as ::zerocopy::HasField<
+                                ẕ4,
+                                { ::zerocopy::STRUCT_VARIANT_ID },
+                                { ::zerocopy::ident_id!(4) },
+                            >>::Type {
                                 let slf = slf.as_ptr();
                                 unsafe {
                                     ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -855,6 +924,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕ__field_StructLike {}
@@ -870,6 +940,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -889,7 +960,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_StructLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -925,6 +1000,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -944,7 +1020,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__field_TupleLike,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -980,6 +1060,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -997,7 +1078,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕ__nonempty,
+                            { ::zerocopy::UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__nonempty) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1047,6 +1132,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 enum ẕtag {}
@@ -1061,6 +1147,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1078,7 +1165,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕtag,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(tag) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1098,6 +1189,7 @@ const _: () = {
                     non_ascii_idents,
                     clippy::missing_inline_in_public_items,
                 )]
+                #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
                     unsafe impl<
@@ -1115,7 +1207,11 @@ const _: () = {
                         #[inline(always)]
                         fn project(
                             slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                        ) -> *mut Self::Type {
+                        ) -> *mut <Self as ::zerocopy::HasField<
+                            ẕvariants,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >>::Type {
                             let slf = slf.as_ptr();
                             unsafe {
                                 ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
@@ -1136,6 +1232,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1156,7 +1253,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(a) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1205,6 +1306,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1225,7 +1327,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(b) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1274,6 +1380,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1294,7 +1401,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(c) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1343,6 +1454,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1363,7 +1475,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(d) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1412,6 +1528,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1432,7 +1549,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(StructLike) },
+                        { ::zerocopy::ident_id!(e) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1481,6 +1602,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1501,7 +1623,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(0) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1550,6 +1676,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1570,7 +1697,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(1) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<
@@ -1619,6 +1750,7 @@ const _: () = {
                 non_ascii_idents,
                 clippy::missing_inline_in_public_items,
             )]
+            #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
                 unsafe impl<
@@ -1639,7 +1771,11 @@ const _: () = {
                     #[inline(always)]
                     fn project(
                         slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                    ) -> *mut Self::Type {
+                    ) -> *mut <Self as ::zerocopy::HasField<
+                        (),
+                        { ::zerocopy::ident_id!(TupleLike) },
+                        { ::zerocopy::ident_id!(2) },
+                    >>::Type {
                         use ::zerocopy::pointer::cast::{CastSized, Projection};
                         slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
                             .project::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {

--- a/zerocopy-derive/src/output_tests/expected/unaligned.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/unaligned.expected.rs
@@ -8,6 +8,7 @@
     non_ascii_idents,
     clippy::missing_inline_in_public_items,
 )]
+#[deny(ambiguous_associated_items)]
 #[automatically_derived]
 const _: () = {
     unsafe impl ::zerocopy::Unaligned for Foo {

--- a/zerocopy-derive/src/util.rs
+++ b/zerocopy-derive/src/util.rs
@@ -601,6 +601,7 @@ pub(crate) fn const_block(items: impl IntoIterator<Item = Option<TokenStream>>) 
             non_ascii_idents,
             clippy::missing_inline_in_public_items,
         )]
+        #[deny(ambiguous_associated_items)]
         // While there are not currently any warnings that this suppresses
         // (that we're aware of), it's good future-proofing hygiene.
         #[automatically_derived]

--- a/zerocopy-derive/tests/issue_2915.rs
+++ b/zerocopy-derive/tests/issue_2915.rs
@@ -1,0 +1,78 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![no_implicit_prelude]
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+
+include!("include.rs");
+
+// Original reproducer from #2915
+#[derive(imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum MyEnum {
+    Type,
+    OtherWithData(u8),
+}
+
+// Tests for all other associated types which may be problematic in our codebase
+// as of this commit.
+
+#[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned, imp::Immutable, imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+pub struct StructCollision {
+    pub Type: u8,
+    pub LAYOUT: u8,
+    pub PointerMetadata: u8,
+    pub Tag: u8,
+    pub tag: u8,
+    pub variants: u8,
+}
+
+impl StructCollision {
+    pub const Type: () = ();
+    pub const LAYOUT: () = ();
+    pub const PointerMetadata: () = ();
+}
+
+#[derive(imp::FromZeros, imp::Immutable, imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+pub enum EnumCollision {
+    Type { x: u8 },
+    LAYOUT { x: u8 },
+    PointerMetadata { x: u8 },
+    Tag { x: u8 },
+    tag { x: u8 },
+    variants { x: u8 },
+}
+
+// Case where generic parameter has associated type colliding with internal usage
+pub trait AmbiguousTrait {
+    type Type;
+    const LAYOUT: usize;
+    type PointerMetadata;
+}
+
+#[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned, imp::Immutable, imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+pub struct GenericCollision<T: AmbiguousTrait> {
+    pub field: u8,
+    pub typ: T::Type,
+    pub pointer_metadata: T::PointerMetadata,
+    pub _marker: imp::PhantomData<T>,
+}
+
+#[test]
+fn test_compilation() {
+    // If the derives compile, we are good.
+    let _ = StructCollision { Type: 0, LAYOUT: 0, PointerMetadata: 0, Tag: 0, tag: 0, variants: 0 };
+    let _ = EnumCollision::Type { x: 0 };
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.34.

Closes #2915




---

- &#x3000; #2918
- 👉 #2917


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v3..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v3..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v2..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v1..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v2..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v1..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v1..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gc3a755f2c72ce9e1d064eccd1101a5c37acb211e", "parent": null, "child": "Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c"}" -->