### PR TITLE
[cargo-zerocopy] Pass `RUSTDOCFLAGS`

### DIFF
--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -239,7 +239,10 @@ fn delegate_cargo() -> Result<(), Error> {
                     env_rustflags,
                 );
 
+                // Pass RUSTFLAGS to both Rust (via `RUSTFLAGS`) and Rustdoc
+                // (via `RUSTDOCFLAGS`).
                 let mut cmd = rustup(["run", version, "cargo"], Some(("RUSTFLAGS", &rustflags)));
+                cmd.env("RUSTDOCFLAGS", &rustflags);
 
                 if env::var("CARGO_TARGET_DIR").is_ok() {
                     eprintln!("[cargo-zerocopy] WARNING: `CARGO_TARGET_DIR` is set - this may cause `cargo-zerocopy` to behave unexpectedly");


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Pass the same set of flags to `RUSTFLAGS` and `RUSTDOCFLAGS`. Some of
our tests - specifically `src/doctests.rs` - use `cfg`s which are set by
`cargo-zerocopy`, but these were previously not passed when evaluating
doc tests.

This follows up on #2960, which introduced this bug.




---

- 　  #2986
- 　  #2988
- 👉 #2987


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v1..gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v1..gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G413a86267ff4384a9806de9a784407f1f5be96aa/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G413a86267ff4384a9806de9a784407f1f5be96aa && git checkout -b pr-G413a86267ff4384a9806de9a784407f1f5be96aa FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G413a86267ff4384a9806de9a784407f1f5be96aa && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G413a86267ff4384a9806de9a784407f1f5be96aa && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G413a86267ff4384a9806de9a784407f1f5be96aa
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G413a86267ff4384a9806de9a784407f1f5be96aa", "parent": null, "child": "G793f61a136b912fbd5ee4315cdea7cf3cf3cf8fb"}" -->