### PR TITLE
[WIP] Wrapped projections

### DIFF
--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -684,6 +684,18 @@ const _: () = {
     impl<T: ?Sized> SizeEq<T> for ReadOnly<T> {
         type CastFrom = CastToReadOnly;
     }
+
+    // SAFETY: TODO
+    unsafe impl<T: ?Sized> crate::pointer::cast::Wrapped for ReadOnly<T> {
+        type Unwrapped = T;
+        type CastToUnwrapped = CastFromReadOnly;
+        type CastFromUnwrapped = CastToReadOnly;
+    }
+
+    // SAFETY: TODO
+    unsafe impl<T: ?Sized, F: ?Sized> crate::pointer::cast::HasWrappedField<F> for ReadOnly<T> {
+        type WrappedField = ReadOnly<F>;
+    }
 };
 
 // SAFETY: `ReadOnly<T>` is a `#[repr(transparent)]` wrapper around `T`, and so


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Makes progress on #2336




---

- &#x3000; #2876
- &#x3000; #2873
- 👉 #2919


**Latest Update:** v9 — [Compare vs v8](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v9|[v8](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v7](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v6](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v5](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v4](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v9)|
|v8||[v7](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v6](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v5](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v4](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v8)|
|v7|||[v6](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[v5](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[v4](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v7)|
|v6||||[v5](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|[v4](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v6)|
|v5|||||[v4](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5)|[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v5)|
|v4||||||[v3](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4)|[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v4)|
|v3|||||||[v2](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3)|[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v3)|
|v2||||||||[v1](/google/zerocopy/compare/gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2)|[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v2)|
|v1|||||||||[Base](/google/zerocopy/compare/main..gherrit/G17f9a0ab1a99ba2147dbc334934cb9e1f3709128/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G17f9a0ab1a99ba2147dbc334934cb9e1f3709128", "parent": null, "child": "G7691845b6b02e9f3d9578435d732bacfa6ca674f"}" -->