### PR TITLE
[projection] Clarify comment explaining fallibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1224,11 +1224,13 @@ where
                     _enum_variant => {
                         use crate::invariant::{Validity, ValidityKind};
                         match I::Validity::KIND {
-                            // The projectability of a field from an `Uninit` or
-                            // `Initialized` union cannot generally depend on
-                            // the referent's value, because the union's
-                            // discriminant is not in a valid state, and thus
-                            // cannot be used to discriminate between variants.
+                            // The `Uninit` and `Initialized` validity
+                            // invariants do not depend on the enum's tag. In
+                            // particular, we don't actually care about what
+                            // variant is present – we can treat *any* range of
+                            // uninitialized or initialized memory as containing
+                            // an uninitialized or initialized instance of *any*
+                            // type – the type itself is irrelevant.
                             ValidityKind::Uninit | ValidityKind::Initialized => true,
                             // The projectability of an enum field from an
                             // `AsInitialized` or `Valid` state is a dynamic


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- &#x3000; #2938
- &#x3000; #2876
- &#x3000; #2873
- 👉 #2939


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v2..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v2..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v3)|[vs v1](/google/zerocopy/compare/gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v1..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v1..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/G11dfbd515f9e3a58b6e66367f787a5d5debe31bf/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G11dfbd515f9e3a58b6e66367f787a5d5debe31bf", "parent": null, "child": "G7691845b6b02e9f3d9578435d732bacfa6ca674f"}" -->