### PR TITLE
[tests] Rely on `cargo-zerocopy` toolchain resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,38 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "camino"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,12 +61,6 @@ checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -210,15 +172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,15 +188,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -271,7 +215,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "itoa 1.0.15",
+ "itoa",
  "memchr",
  "ryu",
  "serde",
@@ -313,62 +257,11 @@ dependencies = [
 name = "testutil"
 version = "0.0.0"
 dependencies = [
- "cargo-platform",
- "cargo_metadata",
  "lock_api",
  "memchr",
  "parking_lot",
  "parking_lot_core",
- "rustc_version",
- "time",
- "toml",
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf2535c6456e772ad756a0854ec907ede55d73d0b5a34855d808cb2d2f0942e"
-dependencies = [
- "itoa 0.4.8",
- "libc",
- "time-macros",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10758c2d95454f52ffd0173cd4a0dce8d6b118b9aac27c5a4b785ddf9a499c72"
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -25,10 +25,11 @@ use testutil::{set_rustflags_w_warnings, ToolchainVersion};
 #[test]
 #[cfg_attr(miri, ignore)]
 fn ui() {
-    let version = ToolchainVersion::extract_from_pwd().unwrap();
     // See the doc comment on this method for an explanation of what this does
     // and why we store source files in different directories.
-    let source_files_dirname = version.get_ui_source_files_dirname_and_maybe_print_warning();
+    let source_files_dirname = ToolchainVersion::extract_from_env()
+        .expect("UI tests must only be run on pinned MSRV, stable, or nightly toolchains")
+        .get_ui_source_files_dirname();
 
     // Set `-Wwarnings` in the `RUSTFLAGS` environment variable to ensure that
     // `.stderr` files reflect what the typical user would encounter.

--- a/testutil/Cargo.toml
+++ b/testutil/Cargo.toml
@@ -12,10 +12,6 @@ version = "0.0.0"
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.18.0"
-# Pin to 0.1.5 because more recent versions require a Rust version more recent
-# than our MSRV.
-cargo-platform = "=0.1.5"
 # Pin to 0.4.11 because more recent versions require a Rust version more recent
 # than our MSRV.
 lock_api = "=0.4.11"
@@ -26,12 +22,13 @@ parking_lot = "=0.12.1"
 # Pin to 0.9.10 because more recent versions require a Rust version more recent
 # than our MSRV.
 parking_lot_core = "=0.9.10"
-rustc_version = "0.4.0"
-# Pin to 0.3.0 because more recent versions require a Rust version more recent
-# than our MSRV.
-time = { version = "=0.3.0", default-features = false, features = ["formatting", "macros", "parsing"] }
-toml = "0.5.11"
 # Pin to 0.1.8 because 0.1.9 takes a dependency on windows-sys 0.59.0, which
 # in turn requires a Rust version more recent than our MSRV. By contrast,
 # 0.1.8 depends on windows-sys 0.52.0, which works with our MSRV.
 winapi-util = "=0.1.8"
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = [
+    'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)',
+    'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN, values("msrv", "stable", "nightly"))',
+] }

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -6,59 +6,8 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-// Inlining format args isn't supported on our MSRV.
-#![allow(clippy::uninlined_format_args)]
-
-use std::{env, error::Error, fs};
-
-use rustc_version::{Channel, Version};
-
-struct PinnedVersions {
-    msrv: String,
-    stable: String,
-    nightly: String,
-}
-
-impl PinnedVersions {
-    /// Attempts to extract pinned toolchain versions based on the current
-    /// working directory.
-    ///
-    /// `extract_from_pwd` expects to be called from a directory which is a
-    /// child of a Cargo workspace. It extracts the pinned versions from the
-    /// metadata of the root package.
-    fn extract_from_pwd() -> Result<PinnedVersions, Box<dyn Error>> {
-        let manifest_dir = env::var_os("CARGO_MANIFEST_DIR")
-            .ok_or("CARGO_MANIFEST_DIR environment variable not set")?
-            .into_string()
-            .map_err(|_| "could not parse $CARGO_MANIFEST_DIR as UTF-8")?;
-        let manifest_path = if manifest_dir.ends_with("zerocopy-derive") {
-            manifest_dir + "/../Cargo.toml"
-        } else {
-            manifest_dir + "/Cargo.toml"
-        };
-        let manifest = fs::read_to_string(manifest_path)?;
-        let manifest: toml::map::Map<String, toml::Value> = toml::from_str(&manifest)?;
-        let manifest = toml::Value::Table(manifest);
-
-        let extract = |keys: &[&str]| -> Result<String, String> {
-            let mut val = &manifest;
-            for k in keys {
-                val = val
-                    .get(k)
-                    .ok_or(format!("failed to look up path in Cargo.toml: {:?}", keys))?;
-            }
-
-            val.as_str()
-                .map(|s| s.to_string())
-                .ok_or(format!("expected string value for path in Cargo.toml: {:?}", keys))
-        };
-
-        let msrv = extract(&["package", "rust-version"])?;
-        let stable = extract(&["package", "metadata", "ci", "pinned-stable"])?;
-        let nightly = extract(&["package", "metadata", "ci", "pinned-nightly"])?;
-        Ok(PinnedVersions { msrv, stable, nightly })
-    }
-}
+#![allow(unknown_lints)]
+#![deny(unexpected_cfgs)]
 
 #[derive(Debug)]
 pub enum ToolchainVersion {
@@ -69,76 +18,25 @@ pub enum ToolchainVersion {
     PinnedStable,
     /// The nightly version pinned in CI
     PinnedNightly,
-    /// A stable version other than the one pinned in CI.
-    OtherStable,
-    /// A nightly version other than the one pinned in CI.
-    OtherNightly,
 }
 
 impl ToolchainVersion {
     /// Attempts to determine whether the current toolchain version matches one
     /// of the versions pinned in CI and if so, which one.
-    pub fn extract_from_pwd() -> Result<ToolchainVersion, Box<dyn Error>> {
-        let pinned_versions = PinnedVersions::extract_from_pwd()?;
-        let current = rustc_version::version_meta()?;
-
-        let s = match current.channel {
-            Channel::Dev | Channel::Beta => {
-                return Err(format!("unsupported channel: {:?}", current.channel).into())
-            }
-            Channel::Nightly => {
-                format!(
-                    "nightly-{}",
-                    current.commit_date.as_ref().ok_or("nightly channel missing commit date")?
-                )
-            }
-            Channel::Stable => {
-                let Version { major, minor, patch, .. } = current.semver;
-                format!("{}.{}.{}", major, minor, patch)
-            }
-        };
-
-        // Due to a quirk of how Rust nightly versions are encoded and published
-        // [1], the version as understood by rustup uses a date one day ahead of
-        // the version as encoded in the `rustc` binary itself.
-        // `pinned_versions` encodes the former notion of the date (as it is
-        // meant to be passed as the `+<toolchain>` selector syntax understood
-        // by rustup), while `current` encodes the latter notion of the date (as
-        // it is extracted from `rustc`). Without this adjustment, toolchain
-        // versions that should be considered equal would not be.
-        //
-        // [1] https://github.com/rust-lang/rust/issues/51533
-        let pinned_nightly_adjusted = {
-            let desc = time::macros::format_description!("nightly-[year]-[month]-[day]");
-            let date = time::Date::parse(&pinned_versions.nightly, &desc).map_err(|_| {
-                format!("failed to parse nightly version: {}", pinned_versions.nightly)
-            })?;
-            let adjusted = date - time::Duration::DAY;
-            adjusted.format(&desc).unwrap()
-        };
-
-        Ok(match s {
-            s if s == pinned_versions.msrv => ToolchainVersion::PinnedMsrv,
-            s if s == pinned_versions.stable => ToolchainVersion::PinnedStable,
-            s if s == pinned_nightly_adjusted => ToolchainVersion::PinnedNightly,
-            _ if current.channel == Channel::Stable => ToolchainVersion::OtherStable,
-            _ if current.channel == Channel::Nightly => ToolchainVersion::OtherNightly,
-            _ => {
-                return Err(format!(
-                    "current toolchain ({:?}) doesn't match any known version",
-                    current
-                )
-                .into())
-            }
-        })
+    pub fn extract_from_env() -> Option<ToolchainVersion> {
+        if cfg!(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv") {
+            Some(ToolchainVersion::PinnedMsrv)
+        } else if cfg!(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "stable") {
+            Some(ToolchainVersion::PinnedStable)
+        } else if cfg!(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "nightly") {
+            Some(ToolchainVersion::PinnedNightly)
+        } else {
+            None
+        }
     }
 
     /// Gets the name of the directory in which to store source files and
     /// expected output for UI tests for this toolchain version.
-    ///
-    /// For toolchain versions which are not pinned in CI, prints a warning to
-    /// `stderr` which will be captured by the test harness and only printed on
-    /// test failure.
     ///
     /// UI tests depend on the exact error messages emitted by rustc, but those
     /// error messages are not stable, and sometimes change between Rust
@@ -153,17 +51,11 @@ impl ToolchainVersion {
     ///   `tests/ui-nightly`, and contains `.err` and `.out` files for stable
     /// - `tests/ui-msrv` - Contains symlinks to the `.rs` files in
     ///   `tests/ui-nightly`, and contains `.err` and `.out` files for MSRV
-    pub fn get_ui_source_files_dirname_and_maybe_print_warning(&self) -> &'static str {
-        if matches!(self, ToolchainVersion::OtherStable | ToolchainVersion::OtherNightly) {
-            // This will be eaten by the test harness and only displayed on
-            // failure.
-            eprintln!("warning: current toolchain does not match any toolchain pinned in CI; this may cause spurious test failure");
-        }
-
+    pub fn get_ui_source_files_dirname(&self) -> &'static str {
         match self {
             ToolchainVersion::PinnedMsrv => "ui-msrv",
-            ToolchainVersion::PinnedStable | ToolchainVersion::OtherStable => "ui-stable",
-            ToolchainVersion::PinnedNightly | ToolchainVersion::OtherNightly => "ui-nightly",
+            ToolchainVersion::PinnedStable => "ui-stable",
+            ToolchainVersion::PinnedNightly => "ui-nightly",
         }
     }
 }
@@ -180,9 +72,9 @@ pub fn set_rustflags_w_warnings() {
     // [1] https://github.com/rust-lang/rust/issues/27970
     let guard = ENV_MTX.lock();
 
-    let mut rustflags = env::var_os("RUSTFLAGS").unwrap_or_default();
+    let mut rustflags = std::env::var_os("RUSTFLAGS").unwrap_or_default();
     rustflags.push(" -Wwarnings");
-    env::set_var("RUSTFLAGS", rustflags);
+    std::env::set_var("RUSTFLAGS", rustflags);
 
     std::mem::drop(guard);
 }

--- a/zerocopy-derive/tests/trybuild.rs
+++ b/zerocopy-derive/tests/trybuild.rs
@@ -10,13 +10,14 @@
 
 use std::env;
 
-use testutil::set_rustflags_w_warnings;
+use testutil::{set_rustflags_w_warnings, ToolchainVersion};
 
 fn test(subdir: &str) {
-    let version = testutil::ToolchainVersion::extract_from_pwd().unwrap();
     // See the doc comment on this method for an explanation of what this does
     // and why we store source files in different directories.
-    let source_files_dirname = version.get_ui_source_files_dirname_and_maybe_print_warning();
+    let source_files_dirname = ToolchainVersion::extract_from_env()
+        .expect("UI tests must only be run on pinned MSRV, stable, or nightly toolchains")
+        .get_ui_source_files_dirname();
 
     // Set `-Wwarnings` in the `RUSTFLAGS` environment variable to ensure that
     // `.stderr` files reflect what the typical user would encounter.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

`cargo-zerocopy` now passes the toolchain name in `--cfg
__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN="..."`. In the trybuild test
machinery in `testutil`, use this instead of attempting to dynamically
re-discover the toolchain name.




---

- 　  #2991
- 　  #2990
- 👉 #2989


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)|[vs v3](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v3..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)|[vs v2](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v2..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)|[vs v1](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v1..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v3..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4)|[vs v2](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v2..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4)|[vs v1](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v1..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v2..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v3)|[vs v1](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v1..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v1..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/G84649ff5c69192524bd50158850a16250dbd194c/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G84649ff5c69192524bd50158850a16250dbd194c && git checkout -b pr-G84649ff5c69192524bd50158850a16250dbd194c FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G84649ff5c69192524bd50158850a16250dbd194c && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G84649ff5c69192524bd50158850a16250dbd194c && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G84649ff5c69192524bd50158850a16250dbd194c
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G84649ff5c69192524bd50158850a16250dbd194c", "parent": null, "child": "G81f5e2ed65497afb56332df51ac957252c86dcab"}" -->