### PR TITLE
[derive] In tests, assert hygiene of output

### DIFF
--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -41,6 +41,7 @@ proc-macro2 = "=1.0.80"
 quote = "=1.0.40"
 rustversion = "1.0"
 static_assertions = "1.1"
+syn = { version = "2.0.46", features = ["visit"] }
 testutil = { path = "../testutil" }
 # Pinned to a specific version so that the version used for local development
 # and the version used in CI are guaranteed to be the same. Future versions

--- a/zerocopy-derive/src/lib.rs
+++ b/zerocopy-derive/src/lib.rs
@@ -89,7 +89,10 @@ macro_rules! derive {
             // We wrap in `const_block` as a backstop in case any derive fails
             // to wrap its output in `const_block` (and thus fails to annotate)
             // with the full set of `#[allow(...)]` attributes).
-            const_block([Some(ts)]).into()
+            let ts = const_block([Some(ts)]);
+            #[cfg(test)]
+            crate::util::testutil::check_hygiene(ts.clone());
+            ts.into()
         }
     };
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

When testing, perform a post-processing pass on all derive output which
checks for hygiene violations. Eventually, we may want to extend this
machinery to check for other violations as well.

Follows up on #2915 and #2917




---

- 👉 #2918


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v2..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v2..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v1..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v1..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gc4ce934d790d2094b7c63c1d6b7094514c8ac40c", "parent": null, "child": null}" -->