### PR TITLE
[ci] Run Miri tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ name: Build & Tests
 on:
   pull_request:
   merge_group:
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This should result in below-maximum CPU utilization for less time. It likely won't result in drastic savings, as the test runners are already likely at maximum CPU utilization for most of the run.

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
