### PR TITLE
[layout] Support sized->unsized, sized->sized casts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,6 +888,12 @@ pub trait PointerMetadata: Copy + Eq + Debug {
     /// `elems`. No other types are currently supported.
     fn from_elem_count(elems: usize) -> Self;
 
+    /// Converts `self` to an element count.
+    ///
+    /// If `Self = ()`, this returns `0`. If `Self = usize`, this returns
+    /// `self`. No other types are currently supported.
+    fn to_elem_count(self) -> usize;
+
     /// Computes the size of the object with the given layout and pointer
     /// metadata.
     ///
@@ -910,6 +916,11 @@ impl PointerMetadata for () {
     fn from_elem_count(_elems: usize) -> () {}
 
     #[inline]
+    fn to_elem_count(self) -> usize {
+        0
+    }
+
+    #[inline]
     fn size_for_metadata(self, layout: DstLayout) -> Option<usize> {
         match layout.size_info {
             SizeInfo::Sized { size } => Some(size),
@@ -924,6 +935,11 @@ impl PointerMetadata for usize {
     #[inline]
     fn from_elem_count(elems: usize) -> usize {
         elems
+    }
+
+    #[inline]
+    fn to_elem_count(self) -> usize {
+        self
     }
 
     #[inline]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Makes progress on #2721




---

- 　  #2944
- 　  #2943
- 👉 #2950


**Latest Update:** v9 — [Compare vs v8](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v9|[v8](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v7](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v6](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v5](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v4](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v9)|
|v8||[v7](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v6](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v5](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v4](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v8)|
|v7|||[v6](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[v5](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[v4](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v7)|
|v6||||[v5](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|[v4](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v6)|
|v5|||||[v4](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5)|[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v5)|
|v4||||||[v3](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4)|[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v4)|
|v3|||||||[v2](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3)|[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v3)|
|v2||||||||[v1](/google/zerocopy/compare/gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2)|[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v2)|
|v1|||||||||[Base](/google/zerocopy/compare/main..gherrit/G374c587ce49c18d4dd1d7de970df8556ed7834e3/v1)|

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G374c587ce49c18d4dd1d7de970df8556ed7834e3", "parent": null, "child": "G73f67c103188ed404d0051bc140c4d0711fe0753"}" -->