### PR TITLE
[ci] Re-enable `cargo miri nextest` by pinning...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,16 +463,19 @@ jobs:
         THREADS=$(echo "$(nproc) * 2" | bc)
         echo "Running Miri tests with $THREADS threads" | tee -a $GITHUB_STEP_SUMMARY
 
+        # FIXME(https://github.com/nextest-rs/nextest/issues/2990): Once the fix
+        # [1] for this `cargo miri nextest` bug is published, either go back to
+        # installing the latest version of `cargo-nextest` or pin and set up a
+        # roller.
+        #
+        # [1] https://github.com/nextest-rs/nextest/pull/2991
+        cargo install --version 0.9.122 cargo-nextest
+
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
-          # FIXME(https://github.com/nextest-rs/nextest/issues/2990): Once
-          # the fix [1] for this `cargo miri nextest` bug is published, go back
-          # to running `cargo miri nextest run` instead of `cargo miri test`.
-          #
-          # [1] https://github.com/nextest-rs/nextest/pull/2991
           MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +$TOOLCHAIN \
-            miri test \
+            miri nextest run \
             --test-threads "$THREADS" \
             --package $CRATE \
             --target $TARGET \


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

...to a working version. This works around a bug [1] in `cargo-nextest`,
the fix for which [2] hasn't been published yet.

[1] https://github.com/nextest-rs/nextest/pull/2990
[2] https://github.com/nextest-rs/nextest/pull/2991




---

- 👉 #2925
- &#x3000; #2924


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v1..gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v1..gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v2)|[vs Base](/google/zerocopy/compare/G03eddca9a410cc8e8d775094cc0f522724486cda..gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v2)|
|v1||[vs Base](/google/zerocopy/compare/G03eddca9a410cc8e8d775094cc0f522724486cda..gherrit/G465843684a728e67607e3a24b8a029f2b71001d8/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G465843684a728e67607e3a24b8a029f2b71001d8", "parent": "G03eddca9a410cc8e8d775094cc0f522724486cda", "child": null}" -->