### PR TITLE
[macros] Clarify size/align behavior of try macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "elain",
  "itertools",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.38"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.37", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.38", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.37", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.38", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -134,4 +134,4 @@ testutil = { path = "testutil" }
 # CI test failures.
 trybuild = { version = "=1.0.89", features = ["diff"] }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.37", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.38", path = "zerocopy-derive" }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -623,6 +623,11 @@ macro_rules! try_transmute {
 /// immutable reference of another type of the same size and compatible
 /// alignment.
 ///
+/// *Note that while the **value** of the referent is checked for validity at
+/// runtime, the **size** and **alignment** are checked at compile time. For
+/// conversions which are fallible with respect to size and alignment, see the
+/// methods on [`TryFromBytes`].*
+///
 /// This macro behaves like an invocation of this function:
 ///
 /// ```ignore
@@ -641,6 +646,8 @@ macro_rules! try_transmute {
 ///
 /// The types `Src` and `Dst` are inferred from the calling context; they cannot
 /// be explicitly specified in the macro invocation.
+///
+/// [`TryFromBytes`]: crate::TryFromBytes
 ///
 /// # Size compatibility
 ///
@@ -744,6 +751,11 @@ macro_rules! try_transmute_ref {
 /// Conditionally transmutes a mutable reference of one type to a mutable
 /// reference of another type of the same size and compatible alignment.
 ///
+/// *Note that while the **value** of the referent is checked for validity at
+/// runtime, the **size** and **alignment** are checked at compile time. For
+/// conversions which are fallible with respect to size and alignment, see the
+/// methods on [`TryFromBytes`].*
+///
 /// This macro behaves like an invocation of this function:
 ///
 /// ```ignore
@@ -762,6 +774,8 @@ macro_rules! try_transmute_ref {
 ///
 /// The types `Src` and `Dst` are inferred from the calling context; they cannot
 /// be explicitly specified in the macro invocation.
+///
+/// [`TryFromBytes`]: crate::TryFromBytes
 ///
 /// # Size compatibility
 ///

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.38"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Clarify that, while `try_transmute_{ref,mut}!` check referent validity
at runtime, they enforce size and alignment compatibility at compile
time.

Release 0.8.38.




---

- 👉 #2975


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v1..gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v1..gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0 && git checkout -b pr-G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2712a29a4b58bdb5d76d4b15763a15f8e8824ae0", "parent": null, "child": null}" -->