### PR TITLE
[WIP] Introduce `TryFromBytes::Uninit`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1700,6 +1700,10 @@ pub unsafe trait TryFromBytes {
     where
         Self: Sized;
 
+    /// The validity of `Self` in an uninitialized state.
+    #[doc(hidden)]
+    type Uninit;
+
     /// Does a given memory range contain a valid instance of `Self`?
     ///
     /// # Safety

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -149,6 +149,8 @@ const _: () = unsafe {
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
         T: TryFromBytes => TryFromBytes for Unalign<T>;
+        // FIXME(#2749): Justify this `Uninit`.
+        type Uninit = crate::invariant::Uninit;
         |c| T::is_bit_valid(c.transmute::<_, _, BecauseImmutable>())
     );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
@@ -668,6 +670,8 @@ const _: () = unsafe {
     unsafe_impl!(T: ?Sized + Unaligned => Unaligned for ReadOnly<T>);
     unsafe_impl!(
         T: ?Sized + TryFromBytes => TryFromBytes for ReadOnly<T>;
+        // FIXME(#2749): Justify this `Uninit`.
+        type Uninit = crate::invariant::Uninit;
         |c| T::is_bit_valid(c.cast::<_, <ReadOnly<T> as SizeEq<ReadOnly<ReadOnly<T>>>>::CastFrom, _>())
     );
     unsafe_impl!(T: ?Sized + FromZeros => FromZeros for ReadOnly<T>);


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3021
- 　  #2984
- 　  #2966


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v2..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v2..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v3)|[vs v1](/google/zerocopy/compare/gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v1..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v3)|[vs Base](/google/zerocopy/compare/Gc3e9ee9afa6945e10c35be84d30c970894395c96..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v1..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v2)|[vs Base](/google/zerocopy/compare/Gc3e9ee9afa6945e10c35be84d30c970894395c96..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v2)|
|v1|||[vs Base](/google/zerocopy/compare/Gc3e9ee9afa6945e10c35be84d30c970894395c96..gherrit/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68 && git checkout -b pr-Geec83fc8d47be6b2e51a15b84a2735bbc909ce68 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Geec83fc8d47be6b2e51a15b84a2735bbc909ce68
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Geec83fc8d47be6b2e51a15b84a2735bbc909ce68", "parent": "Gc3e9ee9afa6945e10c35be84d30c970894395c96", "child": null}" -->