### PR TITLE
[WIP] Introduce compound `Ptr` validity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1268,14 +1268,18 @@ where
                     _enum_variant => {
                         use crate::invariant::{Validity, ValidityKind};
                         match I::Validity::KIND {
-                            // The `Uninit` and `Initialized` validity
-                            // invariants do not depend on the enum's tag. In
-                            // particular, we don't actually care about what
-                            // variant is present – we can treat *any* range of
-                            // uninitialized or initialized memory as containing
-                            // an uninitialized or initialized instance of *any*
-                            // type – the type itself is irrelevant.
-                            ValidityKind::Uninit | ValidityKind::Initialized => true,
+                            // The `Uninit`, `Initialized` and `Compound`
+                            // validity invariants do not depend on the enum's
+                            // tag. In particular, we don't actually care about
+                            // what variant is present – we can treat *any*
+                            // range of uninitialized or initialized memory as
+                            // containing an uninitialized or initialized
+                            // instance of *any* type – the type itself is
+                            // irrelevant.
+                            // TODO: What about compound validity?
+                            ValidityKind::Uninit
+                            | ValidityKind::Initialized
+                            | ValidityKind::Compound(..) => true,
                             // The projectability of an enum field from an
                             // `AsInitialized` or `Valid` state is a dynamic
                             // property of its tag.

--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -64,6 +64,8 @@ pub trait Alignment: Sealed {
 /// other property of `T`. As a consequence, given `V: Validity`, `T`, and `U`
 /// where `T` and `U` have the same bit validity, `S(V, T) = S(V, U)`.
 ///
+/// TODO: Document compound validity.
+///
 /// It is guaranteed that the referent of any `ptr: Ptr<T, V>` is a member of
 /// `S(T, V)`. Unsafe code must ensure that this guarantee will be upheld for
 /// any existing `Ptr`s or any `Ptr`s that that code creates.
@@ -100,6 +102,7 @@ pub enum ValidityKind {
     AsInitialized,
     Initialized,
     Valid,
+    Compound(&'static [ValidityKind]),
 }
 
 /// An [`Aliasing`] invariant which is either [`Shared`] or [`Exclusive`].
@@ -275,7 +278,7 @@ pub enum BecauseExclusive {}
 pub enum BecauseImmutable {}
 
 use sealed::Sealed;
-mod sealed {
+pub(crate) mod sealed {
     use super::*;
 
     pub trait Sealed {}
@@ -290,8 +293,6 @@ mod sealed {
     impl Sealed for AsInitialized {}
     impl Sealed for Initialized {}
     impl Sealed for Valid {}
-
-    impl<A: Sealed, AA: Sealed, V: Sealed> Sealed for (A, AA, V) {}
 
     impl Sealed for BecauseImmutable {}
     impl Sealed for BecauseExclusive {}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

..and implement projection for compound-valid tuples.




---

- 　  #3021
- 　  #2984
- 👉 #2966


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)|[vs v3](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v3..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)|[vs v2](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v2..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)|[vs v1](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v1..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v3..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4)|[vs v2](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v2..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4)|[vs v1](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v1..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v2..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v3)|[vs v1](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v1..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v1..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/G06edd27f8b77b5ad480ca94749098bb4b0808342/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G06edd27f8b77b5ad480ca94749098bb4b0808342 && git checkout -b pr-G06edd27f8b77b5ad480ca94749098bb4b0808342 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G06edd27f8b77b5ad480ca94749098bb4b0808342 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G06edd27f8b77b5ad480ca94749098bb4b0808342 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G06edd27f8b77b5ad480ca94749098bb4b0808342
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G06edd27f8b77b5ad480ca94749098bb4b0808342", "parent": null, "child": "Gc3e9ee9afa6945e10c35be84d30c970894395c96"}" -->