### PR TITLE
Adopt and document a preference for aligned loads in validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1713,7 +1713,9 @@ pub unsafe trait TryFromBytes {
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid(candidate: Maybe<'_, Self>) -> bool;
+    fn is_bit_valid<A>(candidate: Maybe<'_, Self, A>) -> bool
+    where
+        A: invariant::Alignment;
 
     /// Attempts to interpret the given `source` as a `&Self`.
     ///
@@ -2882,12 +2884,22 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &mut [0x10, 0xC0, 240, 77][..];
     /// assert!(Packet::try_read_from_bytes(bytes).is_err());
     /// ```
+    ///
+    /// # Performance Considerations
+    ///
+    /// In this version of zerocopy, this method reads the `source` into a
+    /// well-aligned stack allocation and *then* validates that the allocation
+    /// is a valid `Self`. This ensures that validation can be performed using
+    /// aligned reads (which carry a performance advantage over unaligned reads
+    /// on many platforms) at the cost of an unconditional copy.
     #[must_use = "has no side effects"]
     #[inline]
     fn try_read_from_bytes(source: &[u8]) -> Result<Self, TryReadError<&[u8], Self>>
     where
         Self: Sized,
     {
+        // FIXME(#2981): If `align_of::<Self>() == 1`, validate `source` in-place.
+
         let candidate = match CoreMaybeUninit::<Self>::read_from_bytes(source) {
             Ok(candidate) => candidate,
             Err(e) => {
@@ -2943,12 +2955,22 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &[0x10, 0xC0, 240, 77, 0, 1, 2, 3, 4, 5, 6][..];
     /// assert!(Packet::try_read_from_prefix(bytes).is_err());
     /// ```
+    ///
+    /// # Performance Considerations
+    ///
+    /// In this version of zerocopy, this method reads the `source` into a
+    /// well-aligned stack allocation and *then* validates that the allocation
+    /// is a valid `Self`. This ensures that validation can be performed using
+    /// aligned reads (which carry a performance advantage over unaligned reads
+    /// on many platforms) at the cost of an unconditional copy.
     #[must_use = "has no side effects"]
     #[inline]
     fn try_read_from_prefix(source: &[u8]) -> Result<(Self, &[u8]), TryReadError<&[u8], Self>>
     where
         Self: Sized,
     {
+        // FIXME(#2981): If `align_of::<Self>() == 1`, validate `source` in-place.
+
         let (candidate, suffix) = match CoreMaybeUninit::<Self>::read_from_prefix(source) {
             Ok(candidate) => candidate,
             Err(e) => {
@@ -3005,12 +3027,22 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &[0, 1, 2, 3, 4, 5, 0x10, 0xC0, 240, 77][..];
     /// assert!(Packet::try_read_from_suffix(bytes).is_err());
     /// ```
+    ///
+    /// # Performance Considerations
+    ///
+    /// In this version of zerocopy, this method reads the `source` into a
+    /// well-aligned stack allocation and *then* validates that the allocation
+    /// is a valid `Self`. This ensures that validation can be performed using
+    /// aligned reads (which carry a performance advantage over unaligned reads
+    /// on many platforms) at the cost of an unconditional copy.
     #[must_use = "has no side effects"]
     #[inline]
     fn try_read_from_suffix(source: &[u8]) -> Result<(&[u8], Self), TryReadError<&[u8], Self>>
     where
         Self: Sized,
     {
+        // FIXME(#2981): If `align_of::<Self>() == 1`, validate `source` in-place.
+
         let (prefix, candidate) = match CoreMaybeUninit::<Self>::read_from_suffix(source) {
             Ok(candidate) => candidate,
             Err(e) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -983,8 +983,11 @@ macro_rules! cryptocorrosion_derive_traits {
                 $($field_ty: $crate::FromBytes,)*
             )?
         {
-            #[inline]
-            fn is_bit_valid(_c: $crate::Maybe<'_, Self>) -> bool {
+            #[inline(always)]
+            fn is_bit_valid<A>(_: $crate::Maybe<'_, Self, A>) -> bool
+            where
+                A: $crate::invariant::Alignment,
+            {
                 // SAFETY: This macro only accepts `#[repr(C)]` and
                 // `#[repr(transparent)]` structs, and this `impl` block
                 // requires all field types to be `FromBytes`. Thus, all
@@ -1124,8 +1127,11 @@ macro_rules! cryptocorrosion_derive_traits {
                 $field_ty: $crate::FromBytes,
             )*
         {
-            #[inline]
-            fn is_bit_valid(_c: $crate::Maybe<'_, Self>) -> bool {
+            #[inline(always)]
+            fn is_bit_valid<A>(_: $crate::Maybe<'_, Self, A>) -> bool
+            where
+                A: $crate::invariant::Alignment,
+            {
                 // SAFETY: This macro only accepts `#[repr(C)]` unions, and this
                 // `impl` block requires all field types to be `FromBytes`.
                 // Thus, all initialized byte sequences constitutes valid

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -28,8 +28,8 @@ use crate::wrappers::ReadOnly;
 /// to [`TryFromBytes::is_bit_valid`].
 ///
 /// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
-pub type Maybe<'a, T, Aliasing = invariant::Shared, Alignment = invariant::Unaligned> =
-    Ptr<'a, ReadOnly<T>, (Aliasing, Alignment, invariant::Initialized)>;
+pub type Maybe<'a, T, Alignment = invariant::Unaligned> =
+    Ptr<'a, ReadOnly<T>, (invariant::Shared, Alignment, invariant::Initialized)>;
 
 /// Checks if the referent is zeroed.
 pub(crate) fn is_zeroed<T, I>(ptr: Ptr<'_, T, I>) -> bool

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -584,13 +584,13 @@ mod _conversions {
     {
         /// Reads the referent.
         #[must_use]
-        #[inline]
-        pub fn read_unaligned<R>(self) -> T
+        #[inline(always)]
+        pub fn read<R>(self) -> T
         where
             T: Copy,
             T: Read<I::Aliasing, R>,
         {
-            (*self.into_unalign().as_ref()).into_inner()
+            <I::Alignment as Alignment>::read(self)
         }
 
         /// Views the value as an aligned reference.

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -135,7 +135,10 @@ macro_rules! unsafe_impl {
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid($candidate: Maybe<'_, Self>) -> bool {
+        fn is_bit_valid<Alignment>($candidate: Maybe<'_, Self, Alignment>) -> bool
+        where
+            Alignment: crate::invariant::Alignment,
+        {
             $is_bit_valid
         }
     };
@@ -143,7 +146,13 @@ macro_rules! unsafe_impl {
         #[allow(clippy::missing_inline_in_public_items)]
         #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        #[inline(always)] fn is_bit_valid(_candidate: Maybe<'_, Self>) -> bool { true }
+        #[inline(always)]
+        fn is_bit_valid<Alignment>(_candidate: Maybe<'_, Self, Alignment>) -> bool
+        where
+            Alignment: crate::invariant::Alignment,
+        {
+            true
+        }
     };
     (@method $trait:ident) => {
         #[allow(clippy::missing_inline_in_public_items, dead_code)]
@@ -217,8 +226,11 @@ macro_rules! impl_for_transmute_from {
         $(<$tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?>)?
         TryFromBytes for $ty:ty [$repr:ty]
     ) => {
-        #[inline]
-        fn is_bit_valid(candidate: $crate::Maybe<'_, Self>) -> bool {
+        #[inline(always)]
+        fn is_bit_valid<Alignment>(candidate: $crate::Maybe<'_, Self, Alignment>) -> bool
+        where
+            Alignment: $crate::invariant::Alignment,
+        {
             // SAFETY: This macro ensures that `$repr` and `Self` have the same
             // size and bit validity. Thus, a bit-valid instance of `$repr` is
             // also a bit-valid instance of `Self`.

--- a/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -369,9 +369,13 @@ pub(crate) fn derive_is_bit_valid(
         // enum's tag corresponds to one of the enum's discriminants. Then, we
         // check the bit validity of each field of the corresponding variant.
         // Thus, this is a sound implementation of `is_bit_valid`.
-        fn is_bit_valid(
-            mut candidate: #zerocopy_crate::Maybe<'_, Self>,
-        ) -> #core::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> #core::primitive::bool
+        where
+            ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
+        {
             #tag_enum
 
             type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
@@ -415,7 +419,7 @@ pub(crate) fn derive_is_bit_valid(
                         #zerocopy_crate::pointer::cast::CastSized
                     >()
                 };
-                tag_ptr.recall_validity::<_, (_, (_, _))>().read_unaligned::<#zerocopy_crate::BecauseImmutable>()
+                tag_ptr.recall_validity::<_, (_, (_, _))>().read::<#zerocopy_crate::BecauseImmutable>()
             };
 
             let mut raw_enum = candidate.cast::<
@@ -570,9 +574,13 @@ fn derive_try_from_bytes_struct(
             // validity of a struct is just the composition of the bit
             // validities of its fields, so this is a sound implementation
             // of `is_bit_valid`.
-            fn is_bit_valid(
-                mut candidate: #zerocopy_crate::Maybe<Self>,
-            ) -> #core::primitive::bool {
+            #[inline]
+            fn is_bit_valid<___ZcAlignment>(
+                mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
+            ) -> #core::primitive::bool
+            where
+                ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
+            {
                 true #(&& {
                     let field_candidate =   #zerocopy_crate::into_inner!(candidate.reborrow().project::<
                         _,
@@ -614,9 +622,13 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
             // The bit validity of a union is not yet well defined in Rust,
             // but it is guaranteed to be no more strict than this
             // definition. See #696 for a more in-depth discussion.
-            fn is_bit_valid(
-                mut candidate: #zerocopy_crate::Maybe<'_, Self>,
-            ) -> #core::primitive::bool {
+            #[inline]
+            fn is_bit_valid<___ZcAlignment>(
+                mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
+            ) -> #core::primitive::bool
+            where
+                ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
+            {
                 false #(|| {
                     // SAFETY:
                     // - Since `ReadOnly<Self>: Immutable` unconditionally,
@@ -690,9 +702,13 @@ fn try_gen_trivial_is_bit_valid(ctx: &Ctx, top_level: Trait) -> Option<proc_macr
         let core = ctx.core_path();
         Some(quote!(
             // SAFETY: See inline.
-            fn is_bit_valid(
-                _candidate: #zerocopy_crate::Maybe<Self>,
-            ) -> #core::primitive::bool {
+            #[inline(always)]
+            fn is_bit_valid<___ZcAlignment>(
+                _candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
+            ) -> #core::primitive::bool
+            where
+                ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
+            {
                 if false {
                     fn assert_is_from_bytes<T>()
                     where
@@ -720,9 +736,13 @@ unsafe fn gen_trivial_is_bit_valid_unchecked(ctx: &Ctx) -> proc_macro2::TokenStr
     quote!(
         // SAFETY: The caller of `gen_trivial_is_bit_valid_unchecked` has
         // promised that all initialized bit patterns are valid for `Self`.
-        fn is_bit_valid(
-            _candidate: #zerocopy_crate::Maybe<Self>,
-        ) -> #core::primitive::bool {
+        #[inline(always)]
+        fn is_bit_valid<___ZcAlignment>(
+            _candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> #core::primitive::bool
+        where
+            ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
+        {
             true
         }
     )

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
@@ -13,9 +13,13 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            _candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline(always)]
+        fn is_bit_valid<___ZcAlignment>(
+            _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             if false {
                 fn assert_is_from_bytes<T>()
                 where

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
@@ -13,9 +13,13 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            _candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline(always)]
+        fn is_bit_valid<___ZcAlignment>(
+            _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             if false {
                 fn assert_is_from_bytes<T>()
                 where

--- a/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
@@ -16,9 +16,13 @@ const _: () = {
         u8: ::zerocopy::TryFromBytes,
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            _candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline(always)]
+        fn is_bit_valid<___ZcAlignment>(
+            _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             if false {
                 fn assert_is_from_bytes<T>()
                 where

--- a/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
@@ -13,9 +13,13 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            mut candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             true
         }
     }

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
@@ -13,9 +13,13 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            mut candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             true
         }
     }

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -25,9 +25,13 @@ const _: () = {
         PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            mut candidate: ::zerocopy::Maybe<'_, Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             #[repr(u8)]
             #[allow(dead_code)]
             pub enum ___ZerocopyTag {
@@ -109,9 +113,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -879,9 +887,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -2729,7 +2741,7 @@ const _: () = {
                 };
                 tag_ptr
                     .recall_validity::<_, (_, (_, _))>()
-                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+                    .read::<::zerocopy::BecauseImmutable>()
             };
             let mut raw_enum = candidate
                 .cast::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -25,9 +25,13 @@ const _: () = {
         PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            mut candidate: ::zerocopy::Maybe<'_, Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             #[repr(u32)]
             #[allow(dead_code)]
             pub enum ___ZerocopyTag {
@@ -109,9 +113,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -879,9 +887,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -2729,7 +2741,7 @@ const _: () = {
                 };
                 tag_ptr
                     .recall_validity::<_, (_, (_, _))>()
-                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+                    .read::<::zerocopy::BecauseImmutable>()
             };
             let mut raw_enum = candidate
                 .cast::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -25,9 +25,13 @@ const _: () = {
         PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            mut candidate: ::zerocopy::Maybe<'_, Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline]
+        fn is_bit_valid<___ZcAlignment>(
+            mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             #[repr(C)]
             #[allow(dead_code)]
             pub enum ___ZerocopyTag {
@@ -109,9 +113,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -879,9 +887,13 @@ const _: () = {
                     >: ::zerocopy::TryFromBytes,
                 {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
-                    fn is_bit_valid(
-                        mut candidate: ::zerocopy::Maybe<Self>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+                    #[inline]
+                    fn is_bit_valid<___ZcAlignment>(
+                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+                    where
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    {
                         true
                             && {
                                 let field_candidate = ::zerocopy::into_inner!(
@@ -2729,7 +2741,7 @@ const _: () = {
                 };
                 tag_ptr
                     .recall_validity::<_, (_, (_, _))>()
-                    .read_unaligned::<::zerocopy::BecauseImmutable>()
+                    .read::<::zerocopy::BecauseImmutable>()
             };
             let mut raw_enum = candidate
                 .cast::<

--- a/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs
@@ -13,9 +13,13 @@
 const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
-        fn is_bit_valid(
-            _candidate: ::zerocopy::Maybe<Self>,
-        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool {
+        #[inline(always)]
+        fn is_bit_valid<___ZcAlignment>(
+            _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
+        ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
+        where
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        {
             true
         }
     }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This commit parameterizes `TryFromBytes::is_bit_valid` and
`Ptr::read` over alignment, ensuring that well-aligned loads are
used at the leaves of validation whenever possible. This carries
a performance advantage over unaligned loads on many platforms.
This manifests in our API as an optimization for `try_transmute!`
and `TryFromBytes::try_read_from_*` for destination types with
alignments greater than 1. For trivially-aligned destination types,
this commit introduces an optimization FIXME noting that validation
could (and should) be performed in-place.

Makes progress towards #2981.




---

- 👉 #2985


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)|[vs v3](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v3..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)|[vs v2](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v2..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)|[vs v1](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v1..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v3..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4)|[vs v2](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v2..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4)|[vs v1](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v1..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v2..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v3)|[vs v1](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v1..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v1..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/G74407a530f46f997b4faaeac52452ebc9892b2ae/v1)|

</details>
<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G74407a530f46f997b4faaeac52452ebc9892b2ae", "parent": null, "child": null}" -->