### PR TITLE
[cargo-zerocopy] Pass --cfg __ZEROCOPY_INTERNAL_USE_ONL_TOOLCHAIN=...

### DIFF
--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -169,6 +169,7 @@ fn get_rustflags(name: &str) -> String {
     let mut flags =
         "--cfg zerocopy_derive_union_into_bytes --cfg __ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE"
             .to_string();
+    flags += &format!(" --cfg __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN=\"{name}\"");
 
     if name == "nightly" {
         flags += " --cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS";


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This allows testing code to detect the current named toolchain. Unlike
the `rustversion` crate, it won't require us to update use sites when we
update pinned toolchain versions.




---

- 　  #2982
- 👉 #2983


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v2..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v2..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v3)|[vs v1](/google/zerocopy/compare/gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v1..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v1..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/G9c6fe23f1983e0f1a3d30e1db70e020595260e23/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G9c6fe23f1983e0f1a3d30e1db70e020595260e23 && git checkout -b pr-G9c6fe23f1983e0f1a3d30e1db70e020595260e23 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G9c6fe23f1983e0f1a3d30e1db70e020595260e23 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G9c6fe23f1983e0f1a3d30e1db70e020595260e23 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G9c6fe23f1983e0f1a3d30e1db70e020595260e23
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G9c6fe23f1983e0f1a3d30e1db70e020595260e23", "parent": null, "child": "G4f303a34ae0677fde28c03a0e395212a3bd05ab2"}" -->