### PR TITLE
Make `Ptr::try_with_unchecked` safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "elain",
  "itertools",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -916,27 +916,28 @@ mod _casts {
 
         /// Attempts to transform the pointer, restoring the original on
         /// failure.
-        ///
-        /// # Safety
-        ///
-        /// If `I::Aliasing != Shared`, then if `f` returns `Err(err)`, no copy
-        /// of `f`'s argument must exist outside of `err`.
         #[inline(always)]
-        pub(crate) unsafe fn try_with_unchecked<U, J, E, F>(
-            self,
-            f: F,
-        ) -> Result<Ptr<'a, U, J>, E::Mapped>
+        pub(crate) fn try_with<U, J, E, F>(self, f: F) -> Result<Ptr<'a, U, J>, E::Mapped>
         where
             U: 'a + ?Sized,
             J: Invariants<Aliasing = I::Aliasing>,
             E: TryWithError<Self>,
-            F: FnOnce(Ptr<'a, T, I>) -> Result<Ptr<'a, U, J>, E>,
+            // TODO: The invariance issue is caused by `E` not being bound by
+            // `'b`, which thus requires it to be `'static`. If we can somehow
+            // polyfill a GAT so that it's actually `E<'b>` here, then we should
+            // be able to solve the `'static` issue. That will, in turn, remove
+            // the need for us to add `.map_err(|err| err.map_src(drop))` to
+            // many `f` closures.
+            F: for<'b> FnOnce(Ptr<'b, T, I>) -> Result<Ptr<'b, U, J>, E>,
         {
             let old_inner = self.as_inner();
             #[rustfmt::skip]
             let res = f(self).map_err(#[inline(always)] move |err: E| {
                 err.map(#[inline(always)] |src| {
                     drop(src);
+
+                    // TODO: Mention the `for<'b>` variance on `F` to prove that
+                    // `f` cannot make another copy of `self`.
 
                     // SAFETY:
                     // 0. Aliasing is either `Shared` or `Exclusive`:
@@ -967,21 +968,6 @@ mod _casts {
                 })
             });
             res
-        }
-
-        /// Attempts to transform the pointer, restoring the original on
-        /// failure.
-        pub(crate) fn try_with<U, J, E, F>(self, f: F) -> Result<Ptr<'a, U, J>, E::Mapped>
-        where
-            U: 'a + ?Sized,
-            J: Invariants<Aliasing = I::Aliasing>,
-            E: TryWithError<Self>,
-            F: FnOnce(Ptr<'a, T, I>) -> Result<Ptr<'a, U, J>, E>,
-            I: Invariants<Aliasing = Shared>,
-        {
-            // SAFETY: `I::Aliasing = Shared`, so the safety condition does not
-            // apply.
-            unsafe { self.try_with_unchecked(f) }
         }
     }
 
@@ -1162,19 +1148,17 @@ mod _casts {
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
             [u8]: Read<I::Aliasing, R>,
         {
-            // SAFETY: The provided closure returns the only copy of `slf`.
-            unsafe {
-                self.try_with_unchecked(|slf| match slf.try_cast_into(CastType::Prefix, meta) {
-                    Ok((slf, remainder)) => {
-                        if remainder.len() == 0 {
-                            Ok(slf)
-                        } else {
-                            Err(CastError::Size(SizeError::<_, U>::new(())))
-                        }
+            #[rustfmt::skip]
+            return self.try_with(#[inline(always)] |slf| match slf.try_cast_into(CastType::Prefix, meta) {
+                Ok((slf, remainder)) => {
+                    if remainder.len() == 0 {
+                        Ok(slf)
+                    } else {
+                        Err(CastError::Size(SizeError::<_, U>::new(())))
                     }
-                    Err(err) => Err(err.map_src(|_slf| ())),
-                })
-            }
+                }
+                Err(err) => Err(err.map_src(|_slf| ())),
+            });
         }
     }
 

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -584,7 +584,7 @@ where
         let res = ptr.try_with(#[inline(always)] |ptr| {
             let ptr = ptr.recall_validity::<Initialized, _>();
             let ptr = ptr.cast::<_, crate::layout::CastFrom<Dst>, _>();
-            ptr.try_into_valid()
+            ptr.try_into_valid().map_err(|err| err.map_src(drop))
         });
         match res {
             Ok(ptr) => {
@@ -643,13 +643,11 @@ where
         let ptr = Ptr::from_mut(self.0);
         // SAFETY: The provided closure returns the only copy of `ptr`.
         #[rustfmt::skip]
-        let res = unsafe {
-            ptr.try_with_unchecked(#[inline(always)] |ptr| {
-                let ptr = ptr.recall_validity::<Initialized, (_, (_, _))>();
-                let ptr = ptr.cast::<_, crate::layout::CastFrom<Dst>, _>();
-                ptr.try_into_valid()
-            })
-        };
+        let res = ptr.try_with(#[inline(always)] |ptr| {
+            let ptr = ptr.recall_validity::<Initialized, (_, (_, _))>();
+            let ptr = ptr.cast::<_, crate::layout::CastFrom<Dst>, _>();
+            ptr.try_into_valid().map_err(|err| err.map_src(drop))
+        });
         match res {
             Ok(ptr) => {
                 static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Rename it to `Ptr::try_with` and remove the old method of the same name.
In order to guarantee that the `f` closure doesn't leak its argument,
make `f` variant on lifetime (ie, for `f: F`, go from `F: FnOnce` to `F:
for<'b> FnOnce`).




---

- 　  #2952
- 👉 #2953
- 　  #2957


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v2..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v2..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v3)|[vs v1](/google/zerocopy/compare/gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v1..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v3)|[vs Base](/google/zerocopy/compare/Gd4257e94754893127a547297565b5e06f6eeeba8..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v1..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v2)|[vs Base](/google/zerocopy/compare/Gd4257e94754893127a547297565b5e06f6eeeba8..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v2)|
|v1|||[vs Base](/google/zerocopy/compare/Gd4257e94754893127a547297565b5e06f6eeeba8..gherrit/G1797ed669d2bae97562a2b84e0ac229b00d5acb7/v1)|

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G1797ed669d2bae97562a2b84e0ac229b00d5acb7", "parent": "Gd4257e94754893127a547297565b5e06f6eeeba8", "child": "G7ef173122e7ebd6e3ce2659d432363d56972eb88"}" -->