### PR TITLE
[util] `use` more items to make code more concise

### DIFF
--- a/zerocopy-derive/tests/ui-nightly/enum.stderr
+++ b/zerocopy-derive/tests/ui-nightly/enum.stderr
@@ -482,7 +482,7 @@ help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -504,7 +504,7 @@ help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -526,7 +526,7 @@ help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-nightly/struct.stderr
+++ b/zerocopy-derive/tests/ui-nightly/struct.stderr
@@ -325,7 +325,7 @@ help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -347,7 +347,7 @@ help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -405,7 +405,7 @@ help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -427,7 +427,7 @@ help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -449,7 +449,7 @@ help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/enum.stderr
+++ b/zerocopy-derive/tests/ui-stable/enum.stderr
@@ -439,7 +439,7 @@ help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -457,7 +457,7 @@ help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -475,7 +475,7 @@ help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy-derive/tests/ui-stable/struct.stderr
+++ b/zerocopy-derive/tests/ui-stable/struct.stderr
@@ -293,7 +293,7 @@ help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -311,7 +311,7 @@ help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 65 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 68 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -365,7 +365,7 @@ help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -383,7 +383,7 @@ help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -401,7 +401,7 @@ help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `(
       but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
    --> $WORKSPACE/src/util/macro_util.rs
     |
- 83 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+ 86 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- &#x3000; #2938
- 👉 #2942


**Latest Update:** v8 — [Compare vs v7](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v8|[vs v7](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v6](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v5](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v4](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v3](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v8)|
|v7||[vs v6](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs v5](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs v4](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs v3](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v7)|
|v6|||[vs v5](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|[vs v4](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|[vs v3](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v6)|
|v5||||[vs v4](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v5)|
|v4|||||[vs v3](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v4)|
|v3||||||[vs v2](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v3)|
|v2|||||||[vs v1](/google/zerocopy/compare/gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v2)|
|v1||||||||[vs Base](/google/zerocopy/compare/main..gherrit/Gf52a0089dd6f24906cd4488f99c158bacc746f06/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gf52a0089dd6f24906cd4488f99c158bacc746f06", "parent": null, "child": "G5520d1263ed335298ddd307e45c38b41ff28aa90"}" -->