### PR TITLE
[test] Detect and warn about using cargo for development

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,13 +412,13 @@ pub use crate::pointer::{invariant::BecauseImmutable, Maybe, Ptr};
 #[allow(unused_imports)]
 use crate::util::polyfills::{self, NonNullExt as _, NumExt as _};
 
-#[rustversion::nightly]
-#[cfg(all(test, not(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)))]
+#[cfg(all(test, not(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)))]
 const _: () = {
-    #[deprecated = "some tests may be skipped due to missing RUSTFLAGS=\"--cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS\""]
-    const _WARNING: () = ();
+    #[deprecated = "Development of zerocopy using cargo is not supported. Please use `cargo.sh` or `win-cargo.bat` instead."]
+    #[allow(unused)]
+    const WARNING: () = ();
     #[warn(deprecated)]
-    _WARNING
+    WARNING
 };
 
 /// Implements [`KnownLayout`].


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #2991
- 👉 #2990
- 　  #2989


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v3..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v3..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v4)|[vs v2](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v2..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v4)|[vs v1](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v1..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v4)|[vs Base](/google/zerocopy/compare/G84649ff5c69192524bd50158850a16250dbd194c..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v2..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v3)|[vs v1](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v1..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v3)|[vs Base](/google/zerocopy/compare/G84649ff5c69192524bd50158850a16250dbd194c..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v1..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v2)|[vs Base](/google/zerocopy/compare/G84649ff5c69192524bd50158850a16250dbd194c..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v2)|
|v1||||[vs Base](/google/zerocopy/compare/G84649ff5c69192524bd50158850a16250dbd194c..gherrit/G81f5e2ed65497afb56332df51ac957252c86dcab/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G81f5e2ed65497afb56332df51ac957252c86dcab && git checkout -b pr-G81f5e2ed65497afb56332df51ac957252c86dcab FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G81f5e2ed65497afb56332df51ac957252c86dcab && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G81f5e2ed65497afb56332df51ac957252c86dcab && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G81f5e2ed65497afb56332df51ac957252c86dcab
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G81f5e2ed65497afb56332df51ac957252c86dcab", "parent": "G84649ff5c69192524bd50158850a16250dbd194c", "child": "G56d361c99cff83d83a76462d778b02e43db0f26a"}" -->