### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "elain",
  "itertools",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "dissimilar",
  "prettyplease",


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #2943
- 　  #2944
- 👉 #2949


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)|[vs v3](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v3..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)|[vs v2](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v2..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)|[vs v1](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v1..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v3..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4)|[vs v2](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v2..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4)|[vs v1](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v1..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v2..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v3)|[vs v1](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v1..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v1..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/G59af5c6b6a95913c3b772c5d1039e766c61a8e42/v1)|

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G59af5c6b6a95913c3b772c5d1039e766c61a8e42", "parent": null, "child": "Gdf81e39c9f13236c2c2bad3bfbd2bb931e73b706"}" -->