### PR TITLE
[atomic] Initial commit of `Atomic<T>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "elain",
  "itertools",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,0 +1,292 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+//! TODO
+
+use core::{
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit},
+    sync::atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering},
+};
+
+use crate::{IntoBytes, KnownLayout};
+
+// TODO: This selector mechanism may have a soundness hole. In particular, imagine
+// that, in derive code, we say that any generic type is unsupported, and so we
+// implement `KnownLayout` with `AtomicType = ()`. However, the PME code is simply
+// based on `T`'s size, and so it might permit such a type, expecting the atomic
+// to be larger than `T` while it's in fact `()`.
+//
+// TODO: If instead of storing `T::Atomic`, we store a type which actually wraps
+// `T` (but has its size and alignment rounded up to the next power of two), then
+// we can actually support generic types *and* avoid this bug.
+
+/// TODO
+#[repr(transparent)]
+#[allow(missing_copy_implementations, missing_debug_implementations)]
+pub struct Atomic<T: KnownLayout> {
+    // INVARIANT: The first `size_of::<T>()` bytes of `atomic` have the same
+    // validity as `T`, and logically own a `T`.
+    atomic: T::Atomic,
+    _marker: PhantomData<T>,
+}
+
+// TODO: Impl traits (Copy, Clone, Debug, Send, Sync, etc).
+
+impl<T: IntoBytes + KnownLayout> Atomic<T> {
+    /// TODO
+    #[inline(always)]
+    #[must_use]
+    pub fn new(v: T) -> Self {
+        let prim = into_atomic(v);
+        let atomic = T::Atomic::new(prim);
+        Self { atomic, _marker: PhantomData }
+    }
+
+    /// TODO
+    #[inline]
+    pub fn store(&self, v: T, ordering: Ordering) {
+        let prim = into_atomic(v);
+        self.atomic.store(prim, ordering);
+    }
+}
+
+impl<T: KnownLayout> Atomic<T> {
+    /// TODO
+    #[inline]
+    #[must_use]
+    pub fn load(&self, ordering: Ordering) -> T {
+        let v = self.atomic.load(ordering);
+        let mu = from_atomic(v);
+        // SAFETY: TODO
+        unsafe { mu.assume_init() }
+    }
+}
+
+fn into_atomic<T: IntoBytes + KnownLayout>(t: T) -> <T::Atomic as AtomicOps>::Value {
+    static_assert!(T => macro_util::SupportedSize::try_for_type::<T>().is_some(), "type is too large for atomic operations");
+
+    #[repr(C)]
+    union Transmute<T: KnownLayout> {
+        t: ManuallyDrop<T>,
+        prim: <T::Atomic as AtomicOps>::Value,
+    }
+
+    let mut u = Transmute { prim: Default::default() };
+    u.t = ManuallyDrop::new(t);
+    // SAFETY: TODO
+    unsafe { u.prim }
+}
+
+fn from_atomic<T: KnownLayout>(v: <T::Atomic as AtomicOps>::Value) -> MaybeUninit<T> {
+    static_assert!(T => macro_util::SupportedSize::try_for_type::<T>().is_some(), "type is too large for atomic operations");
+
+    #[repr(C)]
+    union Transmute<T: KnownLayout> {
+        t: ManuallyDrop<MaybeUninit<T>>,
+        prim: <T::Atomic as AtomicOps>::Value,
+    }
+
+    let u = Transmute { prim: v };
+    // SAFETY: TODO
+    ManuallyDrop::into_inner(unsafe { u.t })
+}
+
+/// # Safety
+///
+/// TODO
+#[doc(hidden)]
+pub(crate) unsafe trait AtomicOps {
+    type Value: Copy + Default;
+
+    fn new(value: Self::Value) -> Self;
+    fn load(&self, ordering: Ordering) -> Self::Value;
+    fn store(&self, value: Self::Value, ordering: Ordering);
+}
+
+unsafe impl AtomicOps for () {
+    type Value = ();
+
+    #[inline(always)]
+    fn new(_: ()) -> Self {}
+
+    #[inline(always)]
+    fn load(&self, _: Ordering) -> Self::Value {}
+
+    #[inline(always)]
+    fn store(&self, _: Self::Value, _: Ordering) {}
+}
+
+#[doc(hidden)]
+pub mod macro_util {
+    use super::*;
+
+    pub(super) enum SupportedSize {
+        B0 = 0,
+        B1 = 1,
+        B2 = 2,
+        B3 = 3,
+        B4 = 4,
+        B5 = 5,
+        B6 = 6,
+        B7 = 7,
+        B8 = 8,
+    }
+
+    impl SupportedSize {
+        pub(super) const fn try_for_type<T>() -> Option<Self> {
+            match core::mem::size_of::<T>() {
+                0 => Some(Self::B0),
+                1 => Some(Self::B1),
+                2 => Some(Self::B2),
+                3 => Some(Self::B3),
+                4 => Some(Self::B4),
+                5 => Some(Self::B5),
+                6 => Some(Self::B6),
+                7 => Some(Self::B7),
+                8 => Some(Self::B8),
+                _ => None,
+            }
+        }
+    }
+
+    pub const fn selector_for_type<T>() -> usize {
+        #[allow(clippy::as_conversions)]
+        match SupportedSize::try_for_type::<T>() {
+            Some(size) => size as usize,
+            None => 0,
+        }
+    }
+
+    /// # Safety
+    ///
+    /// TODO
+    pub unsafe trait AtomicSelector<const N: usize> {
+        type AtomicType;
+        const PADDING: usize;
+    }
+
+    unsafe impl AtomicSelector<0> for () {
+        type AtomicType = ();
+        const PADDING: usize = 0;
+    }
+
+    macro_rules! impl_atomic_selector {
+        ($atomic:ty [$value:ty]; $($size:expr),+) => {
+            // SAFETY: TODO
+            unsafe impl AtomicOps for $atomic {
+                type Value = $value;
+
+                #[inline(always)]
+                fn new(value: Self::Value) -> Self {
+                    Self::new(value)
+                }
+
+                #[inline(always)]
+                fn load(&self, ordering: Ordering) -> Self::Value {
+                    self.load(ordering)
+                }
+
+                #[inline(always)]
+                fn store(&self, value: Self::Value, ordering: Ordering) {
+                    self.store(value, ordering)
+                }
+            }
+
+            $(
+                // SAFETY: TODO
+                unsafe impl AtomicSelector<$size> for () {
+                    type AtomicType = $atomic;
+                    const PADDING: usize = core::mem::size_of::<$atomic>() - $size;
+                }
+            )+
+        };
+    }
+
+    impl_atomic_selector!(AtomicU8 [u8]; 1);
+    impl_atomic_selector!(AtomicU16 [u16]; 2);
+    impl_atomic_selector!(AtomicU32 [u32]; 3, 4);
+    impl_atomic_selector!(AtomicU64 [u64]; 5, 6, 7, 8);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Immutable, IntoBytes, KnownLayout};
+
+    #[derive(IntoBytes, KnownLayout, Immutable, Clone, Copy, Debug, PartialEq)]
+    #[repr(C)]
+    struct MyStruct {
+        a: u32,
+    }
+
+    #[derive(IntoBytes, KnownLayout, Immutable, Clone, Copy, Debug, PartialEq)]
+    #[repr(u8)]
+    enum MyEnum {
+        A = 0,
+        B = 1,
+    }
+
+    #[test]
+    fn test_atomic_u32() {
+        let a = Atomic::new(10u32);
+        assert_eq!(a.load(Ordering::SeqCst), 10);
+        a.store(20, Ordering::SeqCst);
+        assert_eq!(a.load(Ordering::SeqCst), 20);
+        assert_eq!(a.swap(30, Ordering::SeqCst), 20);
+        assert_eq!(a.load(Ordering::SeqCst), 30);
+    }
+
+    #[test]
+    fn test_atomic_struct() {
+        let s1 = MyStruct { a: 10 };
+        let s2 = MyStruct { a: 20 };
+        let a = Atomic::new(s1);
+        assert_eq!(a.load(Ordering::SeqCst), s1);
+        a.store(s2, Ordering::SeqCst);
+        assert_eq!(a.load(Ordering::SeqCst), s2);
+    }
+
+    #[test]
+    fn test_atomic_enum() {
+        let a = Atomic::new(MyEnum::A);
+        assert_eq!(a.load(Ordering::SeqCst), MyEnum::A);
+        a.store(MyEnum::B, Ordering::SeqCst);
+        assert_eq!(a.load(Ordering::SeqCst), MyEnum::B);
+    }
+
+    #[test]
+    fn test_compare_exchange() {
+        let a = Atomic::new(10u32);
+        let res = a.compare_exchange(10, 20, Ordering::SeqCst, Ordering::SeqCst);
+        assert_eq!(res, Ok(10));
+        assert_eq!(a.load(Ordering::SeqCst), 20);
+        let res = a.compare_exchange(10, 30, Ordering::SeqCst, Ordering::SeqCst);
+        assert_eq!(res, Err(20));
+        assert_eq!(a.load(Ordering::SeqCst), 20);
+    }
+
+    #[test]
+    fn test_fetch_update() {
+        let a = Atomic::new(10u32);
+        let res = a.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some(v + 1));
+        assert_eq!(res, Ok(10));
+        assert_eq!(a.load(Ordering::SeqCst), 11);
+    }
+}
+
+#[allow(dead_code)]
+#[doc(hidden)]
+pub mod doctests {
+    /// ```compile_fail,E0080
+    /// use core::sync::atomic::Ordering;
+    /// let a = zerocopy::atomic::Atomic::new([0u8; 64]);
+    /// a.load(Ordering::SeqCst);
+    /// ```
+    enum OversizedTypesPme {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@ extern crate test;
 #[macro_use]
 pub mod util;
 
+pub mod atomic;
 pub mod byte_slice;
 pub mod byteorder;
 mod deprecated;
@@ -759,6 +760,10 @@ pub unsafe trait KnownLayout {
     #[doc(hidden)]
     type MaybeUninit: ?Sized + KnownLayout<PointerMetadata = Self::PointerMetadata>;
 
+    #[allow(private_bounds)]
+    #[doc(hidden)]
+    type Atomic: Send + Sync + atomic::AtomicOps;
+
     /// The layout of `Self`.
     ///
     /// # Safety
@@ -1000,6 +1005,8 @@ unsafe impl<T> KnownLayout for [T] {
     //   element of the array is offset from the start of the array by `n *
     //   size_of::<T>()` bytes.
     type MaybeUninit = [CoreMaybeUninit<T>];
+
+    type Atomic = ();
 
     const LAYOUT: DstLayout = DstLayout::for_slice::<T>();
 

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -437,6 +437,9 @@ macro_rules! impl_known_layout {
                 //   `MaybeUninit<T>` is guaranteed to have the same size,
                 //   alignment, and ABI as `T`
                 type MaybeUninit = core::mem::MaybeUninit<Self>;
+                // TODO: Support these types.
+                type Atomic = ();
+                // type Atomic = <() as AtomicSelector<{ atomic::macro_util::selector_for_type::<$ty>() }>>::AtomicType;
 
                 const LAYOUT: crate::DstLayout = crate::DstLayout::for_type::<$ty>();
 
@@ -483,6 +486,7 @@ macro_rules! unsafe_impl_known_layout {
 
             type PointerMetadata = <$repr as KnownLayout>::PointerMetadata;
             type MaybeUninit = <$repr as KnownLayout>::MaybeUninit;
+            type Atomic = <$repr as KnownLayout>::Atomic;
 
             const LAYOUT: DstLayout = <$repr as KnownLayout>::LAYOUT;
 
@@ -552,7 +556,7 @@ macro_rules! const_panic {
         // This will type check to whatever type is expected based on the call
         // site.
         let panic: [_; 0] = [];
-        // This will always fail (since we're indexing into an array of size 0.
+        // This will always fail (since we're indexing into an array of size 0).
         #[allow(unconditional_panic)]
         panic[0]
     }};

--- a/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy-derive/src/derive/known_layout.rs
@@ -93,6 +93,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
             type PointerMetadata = <#trailing_field_ty as #zerocopy_crate::KnownLayout>::PointerMetadata;
 
             type MaybeUninit = __ZerocopyKnownLayoutMaybeUninit #ty_generics;
+            type Atomic = ();
 
             // SAFETY: `LAYOUT` accurately describes the layout of `Self`.
             // The documentation of `DstLayout::for_repr_c_struct` vows that
@@ -235,6 +236,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
                 type PointerMetadata = <#ident #ty_generics as #zerocopy_crate::KnownLayout>::PointerMetadata;
 
                 type MaybeUninit = Self;
+                type Atomic = ();
 
                 const LAYOUT: #zerocopy_crate::DstLayout = <#ident #ty_generics as #zerocopy_crate::KnownLayout>::LAYOUT;
 
@@ -281,6 +283,9 @@ pub(crate) fn derive(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error>
                     type PointerMetadata = ();
                     type MaybeUninit =
                         #core::mem::MaybeUninit<Self>;
+                    // TODO: Support these types.
+                    type Atomic = ();
+                    // type Atomic = <() as #zerocopy_crate::atomic::macro_util::AtomicSelector<{ #zerocopy_crate::atomic::macro_util::selector_for_type::<Self>() }>>::AtomicType;
 
                     // SAFETY: `LAYOUT` is guaranteed to accurately describe the
                     // layout of `Self`, because that is the documented safety


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #2959


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v2..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v2..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v3)|[vs v1](/google/zerocopy/compare/gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v1..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v1..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Ge6a504780e973e00e15ad398613d1473ad57ae64/v1)|

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Ge6a504780e973e00e15ad398613d1473ad57ae64", "parent": null, "child": null}" -->