### PR TITLE
Add `Ptr::try_with_as_{ref,mut}`

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -160,7 +160,10 @@ mod _external {
 /// Methods for converting to and from `Ptr` and Rust's safe reference types.
 mod _conversions {
     use super::*;
-    use crate::pointer::cast::{CastExact, CastSized, IdCast};
+    use crate::{
+        pointer::cast::{CastExact, CastSized, IdCast},
+        Unalign,
+    };
 
     /// `&'a T` → `Ptr<'a, T>`
     impl<'a, T> Ptr<'a, T, (Shared, Aligned, Valid)>
@@ -371,9 +374,10 @@ mod _conversions {
     }
 
     /// `Ptr<'a, T>` → `&'a mut T`
-    impl<'a, T> Ptr<'a, T, (Exclusive, Aligned, Valid)>
+    impl<'a, T, I> Ptr<'a, T, I>
     where
         T: 'a + ?Sized,
+        I: Invariants<Aliasing = Exclusive, Alignment = Aligned, Validity = Valid>,
     {
         /// Converts `self` to a mutable reference.
         #[allow(clippy::wrong_self_convention)]
@@ -548,7 +552,7 @@ mod _conversions {
         /// `Unalign<T>`.
         pub(crate) fn into_unalign(
             self,
-        ) -> Ptr<'a, crate::Unalign<T>, (I::Aliasing, Aligned, I::Validity)> {
+        ) -> Ptr<'a, Unalign<T>, (I::Aliasing, Aligned, I::Validity)> {
             // FIXME(#1359): This should be a `transmute_with` call.
             // Unfortunately, to avoid blanket impl conflicts, we only implement
             // `TransmuteFrom<T>` for `Unalign<T>` (and vice versa) specifically
@@ -968,6 +972,59 @@ mod _casts {
                 })
             });
             res
+        }
+    }
+
+    // TODO: Unify these two methods and delegate to `Ptr::as_ref` or
+    // `Ptr::as_mut` automatically.
+
+    impl<'a, T, I> Ptr<'a, T, I>
+    where
+        T: 'a + ?Sized,
+        I: Invariants<Aliasing = Shared, Alignment = Aligned, Validity = Valid>,
+    {
+        /// Like [`try_with`], but returns a reference instead of a pointer
+        /// in both the success and error cases.
+        pub(crate) fn try_with_as_ref<U, J, E, F>(
+            self,
+            f: F,
+        ) -> Result<&'a U, <E::Mapped as TryWithError<&'a T>>::Mapped>
+        where
+            U: 'a + ?Sized,
+            J: Invariants<Aliasing = Shared, Alignment = Aligned, Validity = Valid>,
+            E: TryWithError<Self>,
+            E::Mapped: TryWithError<&'a T, Inner = Self>,
+            F: for<'b> FnOnce(Ptr<'b, T, I>) -> Result<Ptr<'b, U, J>, E>,
+        {
+            match self.try_with(f) {
+                Ok(ptr) => Ok(ptr.as_ref()),
+                Err(err) => Err(TryWithError::map(err, Ptr::as_ref)),
+            }
+        }
+    }
+
+    impl<'a, T, I> Ptr<'a, T, I>
+    where
+        T: 'a + ?Sized,
+        I: Invariants<Aliasing = Exclusive, Alignment = Aligned, Validity = Valid>,
+    {
+        /// Like [`try_with`], but returns a mutable reference instead of a
+        /// pointer in both the success and error cases.
+        pub(crate) fn try_with_as_mut<U, J, E, F>(
+            self,
+            f: F,
+        ) -> Result<&'a mut U, <E::Mapped as TryWithError<&'a mut T>>::Mapped>
+        where
+            U: 'a + ?Sized,
+            J: Invariants<Aliasing = Exclusive, Alignment = Aligned, Validity = Valid>,
+            E: TryWithError<Self>,
+            E::Mapped: TryWithError<&'a mut T, Inner = Self>,
+            F: for<'b> FnOnce(Ptr<'b, T, I>) -> Result<Ptr<'b, U, J>, E>,
+        {
+            match self.try_with(f) {
+                Ok(ptr) => Ok(ptr.as_mut()),
+                Err(err) => Err(TryWithError::map(err, Ptr::as_mut)),
+            }
         }
     }
 

--- a/src/split_at.rs
+++ b/src/split_at.rs
@@ -700,7 +700,7 @@ where
         // SAFETY: `self.source.as_mut()` points to exactly the same referent as
         // `self.source` and thus maintains the invariants of `self` with
         // respect to `l_len`.
-        unsafe { Split::new(self.source.unify_invariants().as_mut(), self.l_len) }
+        unsafe { Split::new(self.source.as_mut(), self.l_len) }
     }
 
     /// Produces the length of `self`'s left part.

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -198,11 +198,11 @@ impl<T> Unalign<T> {
     /// may prefer [`Deref::deref`], which is infallible.
     #[inline(always)]
     pub fn try_deref(&self) -> Result<&T, AlignmentError<&Self, T>> {
-        let inner = Ptr::from_ref(self).transmute();
-        match inner.try_into_aligned() {
-            Ok(aligned) => Ok(aligned.as_ref()),
-            Err(err) => Err(err.map_src(|src| src.into_unalign().as_ref())),
-        }
+        let ptr = Ptr::from_ref(self);
+        #[rustfmt::skip]
+        return ptr.try_with_as_ref(#[inline(always)] |ptr| {
+            ptr.transmute().try_into_aligned().map_err(|err| err.map_src(drop))
+        });
     }
 
     /// Attempts to return a mutable reference to the wrapped `T`, failing if


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

A common operation is to try a fallible `Ptr` conversion and then
dereference the `Ptr` to a `&` or `&mut` in both the success and error
cases. These functions handle the dereferencing boilerplate.




---

- 👉 #2952
- 　  #2953
- 　  #2957


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)|[vs v3](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v3..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)|[vs v2](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v2..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)|[vs v1](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v1..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)|[vs Base](/google/zerocopy/compare/G1797ed669d2bae97562a2b84e0ac229b00d5acb7..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v3..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4)|[vs v2](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v2..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4)|[vs v1](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v1..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4)|[vs Base](/google/zerocopy/compare/G1797ed669d2bae97562a2b84e0ac229b00d5acb7..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v2..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v3)|[vs v1](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v1..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v3)|[vs Base](/google/zerocopy/compare/G1797ed669d2bae97562a2b84e0ac229b00d5acb7..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v1..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v2)|[vs Base](/google/zerocopy/compare/G1797ed669d2bae97562a2b84e0ac229b00d5acb7..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/G1797ed669d2bae97562a2b84e0ac229b00d5acb7..gherrit/G7ef173122e7ebd6e3ce2659d432363d56972eb88/v1)|

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G7ef173122e7ebd6e3ce2659d432363d56972eb88", "parent": "G1797ed669d2bae97562a2b84e0ac229b00d5acb7", "child": null}" -->