### PR TITLE
[macros] Fix doc bug in `transmute_mut!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -367,8 +367,8 @@ macro_rules! transmute_ref {
 /// const fn transmute_mut<'src, 'dst, Src, Dst>(src: &'src mut Src) -> &'dst mut Dst
 /// where
 ///     'src: 'dst,
-///     Src: FromBytes + IntoBytes,
-///     Dst: FromBytes + IntoBytes,
+///     Src: FromBytes + IntoBytes + ?Sized,
+///     Dst: FromBytes + IntoBytes + ?Sized,
 ///     align_of::<Src>() >= align_of::<Dst>(),
 ///     size_compatible::<Src, Dst>(),
 /// {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

When we updated `transmute_mut!` to support unsized types, we forgot to
update one location in the documentation to reflect this.




---

- 　  #2944
- 　  #2943
- 　  #2950
- 👉 #2951


*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gf4fc8f4ade59c568c9fef502015da09b4a508560", "parent": null, "child": "G374c587ce49c18d4dd1d7de970df8556ed7834e3"}" -->