### PR TITLE
[tests] Annotate UI test files with error requirements

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/tests/ui/diagnostic-not-implemented-from-bytes.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-bytes.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: FromBytes` is not satisfied
    |                        ^^^^^^^^^^^ the trait `FromBytes` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_from_bytes`
-  --> $DIR/diagnostic-not-implemented-from-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-bytes.rs:20:24
    |
-19 | fn takes_from_bytes<T: FromBytes>() {}
+20 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-from-bytes.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-bytes.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 79 others
 note: required by a bound in `takes_from_bytes`
-  --> $DIR/diagnostic-not-implemented-from-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-bytes.rs:20:24
    |
-19 | fn takes_from_bytes<T: FromBytes>() {}
+20 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-from-bytes.rs
+++ b/tests/ui/diagnostic-not-implemented-from-bytes.rs
@@ -14,6 +14,7 @@ use zerocopy::FromBytes;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_from_bytes::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: FromBytes` is not satisfied
 }
 
 fn takes_from_bytes<T: FromBytes>() {}

--- a/tests/ui/diagnostic-not-implemented-from-bytes.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-bytes.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 79 others
 note: required by a bound in `takes_from_bytes`
-  --> $DIR/diagnostic-not-implemented-from-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-bytes.rs:20:24
    |
-19 | fn takes_from_bytes<T: FromBytes>() {}
+20 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-from-zeros.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-zeros.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
    |                        ^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_from_zeros`
-  --> $DIR/diagnostic-not-implemented-from-zeros.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-zeros.rs:20:24
    |
-19 | fn takes_from_zeros<T: FromZeros>() {}
+20 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-from-zeros.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-zeros.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 141 others
 note: required by a bound in `takes_from_zeros`
-  --> $DIR/diagnostic-not-implemented-from-zeros.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-zeros.rs:20:24
    |
-19 | fn takes_from_zeros<T: FromZeros>() {}
+20 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-from-zeros.rs
+++ b/tests/ui/diagnostic-not-implemented-from-zeros.rs
@@ -14,6 +14,7 @@ use zerocopy::FromZeros;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_from_zeros::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: FromZeros` is not satisfied
 }
 
 fn takes_from_zeros<T: FromZeros>() {}

--- a/tests/ui/diagnostic-not-implemented-from-zeros.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-from-zeros.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 141 others
 note: required by a bound in `takes_from_zeros`
-  --> $DIR/diagnostic-not-implemented-from-zeros.rs:19:24
+  --> $DIR/diagnostic-not-implemented-from-zeros.rs:20:24
    |
-19 | fn takes_from_zeros<T: FromZeros>() {}
+20 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-immutable.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-immutable.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
    |                       ^^^^^^^^^^^ the trait `Immutable` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_immutable`
-  --> $DIR/diagnostic-not-implemented-immutable.rs:19:23
+  --> $DIR/diagnostic-not-implemented-immutable.rs:20:23
    |
-19 | fn takes_immutable<T: Immutable>() {}
+20 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-immutable.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-immutable.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
            and 128 others
 note: required by a bound in `takes_immutable`
-  --> $DIR/diagnostic-not-implemented-immutable.rs:19:23
+  --> $DIR/diagnostic-not-implemented-immutable.rs:20:23
    |
-19 | fn takes_immutable<T: Immutable>() {}
+20 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-immutable.rs
+++ b/tests/ui/diagnostic-not-implemented-immutable.rs
@@ -14,6 +14,7 @@ use zerocopy::Immutable;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_immutable::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: Immutable` is not satisfied
 }
 
 fn takes_immutable<T: Immutable>() {}

--- a/tests/ui/diagnostic-not-implemented-immutable.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-immutable.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
            and 128 others
 note: required by a bound in `takes_immutable`
-  --> $DIR/diagnostic-not-implemented-immutable.rs:19:23
+  --> $DIR/diagnostic-not-implemented-immutable.rs:20:23
    |
-19 | fn takes_immutable<T: Immutable>() {}
+20 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-into-bytes.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-into-bytes.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
    |                        ^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_into_bytes`
-  --> $DIR/diagnostic-not-implemented-into-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-into-bytes.rs:20:24
    |
-19 | fn takes_into_bytes<T: IntoBytes>() {}
+20 | fn takes_into_bytes<T: IntoBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_into_bytes`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-into-bytes.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-into-bytes.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicIsize
            and 68 others
 note: required by a bound in `takes_into_bytes`
-  --> $DIR/diagnostic-not-implemented-into-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-into-bytes.rs:20:24
    |
-19 | fn takes_into_bytes<T: IntoBytes>() {}
+20 | fn takes_into_bytes<T: IntoBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_into_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-into-bytes.rs
+++ b/tests/ui/diagnostic-not-implemented-into-bytes.rs
@@ -14,6 +14,7 @@ use zerocopy::IntoBytes;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_into_bytes::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: IntoBytes` is not satisfied
 }
 
 fn takes_into_bytes<T: IntoBytes>() {}

--- a/tests/ui/diagnostic-not-implemented-into-bytes.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-into-bytes.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicIsize
            and 68 others
 note: required by a bound in `takes_into_bytes`
-  --> $DIR/diagnostic-not-implemented-into-bytes.rs:19:24
+  --> $DIR/diagnostic-not-implemented-into-bytes.rs:20:24
    |
-19 | fn takes_into_bytes<T: IntoBytes>() {}
+20 | fn takes_into_bytes<T: IntoBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_into_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-issue-1296.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-issue-1296.nightly.stderr
@@ -7,9 +7,9 @@ error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
    |         required by a bound introduced by this call
    |
 note: required by a bound in `Foo::write_obj`
-  --> $DIR/diagnostic-not-implemented-issue-1296.rs:56:21
+  --> $DIR/diagnostic-not-implemented-issue-1296.rs:58:21
    |
-56 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
    |                     ^^^^^^^^^ required by this bound in `Foo::write_obj`
 help: consider borrowing here
    |
@@ -43,9 +43,9 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicIsize
            and 68 others
 note: required by a bound in `Foo::write_obj`
-  --> $DIR/diagnostic-not-implemented-issue-1296.rs:56:33
+  --> $DIR/diagnostic-not-implemented-issue-1296.rs:58:33
    |
-56 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
    |                                 ^^^^^^^^^ required by this bound in `Foo::write_obj`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/diagnostic-not-implemented-issue-1296.rs
+++ b/tests/ui/diagnostic-not-implemented-issue-1296.rs
@@ -48,6 +48,8 @@ fn main() {
     // that we can capture the current behavior, but we will update it once that
     // Rust issue is fixed.
     Foo.write_obj(NotZerocopy(()));
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: Immutable` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: IntoBytes` is not satisfied
 }
 
 struct Foo;

--- a/tests/ui/diagnostic-not-implemented-issue-1296.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-issue-1296.stable.stderr
@@ -7,9 +7,9 @@ error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
    |         required by a bound introduced by this call
    |
 note: required by a bound in `Foo::write_obj`
-  --> $DIR/diagnostic-not-implemented-issue-1296.rs:56:21
+  --> $DIR/diagnostic-not-implemented-issue-1296.rs:58:21
    |
-56 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
    |                     ^^^^^^^^^ required by this bound in `Foo::write_obj`
 help: consider borrowing here
    |
@@ -43,9 +43,9 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicIsize
            and 68 others
 note: required by a bound in `Foo::write_obj`
-  --> $DIR/diagnostic-not-implemented-issue-1296.rs:56:33
+  --> $DIR/diagnostic-not-implemented-issue-1296.rs:58:33
    |
-56 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
+58 |     fn write_obj<T: Immutable + IntoBytes>(&mut self, _val: T) {}
    |                                 ^^^^^^^^^ required by this bound in `Foo::write_obj`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/diagnostic-not-implemented-known-layout.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-known-layout.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: KnownLayout` is not satisfied
    |                          ^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_known_layout`
-  --> $DIR/diagnostic-not-implemented-known-layout.rs:19:26
+  --> $DIR/diagnostic-not-implemented-known-layout.rs:20:26
    |
-19 | fn takes_known_layout<T: KnownLayout>() {}
+20 | fn takes_known_layout<T: KnownLayout>() {}
    |                          ^^^^^^^^^^^ required by this bound in `takes_known_layout`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-known-layout.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-known-layout.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AtomicI16
            and 65 others
 note: required by a bound in `takes_known_layout`
-  --> $DIR/diagnostic-not-implemented-known-layout.rs:19:26
+  --> $DIR/diagnostic-not-implemented-known-layout.rs:20:26
    |
-19 | fn takes_known_layout<T: KnownLayout>() {}
+20 | fn takes_known_layout<T: KnownLayout>() {}
    |                          ^^^^^^^^^^^ required by this bound in `takes_known_layout`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-known-layout.rs
+++ b/tests/ui/diagnostic-not-implemented-known-layout.rs
@@ -14,6 +14,7 @@ use zerocopy::KnownLayout;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_known_layout::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: KnownLayout` is not satisfied
 }
 
 fn takes_known_layout<T: KnownLayout>() {}

--- a/tests/ui/diagnostic-not-implemented-known-layout.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-known-layout.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AtomicI16
            and 65 others
 note: required by a bound in `takes_known_layout`
-  --> $DIR/diagnostic-not-implemented-known-layout.rs:19:26
+  --> $DIR/diagnostic-not-implemented-known-layout.rs:20:26
    |
-19 | fn takes_known_layout<T: KnownLayout>() {}
+20 | fn takes_known_layout<T: KnownLayout>() {}
    |                          ^^^^^^^^^^^ required by this bound in `takes_known_layout`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-try-from-bytes.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-try-from-bytes.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    |                            ^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_try_from_bytes`
-  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:19:28
+  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:20:28
    |
-19 | fn takes_try_from_bytes<T: TryFromBytes>() {}
+20 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-try-from-bytes.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-try-from-bytes.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 153 others
 note: required by a bound in `takes_try_from_bytes`
-  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:19:28
+  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:20:28
    |
-19 | fn takes_try_from_bytes<T: TryFromBytes>() {}
+20 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-try-from-bytes.rs
+++ b/tests/ui/diagnostic-not-implemented-try-from-bytes.rs
@@ -14,6 +14,7 @@ use zerocopy::TryFromBytes;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_try_from_bytes::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
 }
 
 fn takes_try_from_bytes<T: TryFromBytes>() {}

--- a/tests/ui/diagnostic-not-implemented-try-from-bytes.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-try-from-bytes.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 153 others
 note: required by a bound in `takes_try_from_bytes`
-  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:19:28
+  --> $DIR/diagnostic-not-implemented-try-from-bytes.rs:20:28
    |
-19 | fn takes_try_from_bytes<T: TryFromBytes>() {}
+20 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-unaligned.msrv.stderr
+++ b/tests/ui/diagnostic-not-implemented-unaligned.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfie
    |                       ^^^^^^^^^^^ the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
    |
 note: required by a bound in `takes_unaligned`
-  --> $DIR/diagnostic-not-implemented-unaligned.rs:19:23
+  --> $DIR/diagnostic-not-implemented-unaligned.rs:20:23
    |
-19 | fn takes_unaligned<T: Unaligned>() {}
+20 | fn takes_unaligned<T: Unaligned>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_unaligned`
 
 error: aborting due to previous error

--- a/tests/ui/diagnostic-not-implemented-unaligned.nightly.stderr
+++ b/tests/ui/diagnostic-not-implemented-unaligned.nightly.stderr
@@ -21,9 +21,9 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              I128<O>
            and 26 others
 note: required by a bound in `takes_unaligned`
-  --> $DIR/diagnostic-not-implemented-unaligned.rs:19:23
+  --> $DIR/diagnostic-not-implemented-unaligned.rs:20:23
    |
-19 | fn takes_unaligned<T: Unaligned>() {}
+20 | fn takes_unaligned<T: Unaligned>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_unaligned`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-not-implemented-unaligned.rs
+++ b/tests/ui/diagnostic-not-implemented-unaligned.rs
@@ -14,6 +14,7 @@ use zerocopy::Unaligned;
 fn main() {
     // We expect the proper diagnostic to be emitted on Rust 1.78.0 and later.
     takes_unaligned::<NotZerocopy>();
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
 }
 
 fn takes_unaligned<T: Unaligned>() {}

--- a/tests/ui/diagnostic-not-implemented-unaligned.stable.stderr
+++ b/tests/ui/diagnostic-not-implemented-unaligned.stable.stderr
@@ -21,9 +21,9 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              I128<O>
            and 26 others
 note: required by a bound in `takes_unaligned`
-  --> $DIR/diagnostic-not-implemented-unaligned.rs:19:23
+  --> $DIR/diagnostic-not-implemented-unaligned.rs:20:23
    |
-19 | fn takes_unaligned<T: Unaligned>() {}
+20 | fn takes_unaligned<T: Unaligned>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_unaligned`
 
 error: aborting due to 1 previous error

--- a/tests/ui/include_value_not_from_bytes.rs
+++ b/tests/ui/include_value_not_from_bytes.rs
@@ -15,3 +15,4 @@ fn main() {}
 // Should fail because `NotZerocopy<u32>: !FromBytes`.
 const NOT_FROM_BYTES: NotZerocopy<u32> =
     zerocopy::include_value!("../../testdata/include_value/data");
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy<u32>: FromBytes` is not satisfied

--- a/tests/ui/include_value_wrong_size.rs
+++ b/tests/ui/include_value_wrong_size.rs
@@ -10,3 +10,5 @@ fn main() {}
 
 // Should fail because the file is 4 bytes long, not 8.
 const WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+//~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
+//~[stable, nightly]^^ ERROR: transmuting from 4-byte type to 8-byte type: `[u8; 4]` -> `u64`

--- a/tests/ui/max-align.rs
+++ b/tests/ui/max-align.rs
@@ -94,6 +94,7 @@ struct Align13421772;
 struct Align26843545;
 
 #[repr(C, align(1073741824))]
+//~[msrv, stable, nightly]^ ERROR: invalid `repr(align)` attribute: larger than 2^29
 struct Align1073741824;
 
 fn main() {}

--- a/tests/ui/ptr-is-invariant-over-v.msrv.stderr
+++ b/tests/ui/ptr-is-invariant-over-v.msrv.stderr
@@ -8,12 +8,12 @@ error[E0623]: lifetime mismatch
    |              ^^^ ...but data from `big` flows into `big` here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ptr-is-invariant-over-v.rs:26:14
+  --> $DIR/ptr-is-invariant-over-v.rs:28:14
    |
-23 |     big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
+25 |     big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
    |          ------------------------------------------------ these two types are declared with different lifetimes...
 ...
-26 |     _small = big;
+28 |     _small = big;
    |              ^^^ ...but data from `big` flows into `big` here
 
 error: aborting due to 2 previous errors

--- a/tests/ui/ptr-is-invariant-over-v.nightly.stderr
+++ b/tests/ui/ptr-is-invariant-over-v.nightly.stderr
@@ -15,14 +15,14 @@ error: lifetime may not live long enough
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-is-invariant-over-v.rs:26:5
+  --> $DIR/ptr-is-invariant-over-v.rs:28:5
    |
-22 | fn _when_shared<'big: 'small, 'small>(
+24 | fn _when_shared<'big: 'small, 'small>(
    |                 ----          ------ lifetime `'small` defined here
    |                 |
    |                 lifetime `'big` defined here
 ...
-26 |     _small = big;
+28 |     _small = big;
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`

--- a/tests/ui/ptr-is-invariant-over-v.rs
+++ b/tests/ui/ptr-is-invariant-over-v.rs
@@ -17,6 +17,8 @@ fn _when_exclusive<'big: 'small, 'small>(
     mut _small: Ptr<'small, &'small u32, (Exclusive, Aligned, Valid)>,
 ) {
     _small = big;
+    //~[msrv]^ ERROR: lifetime mismatch
+    //~[stable, nightly]^^ ERROR: lifetime may not live long enough
 }
 
 fn _when_shared<'big: 'small, 'small>(
@@ -24,6 +26,8 @@ fn _when_shared<'big: 'small, 'small>(
     mut _small: Ptr<'small, &'small u32, (Shared, Aligned, Valid)>,
 ) {
     _small = big;
+    //~[msrv]^ ERROR: lifetime mismatch
+    //~[stable, nightly]^^ ERROR: lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/ptr-is-invariant-over-v.stable.stderr
+++ b/tests/ui/ptr-is-invariant-over-v.stable.stderr
@@ -15,14 +15,14 @@ error: lifetime may not live long enough
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-is-invariant-over-v.rs:26:5
+  --> $DIR/ptr-is-invariant-over-v.rs:28:5
    |
-22 | fn _when_shared<'big: 'small, 'small>(
+24 | fn _when_shared<'big: 'small, 'small>(
    |                 ----          ------ lifetime `'small` defined here
    |                 |
    |                 lifetime `'big` defined here
 ...
-26 |     _small = big;
+28 |     _small = big;
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`

--- a/tests/ui/transmute-dst-not-frombytes.rs
+++ b/tests/ui/transmute-dst-not-frombytes.rs
@@ -15,3 +15,4 @@ fn main() {}
 
 // `transmute` requires that the destination type implements `FromBytes`
 const DST_NOT_FROM_BYTES: NotZerocopy = transmute!(AU16(0));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: FromBytes` is not satisfied

--- a/tests/ui/transmute-mut-const.rs
+++ b/tests/ui/transmute-mut-const.rs
@@ -16,3 +16,11 @@ const ARRAY_OF_U8S: [u8; 2] = [0u8; 2];
 
 // `transmute_mut!` cannot, generally speaking, be used in const contexts.
 const CONST_CONTEXT: &mut [u8; 2] = transmute_mut!(&mut ARRAY_OF_U8S);
+//~[msrv]^ ERROR: mutable references are not allowed in constants
+//~[msrv]^^ ERROR: calls in constants are limited to constant functions, tuple structs and tuple variants
+//~[msrv]^^^ ERROR: calls in constants are limited to constant functions, tuple structs and tuple variants
+//~[msrv]^^^^ ERROR: temporary value dropped while borrowed
+//~[stable]^^^^^ ERROR: cannot call non-const method `Wrap::<&mut [u8; 2], &mut [u8; 2]>::transmute_mut_inference_helper` in constants
+//~[stable]^^^^^^ ERROR: cannot call non-const method `Wrap::<&mut [u8; 2], &mut [u8; 2]>::transmute_mut` in constants
+//~[nightly]^^^^^^^ ERROR: cannot call non-const method `zerocopy::util::macro_util::Wrap::<&mut [u8; 2], &mut [u8; 2]>::transmute_mut_inference_helper` in constants
+//~[nightly]^^^^^^^^ ERROR: cannot call non-const method `zerocopy::util::macro_util::Wrap::<&mut [u8; 2], &mut [u8; 2]>::transmute_mut` in constants

--- a/tests/ui/transmute-mut-dst-not-a-reference.rs
+++ b/tests/ui/transmute-mut-dst-not-a-reference.rs
@@ -13,3 +13,5 @@ fn main() {}
 // `transmute_mut!` does not support transmuting into a non-reference
 // destination type.
 const DST_NOT_A_REFERENCE: usize = transmute_mut!(&mut 0u8);
+//~[msrv, stable, nightly]^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^ ERROR: mismatched types

--- a/tests/ui/transmute-mut-dst-not-frombytes.rs
+++ b/tests/ui/transmute-mut-dst-not-frombytes.rs
@@ -20,3 +20,4 @@ struct Dst;
 
 // `transmute_mut` requires that the destination type implements `FromBytes`
 const DST_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Dst: FromBytes` is not satisfied

--- a/tests/ui/transmute-mut-dst-not-intobytes.rs
+++ b/tests/ui/transmute-mut-dst-not-intobytes.rs
@@ -20,3 +20,4 @@ struct Dst;
 
 // `transmute_mut` requires that the destination type implements `IntoBytes`
 const DST_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Dst: IntoBytes` is not satisfied

--- a/tests/ui/transmute-mut-illegal-lifetime.msrv.stderr
+++ b/tests/ui/transmute-mut-illegal-lifetime.msrv.stderr
@@ -5,7 +5,8 @@ error[E0597]: `x` does not live long enough
    |            ----------------                            ^^^^^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to previous error

--- a/tests/ui/transmute-mut-illegal-lifetime.nightly.stderr
+++ b/tests/ui/transmute-mut-illegal-lifetime.nightly.stderr
@@ -8,7 +8,8 @@ error[E0597]: `x` does not live long enough
    |            ----------------                            ^^^^^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmute-mut-illegal-lifetime.rs
+++ b/tests/ui/transmute-mut-illegal-lifetime.rs
@@ -12,4 +12,5 @@ fn increase_lifetime() {
     let mut x = 0u64;
     // It is illegal to increase the lifetime scope.
     let _: &'static mut u64 = zerocopy::transmute_mut!(&mut x);
+    //~[msrv, stable, nightly]^ ERROR: `x` does not live long enough
 }

--- a/tests/ui/transmute-mut-illegal-lifetime.stable.stderr
+++ b/tests/ui/transmute-mut-illegal-lifetime.stable.stderr
@@ -8,7 +8,8 @@ error[E0597]: `x` does not live long enough
    |            ----------------                            ^^^^^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmute-mut-src-dst-not-references.rs
+++ b/tests/ui/transmute-mut-src-dst-not-references.rs
@@ -13,3 +13,4 @@ fn main() {}
 // `transmute_mut!` does not support transmuting between non-reference source
 // and destination types.
 const SRC_DST_NOT_REFERENCES: &mut usize = transmute_mut!(0usize);
+//~[msrv, stable, nightly]^ ERROR: mismatched types

--- a/tests/ui/transmute-mut-src-immutable.rs
+++ b/tests/ui/transmute-mut-src-immutable.rs
@@ -13,4 +13,5 @@ fn main() {}
 fn ref_src_immutable() {
     // `transmute_mut!` requires that its source type be a mutable reference.
     let _: &mut u8 = transmute_mut!(&0u8);
+    //~[msrv, stable, nightly]^ ERROR: mismatched types
 }

--- a/tests/ui/transmute-mut-src-not-a-reference.rs
+++ b/tests/ui/transmute-mut-src-not-a-reference.rs
@@ -13,3 +13,4 @@ fn main() {}
 // `transmute_mut!` does not support transmuting from a non-reference source
 // type.
 const SRC_NOT_A_REFERENCE: &mut u8 = transmute_mut!(0usize);
+//~[msrv, stable, nightly]^ ERROR: mismatched types

--- a/tests/ui/transmute-mut-src-not-frombytes.rs
+++ b/tests/ui/transmute-mut-src-not-frombytes.rs
@@ -20,3 +20,4 @@ struct Dst;
 
 // `transmute_mut` requires that the source type implements `FromBytes`
 const SRC_NOT_FROM_BYTES: &mut Dst = transmute_mut!(&mut Src);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Src: FromBytes` is not satisfied

--- a/tests/ui/transmute-mut-src-not-intobytes.rs
+++ b/tests/ui/transmute-mut-src-not-intobytes.rs
@@ -20,3 +20,4 @@ struct Dst;
 
 // `transmute_mut` requires that the source type implements `IntoBytes`
 const SRC_NOT_AS_BYTES: &mut Dst = transmute_mut!(&mut Src);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Src: IntoBytes` is not satisfied

--- a/tests/ui/transmute-mut-src-unsized.rs
+++ b/tests/ui/transmute-mut-src-unsized.rs
@@ -13,3 +13,5 @@ fn main() {}
 // `transmute_mut!` does not support transmuting from an unsized source type to
 // a sized destination type.
 const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
+//~[msrv, stable]^ ERROR: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut [u8; 1]>`, but its trait bounds were not satisfied
+//~[nightly]^^ ERROR: transmute_mut` exists for struct `zerocopy::util::macro_util::Wrap<&mut [u8], &mut [u8; 1]>`, but its trait bounds were not satisfied

--- a/tests/ui/transmute-ptr-to-usize.msrv.stderr
+++ b/tests/ui/transmute-ptr-to-usize.msrv.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `*const usize`
    |
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              required by a bound in this

--- a/tests/ui/transmute-ptr-to-usize.nightly.stderr
+++ b/tests/ui/transmute-ptr-to-usize.nightly.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              the trait `IntoBytes` is not implemented for `*const usize`
@@ -19,9 +19,9 @@ help: the trait `IntoBytes` is implemented for `usize`
 77 |     unsafe_impl!(usize: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
    |     ----------------------------------------------------------------------------- in this macro invocation
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              required by a bound in this function

--- a/tests/ui/transmute-ptr-to-usize.rs
+++ b/tests/ui/transmute-ptr-to-usize.rs
@@ -15,4 +15,6 @@ fn main() {}
 // becomes valid due to the requisite implementations of `FromBytes` being
 // added, that we re-examine whether it should specifically be valid in a const
 // context.
+
 const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `*const usize: IntoBytes` is not satisfied

--- a/tests/ui/transmute-ptr-to-usize.stable.stderr
+++ b/tests/ui/transmute-ptr-to-usize.stable.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              the trait `IntoBytes` is not implemented for `*const usize`
@@ -14,9 +14,9 @@ help: the trait `IntoBytes` is implemented for `usize`
 77 |     unsafe_impl!(usize: Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `POINTER_VALUE::transmute`
-  --> $DIR/transmute-ptr-to-usize.rs:18:30
+  --> $DIR/transmute-ptr-to-usize.rs:19:30
    |
-18 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
+19 | const POINTER_VALUE: usize = transmute!(&0usize as *const usize);
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                              |
    |                              required by a bound in this function

--- a/tests/ui/transmute-ref-dst-mutable.rs
+++ b/tests/ui/transmute-ref-dst-mutable.rs
@@ -14,4 +14,8 @@ fn ref_dst_mutable() {
     // `transmute_ref!` requires that its destination type be an immutable
     // reference.
     let _: &mut u8 = transmute_ref!(&0u8);
+    //~[msrv, stable, nightly]^ ERROR: mismatched types
+    //~[msrv, stable, nightly]^^ ERROR: mismatched types
+    //~[msrv, stable, nightly]^^^ ERROR: mismatched types
+    //~[msrv, stable, nightly]^^^^ ERROR: mismatched types
 }

--- a/tests/ui/transmute-ref-dst-not-a-reference.rs
+++ b/tests/ui/transmute-ref-dst-not-a-reference.rs
@@ -13,3 +13,7 @@ fn main() {}
 // `transmute_ref!` does not support transmuting into a non-reference
 // destination type.
 const DST_NOT_A_REFERENCE: usize = transmute_ref!(&0u8);
+//~[msrv, stable, nightly]^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^^^ ERROR: mismatched types

--- a/tests/ui/transmute-ref-dst-not-frombytes.rs
+++ b/tests/ui/transmute-ref-dst-not-frombytes.rs
@@ -19,3 +19,4 @@ struct Dst(AU16);
 
 // `transmute_ref` requires that the destination type implements `FromBytes`
 const DST_NOT_FROM_BYTES: &Dst = transmute_ref!(&AU16(0));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Dst: FromBytes` is not satisfied

--- a/tests/ui/transmute-ref-dst-not-nocell.rs
+++ b/tests/ui/transmute-ref-dst-not-nocell.rs
@@ -19,3 +19,4 @@ struct Dst(AU16);
 
 // `transmute_ref` requires that the destination type implements `Immutable`
 const DST_NOT_IMMUTABLE: &Dst = transmute_ref!(&AU16(0));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Dst: Immutable` is not satisfied

--- a/tests/ui/transmute-ref-illegal-lifetime.msrv.stderr
+++ b/tests/ui/transmute-ref-illegal-lifetime.msrv.stderr
@@ -5,7 +5,8 @@ error[E0597]: `x` does not live long enough
    |            ------------                            ^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to previous error

--- a/tests/ui/transmute-ref-illegal-lifetime.nightly.stderr
+++ b/tests/ui/transmute-ref-illegal-lifetime.nightly.stderr
@@ -8,7 +8,8 @@ error[E0597]: `x` does not live long enough
    |            ------------                            ^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmute-ref-illegal-lifetime.rs
+++ b/tests/ui/transmute-ref-illegal-lifetime.rs
@@ -12,4 +12,5 @@ fn increase_lifetime() {
     let x = 0u64;
     // It is illegal to increase the lifetime scope.
     let _: &'static u64 = zerocopy::transmute_ref!(&x);
+    //~[msrv, stable, nightly]^ ERROR: `x` does not live long enough
 }

--- a/tests/ui/transmute-ref-illegal-lifetime.stable.stderr
+++ b/tests/ui/transmute-ref-illegal-lifetime.stable.stderr
@@ -8,7 +8,8 @@ error[E0597]: `x` does not live long enough
    |            ------------                            ^^ borrowed value does not live long enough
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
-15 | }
+15 |
+16 | }
    | - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmute-ref-src-dst-not-references.rs
+++ b/tests/ui/transmute-ref-src-dst-not-references.rs
@@ -13,3 +13,8 @@ fn main() {}
 // `transmute_ref!` does not support transmuting between non-reference source
 // and destination types.
 const SRC_DST_NOT_REFERENCES: usize = transmute_ref!(0usize);
+//~[msrv, stable, nightly]^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^^^ ERROR: mismatched types
+//~[msrv, stable, nightly]^^^^^ ERROR: mismatched types

--- a/tests/ui/transmute-ref-src-not-a-reference.rs
+++ b/tests/ui/transmute-ref-src-not-a-reference.rs
@@ -13,3 +13,4 @@ fn main() {}
 // `transmute_ref!` does not support transmuting from a non-reference source
 // type.
 const SRC_NOT_A_REFERENCE: &u8 = transmute_ref!(0usize);
+//~[msrv, stable, nightly]^ ERROR: mismatched types

--- a/tests/ui/transmute-ref-src-not-intobytes.rs
+++ b/tests/ui/transmute-ref-src-not-intobytes.rs
@@ -19,3 +19,5 @@ struct Src(AU16);
 
 // `transmute_ref` requires that the source type implements `IntoBytes`
 const SRC_NOT_AS_BYTES: &AU16 = transmute_ref!(&Src(AU16(0)));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Src: IntoBytes` is not satisfied
+//~[msrv, stable, nightly]^^ ERROR: the trait bound `Src: IntoBytes` is not satisfied

--- a/tests/ui/transmute-ref-src-not-nocell.rs
+++ b/tests/ui/transmute-ref-src-not-nocell.rs
@@ -19,3 +19,5 @@ struct Src(AU16);
 
 // `transmute_ref` requires that the source type implements `Immutable`
 const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&Src(AU16(0)));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `Src: Immutable` is not satisfied
+//~[msrv, stable, nightly]^^ ERROR: the trait bound `Src: Immutable` is not satisfied

--- a/tests/ui/transmute-ref-src-unsized.rs
+++ b/tests/ui/transmute-ref-src-unsized.rs
@@ -12,3 +12,5 @@ fn main() {}
 
 // `transmute_ref!` does not support transmuting from an unsized source type.
 const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
+//~[msrv, stable]^ ERROR: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied
+//~[nightly]^^ ERROR: the method `transmute_ref` exists for struct `zerocopy::util::macro_util::Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied

--- a/tests/ui/transmute-size-decrease.rs
+++ b/tests/ui/transmute-size-decrease.rs
@@ -16,3 +16,5 @@ fn main() {}
 // Although this is not a soundness requirement, we currently require that the
 // size of the destination type is not smaller than the size of the source type.
 const DECREASE_SIZE: u8 = transmute!(AU16(0));
+//~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
+//~[stable, nightly]^^ ERROR: transmuting from 2-byte type to 1-byte type: `AU16` -> `u8`

--- a/tests/ui/transmute-size-increase-allow-shrink.rs
+++ b/tests/ui/transmute-size-increase-allow-shrink.rs
@@ -16,3 +16,5 @@ fn main() {}
 // `transmute!` does not support transmuting from a smaller type to a larger
 // one.
 const INCREASE_SIZE: AU16 = transmute!(#![allow(shrink)] 0u8);
+//~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
+//~[stable, nightly]^^ ERROR: transmuting from 1-byte type to 2-byte type: `u8` -> `Transmute<u8, AU16>`

--- a/tests/ui/transmute-size-increase.rs
+++ b/tests/ui/transmute-size-increase.rs
@@ -16,3 +16,5 @@ fn main() {}
 // `transmute!` does not support transmuting from a smaller type to a larger
 // one.
 const INCREASE_SIZE: AU16 = transmute!(0u8);
+//~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
+//~[stable, nightly]^^ ERROR: transmuting from 1-byte type to 2-byte type: `u8` -> `AU16`

--- a/tests/ui/transmute-src-not-intobytes.rs
+++ b/tests/ui/transmute-src-not-intobytes.rs
@@ -15,3 +15,4 @@ fn main() {}
 
 // `transmute` requires that the source type implements `IntoBytes`
 const SRC_NOT_AS_BYTES: AU16 = transmute!(NotZerocopy(AU16(0)));
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/tests/ui/try_transmute-dst-not-tryfrombytes.rs
+++ b/tests/ui/try_transmute-dst-not-tryfrombytes.rs
@@ -13,4 +13,7 @@ use zerocopy::try_transmute;
 
 fn main() {
     let dst_not_try_from_bytes: Result<NotZerocopy, _> = try_transmute!(AU16(0));
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
 }

--- a/tests/ui/try_transmute-size-decrease.rs
+++ b/tests/ui/try_transmute-size-decrease.rs
@@ -15,4 +15,5 @@ use zerocopy::try_transmute;
 // size of the destination type is not smaller than the size of the source type.
 fn main() {
     let _decrease_size: Result<u8, _> = try_transmute!(AU16(0));
+    //~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
 }

--- a/tests/ui/try_transmute-size-increase.rs
+++ b/tests/ui/try_transmute-size-increase.rs
@@ -15,4 +15,5 @@ use zerocopy::try_transmute;
 // one.
 fn main() {
     let _increase_size: Result<AU16, _> = try_transmute!(0u8);
+    //~[msrv, stable, nightly]^ ERROR: cannot transmute between types of different sizes, or dependently-sized types
 }

--- a/tests/ui/try_transmute-src-not-intobytes.rs
+++ b/tests/ui/try_transmute-src-not-intobytes.rs
@@ -14,4 +14,5 @@ use zerocopy::try_transmute;
 fn main() {
     // `try_transmute` requires that the source type implements `IntoBytes`
     let src_not_into_bytes: Result<AU16, _> = try_transmute!(NotZerocopy(AU16(0)));
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
 }

--- a/tests/ui/try_transmute_mut-dst-not-tryfrombytes.rs
+++ b/tests/ui/try_transmute_mut-dst-not-tryfrombytes.rs
@@ -16,4 +16,8 @@ fn main() {
     // `IntoBytes`
     let src = &mut AU16(0);
     let dst_not_try_from_bytes: Result<&mut NotZerocopy, _> = try_transmute_mut!(src);
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^^ ERROR: the trait bound `NotZerocopy: IntoBytes` is not satisfied
 }

--- a/tests/ui/try_transmute_mut-src-not-frombytes.rs
+++ b/tests/ui/try_transmute_mut-src-not-frombytes.rs
@@ -19,4 +19,7 @@ struct Dst;
 fn main() {
     // `try_transmute_mut` requires that the source type implements `FromBytes`
     let src_not_from_bytes: &mut Dst = transmute_mut!(&mut Src);
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `Src: FromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `Dst: FromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^ ERROR: the trait bound `Dst: IntoBytes` is not satisfied
 }

--- a/tests/ui/try_transmute_mut-src-not-intobytes.rs
+++ b/tests/ui/try_transmute_mut-src-not-intobytes.rs
@@ -19,4 +19,7 @@ struct Dst;
 fn main() {
     // `try_transmute_mut` requires that the source type implements `IntoBytes`
     let src_not_from_bytes: &mut Dst = transmute_mut!(&mut Src);
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `Src: IntoBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `Dst: FromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^ ERROR: the trait bound `Dst: IntoBytes` is not satisfied
 }

--- a/tests/ui/try_transmute_ref-dst-mutable.rs
+++ b/tests/ui/try_transmute_ref-dst-mutable.rs
@@ -14,4 +14,6 @@ fn ref_dst_mutable() {
     // `try_transmute_ref!` requires that its destination type be an immutable
     // reference.
     let _: Result<&mut u8, _> = try_transmute_ref!(&0u8);
+    //~[msrv, stable, nightly]^ ERROR: mismatched types
+    //~[msrv, stable, nightly]^^ ERROR: mismatched types
 }

--- a/tests/ui/try_transmute_ref-dst-not-immutable-tryfrombytes.rs
+++ b/tests/ui/try_transmute_ref-dst-not-immutable-tryfrombytes.rs
@@ -15,4 +15,8 @@ fn main() {
     // `try_transmute_ref` requires that the source type implements `Immutable`
     // and `IntoBytes`
     let dst_not_try_from_bytes: Result<&NotZerocopy, _> = try_transmute_ref!(&AU16(0));
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^ ERROR: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
+    //~[msrv, stable, nightly]^^^^ ERROR: the trait bound `NotZerocopy: Immutable` is not satisfied
 }

--- a/tests/ui/try_transmute_ref-src-not-immutable-intobytes.rs
+++ b/tests/ui/try_transmute_ref-src-not-immutable-intobytes.rs
@@ -15,4 +15,6 @@ fn main() {
     // `try_transmute_ref` requires that the source type implements `Immutable`
     // and `IntoBytes`
     let src_not_into_bytes: Result<&AU16, _> = try_transmute_ref!(&NotZerocopy(AU16(0)));
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
+    //~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy<AU16>: Immutable` is not satisfied
 }

--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -170,8 +170,8 @@ impl UiTestRunner {
 
         let stdout = String::from_utf8(output.stdout).unwrap();
         // DEBUG: print stdout and stderr to see if it rebuilt
-        println!("CARGO BUILD STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
-        println!("CARGO BUILD STDOUT:\n{}", stdout);
+        // println!("CARGO BUILD STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
+        // println!("CARGO BUILD STDOUT:\n{}", stdout);
         for msg in cargo_metadata::Message::parse_stream(stdout.as_bytes()) {
             if let Ok(cargo_metadata::Message::CompilerArtifact(artifact)) = msg {
                 if artifact.profile.test {

--- a/zerocopy-derive/tests/ui/absence_of_deprecated_warning.rs
+++ b/zerocopy-derive/tests/ui/absence_of_deprecated_warning.rs
@@ -30,5 +30,6 @@ trait T {}
 
 // Intentionally trigger a deprecation error
 impl T for OldHeader {}
+//~[msrv, stable, nightly]^ ERROR: use of deprecated struct `OldHeader`: Do not use
 
 fn main() {}

--- a/zerocopy-derive/tests/ui/derive_transparent.msrv.stderr
+++ b/zerocopy-derive/tests/ui/derive_transparent.msrv.stderr
@@ -17,9 +17,9 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/derive_transparent.rs:36:1
+  --> $DIR/derive_transparent.rs:38:1
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `FromZeros` for `TransparentStruct<NotZerocopy>`
@@ -28,16 +28,16 @@ note: required because of the requirements on the impl of `FromZeros` for `Trans
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                     ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:36:1
+  --> $DIR/derive_transparent.rs:38:1
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:37:1
+  --> $DIR/derive_transparent.rs:41:1
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `zerocopy_renamed::FromBytes` for `TransparentStruct<NotZerocopy>`
@@ -46,16 +46,16 @@ note: required because of the requirements on the impl of `zerocopy_renamed::Fro
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                     ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:37:1
+  --> $DIR/derive_transparent.rs:41:1
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:38:1
+  --> $DIR/derive_transparent.rs:44:1
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `zerocopy_renamed::IntoBytes` for `TransparentStruct<NotZerocopy>`
@@ -64,16 +64,16 @@ note: required because of the requirements on the impl of `zerocopy_renamed::Int
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |          ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:38:1
+  --> $DIR/derive_transparent.rs:44:1
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/derive_transparent.rs:39:1
+  --> $DIR/derive_transparent.rs:47:1
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocopy`
    |
 note: required because of the requirements on the impl of `zerocopy_renamed::Unaligned` for `TransparentStruct<NotZerocopy>`
@@ -82,9 +82,9 @@ note: required because of the requirements on the impl of `zerocopy_renamed::Una
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                                ^^^^^^^^^
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:39:1
+  --> $DIR/derive_transparent.rs:47:1
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the macro `::static_assertions::assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
+++ b/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
@@ -38,9 +38,9 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/derive_transparent.rs:36:23
+  --> $DIR/derive_transparent.rs:38:23
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -70,16 +70,16 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
 74 |                 ::static_assertions::assert_impl_all!($type: $($trait),+);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    |
-  ::: $DIR/derive_transparent.rs:36:1
+  ::: $DIR/derive_transparent.rs:38:1
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ---------------------------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:37:23
+  --> $DIR/derive_transparent.rs:41:23
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -109,16 +109,16 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
 74 |                 ::static_assertions::assert_impl_all!($type: $($trait),+);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    |
-  ::: $DIR/derive_transparent.rs:37:1
+  ::: $DIR/derive_transparent.rs:41:1
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ---------------------------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:38:23
+  --> $DIR/derive_transparent.rs:44:23
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
@@ -148,16 +148,16 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
 74 |                 ::static_assertions::assert_impl_all!($type: $($trait),+);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    |
-  ::: $DIR/derive_transparent.rs:38:1
+  ::: $DIR/derive_transparent.rs:44:1
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    | ---------------------------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/derive_transparent.rs:39:23
+  --> $DIR/derive_transparent.rs:47:23
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocopy`
@@ -187,9 +187,9 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
 74 |                 ::static_assertions::assert_impl_all!($type: $($trait),+);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    |
-  ::: $DIR/derive_transparent.rs:39:1
+  ::: $DIR/derive_transparent.rs:47:1
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ---------------------------------------------------------------- in this macro invocation
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/derive_transparent.rs
+++ b/zerocopy-derive/tests/ui/derive_transparent.rs
@@ -33,7 +33,16 @@ struct TransparentStruct<T> {
 // must also ensure the traits are only implemented when the inner type
 // implements them.
 util_assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
+
 util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: FromZeros` is not satisfied
+
 util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
+
 util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
+
 util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::Unaligned` is not satisfied

--- a/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
+++ b/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
@@ -33,9 +33,9 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/derive_transparent.rs:36:23
+  --> $DIR/derive_transparent.rs:38:23
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -60,16 +60,16 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:36:1
+  --> $DIR/derive_transparent.rs:38:1
    |
-36 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
+38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:37:23
+  --> $DIR/derive_transparent.rs:41:23
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -94,16 +94,16 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renam
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                     ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:37:1
+  --> $DIR/derive_transparent.rs:41:1
    |
-37 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
+41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/derive_transparent.rs:38:23
+  --> $DIR/derive_transparent.rs:44:23
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
@@ -128,16 +128,16 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renam
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:38:1
+  --> $DIR/derive_transparent.rs:44:1
    |
-38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
+44 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: IntoBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `IntoBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/derive_transparent.rs:39:23
+  --> $DIR/derive_transparent.rs:47:23
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocopy`
@@ -162,9 +162,9 @@ note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renam
 24 | #[derive(IntoBytes, FromBytes, Unaligned)]
    |                                ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
-  --> $DIR/derive_transparent.rs:39:1
+  --> $DIR/derive_transparent.rs:47:1
    |
-39 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
+47 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: Unaligned);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
    = note: this error originates in the derive macro `Unaligned` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/enum.msrv.stderr
+++ b/zerocopy-derive/tests/ui/enum.msrv.stderr
@@ -5,56 +5,44 @@ error: unrecognized representation hint
    |        ^^^^^
 
 error: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:32:10
+  --> $DIR/enum.rs:36:10
    |
-32 | #[derive(FromBytes)]
+36 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-  --> $DIR/enum.rs:41:12
+  --> $DIR/enum.rs:46:12
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |            ^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:46:10
+  --> $DIR/enum.rs:53:10
    |
-46 | #[derive(FromBytes)]
+53 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:78:1
+  --> $DIR/enum.rs:88:1
    |
-78 | #[zerocopy(crate = "zerocopy_renamed")]
+88 | #[zerocopy(crate = "zerocopy_renamed")]
    | ^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:84:1
+  --> $DIR/enum.rs:95:1
    |
-84 | #[zerocopy(crate = "zerocopy_renamed")]
+95 | #[zerocopy(crate = "zerocopy_renamed")]
    | ^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:104:1
-    |
-104 | #[zerocopy(crate = "zerocopy_renamed")]
-    | ^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:110:1
-    |
-110 | #[zerocopy(crate = "zerocopy_renamed")]
-    | ^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:117:1
@@ -62,150 +50,125 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
 117 | #[zerocopy(crate = "zerocopy_renamed")]
     | ^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:124:1
     |
-124 | / #[zerocopy(crate = "zerocopy_renamed")]
-125 | | #[repr(u8)]
-126 | | enum FromZeros4 {
-127 | |     A = 1,
-128 | |     B = 2,
-129 | | }
+124 | #[zerocopy(crate = "zerocopy_renamed")]
+    | ^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> $DIR/enum.rs:132:1
+    |
+132 | #[zerocopy(crate = "zerocopy_renamed")]
+    | ^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:140:1
+    |
+140 | / #[zerocopy(crate = "zerocopy_renamed")]
+141 | |
+142 | | #[repr(u8)]
+143 | | enum FromZeros4 {
+144 | |     A = 1,
+145 | |     B = 2,
+146 | | }
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
 help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
-   --> $DIR/enum.rs:134:1
-    |
-134 | / #[zerocopy(crate = "zerocopy_renamed")]
-135 | | #[repr(i8)]
-136 | | enum FromZeros5 {
-137 | |     A = NEGATIVE_ONE,
-138 | |     B,
-139 | | }
-    | |_^
-
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
-152 | | #[repr(u8)]
-153 | | enum FromZeros7 {
-154 | |     A = 1,
-155 | |     B(NotFromZeros),
-156 | | }
+152 | |
+153 | | #[repr(i8)]
+154 | | enum FromZeros5 {
+155 | |     A = NEGATIVE_ONE,
+156 | |     B,
+157 | | }
+    | |_^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:171:1
+    |
+171 | / #[zerocopy(crate = "zerocopy_renamed")]
+172 | |
+173 | | #[repr(u8)]
+174 | | enum FromZeros7 {
+...   |
+177 | |     B(NotFromZeros),
+178 | | }
     | |_^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:162:10
+   --> $DIR/enum.rs:184:10
     |
-162 | #[derive(FromBytes)]
+184 | #[derive(FromBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:170:8
+   --> $DIR/enum.rs:193:8
     |
-170 | #[repr(C)]
+193 | #[repr(C)]
     |        ^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:177:8
+   --> $DIR/enum.rs:201:8
     |
-177 | #[repr(usize)]
+201 | #[repr(usize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:184:8
+   --> $DIR/enum.rs:209:8
     |
-184 | #[repr(isize)]
+209 | #[repr(isize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:191:8
+   --> $DIR/enum.rs:217:8
     |
-191 | #[repr(u32)]
+217 | #[repr(u32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:198:8
+   --> $DIR/enum.rs:225:8
     |
-198 | #[repr(i32)]
+225 | #[repr(i32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:205:8
+   --> $DIR/enum.rs:233:8
     |
-205 | #[repr(u64)]
+233 | #[repr(u64)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:212:8
+   --> $DIR/enum.rs:241:8
     |
-212 | #[repr(i64)]
+241 | #[repr(i64)]
     |        ^^^
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:483:10
+   --> $DIR/enum.rs:515:10
     |
-483 | #[derive(Unaligned)]
+515 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:490:10
+   --> $DIR/enum.rs:523:10
     |
-490 | #[derive(Unaligned)]
+523 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:497:10
+   --> $DIR/enum.rs:531:10
     |
-497 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:504:10
-    |
-504 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:511:10
-    |
-511 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:518:10
-    |
-518 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:525:10
-    |
-525 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:532:10
-    |
-532 | #[derive(Unaligned)]
+531 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -218,60 +181,101 @@ error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:548:12
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:547:10
     |
-548 | #[repr(u8, align(2))]
+547 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:555:10
+    |
+555 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:563:10
+    |
+563 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:571:10
+    |
+571 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:579:10
+    |
+579 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> $DIR/enum.rs:589:12
+    |
+589 | #[repr(u8, align(2))]
     |            ^^^^^
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:555:12
+   --> $DIR/enum.rs:597:12
     |
-555 | #[repr(i8, align(2))]
+597 | #[repr(i8, align(2))]
     |            ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:562:18
+   --> $DIR/enum.rs:605:18
     |
-562 | #[repr(align(1), align(2))]
+605 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:569:18
+   --> $DIR/enum.rs:613:18
     |
-569 | #[repr(align(2), align(4))]
+613 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:606:10
+   --> $DIR/enum.rs:657:10
     |
-606 | #[derive(IntoBytes)]
+657 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:613:10
+   --> $DIR/enum.rs:665:10
     |
-613 | #[derive(IntoBytes)]
+665 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
-   --> $DIR/enum.rs:623:7
+   --> $DIR/enum.rs:677:7
     |
-623 |     A(T),
+677 |     A(T),
     |       ^ cannot perform const operation using `T`
     |
     = note: type parameters may not be used in const expressions
 
 error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
-   --> $DIR/enum.rs:154:9
+   --> $DIR/enum.rs:175:9
     |
-154 |     A = 1,
+175 |     A = 1,
     |         ^ disallowed custom discriminant
-155 |     B(NotFromZeros),
+176 |
+177 |     B(NotFromZeros),
     |     --------------- tuple variant defined here
     |
     = note: see issue #60553 <https://github.com/rust-lang/rust/issues/60553> for more information
@@ -283,15 +287,15 @@ error[E0565]: meta item in `repr` must be an identifier
    |        ^^^^^
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
 
 error[E0566]: conflicting representation hints
-  --> $DIR/enum.rs:41:8
+  --> $DIR/enum.rs:46:8
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
    = note: `#[deny(conflicting_repr_hints)]` on by default
@@ -299,63 +303,63 @@ error[E0566]: conflicting representation hints
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
 
 error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
-  --> $DIR/enum.rs:56:10
+  --> $DIR/enum.rs:64:10
    |
-56 | #[derive(Immutable)]
+64 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
-  --> $DIR/enum.rs:66:10
+  --> $DIR/enum.rs:75:10
    |
-66 | #[derive(Immutable)]
+75 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
-  --> $DIR/enum.rs:92:10
-   |
-92 | #[derive(TryFromBytes)]
-   |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
-   |
-   = help: see issue #48214
-   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/enum.rs:104:10
+    |
+104 | #[derive(TryFromBytes)]
+    |          ^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
+    |
+    = help: see issue #48214
+    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotFromZeros`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotFromZeros`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, 1_usize>` is not satisfied
-   --> $DIR/enum.rs:578:10
+   --> $DIR/enum.rs:623:10
     |
-578 | #[derive(IntoBytes)]
+623 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes1, 1_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -364,9 +368,9 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes1, 1_usize>` is not sati
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 3_usize>` is not satisfied
-   --> $DIR/enum.rs:591:10
+   --> $DIR/enum.rs:638:10
     |
-591 | #[derive(IntoBytes)]
+638 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, 3_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -375,9 +379,9 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 3_usize>` is not sati
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, 2_usize>` is not satisfied
-   --> $DIR/enum.rs:598:10
+   --> $DIR/enum.rs:647:10
     |
-598 | #[derive(IntoBytes)]
+647 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes3, 2_usize>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -386,15 +390,15 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes3, 2_usize>` is not sati
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic `Self` types are currently not permitted in anonymous constants
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
 note: not a concrete type
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -5,225 +5,193 @@ error: unrecognized representation hint
    |        ^^^^^
 
 error: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:32:10
+  --> $DIR/enum.rs:36:10
    |
-32 | #[derive(FromBytes)]
+36 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-  --> $DIR/enum.rs:41:8
+  --> $DIR/enum.rs:46:8
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |        ^^^^^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:46:10
+  --> $DIR/enum.rs:53:10
    |
-46 | #[derive(FromBytes)]
+53 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:78:1
+  --> $DIR/enum.rs:88:1
    |
-78 | / #[zerocopy(crate = "zerocopy_renamed")]
-79 | | enum TryFromBytes1 {
-80 | |     A,
-81 | | }
+88 | / #[zerocopy(crate = "zerocopy_renamed")]
+89 | |
+90 | | enum TryFromBytes1 {
+91 | |     A,
+92 | | }
    | |_^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:84:1
-   |
-84 | / #[zerocopy(crate = "zerocopy_renamed")]
-85 | | enum TryFromBytes2 {
-86 | |     A,
-87 | |     B(u8),
-88 | | }
-   | |_^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:104:1
+   --> $DIR/enum.rs:95:1
     |
-104 | / #[zerocopy(crate = "zerocopy_renamed")]
-105 | | enum FromZeros1 {
-106 | |     A(u8),
-107 | | }
-    | |_^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:110:1
-    |
-110 | / #[zerocopy(crate = "zerocopy_renamed")]
-111 | | enum FromZeros2 {
-112 | |     A,
-113 | |     B(u8),
-114 | | }
+ 95 | / #[zerocopy(crate = "zerocopy_renamed")]
+ 96 | |
+ 97 | | enum TryFromBytes2 {
+ 98 | |     A,
+ 99 | |     B(u8),
+100 | | }
     | |_^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:117:1
     |
 117 | / #[zerocopy(crate = "zerocopy_renamed")]
-118 | | enum FromZeros3 {
-119 | |     A = 1,
-120 | |     B,
+118 | |
+119 | | enum FromZeros1 {
+120 | |     A(u8),
 121 | | }
     | |_^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:124:1
     |
 124 | / #[zerocopy(crate = "zerocopy_renamed")]
-125 | | #[repr(u8)]
-126 | | enum FromZeros4 {
-127 | |     A = 1,
-128 | |     B = 2,
+125 | |
+126 | | enum FromZeros2 {
+127 | |     A,
+128 | |     B(u8),
 129 | | }
+    | |_^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> $DIR/enum.rs:132:1
+    |
+132 | / #[zerocopy(crate = "zerocopy_renamed")]
+133 | |
+134 | | enum FromZeros3 {
+135 | |     A = 1,
+136 | |     B,
+137 | | }
+    | |_^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:140:1
+    |
+140 | / #[zerocopy(crate = "zerocopy_renamed")]
+141 | |
+142 | | #[repr(u8)]
+143 | | enum FromZeros4 {
+144 | |     A = 1,
+145 | |     B = 2,
+146 | | }
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
        help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
-   --> $DIR/enum.rs:134:1
-    |
-134 | / #[zerocopy(crate = "zerocopy_renamed")]
-135 | | #[repr(i8)]
-136 | | enum FromZeros5 {
-137 | |     A = NEGATIVE_ONE,
-138 | |     B,
-139 | | }
-    | |_^
-
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
-152 | | #[repr(u8)]
-153 | | enum FromZeros7 {
-154 | |     A = 1,
-155 | |     B(NotFromZeros),
-156 | | }
+152 | |
+153 | | #[repr(i8)]
+154 | | enum FromZeros5 {
+155 | |     A = NEGATIVE_ONE,
+156 | |     B,
+157 | | }
+    | |_^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:171:1
+    |
+171 | / #[zerocopy(crate = "zerocopy_renamed")]
+172 | |
+173 | | #[repr(u8)]
+174 | | enum FromZeros7 {
+...   |
+177 | |     B(NotFromZeros),
+178 | | }
     | |_^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:162:10
+   --> $DIR/enum.rs:184:10
     |
-162 | #[derive(FromBytes)]
+184 | #[derive(FromBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:170:8
+   --> $DIR/enum.rs:193:8
     |
-170 | #[repr(C)]
+193 | #[repr(C)]
     |        ^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:177:8
+   --> $DIR/enum.rs:201:8
     |
-177 | #[repr(usize)]
+201 | #[repr(usize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:184:8
+   --> $DIR/enum.rs:209:8
     |
-184 | #[repr(isize)]
+209 | #[repr(isize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:191:8
+   --> $DIR/enum.rs:217:8
     |
-191 | #[repr(u32)]
+217 | #[repr(u32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:198:8
+   --> $DIR/enum.rs:225:8
     |
-198 | #[repr(i32)]
+225 | #[repr(i32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:205:8
+   --> $DIR/enum.rs:233:8
     |
-205 | #[repr(u64)]
+233 | #[repr(u64)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:212:8
+   --> $DIR/enum.rs:241:8
     |
-212 | #[repr(i64)]
+241 | #[repr(i64)]
     |        ^^^
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:483:10
+   --> $DIR/enum.rs:515:10
     |
-483 | #[derive(Unaligned)]
+515 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:490:10
+   --> $DIR/enum.rs:523:10
     |
-490 | #[derive(Unaligned)]
+523 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:497:10
+   --> $DIR/enum.rs:531:10
     |
-497 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:504:10
-    |
-504 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:511:10
-    |
-511 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:518:10
-    |
-518 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:525:10
-    |
-525 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:532:10
-    |
-532 | #[derive(Unaligned)]
+531 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -236,50 +204,90 @@ error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:548:12
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:547:10
     |
-548 | #[repr(u8, align(2))]
+547 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:555:10
+    |
+555 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:563:10
+    |
+563 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:571:10
+    |
+571 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:579:10
+    |
+579 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> $DIR/enum.rs:589:12
+    |
+589 | #[repr(u8, align(2))]
     |            ^^^^^^^^
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:555:12
+   --> $DIR/enum.rs:597:12
     |
-555 | #[repr(i8, align(2))]
+597 | #[repr(i8, align(2))]
     |            ^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:562:8
+   --> $DIR/enum.rs:605:8
     |
-562 | #[repr(align(1), align(2))]
+605 | #[repr(align(1), align(2))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:569:8
+   --> $DIR/enum.rs:613:8
     |
-569 | #[repr(align(2), align(4))]
+613 | #[repr(align(2), align(4))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:606:10
+   --> $DIR/enum.rs:657:10
     |
-606 | #[derive(IntoBytes)]
+657 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:613:10
+   --> $DIR/enum.rs:665:10
     |
-613 | #[derive(IntoBytes)]
+665 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
-   --> $DIR/enum.rs:623:7
+   --> $DIR/enum.rs:677:7
     |
-623 |     A(T),
+677 |     A(T),
     |       ^ cannot perform const operation using `T`
     |
     = note: type parameters may not be used in const expressions
@@ -292,18 +300,18 @@ error[E0565]: meta item in `repr` must be an identifier
    | ^^^^^^^^^^^^^^
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
    |
    = help: valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/enum.rs:41:8
+  --> $DIR/enum.rs:46:8
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -311,9 +319,9 @@ error[E0566]: conflicting representation hints
    = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
-  --> $DIR/enum.rs:56:10
+  --> $DIR/enum.rs:64:10
    |
-56 | #[derive(Immutable)]
+64 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<()>`
@@ -335,9 +343,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
-  --> $DIR/enum.rs:66:10
+  --> $DIR/enum.rs:75:10
    |
-66 | #[derive(Immutable)]
+75 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<u8>`
@@ -359,44 +367,44 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
-  --> $DIR/enum.rs:92:10
-   |
-92 | #[derive(TryFromBytes)]
-   |          ^^^^^^^^^^^^ unsatisfied trait bound
-   |
+   --> $DIR/enum.rs:104:10
+    |
+104 | #[derive(TryFromBytes)]
+    |          ^^^^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
-  --> $DIR/enum.rs:90:1
-   |
-90 | struct NotTryFromBytes;
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
-   = help: the following other types implement trait `TryFromBytes`:
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
-             (A, B, C, D, E, F, G)
-             (A, B, C, D, E, F, G, H)
-           and 157 others
-   = help: see issue #48214
-   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/enum.rs:102:1
+    |
+102 | struct NotTryFromBytes;
+    | ^^^^^^^^^^^^^^^^^^^^^^
+    = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
+    = help: the following other types implement trait `TryFromBytes`:
+              ()
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
+            and 157 others
+    = help: see issue #48214
+    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-   |
- 9 + #![feature(trivial_bounds)]
-   |
+    |
+  9 + #![feature(trivial_bounds)]
+    |
 
 error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
-   --> $DIR/enum.rs:141:1
+   --> $DIR/enum.rs:159:1
     |
-141 | struct NotFromZeros;
+159 | struct NotFromZeros;
     | ^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
     = help: the following other types implement trait `TryFromBytes`:
@@ -417,15 +425,15 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `FromZeros` is not implemented for `NotFromZeros`
-   --> $DIR/enum.rs:141:1
+   --> $DIR/enum.rs:159:1
     |
-141 | struct NotFromZeros;
+159 | struct NotFromZeros;
     | ^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(FromZeros)]` to `NotFromZeros`
     = help: the following other types implement trait `FromZeros`:
@@ -446,9 +454,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -470,9 +478,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
-   --> $DIR/enum.rs:578:10
+   --> $DIR/enum.rs:623:10
     |
-578 | #[derive(IntoBytes)]
+623 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -489,9 +497,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
-   --> $DIR/enum.rs:591:10
+   --> $DIR/enum.rs:638:10
     |
-591 | #[derive(IntoBytes)]
+638 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -508,9 +516,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
-   --> $DIR/enum.rs:598:10
+   --> $DIR/enum.rs:647:10
     |
-598 | #[derive(IntoBytes)]
+647 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -527,22 +535,22 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error: generic `Self` types are currently not permitted in anonymous constants
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
 note: not a concrete type
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -557,14 +565,14 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F, G, H)
             and 79 others
 note: required for `FooU8` to implement `FromBytes`
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_is_from_bytes`
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/enum.rs
+++ b/zerocopy-derive/tests/ui/enum.rs
@@ -18,6 +18,8 @@ fn main() {}
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr("foo")]
+//~[msrv, stable, nightly]^ ERROR: unrecognized representation hint
+//~[msrv, stable, nightly]^^ ERROR: meta item in `repr` must be an identifier
 enum Generic1 {
     A,
 }
@@ -25,11 +27,14 @@ enum Generic1 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(foo)]
+//~[msrv, stable, nightly]^ ERROR: unrecognized representation hint
+//~[msrv, stable, nightly]^^ ERROR: unrecognized representation hint
 enum Generic2 {
     A,
 }
 
 #[derive(FromBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(transparent)]
 enum Generic3 {
@@ -39,11 +44,14 @@ enum Generic3 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8, u16)]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
+//~[msrv, stable, nightly]^^ ERROR: conflicting representation hints
 enum Generic4 {
     A,
 }
 
 #[derive(FromBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 #[zerocopy(crate = "zerocopy_renamed")]
 enum Generic5 {
     A,
@@ -54,6 +62,7 @@ enum Generic5 {
 //
 
 #[derive(Immutable)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 enum Immutable1 {
     A(core::cell::UnsafeCell<()>),
@@ -64,6 +73,7 @@ enum Immutable1 {
 enum Never {}
 
 #[derive(Immutable)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 enum Immutable2 {
     Uninhabited(Never, core::cell::UnsafeCell<u8>),
@@ -76,12 +86,14 @@ enum Immutable2 {
 
 #[derive(TryFromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 enum TryFromBytes1 {
     A,
 }
 
 #[derive(TryFromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 enum TryFromBytes2 {
     A,
     B(u8),
@@ -90,6 +102,7 @@ enum TryFromBytes2 {
 struct NotTryFromBytes;
 
 #[derive(TryFromBytes)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum TryFromBytes3 {
@@ -102,12 +115,14 @@ enum TryFromBytes3 {
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 enum FromZeros1 {
     A(u8),
 }
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 enum FromZeros2 {
     A,
     B(u8),
@@ -115,6 +130,7 @@ enum FromZeros2 {
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 enum FromZeros3 {
     A = 1,
     B,
@@ -122,6 +138,7 @@ enum FromZeros3 {
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: FromZeros only supported on enums with a variant that has a discriminant of `0`
 #[repr(u8)]
 enum FromZeros4 {
     A = 1,
@@ -132,6 +149,7 @@ const NEGATIVE_ONE: i8 = -1;
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: FromZeros only supported on enums with a variant that has a discriminant of `0`
 #[repr(i8)]
 enum FromZeros5 {
     A = NEGATIVE_ONE,
@@ -141,6 +159,8 @@ enum FromZeros5 {
 struct NotFromZeros;
 
 #[derive(FromZeros)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
+//~[msrv, stable, nightly]^^ ERROR: the trait bound `NotFromZeros: FromZeros` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum FromZeros6 {
@@ -149,9 +169,11 @@ enum FromZeros6 {
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: FromZeros only supported on enums with a variant that has a discriminant of `0`
 #[repr(u8)]
 enum FromZeros7 {
     A = 1,
+    //~[msrv]^ ERROR: custom discriminant values are not allowed in enums with tuple or struct variants
     B(NotFromZeros),
 }
 
@@ -160,6 +182,7 @@ enum FromZeros7 {
 //
 
 #[derive(FromBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 #[zerocopy(crate = "zerocopy_renamed")]
 enum FromBytes1 {
     A,
@@ -168,6 +191,7 @@ enum FromBytes1 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes2 {
     A,
 }
@@ -175,6 +199,7 @@ enum FromBytes2 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(usize)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes3 {
     A,
 }
@@ -182,6 +207,7 @@ enum FromBytes3 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(isize)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes4 {
     A,
 }
@@ -189,6 +215,7 @@ enum FromBytes4 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u32)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes5 {
     A,
 }
@@ -196,6 +223,7 @@ enum FromBytes5 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i32)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes6 {
     A,
 }
@@ -203,6 +231,7 @@ enum FromBytes6 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u64)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes7 {
     A,
 }
@@ -210,11 +239,14 @@ enum FromBytes7 {
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i64)]
+//~[msrv, stable, nightly]^ ERROR: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
 enum FromBytes8 {
     A,
 }
 
 #[derive(FromBytes)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `bool: FromBytes` is not satisfied
+//~[stable, nightly]^^ ERROR: the trait bound `bool: FromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum FooU8 {
@@ -481,6 +513,7 @@ enum FooU8 {
 //
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 enum Unaligned1 {
@@ -488,6 +521,7 @@ enum Unaligned1 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u16)]
 enum Unaligned2 {
@@ -495,6 +529,7 @@ enum Unaligned2 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i16)]
 enum Unaligned3 {
@@ -502,6 +537,7 @@ enum Unaligned3 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u32)]
 enum Unaligned4 {
@@ -509,6 +545,7 @@ enum Unaligned4 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i32)]
 enum Unaligned5 {
@@ -516,6 +553,7 @@ enum Unaligned5 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u64)]
 enum Unaligned6 {
@@ -523,6 +561,7 @@ enum Unaligned6 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i64)]
 enum Unaligned7 {
@@ -530,6 +569,7 @@ enum Unaligned7 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(usize)]
 enum Unaligned8 {
@@ -537,6 +577,7 @@ enum Unaligned8 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(isize)]
 enum Unaligned9 {
@@ -546,6 +587,7 @@ enum Unaligned9 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8, align(2))]
+//~[msrv, stable, nightly]^ ERROR: cannot derive `Unaligned` on type with alignment greater than 1
 enum Unaligned10 {
     A,
 }
@@ -553,6 +595,7 @@ enum Unaligned10 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i8, align(2))]
+//~[msrv, stable, nightly]^ ERROR: cannot derive `Unaligned` on type with alignment greater than 1
 enum Unaligned11 {
     A,
 }
@@ -560,6 +603,7 @@ enum Unaligned11 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(align(1), align(2))]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
 enum Unaligned12 {
     A,
 }
@@ -567,6 +611,7 @@ enum Unaligned12 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(align(2), align(4))]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
 enum Unaligned13 {
     A,
 }
@@ -576,6 +621,8 @@ enum Unaligned13 {
 //
 
 #[derive(IntoBytes)]
+//~[msrv]^ ERROR: the trait bound `(): PaddingFree<IntoBytes1, 1_usize>` is not satisfied
+//~[stable, nightly]^^ ERROR: `IntoBytes1` has 1 total byte(s) of padding
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum IntoBytes1 {
@@ -589,6 +636,8 @@ enum IntoBytes1 {
 struct Align4IntoBytes(u32);
 
 #[derive(IntoBytes)]
+//~[msrv]^ ERROR: the trait bound `(): PaddingFree<IntoBytes2, 3_usize>` is not satisfied
+//~[stable, nightly]^^ ERROR: `IntoBytes2` has 3 total byte(s) of padding
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum IntoBytes2 {
@@ -596,6 +645,8 @@ enum IntoBytes2 {
 }
 
 #[derive(IntoBytes)]
+//~[msrv]^ ERROR: the trait bound `(): PaddingFree<IntoBytes3, 2_usize>` is not satisfied
+//~[stable, nightly]^^ ERROR: `IntoBytes3` has 2 total byte(s) of padding
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u32)]
 enum IntoBytes3 {
@@ -604,6 +655,7 @@ enum IntoBytes3 {
 }
 
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 #[zerocopy(crate = "zerocopy_renamed")]
 enum IntoBytes4 {
     A(u32),
@@ -611,14 +663,17 @@ enum IntoBytes4 {
 }
 
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
 #[zerocopy(crate = "zerocopy_renamed")]
 enum IntoBytes5 {
     A(u32),
 }
 
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: generic `Self` types are currently not permitted in anonymous constants
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u8)]
 enum IntoBytes6<T> {
     A(T),
+    //~[msrv, stable, nightly]^ ERROR: generic parameters may not be used in const operations
 }

--- a/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -5,56 +5,44 @@ error: unrecognized representation hint
    |        ^^^^^
 
 error: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:32:10
+  --> $DIR/enum.rs:36:10
    |
-32 | #[derive(FromBytes)]
+36 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-  --> $DIR/enum.rs:41:12
+  --> $DIR/enum.rs:46:12
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |            ^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:46:10
+  --> $DIR/enum.rs:53:10
    |
-46 | #[derive(FromBytes)]
+53 | #[derive(FromBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:78:1
+  --> $DIR/enum.rs:88:1
    |
-78 | #[zerocopy(crate = "zerocopy_renamed")]
+88 | #[zerocopy(crate = "zerocopy_renamed")]
    | ^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-  --> $DIR/enum.rs:84:1
+  --> $DIR/enum.rs:95:1
    |
-84 | #[zerocopy(crate = "zerocopy_renamed")]
+95 | #[zerocopy(crate = "zerocopy_renamed")]
    | ^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:104:1
-    |
-104 | #[zerocopy(crate = "zerocopy_renamed")]
-    | ^
-
-error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:110:1
-    |
-110 | #[zerocopy(crate = "zerocopy_renamed")]
-    | ^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:117:1
@@ -62,150 +50,125 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
 117 | #[zerocopy(crate = "zerocopy_renamed")]
     | ^
 
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
    --> $DIR/enum.rs:124:1
     |
-124 | / #[zerocopy(crate = "zerocopy_renamed")]
-125 | | #[repr(u8)]
-126 | | enum FromZeros4 {
-127 | |     A = 1,
-128 | |     B = 2,
-129 | | }
+124 | #[zerocopy(crate = "zerocopy_renamed")]
+    | ^
+
+error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
+   --> $DIR/enum.rs:132:1
+    |
+132 | #[zerocopy(crate = "zerocopy_renamed")]
+    | ^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:140:1
+    |
+140 | / #[zerocopy(crate = "zerocopy_renamed")]
+141 | |
+142 | | #[repr(u8)]
+143 | | enum FromZeros4 {
+144 | |     A = 1,
+145 | |     B = 2,
+146 | | }
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
        help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
-   --> $DIR/enum.rs:134:1
-    |
-134 | / #[zerocopy(crate = "zerocopy_renamed")]
-135 | | #[repr(i8)]
-136 | | enum FromZeros5 {
-137 | |     A = NEGATIVE_ONE,
-138 | |     B,
-139 | | }
-    | |_^
-
-error: FromZeros only supported on enums with a variant that has a discriminant of `0`
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
-152 | | #[repr(u8)]
-153 | | enum FromZeros7 {
-154 | |     A = 1,
-155 | |     B(NotFromZeros),
-156 | | }
+152 | |
+153 | | #[repr(i8)]
+154 | | enum FromZeros5 {
+155 | |     A = NEGATIVE_ONE,
+156 | |     B,
+157 | | }
+    | |_^
+
+error: FromZeros only supported on enums with a variant that has a discriminant of `0`
+   --> $DIR/enum.rs:171:1
+    |
+171 | / #[zerocopy(crate = "zerocopy_renamed")]
+172 | |
+173 | | #[repr(u8)]
+174 | | enum FromZeros7 {
+...   |
+177 | |     B(NotFromZeros),
+178 | | }
     | |_^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:162:10
+   --> $DIR/enum.rs:184:10
     |
-162 | #[derive(FromBytes)]
+184 | #[derive(FromBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:170:8
+   --> $DIR/enum.rs:193:8
     |
-170 | #[repr(C)]
+193 | #[repr(C)]
     |        ^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:177:8
+   --> $DIR/enum.rs:201:8
     |
-177 | #[repr(usize)]
+201 | #[repr(usize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:184:8
+   --> $DIR/enum.rs:209:8
     |
-184 | #[repr(isize)]
+209 | #[repr(isize)]
     |        ^^^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:191:8
+   --> $DIR/enum.rs:217:8
     |
-191 | #[repr(u32)]
+217 | #[repr(u32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:198:8
+   --> $DIR/enum.rs:225:8
     |
-198 | #[repr(i32)]
+225 | #[repr(i32)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:205:8
+   --> $DIR/enum.rs:233:8
     |
-205 | #[repr(u64)]
+233 | #[repr(u64)]
     |        ^^^
 
 error: `FromBytes` only supported on enums with `#[repr(...)]` attributes `u8`, `i8`, `u16`, or `i16`
-   --> $DIR/enum.rs:212:8
+   --> $DIR/enum.rs:241:8
     |
-212 | #[repr(i64)]
+241 | #[repr(i64)]
     |        ^^^
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:483:10
+   --> $DIR/enum.rs:515:10
     |
-483 | #[derive(Unaligned)]
+515 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:490:10
+   --> $DIR/enum.rs:523:10
     |
-490 | #[derive(Unaligned)]
+523 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:497:10
+   --> $DIR/enum.rs:531:10
     |
-497 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:504:10
-    |
-504 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:511:10
-    |
-511 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:518:10
-    |
-518 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:525:10
-    |
-525 | #[derive(Unaligned)]
-    |          ^^^^^^^^^
-    |
-    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
-   --> $DIR/enum.rs:532:10
-    |
-532 | #[derive(Unaligned)]
+531 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -218,50 +181,90 @@ error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:548:12
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:547:10
     |
-548 | #[repr(u8, align(2))]
+547 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:555:10
+    |
+555 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:563:10
+    |
+563 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:571:10
+    |
+571 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: must have #[repr(u8)] or #[repr(i8)] attribute in order to guarantee this type's alignment
+   --> $DIR/enum.rs:579:10
+    |
+579 | #[derive(Unaligned)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> $DIR/enum.rs:589:12
+    |
+589 | #[repr(u8, align(2))]
     |            ^^^^^
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/enum.rs:555:12
+   --> $DIR/enum.rs:597:12
     |
-555 | #[repr(i8, align(2))]
+597 | #[repr(i8, align(2))]
     |            ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:562:18
+   --> $DIR/enum.rs:605:18
     |
-562 | #[repr(align(1), align(2))]
+605 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/enum.rs:569:18
+   --> $DIR/enum.rs:613:18
     |
-569 | #[repr(align(2), align(4))]
+613 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:606:10
+   --> $DIR/enum.rs:657:10
     |
-606 | #[derive(IntoBytes)]
+657 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout
-   --> $DIR/enum.rs:613:10
+   --> $DIR/enum.rs:665:10
     |
-613 | #[derive(IntoBytes)]
+665 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
-   --> $DIR/enum.rs:623:7
+   --> $DIR/enum.rs:677:7
     |
-623 |     A(T),
+677 |     A(T),
     |       ^ cannot perform const operation using `T`
     |
     = note: type parameters may not be used in const expressions
@@ -273,18 +276,18 @@ error[E0565]: meta item in `repr` must be an identifier
    | ^^^^^^^^^^^^^^
 
 error[E0552]: unrecognized representation hint
-  --> $DIR/enum.rs:27:8
+  --> $DIR/enum.rs:29:8
    |
-27 | #[repr(foo)]
+29 | #[repr(foo)]
    |        ^^^
    |
    = help: valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
    = note: for more information, visit <https://doc.rust-lang.org/reference/type-layout.html?highlight=repr#representations>
 
 error[E0566]: conflicting representation hints
-  --> $DIR/enum.rs:41:8
+  --> $DIR/enum.rs:46:8
    |
-41 | #[repr(u8, u16)]
+46 | #[repr(u8, u16)]
    |        ^^  ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -292,9 +295,9 @@ error[E0566]: conflicting representation hints
    = note: `#[deny(conflicting_repr_hints)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
-  --> $DIR/enum.rs:56:10
+  --> $DIR/enum.rs:64:10
    |
-56 | #[derive(Immutable)]
+64 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<()>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<()>`
@@ -312,9 +315,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
-  --> $DIR/enum.rs:66:10
+  --> $DIR/enum.rs:75:10
    |
-66 | #[derive(Immutable)]
+75 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<u8>`
@@ -332,40 +335,40 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
-  --> $DIR/enum.rs:92:10
-   |
-92 | #[derive(TryFromBytes)]
-   |          ^^^^^^^^^^^^ unsatisfied trait bound
-   |
+   --> $DIR/enum.rs:104:10
+    |
+104 | #[derive(TryFromBytes)]
+    |          ^^^^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
-  --> $DIR/enum.rs:90:1
-   |
-90 | struct NotTryFromBytes;
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
-   = help: the following other types implement trait `TryFromBytes`:
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
-             (A, B, C, D, E, F, G)
-             (A, B, C, D, E, F, G, H)
-           and 157 others
-   = help: see issue #48214
-   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/enum.rs:102:1
+    |
+102 | struct NotTryFromBytes;
+    | ^^^^^^^^^^^^^^^^^^^^^^
+    = note: Consider adding `#[derive(TryFromBytes)]` to `NotTryFromBytes`
+    = help: the following other types implement trait `TryFromBytes`:
+              ()
+              (A, B)
+              (A, B, C)
+              (A, B, C, D)
+              (A, B, C, D, E)
+              (A, B, C, D, E, F)
+              (A, B, C, D, E, F, G)
+              (A, B, C, D, E, F, G, H)
+            and 157 others
+    = help: see issue #48214
+    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
-   --> $DIR/enum.rs:141:1
+   --> $DIR/enum.rs:159:1
     |
-141 | struct NotFromZeros;
+159 | struct NotFromZeros;
     | ^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(TryFromBytes)]` to `NotFromZeros`
     = help: the following other types implement trait `TryFromBytes`:
@@ -382,15 +385,15 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
-   --> $DIR/enum.rs:143:10
+   --> $DIR/enum.rs:161:10
     |
-143 | #[derive(FromZeros)]
+161 | #[derive(FromZeros)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `FromZeros` is not implemented for `NotFromZeros`
-   --> $DIR/enum.rs:141:1
+   --> $DIR/enum.rs:159:1
     |
-141 | struct NotFromZeros;
+159 | struct NotFromZeros;
     | ^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(FromZeros)]` to `NotFromZeros`
     = help: the following other types implement trait `FromZeros`:
@@ -407,9 +410,9 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -427,9 +430,9 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
-   --> $DIR/enum.rs:578:10
+   --> $DIR/enum.rs:623:10
     |
-578 | #[derive(IntoBytes)]
+623 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -445,9 +448,9 @@ help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
-   --> $DIR/enum.rs:591:10
+   --> $DIR/enum.rs:638:10
     |
-591 | #[derive(IntoBytes)]
+638 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -463,9 +466,9 @@ help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
-   --> $DIR/enum.rs:598:10
+   --> $DIR/enum.rs:647:10
     |
-598 | #[derive(IntoBytes)]
+647 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -481,22 +484,22 @@ help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic `Self` types are currently not permitted in anonymous constants
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
 note: not a concrete type
-   --> $DIR/enum.rs:619:10
+   --> $DIR/enum.rs:672:10
     |
-619 | #[derive(IntoBytes)]
+672 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
     |
     = note: Consider adding `#[derive(FromBytes)]` to `bool`
@@ -511,14 +514,14 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F, G, H)
             and 79 others
 note: required for `FooU8` to implement `FromBytes`
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_is_from_bytes`
-   --> $DIR/enum.rs:217:10
+   --> $DIR/enum.rs:247:10
     |
-217 | #[derive(FromBytes)]
+247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.msrv.stderr
+++ b/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.msrv.stderr
@@ -2,12 +2,12 @@ error: FromBytes only supported on repr(u8) enum with 256 variants
    --> $DIR/enum_from_bytes_u8_too_few.rs:15:1
     |
 15  | / #[zerocopy(crate = "zerocopy_renamed")]
-16  | | #[repr(u8)]
-17  | | enum Foo {
-18  | |     Variant0,
+16  | |
+17  | | #[repr(u8)]
+18  | | enum Foo {
 ...   |
-272 | |     Variant254,
-273 | | }
+273 | |     Variant254,
+274 | | }
     | |_^
 
 error: aborting due to previous error

--- a/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.nightly.stderr
+++ b/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.nightly.stderr
@@ -2,12 +2,12 @@ error: FromBytes only supported on repr(u8) enum with 256 variants
    --> $DIR/enum_from_bytes_u8_too_few.rs:15:1
     |
  15 | / #[zerocopy(crate = "zerocopy_renamed")]
- 16 | | #[repr(u8)]
- 17 | | enum Foo {
- 18 | |     Variant0,
+ 16 | |
+ 17 | | #[repr(u8)]
+ 18 | | enum Foo {
 ...   |
-272 | |     Variant254,
-273 | | }
+273 | |     Variant254,
+274 | | }
     | |_^
 
 error: aborting due to 1 previous error

--- a/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.rs
+++ b/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.rs
@@ -13,6 +13,7 @@ fn main() {}
 
 #[derive(FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
+//~[msrv, stable, nightly]^ ERROR: FromBytes only supported on repr(u8) enum with 256 variants
 #[repr(u8)]
 enum Foo {
     Variant0,

--- a/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.stable.stderr
+++ b/zerocopy-derive/tests/ui/enum_from_bytes_u8_too_few.stable.stderr
@@ -2,12 +2,12 @@ error: FromBytes only supported on repr(u8) enum with 256 variants
    --> $DIR/enum_from_bytes_u8_too_few.rs:15:1
     |
  15 | / #[zerocopy(crate = "zerocopy_renamed")]
- 16 | | #[repr(u8)]
- 17 | | enum Foo {
- 18 | |     Variant0,
+ 16 | |
+ 17 | | #[repr(u8)]
+ 18 | | enum Foo {
 ...   |
-272 | |     Variant254,
-273 | | }
+273 | |     Variant254,
+274 | | }
     | |_^
 
 error: aborting due to 1 previous error

--- a/zerocopy-derive/tests/ui/late_compile_pass.msrv.stderr
+++ b/zerocopy-derive/tests/ui/late_compile_pass.msrv.stderr
@@ -16,85 +16,85 @@ error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is n
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromZeros` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:59:10
+  --> $DIR/late_compile_pass.rs:70:10
    |
-59 | #[derive(IntoBytes)]
+70 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:70:10
+  --> $DIR/late_compile_pass.rs:83:10
    |
-70 | #[derive(Unaligned)]
+83 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:79:10
+  --> $DIR/late_compile_pass.rs:93:10
    |
-79 | #[derive(Unaligned)]
+93 | #[derive(Unaligned)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:87:10
-   |
-87 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
-   |
-   = help: see issue #48214
-   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/late_compile_pass.rs:102:10
+    |
+102 | #[derive(Unaligned)]
+    |          ^^^^^^^^^ the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
+    |
+    = help: see issue #48214
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors; 1 warning emitted
 

--- a/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
+++ b/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
@@ -36,9 +36,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
@@ -65,9 +65,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -94,9 +94,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
@@ -123,9 +123,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -152,9 +152,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -181,9 +181,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:59:10
+  --> $DIR/late_compile_pass.rs:70:10
    |
-59 | #[derive(IntoBytes)]
+70 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
@@ -210,9 +210,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:70:10
+  --> $DIR/late_compile_pass.rs:83:10
    |
-70 | #[derive(Unaligned)]
+83 | #[derive(Unaligned)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -239,9 +239,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:79:10
+  --> $DIR/late_compile_pass.rs:93:10
    |
-79 | #[derive(Unaligned)]
+93 | #[derive(Unaligned)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -268,38 +268,38 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:87:10
-   |
-87 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ unsatisfied trait bound
-   |
+   --> $DIR/late_compile_pass.rs:102:10
+    |
+102 | #[derive(Unaligned)]
+    |          ^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
-   = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `zerocopy_renamed::Unaligned`:
-             ()
-             AtomicBool
-             AtomicI8
-             AtomicU8
-             Cell<T>
-             F32<O>
-             F64<O>
-             I128<O>
-           and 29 others
-   = help: see issue #48214
-   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
+    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
+    = help: the following other types implement trait `zerocopy_renamed::Unaligned`:
+              ()
+              AtomicBool
+              AtomicI8
+              AtomicU8
+              Cell<T>
+              F32<O>
+              F64<O>
+              I128<O>
+            and 29 others
+    = help: see issue #48214
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
-   |
- 9 + #![feature(trivial_bounds)]
-   |
+    |
+  9 + #![feature(trivial_bounds)]
+    |
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -319,14 +319,14 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F, G, H)
            and 80 others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_bit_valid::assert_is_from_bytes`
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/late_compile_pass.rs
+++ b/zerocopy-derive/tests/ui/late_compile_pass.rs
@@ -27,6 +27,8 @@ fn main() {}
 //
 
 #[derive(TryFromBytes)]
+//~[msrv]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
+//~[stable, nightly]^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 struct TryFromBytes1 {
     value: NotZerocopy,
@@ -37,6 +39,9 @@ struct TryFromBytes1 {
 //
 
 #[derive(FromZeros)]
+//~[msrv]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
+//~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: FromZeros` is not satisfied
+//~[stable, nightly]^^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 struct FromZeros1 {
     value: NotZerocopy,
@@ -47,6 +52,12 @@ struct FromZeros1 {
 //
 
 #[derive(FromBytes)]
+//~[msrv]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
+//~[msrv, stable, nightly]^^ ERROR: the trait bound `NotZerocopy: FromZeros` is not satisfied
+//~[msrv]^^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
+//~[stable, nightly]^^^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
+//~[stable, nightly]^^^^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
+//~[stable, nightly]^^^^^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 struct FromBytes1 {
     value: NotZerocopy,
@@ -57,6 +68,8 @@ struct FromBytes1 {
 //
 
 #[derive(IntoBytes)]
+//~[msrv]^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
+//~[stable, nightly]^^ ERROR: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 struct IntoBytes1 {
@@ -68,6 +81,7 @@ struct IntoBytes1 {
 //
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 struct Unaligned1 {
@@ -77,6 +91,7 @@ struct Unaligned1 {
 // This specifically tests a bug we had in an old version of the code in which
 // the trait bound would only be enforced for the first field's type.
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 struct Unaligned2 {
@@ -85,6 +100,7 @@ struct Unaligned2 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(transparent)]
 struct Unaligned3 {

--- a/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
+++ b/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
@@ -32,9 +32,9 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
@@ -57,9 +57,9 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:39:10
+  --> $DIR/late_compile_pass.rs:41:10
    |
-39 | #[derive(FromZeros)]
+41 | #[derive(FromZeros)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -82,9 +82,9 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZerocopy`
@@ -107,9 +107,9 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `FromZeros` is not implemented for `NotZerocopy`
@@ -132,9 +132,9 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -157,9 +157,9 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:59:10
+  --> $DIR/late_compile_pass.rs:70:10
    |
-59 | #[derive(IntoBytes)]
+70 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocopy`
@@ -182,9 +182,9 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:70:10
+  --> $DIR/late_compile_pass.rs:83:10
    |
-70 | #[derive(Unaligned)]
+83 | #[derive(Unaligned)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -207,9 +207,9 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:79:10
+  --> $DIR/late_compile_pass.rs:93:10
    |
-79 | #[derive(Unaligned)]
+93 | #[derive(Unaligned)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -232,34 +232,34 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-  --> $DIR/late_compile_pass.rs:87:10
-   |
-87 | #[derive(Unaligned)]
-   |          ^^^^^^^^^ unsatisfied trait bound
-   |
+   --> $DIR/late_compile_pass.rs:102:10
+    |
+102 | #[derive(Unaligned)]
+    |          ^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
-   = note: Consider adding `#[derive(Unaligned)]` to `AU16`
-   = help: the following other types implement trait `zerocopy_renamed::Unaligned`:
-             ()
-             AtomicBool
-             AtomicI8
-             AtomicU8
-             Cell<T>
-             F32<O>
-             F64<O>
-             I128<O>
-           and 29 others
-   = help: see issue #48214
-   = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
+    = note: Consider adding `#[derive(Unaligned)]` to `AU16`
+    = help: the following other types implement trait `zerocopy_renamed::Unaligned`:
+              ()
+              AtomicBool
+              AtomicI8
+              AtomicU8
+              Cell<T>
+              F32<O>
+              F64<O>
+              I128<O>
+            and 29 others
+    = help: see issue #48214
+    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocopy`
@@ -279,14 +279,14 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F, G, H)
            and 80 others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_bit_valid::assert_is_from_bytes`
-  --> $DIR/late_compile_pass.rs:49:10
+  --> $DIR/late_compile_pass.rs:54:10
    |
-49 | #[derive(FromBytes)]
+54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/mid_compile_pass.msrv.stderr
+++ b/zerocopy-derive/tests/ui/mid_compile_pass.msrv.stderr
@@ -1,18 +1,18 @@
 error[E0277]: the trait bound `T: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:63:26
+  --> $DIR/mid_compile_pass.rs:67:26
    |
-63 | fn test_kl13<T>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T>(t: T) -> impl KnownLayout {
    |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`
    |
 note: required because of the requirements on the impl of `KnownLayout` for `KL13<T>`
-  --> $DIR/mid_compile_pass.rs:58:10
+  --> $DIR/mid_compile_pass.rs:62:10
    |
-58 | #[derive(KnownLayout)]
+62 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-63 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
    |               +++++++++++++++++++++++++++++++
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -46,22 +46,22 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    | 
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/mid_compile_pass.rs:42:15
+  --> $DIR/mid_compile_pass.rs:43:15
    |
-41 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
    |              - this type parameter needs to be `std::marker::Sized`
-42 |     assert_kl(kl);
+43 |     assert_kl(kl);
    |               ^^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `KL06<T>`
-  --> $DIR/mid_compile_pass.rs:39:8
+  --> $DIR/mid_compile_pass.rs:40:8
    |
-39 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
+40 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
    |        ^^^^
 note: required because of the requirements on the impl of `KnownLayout` for `KL06<T>`
-  --> $DIR/mid_compile_pass.rs:37:10
+  --> $DIR/mid_compile_pass.rs:38:10
    |
-37 | #[derive(KnownLayout)]
+38 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26
@@ -71,23 +71,23 @@ note: required by a bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-41 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
-41 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
+42 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    | 
 
 error[E0277]: the trait bound `T: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:53:15
+  --> $DIR/mid_compile_pass.rs:55:15
    |
-53 |     assert_kl(kl)
+55 |     assert_kl(kl)
    |               ^^
    |               |
    |               expected an implementor of trait `KnownLayout`
    |               help: consider borrowing here: `&kl`
    |
 note: required because of the requirements on the impl of `KnownLayout` for `KL12<T>`
-  --> $DIR/mid_compile_pass.rs:47:10
+  --> $DIR/mid_compile_pass.rs:49:10
    |
-47 | #[derive(KnownLayout)]
+49 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26

--- a/zerocopy-derive/tests/ui/mid_compile_pass.nightly.stderr
+++ b/zerocopy-derive/tests/ui/mid_compile_pass.nightly.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the trait bound `T: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:63:26
+  --> $DIR/mid_compile_pass.rs:67:26
    |
-63 | fn test_kl13<T>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T>(t: T) -> impl KnownLayout {
    |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`
-64 |     KL13(0u8, t)
+68 |
+69 |     KL13(0u8, t)
    |     ------------ return type was inferred to be `KL13<T>` here
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `T`
 note: required for `KL13<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:58:10
+  --> $DIR/mid_compile_pass.rs:62:10
    |
-58 | #[derive(KnownLayout)]
+62 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `KnownLayout`
    |
-63 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
    |               +++++++++++++++++++++++++++++++
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -51,24 +52,24 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/mid_compile_pass.rs:42:15
+  --> $DIR/mid_compile_pass.rs:43:15
    |
-41 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
    |              - this type parameter needs to be `Sized`
-42 |     assert_kl(kl);
+43 |     assert_kl(kl);
    |     --------- ^^ doesn't have a size known at compile-time
    |     |
    |     required by a bound introduced by this call
    |
 note: required because it appears within the type `KL06<T>`
-  --> $DIR/mid_compile_pass.rs:39:8
+  --> $DIR/mid_compile_pass.rs:40:8
    |
-39 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
+40 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
    |        ^^^^
 note: required for `KL06<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:37:10
+  --> $DIR/mid_compile_pass.rs:38:10
    |
-37 | #[derive(KnownLayout)]
+38 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26
@@ -78,22 +79,22 @@ note: required by a bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-41 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
-41 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
+42 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    |
 
 error[E0277]: the trait bound `KL12<T>: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:53:15
+  --> $DIR/mid_compile_pass.rs:55:15
    |
-53 |     assert_kl(kl)
+55 |     assert_kl(kl)
    |     --------- ^^ the trait `KnownLayout` is not implemented for `KL12<T>`
    |     |
    |     required by a bound introduced by this call
    |
 note: required for `KL12<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:47:10
+  --> $DIR/mid_compile_pass.rs:49:10
    |
-47 | #[derive(KnownLayout)]
+49 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26
@@ -103,9 +104,9 @@ note: required by a bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
-53 |     assert_kl(&kl)
+55 |     assert_kl(&kl)
    |               +
-53 |     assert_kl(&mut kl)
+55 |     assert_kl(&mut kl)
    |               ++++
 
 error: aborting due to 4 previous errors

--- a/zerocopy-derive/tests/ui/mid_compile_pass.rs
+++ b/zerocopy-derive/tests/ui/mid_compile_pass.rs
@@ -22,28 +22,30 @@ fn main() {}
 
 fn assert_kl<T: ?Sized + KnownLayout>(_: &T) {}
 
-// | `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
-// |          N |        Y |              N |        N |      KL04 |
+// -| `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
+// -|          N |        Y |              N |        N |      KL04 |
 #[derive(KnownLayout)]
 #[zerocopy(crate = "zerocopy_renamed")]
 struct KL04<T: ?Sized>(u8, T);
 
 fn test_kl04<T: ?Sized>(kl: &KL04<T>) {
     assert_kl(kl);
+    //~[msrv, stable, nightly]^ ERROR: the size for values of type `T` cannot be known at compilation time
 }
 
-// | `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
-// |          N |        Y |              Y |        N |      KL06 |
+// -| `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
+// -|          N |        Y |              Y |        N |      KL06 |
 #[derive(KnownLayout)]
 #[zerocopy(crate = "zerocopy_renamed")]
 struct KL06<T: ?Sized + KnownLayout>(u8, T);
 
 fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
     assert_kl(kl);
+    //~[msrv, stable, nightly]^ ERROR: the size for values of type `T` cannot be known at compilation time
 }
 
-// | `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
-// |          Y |        Y |              N |        N |      KL12 |
+// -| `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
+// -|          Y |        Y |              N |        N |      KL12 |
 #[derive(KnownLayout)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
@@ -51,15 +53,18 @@ struct KL12<T: ?Sized>(u8, T);
 
 fn test_kl12<T: ?Sized>(kl: &KL12<T>) {
     assert_kl(kl)
+    //~[msrv]^ ERROR: the trait bound `T: KnownLayout` is not satisfied
+    //~[stable, nightly]^^ ERROR: the trait bound `KL12<T>: KnownLayout` is not satisfied
 }
 
-// | `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
-// |          Y |        Y |              N |        Y |      KL13 |
+// -| `repr(C)`? | generic? | `KnownLayout`? | `Sized`? | Type Name |
+// -|          Y |        Y |              N |        Y |      KL13 |
 #[derive(KnownLayout)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 struct KL13<T>(u8, T);
 
 fn test_kl13<T>(t: T) -> impl KnownLayout {
+    //~[msrv, stable, nightly]^ ERROR: the trait bound `T: KnownLayout` is not satisfied
     KL13(0u8, t)
 }

--- a/zerocopy-derive/tests/ui/mid_compile_pass.stable.stderr
+++ b/zerocopy-derive/tests/ui/mid_compile_pass.stable.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the trait bound `T: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:63:26
+  --> $DIR/mid_compile_pass.rs:67:26
    |
-63 | fn test_kl13<T>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T>(t: T) -> impl KnownLayout {
    |                          ^^^^^^^^^^^^^^^^ the trait `KnownLayout` is not implemented for `T`
-64 |     KL13(0u8, t)
+68 |
+69 |     KL13(0u8, t)
    |     ------------ return type was inferred to be `KL13<T>` here
    |
    = note: Consider adding `#[derive(KnownLayout)]` to `T`
 note: required for `KL13<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:58:10
+  --> $DIR/mid_compile_pass.rs:62:10
    |
-58 | #[derive(KnownLayout)]
+62 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `KnownLayout`
    |
-63 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
+67 | fn test_kl13<T: zerocopy_renamed::KnownLayout>(t: T) -> impl KnownLayout {
    |               +++++++++++++++++++++++++++++++
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
@@ -51,24 +52,24 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/mid_compile_pass.rs:42:15
+  --> $DIR/mid_compile_pass.rs:43:15
    |
-41 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 | fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
    |              - this type parameter needs to be `Sized`
-42 |     assert_kl(kl);
+43 |     assert_kl(kl);
    |     --------- ^^ doesn't have a size known at compile-time
    |     |
    |     required by a bound introduced by this call
    |
 note: required because it appears within the type `KL06<T>`
-  --> $DIR/mid_compile_pass.rs:39:8
+  --> $DIR/mid_compile_pass.rs:40:8
    |
-39 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
+40 | struct KL06<T: ?Sized + KnownLayout>(u8, T);
    |        ^^^^
 note: required for `KL06<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:37:10
+  --> $DIR/mid_compile_pass.rs:38:10
    |
-37 | #[derive(KnownLayout)]
+38 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26
@@ -78,22 +79,22 @@ note: required by a bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-41 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
-41 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
+42 - fn test_kl06<T: ?Sized + KnownLayout>(kl: &KL06<T>) {
+42 + fn test_kl06<T: KnownLayout>(kl: &KL06<T>) {
    |
 
 error[E0277]: the trait bound `KL12<T>: KnownLayout` is not satisfied
-  --> $DIR/mid_compile_pass.rs:53:15
+  --> $DIR/mid_compile_pass.rs:55:15
    |
-53 |     assert_kl(kl)
+55 |     assert_kl(kl)
    |     --------- ^^ the trait `KnownLayout` is not implemented for `KL12<T>`
    |     |
    |     required by a bound introduced by this call
    |
 note: required for `KL12<T>` to implement `KnownLayout`
-  --> $DIR/mid_compile_pass.rs:47:10
+  --> $DIR/mid_compile_pass.rs:49:10
    |
-47 | #[derive(KnownLayout)]
+49 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `assert_kl`
   --> $DIR/mid_compile_pass.rs:23:26
@@ -103,9 +104,9 @@ note: required by a bound in `assert_kl`
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
-53 |     assert_kl(&kl)
+55 |     assert_kl(&kl)
    |               +
-53 |     assert_kl(&mut kl)
+55 |     assert_kl(&mut kl)
    |               ++++
 
 error: aborting due to 4 previous errors

--- a/zerocopy-derive/tests/ui/msrv_specific.rs
+++ b/zerocopy-derive/tests/ui/msrv_specific.rs
@@ -35,5 +35,6 @@ struct IntoBytes1<T> {
 fn is_into_bytes_1<T: IntoBytes>() {
     if false {
         is_into_bytes_1::<IntoBytes1<AU16>>();
+        //~[msrv, stable, nightly]^ ERROR: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
     }
 }

--- a/zerocopy-derive/tests/ui/privacy.msrv.stderr
+++ b/zerocopy-derive/tests/ui/privacy.msrv.stderr
@@ -1,71 +1,71 @@
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:96:9
-   |
-96 |         _,
-   |         ^
-   |
-   = help: const arguments cannot yet be inferred with `_`
-
-error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:101:9
+   --> $DIR/privacy.rs:105:9
     |
-101 |         _,
+105 |         _,
     |         ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:109:9
+   --> $DIR/privacy.rs:112:9
     |
-109 |         _,
+112 |         _,
     |         ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:114:9
+   --> $DIR/privacy.rs:121:9
     |
-114 |         _,
+121 |         _,
     |         ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:120:52
+   --> $DIR/privacy.rs:128:9
     |
-120 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
+128 |         _,
+    |         ^
+    |
+    = help: const arguments cannot yet be inferred with `_`
+
+error[E0747]: type provided when a constant was expected
+   --> $DIR/privacy.rs:135:52
+    |
+135 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
     |                                                    ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:122:52
+   --> $DIR/privacy.rs:138:52
     |
-122 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
     |                                                    ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:127:51
+   --> $DIR/privacy.rs:145:51
     |
-127 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type =
+145 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type =
     |                                                   ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:129:51
+   --> $DIR/privacy.rs:148:51
     |
-129 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type =
+148 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type =
     |                                                   ^
     |
     = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-   --> $DIR/privacy.rs:132:51
+   --> $DIR/privacy.rs:152:51
     |
-132 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
+152 |     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
     |                                                   ^
     |
     = help: const arguments cannot yet be inferred with `_`
@@ -79,65 +79,65 @@ error[E0747]: type provided when a constant was expected
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:36:13
+  --> $DIR/privacy.rs:37:13
    |
-36 |             _,
+37 |             _,
    |             ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:48:13
+  --> $DIR/privacy.rs:50:13
    |
-48 |             _,
+50 |             _,
    |             ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:53:13
+  --> $DIR/privacy.rs:56:13
    |
-53 |             _,
+56 |             _,
    |             ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:66:56
+  --> $DIR/privacy.rs:70:56
    |
-66 |         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
+70 |         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
    |                                                        ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:67:56
+  --> $DIR/privacy.rs:72:56
    |
-67 |         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type = 0u16;
+72 |         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type = 0u16;
    |                                                        ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:79:55
+  --> $DIR/privacy.rs:85:55
    |
-79 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type = 0u8;
+85 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type = 0u8;
    |                                                       ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:80:55
+  --> $DIR/privacy.rs:87:55
    |
-80 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type = 0u16;
+87 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type = 0u16;
    |                                                       ^
    |
    = help: const arguments cannot yet be inferred with `_`
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/privacy.rs:82:55
+  --> $DIR/privacy.rs:90:55
    |
-82 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
+90 |         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
    |                                                       ^
    |
    = help: const arguments cannot yet be inferred with `_`

--- a/zerocopy-derive/tests/ui/privacy.nightly.stderr
+++ b/zerocopy-derive/tests/ui/privacy.nightly.stderr
@@ -1,31 +1,31 @@
 warning: variants `A` and `B` are never constructed
-  --> $DIR/privacy.rs:74:9
+  --> $DIR/privacy.rs:80:9
    |
-73 |     pub enum Enum {
+79 |     pub enum Enum {
    |              ---- variants in this enum
-74 |         A(u8, u16),
+80 |         A(u8, u16),
    |         ^
-75 |         B { a: u8, b: u16 },
+81 |         B { a: u8, b: u16 },
    |         ^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 error: type `private::_::_::_::ẕb` is private
-   --> $DIR/privacy.rs:100:9
+   --> $DIR/privacy.rs:110:9
     |
-100 |         _,
+110 |         _,
     |         ^ private type
 
 error: type `private::_::_::_::ẕ1` is private
-   --> $DIR/privacy.rs:113:9
+   --> $DIR/privacy.rs:126:9
     |
-113 |         _,
+126 |         _,
     |         ^ private type
 
 error: type `private::_::_::_::ẕb` is private
-   --> $DIR/privacy.rs:122:49
+   --> $DIR/privacy.rs:138:49
     |
-122 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
     |                                                 ^ private type
 
 error: aborting due to 3 previous errors; 1 warning emitted

--- a/zerocopy-derive/tests/ui/privacy.rs
+++ b/zerocopy-derive/tests/ui/privacy.rs
@@ -29,11 +29,13 @@ mod private {
         let _: <StructWithNamedFields as zerocopy_renamed::HasField<
             _,
             _,
+            //~[msrv]^ ERROR: type provided when a constant was expected
             { zerocopy_renamed::ident_id!(a) },
         >>::Type = 0u8;
         let _: <StructWithNamedFields as zerocopy_renamed::HasField<
             _,
             _,
+            //~[msrv]^ ERROR: type provided when a constant was expected
             { zerocopy_renamed::ident_id!(b) },
         >>::Type = 0u16;
     };
@@ -46,11 +48,13 @@ mod private {
         let _: <StructWithAnonFields as zerocopy_renamed::HasField<
             _,
             _,
+            //~[msrv]^ ERROR: type provided when a constant was expected
             { zerocopy_renamed::ident_id!(0) },
         >>::Type = 0u8;
         let _: <StructWithAnonFields as zerocopy_renamed::HasField<
             _,
             _,
+            //~[msrv]^ ERROR: type provided when a constant was expected
             { zerocopy_renamed::ident_id!(1) },
         >>::Type = 0u16;
     };
@@ -64,7 +68,9 @@ mod private {
 
     const _: () = {
         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
+        //~[msrv]^ ERROR: type provided when a constant was expected
         let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type = 0u16;
+        //~[msrv]^ ERROR: type provided when a constant was expected
     };
 
     #[derive(TryFromBytes)]
@@ -77,9 +83,12 @@ mod private {
 
     const _: () = {
         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type = 0u8;
+        //~[msrv]^ ERROR: type provided when a constant was expected
         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type = 0u16;
+        //~[msrv]^ ERROR: type provided when a constant was expected
 
         let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type = 0u8;
+        //~[msrv]^ ERROR: type provided when a constant was expected
         let _: <Enum as zerocopy_renamed::HasField<
             _,
             { zerocopy_renamed::ident_id!(B) },
@@ -94,11 +103,14 @@ const _: () = {
     let _: <StructWithNamedFields as zerocopy_renamed::HasField<
         _,
         _,
+        //~[msrv]^ ERROR: type provided when a constant was expected
         { zerocopy_renamed::ident_id!(a) },
     >>::Type = 0u8;
     let _: <StructWithNamedFields as zerocopy_renamed::HasField<
         _,
+        //~[stable, nightly]^ ERROR: type `private::_::_::_::ẕb` is private
         _,
+        //~[msrv]^ ERROR: type provided when a constant was expected
         { zerocopy_renamed::ident_id!(b) },
     >>::Type = 0u16;
 };
@@ -107,29 +119,38 @@ const _: () = {
     let _: <StructWithAnonFields as zerocopy_renamed::HasField<
         _,
         _,
+        //~[msrv]^ ERROR: type provided when a constant was expected
         { zerocopy_renamed::ident_id!(0) },
     >>::Type = 0u8;
     let _: <StructWithAnonFields as zerocopy_renamed::HasField<
         _,
+        //~[stable, nightly]^ ERROR: type `private::_::_::_::ẕ1` is private
         _,
+        //~[msrv]^ ERROR: type provided when a constant was expected
         { zerocopy_renamed::ident_id!(1) },
     >>::Type = 0u16;
 };
 
 const _: () = {
     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
+//~[msrv]^ ERROR: type provided when a constant was expected
         0u8;
     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+//~[msrv]^ ERROR: type provided when a constant was expected
+//~[stable, nightly]^^ ERROR: type `private::_::_::_::ẕb` is private
         0u16;
 };
 
 const _: () = {
     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(0) }>>::Type =
+//~[msrv]^ ERROR: type provided when a constant was expected
         0u8;
     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(1) }>>::Type =
+//~[msrv]^ ERROR: type provided when a constant was expected
         0u16;
 
     let _: <Enum as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(a) }>>::Type =
+//~[msrv]^ ERROR: type provided when a constant was expected
         0u8;
     let _: <Enum as zerocopy_renamed::HasField<
         _,

--- a/zerocopy-derive/tests/ui/privacy.stable.stderr
+++ b/zerocopy-derive/tests/ui/privacy.stable.stderr
@@ -1,31 +1,31 @@
 warning: variants `A` and `B` are never constructed
-  --> $DIR/privacy.rs:74:9
+  --> $DIR/privacy.rs:80:9
    |
-73 |     pub enum Enum {
+79 |     pub enum Enum {
    |              ---- variants in this enum
-74 |         A(u8, u16),
+80 |         A(u8, u16),
    |         ^
-75 |         B { a: u8, b: u16 },
+81 |         B { a: u8, b: u16 },
    |         ^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 error: type `private::_::_::_::ẕb` is private
-   --> $DIR/privacy.rs:100:9
+   --> $DIR/privacy.rs:110:9
     |
-100 |         _,
+110 |         _,
     |         ^ private type
 
 error: type `private::_::_::_::ẕ1` is private
-   --> $DIR/privacy.rs:113:9
+   --> $DIR/privacy.rs:126:9
     |
-113 |         _,
+126 |         _,
     |         ^ private type
 
 error: type `private::_::_::_::ẕb` is private
-   --> $DIR/privacy.rs:122:49
+   --> $DIR/privacy.rs:138:49
     |
-122 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
     |                                                 ^ private type
 
 error: aborting due to 3 previous errors; 1 warning emitted

--- a/zerocopy-derive/tests/ui/struct.msrv.stderr
+++ b/zerocopy-derive/tests/ui/struct.msrv.stderr
@@ -1,15 +1,15 @@
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:185:11
+   --> $DIR/struct.rs:210:11
     |
-185 | #[repr(C, C)] /$RUSTUP_TOOLCHAIN/lib/rustlib/src/rust/library/core/src/mem/mod.rs:303:22
+210 | #[repr(C, C)] /$RUSTUP_TOOLCHAIN/lib/rustlib/src/rust/library/core/src/mem/mod.rs:303:22
     |
 303 | pub const fn size_of<T>() -> usize {
     |                      ^ required by this bound in `std::mem::size_of`
 
 error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes5, true>` is not satisfied
-   --> $DIR/struct.rs:153:10
+   --> $DIR/struct.rs:172:10
     |
-153 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -18,9 +18,9 @@ error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes5, true>` is not 
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes6, true>` is not satisfied
-   --> $DIR/struct.rs:163:10
+   --> $DIR/struct.rs:184:10
     |
-163 | #[derive(IntoBytes)]
+184 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -29,9 +29,9 @@ error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes6, true>` is not 
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes7, true>` is not satisfied
-   --> $DIR/struct.rs:174:10
+   --> $DIR/struct.rs:197:10
     |
-174 | #[derive(IntoBytes)]
+197 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
     |
     = help: the following implementations were found:
@@ -40,9 +40,9 @@ error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes7, true>` is not 
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:278:10
+   --> $DIR/struct.rs:319:10
     |
-278 | #[derive(SplitAt)]
+319 | #[derive(SplitAt)]
     |          ^^^^^^^ the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
     |
 note: required by a bound in `SplitAt`
@@ -53,18 +53,18 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:283:10
+   --> $DIR/struct.rs:325:10
     |
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<u8 as zerocopy_renamed::KnownLayout>::PointerMetadata == usize`
-   --> $DIR/struct.rs:283:10
+   --> $DIR/struct.rs:325:10
     |
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ expected `()`, found `usize`
     |
     = help: see issue #48214

--- a/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -1,93 +1,94 @@
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:185:8
+   --> $DIR/struct.rs:210:8
     |
-185 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+210 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
     |        ^^^^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:190:10
+   --> $DIR/struct.rs:216:10
     |
-190 | #[derive(IntoBytes)]
+216 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:196:10
+   --> $DIR/struct.rs:223:10
     |
-196 | #[derive(IntoBytes)]
+223 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:221:10
+   --> $DIR/struct.rs:250:10
     |
-221 | #[derive(IntoBytes)]
+250 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/struct.rs:234:11
+   --> $DIR/struct.rs:264:11
     |
-234 | #[repr(C, align(2))]
+264 | #[repr(C, align(2))]
     |           ^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:239:8
+   --> $DIR/struct.rs:270:8
     |
-239 | #[repr(transparent, align(2))]
+270 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:246:8
+   --> $DIR/struct.rs:279:8
     |
-246 | #[repr(packed, align(2))]
+279 | #[repr(packed, align(2))]
     |        ^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:251:8
+   --> $DIR/struct.rs:286:8
     |
-251 | #[repr(align(1), align(2))]
+286 | #[repr(align(1), align(2))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:256:8
+   --> $DIR/struct.rs:292:8
     |
-256 | #[repr(align(2), align(4))]
+292 | #[repr(align(2), align(4))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:259:10
+   --> $DIR/struct.rs:296:10
     |
-259 | #[derive(Unaligned)]
+296 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:263:10
+   --> $DIR/struct.rs:301:10
     |
-263 | #[derive(Unaligned)]
+301 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:272:19
+   --> $DIR/struct.rs:311:19
     |
-272 |   #[repr(packed(2), C)]
+311 |   #[repr(packed(2), C)]
     |  ___________________^
-273 | | #[derive(Unaligned)]
-274 | | #[zerocopy(crate = "zerocopy_renamed")]
-275 | | #[repr(C, packed(2))]
+312 | |
+313 | | #[derive(Unaligned)]
+314 | | #[zerocopy(crate = "zerocopy_renamed")]
+315 | | #[repr(C, packed(2))]
     | |________^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> $DIR/struct.rs:239:8
+   --> $DIR/struct.rs:270:8
     |
-239 | #[repr(transparent, align(2))]
+270 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -98,9 +99,9 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: within `KL00`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `KL00`
-  --> $DIR/struct.rs:33:8
+  --> $DIR/struct.rs:34:8
    |
-33 | struct KL00(u8, NotKnownLayoutDst);
+34 | struct KL00(u8, NotKnownLayoutDst);
    |        ^^^^
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -110,16 +111,16 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/struct.rs:37:10
+  --> $DIR/struct.rs:38:10
    |
-37 | #[derive(KnownLayout)]
+38 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `KL02`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `KL02`
-  --> $DIR/struct.rs:39:8
+  --> $DIR/struct.rs:41:8
    |
-39 | struct KL02(u8, [u8]);
+41 | struct KL02(u8, [u8]);
    |        ^^^^
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -129,9 +130,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy_renamed::KnownLayout` is not satisfied
-  --> $DIR/struct.rs:43:10
+  --> $DIR/struct.rs:45:10
    |
-43 | #[derive(KnownLayout)]
+45 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnownLayoutDst`
@@ -158,9 +159,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `NotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-  --> $DIR/struct.rs:50:10
+  --> $DIR/struct.rs:53:10
    |
-50 | #[derive(KnownLayout)]
+53 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnownLayout`
@@ -187,9 +188,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is not satisfied
-  --> $DIR/struct.rs:59:10
+  --> $DIR/struct.rs:63:10
    |
-59 | #[derive(Immutable)]
+63 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Immutable` is not implemented for `UnsafeCell<()>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<()>`
@@ -211,9 +212,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is not satisfied
-  --> $DIR/struct.rs:65:10
+  --> $DIR/struct.rs:70:10
    |
-65 | #[derive(Immutable)]
+70 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<u8>`
@@ -236,22 +237,10 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:78:1
+  --> $DIR/struct.rs:84:1
    |
-78 | struct TryFromBytesPacked {
+84 | struct TryFromBytesPacked {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: `AU16` has a `#[repr(align)]` attribute
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
-
-error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:85:1
-   |
-85 | struct TryFromBytesPackedN {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `AU16` has a `#[repr(align)]` attribute
   --> $DIR/../include.rs:64:5
@@ -262,7 +251,7 @@ note: `AU16` has a `#[repr(align)]` attribute
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
   --> $DIR/struct.rs:92:1
    |
-92 | struct TryFromBytesCPacked {
+92 | struct TryFromBytesPackedN {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `AU16` has a `#[repr(align)]` attribute
@@ -272,21 +261,33 @@ note: `AU16` has a `#[repr(align)]` attribute
    |     ^^^^^^^^^^^^^^^
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:99:1
-   |
-99 | struct TryFromBytesCPackedN {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
+   --> $DIR/struct.rs:100:1
+    |
+100 | struct TryFromBytesCPacked {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
 note: `AU16` has a `#[repr(align)]` attribute
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
+
+error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
+   --> $DIR/struct.rs:108:1
+    |
+108 | struct TryFromBytesCPackedN {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+note: `AU16` has a `#[repr(align)]` attribute
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-   --> $DIR/struct.rs:110:10
+   --> $DIR/struct.rs:120:10
     |
-110 | #[derive(IntoBytes)]
+120 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -313,9 +314,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
-   --> $DIR/struct.rs:118:10
+   --> $DIR/struct.rs:129:10
     |
-118 | #[derive(IntoBytes)]
+129 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -332,9 +333,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
-   --> $DIR/struct.rs:126:10
+   --> $DIR/struct.rs:139:10
     |
-126 | #[derive(IntoBytes)]
+139 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -351,16 +352,16 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> $DIR/struct.rs:143:10
+   --> $DIR/struct.rs:158:10
     |
-143 | #[derive(IntoBytes)]
+158 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `IntoBytes4`
-   --> $DIR/struct.rs:146:8
+   --> $DIR/struct.rs:163:8
     |
-146 | struct IntoBytes4 {
+163 | struct IntoBytes4 {
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `zerocopy_renamed::util::macro_util::__size_of::Sized`
 note: required by a bound in `zerocopy_renamed::util::macro_util::__size_of::size_of`
@@ -368,9 +369,9 @@ note: required by a bound in `zerocopy_renamed::util::macro_util::__size_of::siz
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
-   --> $DIR/struct.rs:148:8
+   --> $DIR/struct.rs:165:8
     |
-148 |     b: SliceU8,
+165 |     b: SliceU8,
     |        ^^^^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
@@ -381,9 +382,9 @@ note: required by a bound in `zerocopy_renamed::util::macro_util::__size_of::siz
    --> src/util/macro_util.rs:306:4
 
 error[E0277]: `IntoBytes5` has one or more padding bytes
-   --> $DIR/struct.rs:153:10
+   --> $DIR/struct.rs:172:10
     |
-153 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -400,9 +401,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes6` has one or more padding bytes
-   --> $DIR/struct.rs:163:10
+   --> $DIR/struct.rs:184:10
     |
-163 | #[derive(IntoBytes)]
+184 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -419,9 +420,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: `IntoBytes7` has one or more padding bytes
-   --> $DIR/struct.rs:174:10
+   --> $DIR/struct.rs:197:10
     |
-174 | #[derive(IntoBytes)]
+197 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -438,21 +439,21 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> $DIR/struct.rs:247:1
+   --> $DIR/struct.rs:281:1
     |
-247 | struct Unaligned3;
+281 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:278:10
+   --> $DIR/struct.rs:319:10
     |
-278 | #[derive(SplitAt)]
+319 | #[derive(SplitAt)]
     |          ^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
-   --> $DIR/struct.rs:281:1
+   --> $DIR/struct.rs:323:1
     |
-281 | struct SplitAtNotKnownLayout([u8]);
+323 | struct SplitAtNotKnownLayout([u8]);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
     = help: the following other types implement trait `zerocopy_renamed::KnownLayout`:
@@ -470,19 +471,19 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:283:10
+   --> $DIR/struct.rs:325:10
     |
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
 help: the following other types implement trait `SplitAt`
-   --> $DIR/struct.rs:278:10
+   --> $DIR/struct.rs:319:10
     |
-278 | #[derive(SplitAt)]
+319 | #[derive(SplitAt)]
     |          ^^^^^^^ `SplitAtNotKnownLayout`
 ...
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ `SplitAtSized`
    --> src/split_at.rs:207:0
     |
@@ -495,9 +496,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-   --> $DIR/struct.rs:216:28
+   --> $DIR/struct.rs:244:28
     |
-216 |         is_into_bytes_11::<IntoBytes11<AU16>>();
+244 |         is_into_bytes_11::<IntoBytes11<AU16>>();
     |                            ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -517,14 +518,14 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               I128<O>
             and 26 others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
-   --> $DIR/struct.rs:204:10
+   --> $DIR/struct.rs:232:10
     |
-204 | #[derive(IntoBytes)]
+232 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `is_into_bytes_11`
-   --> $DIR/struct.rs:214:24
+   --> $DIR/struct.rs:242:24
     |
-214 | fn is_into_bytes_11<T: IntoBytes>() {
+242 | fn is_into_bytes_11<T: IntoBytes>() {
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -1,89 +1,89 @@
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:185:11
+   --> $DIR/struct.rs:210:11
     |
-185 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
+210 | #[repr(C, C)] // zerocopy-derive conservatively treats these as conflicting reprs
     |           ^
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:190:10
+   --> $DIR/struct.rs:216:10
     |
-190 | #[derive(IntoBytes)]
+216 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:196:10
+   --> $DIR/struct.rs:223:10
     |
-196 | #[derive(IntoBytes)]
+223 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
-   --> $DIR/struct.rs:221:10
+   --> $DIR/struct.rs:250:10
     |
-221 | #[derive(IntoBytes)]
+250 | #[derive(IntoBytes)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/struct.rs:234:11
+   --> $DIR/struct.rs:264:11
     |
-234 | #[repr(C, align(2))]
+264 | #[repr(C, align(2))]
     |           ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:239:8
+   --> $DIR/struct.rs:270:8
     |
-239 | #[repr(transparent, align(2))]
+270 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:246:16
+   --> $DIR/struct.rs:279:16
     |
-246 | #[repr(packed, align(2))]
+279 | #[repr(packed, align(2))]
     |                ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:251:18
+   --> $DIR/struct.rs:286:18
     |
-251 | #[repr(align(1), align(2))]
+286 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:256:18
+   --> $DIR/struct.rs:292:18
     |
-256 | #[repr(align(2), align(4))]
+292 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:259:10
+   --> $DIR/struct.rs:296:10
     |
-259 | #[derive(Unaligned)]
+296 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:263:10
+   --> $DIR/struct.rs:301:10
     |
-263 | #[derive(Unaligned)]
+301 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:275:8
+   --> $DIR/struct.rs:315:8
     |
-275 | #[repr(C, packed(2))]
+315 | #[repr(C, packed(2))]
     |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> $DIR/struct.rs:239:8
+   --> $DIR/struct.rs:270:8
     |
-239 | #[repr(transparent, align(2))]
+270 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -94,32 +94,32 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
    |
    = help: within `KL00`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `KL00`
-  --> $DIR/struct.rs:33:8
+  --> $DIR/struct.rs:34:8
    |
-33 | struct KL00(u8, NotKnownLayoutDst);
+34 | struct KL00(u8, NotKnownLayoutDst);
    |        ^^^^
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/struct.rs:37:10
+  --> $DIR/struct.rs:38:10
    |
-37 | #[derive(KnownLayout)]
+38 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `KL02`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `KL02`
-  --> $DIR/struct.rs:39:8
+  --> $DIR/struct.rs:41:8
    |
-39 | struct KL02(u8, [u8]);
+41 | struct KL02(u8, [u8]);
    |        ^^^^
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotKnownLayoutDst: zerocopy_renamed::KnownLayout` is not satisfied
-  --> $DIR/struct.rs:43:10
+  --> $DIR/struct.rs:45:10
    |
-43 | #[derive(KnownLayout)]
+45 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnownLayoutDst`
@@ -142,9 +142,9 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-  --> $DIR/struct.rs:50:10
+  --> $DIR/struct.rs:53:10
    |
-50 | #[derive(KnownLayout)]
+53 | #[derive(KnownLayout)]
    |          ^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnownLayout`
@@ -167,9 +167,9 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is not satisfied
-  --> $DIR/struct.rs:59:10
+  --> $DIR/struct.rs:63:10
    |
-59 | #[derive(Immutable)]
+63 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Immutable` is not implemented for `UnsafeCell<()>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<()>`
@@ -187,9 +187,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is not satisfied
-  --> $DIR/struct.rs:65:10
+  --> $DIR/struct.rs:70:10
    |
-65 | #[derive(Immutable)]
+70 | #[derive(Immutable)]
    |          ^^^^^^^^^ the trait `zerocopy_renamed::Immutable` is not implemented for `UnsafeCell<u8>`
    |
    = note: Consider adding `#[derive(Immutable)]` to `UnsafeCell<u8>`
@@ -208,22 +208,10 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:78:1
+  --> $DIR/struct.rs:84:1
    |
-78 | struct TryFromBytesPacked {
+84 | struct TryFromBytesPacked {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: `AU16` has a `#[repr(align)]` attribute
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
-
-error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:85:1
-   |
-85 | struct TryFromBytesPackedN {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `AU16` has a `#[repr(align)]` attribute
   --> $DIR/../include.rs:64:5
@@ -234,7 +222,7 @@ note: `AU16` has a `#[repr(align)]` attribute
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
   --> $DIR/struct.rs:92:1
    |
-92 | struct TryFromBytesCPacked {
+92 | struct TryFromBytesPackedN {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `AU16` has a `#[repr(align)]` attribute
@@ -244,21 +232,33 @@ note: `AU16` has a `#[repr(align)]` attribute
    |     ^^^^^^^^^^^^^^^
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-  --> $DIR/struct.rs:99:1
-   |
-99 | struct TryFromBytesCPackedN {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
+   --> $DIR/struct.rs:100:1
+    |
+100 | struct TryFromBytesCPacked {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
 note: `AU16` has a `#[repr(align)]` attribute
-  --> $DIR/../include.rs:64:5
-   |
-64 |     pub struct AU16(pub u16);
-   |     ^^^^^^^^^^^^^^^
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
+
+error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
+   --> $DIR/struct.rs:108:1
+    |
+108 | struct TryFromBytesCPackedN {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+note: `AU16` has a `#[repr(align)]` attribute
+   --> $DIR/../include.rs:64:5
+    |
+ 64 |     pub struct AU16(pub u16);
+    |     ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-   --> $DIR/struct.rs:110:10
+   --> $DIR/struct.rs:120:10
     |
-110 | #[derive(IntoBytes)]
+120 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -281,9 +281,9 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
-   --> $DIR/struct.rs:118:10
+   --> $DIR/struct.rs:129:10
     |
-118 | #[derive(IntoBytes)]
+129 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -299,9 +299,9 @@ help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
-   --> $DIR/struct.rs:126:10
+   --> $DIR/struct.rs:139:10
     |
-126 | #[derive(IntoBytes)]
+139 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -317,16 +317,16 @@ help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-   --> $DIR/struct.rs:143:10
+   --> $DIR/struct.rs:158:10
     |
-143 | #[derive(IntoBytes)]
+158 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ doesn't have a size known at compile-time
     |
     = help: within `IntoBytes4`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `IntoBytes4`
-   --> $DIR/struct.rs:146:8
+   --> $DIR/struct.rs:163:8
     |
-146 | struct IntoBytes4 {
+163 | struct IntoBytes4 {
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`
@@ -337,9 +337,9 @@ note: required by a bound in `macro_util::__size_of::size_of`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
-   --> $DIR/struct.rs:148:8
+   --> $DIR/struct.rs:165:8
     |
-148 |     b: SliceU8,
+165 |     b: SliceU8,
     |        ^^^^^^^ `IntoBytes` needs all field types to be `Sized` in order to determine whether there is padding
     |
     = help: the trait `Sized` is not implemented for `[u8]`
@@ -353,9 +353,9 @@ note: required by a bound in `macro_util::__size_of::size_of`
     |                             ^^^^^ required by this bound in `size_of`
 
 error[E0277]: `IntoBytes5` has one or more padding bytes
-   --> $DIR/struct.rs:153:10
+   --> $DIR/struct.rs:172:10
     |
-153 | #[derive(IntoBytes)]
+172 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -371,9 +371,9 @@ help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `(
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes6` has one or more padding bytes
-   --> $DIR/struct.rs:163:10
+   --> $DIR/struct.rs:184:10
     |
-163 | #[derive(IntoBytes)]
+184 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -389,9 +389,9 @@ help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `(
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes7` has one or more padding bytes
-   --> $DIR/struct.rs:174:10
+   --> $DIR/struct.rs:197:10
     |
-174 | #[derive(IntoBytes)]
+197 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
     |
     = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -407,21 +407,21 @@ help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `(
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> $DIR/struct.rs:247:1
+   --> $DIR/struct.rs:281:1
     |
-247 | struct Unaligned3;
+281 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:278:10
+   --> $DIR/struct.rs:319:10
     |
-278 | #[derive(SplitAt)]
+319 | #[derive(SplitAt)]
     |          ^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
-   --> $DIR/struct.rs:281:1
+   --> $DIR/struct.rs:323:1
     |
-281 | struct SplitAtNotKnownLayout([u8]);
+323 | struct SplitAtNotKnownLayout([u8]);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
     = help: the following other types implement trait `zerocopy_renamed::KnownLayout`:
@@ -442,19 +442,19 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:283:10
+   --> $DIR/struct.rs:325:10
     |
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
 help: the following other types implement trait `SplitAt`
-   --> $DIR/struct.rs:278:10
+   --> $DIR/struct.rs:319:10
     |
-278 | #[derive(SplitAt)]
+319 | #[derive(SplitAt)]
     |          ^^^^^^^ `SplitAtNotKnownLayout`
 ...
-283 | #[derive(SplitAt, KnownLayout)]
+325 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ `SplitAtSized`
     |
    ::: $WORKSPACE/src/split_at.rs:207:1
@@ -465,9 +465,9 @@ help: the following other types implement trait `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `AU16: zerocopy_renamed::Unaligned` is not satisfied
-   --> $DIR/struct.rs:216:28
+   --> $DIR/struct.rs:244:28
     |
-216 |         is_into_bytes_11::<IntoBytes11<AU16>>();
+244 |         is_into_bytes_11::<IntoBytes11<AU16>>();
     |                            ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
@@ -487,14 +487,14 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               I128<O>
             and 26 others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
-   --> $DIR/struct.rs:204:10
+   --> $DIR/struct.rs:232:10
     |
-204 | #[derive(IntoBytes)]
+232 | #[derive(IntoBytes)]
     |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `is_into_bytes_11`
-   --> $DIR/struct.rs:214:24
+   --> $DIR/struct.rs:242:24
     |
-214 | fn is_into_bytes_11<T: IntoBytes>() {
+242 | fn is_into_bytes_11<T: IntoBytes>() {
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy-derive/tests/ui/union.msrv.stderr
+++ b/zerocopy-derive/tests/ui/union.msrv.stderr
@@ -1,63 +1,63 @@
 error: unsupported on types with type parameters
-  --> $DIR/union.rs:35:10
+  --> $DIR/union.rs:36:10
    |
-35 | #[derive(IntoBytes)]
+36 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:51:10
+  --> $DIR/union.rs:55:10
    |
-51 | #[derive(IntoBytes)]
+55 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:58:10
+  --> $DIR/union.rs:63:10
    |
-58 | #[derive(IntoBytes)]
+63 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-  --> $DIR/union.rs:71:11
+  --> $DIR/union.rs:77:11
    |
-71 | #[repr(C, align(2))]
+77 | #[repr(C, align(2))]
    |           ^^^^^
 
 error: this conflicts with another representation hint
-  --> $DIR/union.rs:88:16
+  --> $DIR/union.rs:95:16
    |
-88 | #[repr(packed, align(2))]
+95 | #[repr(packed, align(2))]
    |                ^^^^^
 
 error: this conflicts with another representation hint
-  --> $DIR/union.rs:95:18
-   |
-95 | #[repr(align(1), align(2))]
-   |                  ^^^^^
+   --> $DIR/union.rs:104:18
+    |
+104 | #[repr(align(1), align(2))]
+    |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/union.rs:102:18
+   --> $DIR/union.rs:112:18
     |
-102 | #[repr(align(2), align(4))]
+112 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:107:10
+   --> $DIR/union.rs:118:10
     |
-107 | #[derive(Unaligned)]
+118 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:114:10
+   --> $DIR/union.rs:126:10
     |
-114 | #[derive(Unaligned)]
+126 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -73,9 +73,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `(): PaddingFree<IntoBytes2, 1_usize>` is not satisfied
-  --> $DIR/union.rs:42:10
+  --> $DIR/union.rs:44:10
    |
-42 | #[derive(IntoBytes)]
+44 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ the trait `PaddingFree<IntoBytes2, 1_usize>` is not implemented for `()`
    |
    = help: the following implementations were found:

--- a/zerocopy-derive/tests/ui/union.nightly.stderr
+++ b/zerocopy-derive/tests/ui/union.nightly.stderr
@@ -1,63 +1,63 @@
 error: unsupported on types with type parameters
-  --> $DIR/union.rs:35:10
+  --> $DIR/union.rs:36:10
    |
-35 | #[derive(IntoBytes)]
+36 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:51:10
+  --> $DIR/union.rs:55:10
    |
-51 | #[derive(IntoBytes)]
+55 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:58:10
+  --> $DIR/union.rs:63:10
    |
-58 | #[derive(IntoBytes)]
+63 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-  --> $DIR/union.rs:71:11
+  --> $DIR/union.rs:77:11
    |
-71 | #[repr(C, align(2))]
+77 | #[repr(C, align(2))]
    |           ^^^^^^^^
-
-error: this conflicts with another representation hint
-  --> $DIR/union.rs:88:8
-   |
-88 | #[repr(packed, align(2))]
-   |        ^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
   --> $DIR/union.rs:95:8
    |
-95 | #[repr(align(1), align(2))]
-   |        ^^^^^^^^^^^^^^^^^^
+95 | #[repr(packed, align(2))]
+   |        ^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/union.rs:102:8
+   --> $DIR/union.rs:104:8
     |
-102 | #[repr(align(2), align(4))]
+104 | #[repr(align(1), align(2))]
+    |        ^^^^^^^^^^^^^^^^^^
+
+error: this conflicts with another representation hint
+   --> $DIR/union.rs:112:8
+    |
+112 | #[repr(align(2), align(4))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:107:10
+   --> $DIR/union.rs:118:10
     |
-107 | #[derive(Unaligned)]
+118 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:114:10
+   --> $DIR/union.rs:126:10
     |
-114 | #[derive(Unaligned)]
+126 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -88,9 +88,9 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
-  --> $DIR/union.rs:42:10
+  --> $DIR/union.rs:44:10
    |
-42 | #[derive(IntoBytes)]
+44 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
    |
    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -107,15 +107,15 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/union.rs:89:1
+  --> $DIR/union.rs:97:1
    |
-89 | union Unaligned3 {
+97 | union Unaligned3 {
    | ^^^^^^^^^^^^^^^^
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-   --> $DIR/union.rs:117:1
+   --> $DIR/union.rs:130:1
     |
-117 | union Unaligned7 {
+130 | union Unaligned7 {
     | ^^^^^^^^^^^^^^^^
     |
 note: `AU16` has a `#[repr(align)]` attribute

--- a/zerocopy-derive/tests/ui/union.rs
+++ b/zerocopy-derive/tests/ui/union.rs
@@ -23,6 +23,7 @@ fn main() {}
 //
 
 #[derive(Immutable)]
+//~[msrv, stable, nightly]^ ERROR: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 union Immutable1 {
     a: ManuallyDrop<core::cell::UnsafeCell<()>>,
@@ -33,6 +34,7 @@ union Immutable1 {
 //
 
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: unsupported on types with type parameters
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 union IntoBytes1<T> {
@@ -40,6 +42,8 @@ union IntoBytes1<T> {
 }
 
 #[derive(IntoBytes)]
+//~[msrv]^ ERROR: the trait bound `(): PaddingFree<IntoBytes2, 1_usize>` is not satisfied
+//~[stable, nightly]^^ ERROR: `IntoBytes2` has 1 total byte(s) of padding
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 union IntoBytes2 {
@@ -49,6 +53,7 @@ union IntoBytes2 {
 
 // Need a `repr` attribute
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
 #[zerocopy(crate = "zerocopy_renamed")]
 union IntoBytes3 {
     foo: u8,
@@ -56,6 +61,7 @@ union IntoBytes3 {
 
 // `repr(packed(2))` isn't equivalent to `repr(packed)`
 #[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(packed(2))]
 union IntoBytes4 {
@@ -69,6 +75,7 @@ union IntoBytes4 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C, align(2))]
+//~[msrv, stable, nightly]^ ERROR: cannot derive `Unaligned` on type with alignment greater than 1
 union Unaligned1 {
     foo: i16,
     bar: AU16,
@@ -86,13 +93,16 @@ union Unaligned1 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(packed, align(2))]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
 union Unaligned3 {
+    //~[stable, nightly]^ ERROR: type has conflicting packed and align representation hints
     foo: u8,
 }
 
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(align(1), align(2))]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
 struct Unaligned4 {
     foo: u8,
 }
@@ -100,11 +110,13 @@ struct Unaligned4 {
 #[derive(Unaligned)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(align(2), align(4))]
+//~[msrv, stable, nightly]^ ERROR: this conflicts with another representation hint
 struct Unaligned5 {
     foo: u8,
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 union Unaligned6 {
     foo: i16,
@@ -112,9 +124,11 @@ union Unaligned6 {
 }
 
 #[derive(Unaligned)]
+//~[msrv, stable, nightly]^ ERROR: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(packed(2))]
 union Unaligned7 {
+    //~[stable, nightly]^ ERROR: packed type cannot transitively contain a `#[repr(align)]` type
     foo: i16,
     bar: AU16,
 }

--- a/zerocopy-derive/tests/ui/union.stable.stderr
+++ b/zerocopy-derive/tests/ui/union.stable.stderr
@@ -1,63 +1,63 @@
 error: unsupported on types with type parameters
-  --> $DIR/union.rs:35:10
+  --> $DIR/union.rs:36:10
    |
-35 | #[derive(IntoBytes)]
+36 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:51:10
+  --> $DIR/union.rs:55:10
    |
-51 | #[derive(IntoBytes)]
+55 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]
-  --> $DIR/union.rs:58:10
+  --> $DIR/union.rs:63:10
    |
-58 | #[derive(IntoBytes)]
+63 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot derive `Unaligned` on type with alignment greater than 1
-  --> $DIR/union.rs:71:11
+  --> $DIR/union.rs:77:11
    |
-71 | #[repr(C, align(2))]
+77 | #[repr(C, align(2))]
    |           ^^^^^
 
 error: this conflicts with another representation hint
-  --> $DIR/union.rs:88:16
+  --> $DIR/union.rs:95:16
    |
-88 | #[repr(packed, align(2))]
+95 | #[repr(packed, align(2))]
    |                ^^^^^
 
 error: this conflicts with another representation hint
-  --> $DIR/union.rs:95:18
-   |
-95 | #[repr(align(1), align(2))]
-   |                  ^^^^^
+   --> $DIR/union.rs:104:18
+    |
+104 | #[repr(align(1), align(2))]
+    |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/union.rs:102:18
+   --> $DIR/union.rs:112:18
     |
-102 | #[repr(align(2), align(4))]
+112 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:107:10
+   --> $DIR/union.rs:118:10
     |
-107 | #[derive(Unaligned)]
+118 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/union.rs:114:10
+   --> $DIR/union.rs:126:10
     |
-114 | #[derive(Unaligned)]
+126 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -84,9 +84,9 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
-  --> $DIR/union.rs:42:10
+  --> $DIR/union.rs:44:10
    |
-42 | #[derive(IntoBytes)]
+44 | #[derive(IntoBytes)]
    |          ^^^^^^^^^ types with padding cannot implement `IntoBytes`
    |
    = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
@@ -102,15 +102,15 @@ help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0587]: type has conflicting packed and align representation hints
-  --> $DIR/union.rs:89:1
+  --> $DIR/union.rs:97:1
    |
-89 | union Unaligned3 {
+97 | union Unaligned3 {
    | ^^^^^^^^^^^^^^^^
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
-   --> $DIR/union.rs:117:1
+   --> $DIR/union.rs:130:1
     |
-117 | union Unaligned7 {
+130 | union Unaligned7 {
     | ^^^^^^^^^^^^^^^^
     |
 note: `AU16` has a `#[repr(align)]` attribute


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Makes progress on #2999




---

- 👉 #3000


**Latest Update:** v7 — [Compare vs v6](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|
|v7|[vs v6](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs v5](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs v4](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs v3](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs v2](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v7)|
|v6||[vs v5](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|[vs v4](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|[vs v3](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|[vs v2](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v6)|
|v5|||[vs v4](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5)|[vs v3](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5)|[vs v2](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5)|[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v5)|
|v4||||[vs v3](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4)|[vs v2](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4)|[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v4)|
|v3|||||[vs v2](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3)|[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v3)|
|v2||||||[vs v1](/google/zerocopy/compare/gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v2)|
|v1|||||||[vs Base](/google/zerocopy/compare/main..gherrit/G3638fc706fe75313ba5202a53db61e78b5243a1f/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G3638fc706fe75313ba5202a53db61e78b5243a1f && git checkout -b pr-G3638fc706fe75313ba5202a53db61e78b5243a1f FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G3638fc706fe75313ba5202a53db61e78b5243a1f && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G3638fc706fe75313ba5202a53db61e78b5243a1f && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G3638fc706fe75313ba5202a53db61e78b5243a1f
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3638fc706fe75313ba5202a53db61e78b5243a1f", "parent": null, "child": null}" -->