### PR TITLE
[cargo-zerocopy] Pass --cfg __ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,6 +91,7 @@ fn main() {
         println!(
             "cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)"
         );
+        println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)");
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
     }
 

--- a/src/doctests.rs
+++ b/src/doctests.rs
@@ -8,7 +8,7 @@
 // those terms.
 
 #![cfg(feature = "derive")] // Required for derives on `SliceDst`
-#![allow(dead_code)]
+#![allow(dead_code, missing_docs, missing_debug_implementations, missing_copy_implementations)]
 
 //! Our UI test framework, built on the `trybuild` crate, does not support
 //! testing for post-monomorphization errors. Instead, we use doctests, which
@@ -18,7 +18,6 @@ use crate::*;
 
 #[derive(KnownLayout, FromBytes, IntoBytes, Immutable)]
 #[repr(C)]
-#[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct SliceDst<T, U> {
     pub t: T,
     pub u: [U],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ pub mod byte_slice;
 pub mod byteorder;
 mod deprecated;
 
-#[doc(hidden)]
+#[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)]
 pub mod doctests;
 
 // This module is `pub` so that zerocopy's error types and error handling

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -164,17 +164,21 @@ fn install_toolchain_or_exit(versions: &Versions, name: &str) -> Result<(), Erro
     Ok(())
 }
 
-fn get_rustflags(name: &str) -> &'static str {
+fn get_rustflags(name: &str) -> String {
     // See #1792 for context on zerocopy_derive_union_into_bytes.
+    let mut flags =
+        "--cfg zerocopy_derive_union_into_bytes --cfg __ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE"
+            .to_string();
+
     if name == "nightly" {
-        "--cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS --cfg zerocopy_derive_union_into_bytes "
-    } else {
-        "--cfg zerocopy_derive_union_into_bytes "
+        flags += " --cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS";
     }
+
+    flags
 }
 
 fn get_toolchain_rustflags(name: &str) -> String {
-    format!("--cfg __ZEROCOPY_TOOLCHAIN=\"{}\" ", name)
+    format!("--cfg __ZEROCOPY_TOOLCHAIN=\"{}\"", name)
 }
 
 fn rustup<'a>(args: impl IntoIterator<Item = &'a str>, env: Option<(&str, &str)>) -> Command {
@@ -228,7 +232,7 @@ fn delegate_cargo() -> Result<(), Error> {
                     .unwrap_or_default();
 
                 let rustflags = format!(
-                    "{}{}{}",
+                    "{} {} {}",
                     get_rustflags(name),
                     get_toolchain_rustflags(name),
                     env_rustflags,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This allows zerocopy code to detect when it's being compiled during
development or in CI. In this commit, we use this to disable compiling
the `doctests` module in production builds.




---

- 👉 #2960


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)|[vs v3](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v3..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)|[vs v2](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v2..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)|[vs v1](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v1..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v3..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4)|[vs v2](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v2..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4)|[vs v1](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v1..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v2..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v3)|[vs v1](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v1..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v1..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad && git checkout -b pr-G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2bd9f86557e00ed04dc9587f4d5f4b0dbb6513ad", "parent": null, "child": null}" -->