### PR TITLE
clippy: fix borrow_as_ptr lint

### DIFF
--- a/zerocopy/src/ref.rs
+++ b/zerocopy/src/ref.rs
@@ -1234,21 +1234,18 @@ mod tests {
     #[allow(unstable_name_collisions)]
     #[allow(clippy::as_conversions)]
     fn test_into_ref_mut() {
-        #[allow(unused)]
-        use crate::util::AsAddress as _;
-
         let mut buf = Align::<[u8; 8], u64>::default();
         let buf_ptr = buf.t.as_mut_ptr();
 
         let r = Ref::<_, u64>::from_bytes(&buf.t[..]).unwrap();
         let rf = Ref::into_ref(r);
         assert_eq!(rf, &0u64);
-        assert_eq!((rf as *const u64).cast(), buf_ptr);
+        assert_eq!(ptr::addr_of!(*rf).cast(), buf_ptr);
 
         let r = Ref::<_, u64>::from_bytes(&mut buf.t[..]).unwrap();
         let rf = Ref::into_mut(r);
         assert_eq!(rf, &mut 0u64);
-        assert_eq!((rf as *mut u64).cast(), buf_ptr);
+        assert_eq!(ptr::addr_of!(*rf).cast(), buf_ptr);
 
         *rf = u64::MAX;
         assert_eq!(buf.t, [0xFF; 8]);

--- a/zerocopy/src/ref.rs
+++ b/zerocopy/src/ref.rs
@@ -1238,16 +1238,17 @@ mod tests {
         use crate::util::AsAddress as _;
 
         let mut buf = Align::<[u8; 8], u64>::default();
+        let buf_ptr = buf.t.as_mut_ptr();
+
         let r = Ref::<_, u64>::from_bytes(&buf.t[..]).unwrap();
         let rf = Ref::into_ref(r);
         assert_eq!(rf, &0u64);
-        let buf_addr = (&buf.t as *const [u8; 8]).addr();
-        assert_eq!((rf as *const u64).addr(), buf_addr);
+        assert_eq!((rf as *const u64).cast(), buf_ptr);
 
         let r = Ref::<_, u64>::from_bytes(&mut buf.t[..]).unwrap();
         let rf = Ref::into_mut(r);
         assert_eq!(rf, &mut 0u64);
-        assert_eq!((rf as *mut u64).addr(), buf_addr);
+        assert_eq!((rf as *mut u64).cast(), buf_ptr);
 
         *rf = u64::MAX;
         assert_eq!(buf.t, [0xFF; 8]);

--- a/zerocopy/src/wrappers.rs
+++ b/zerocopy/src/wrappers.rs
@@ -1000,7 +1000,7 @@ mod tests {
             let uninit = MaybeUninit::new(&input);
             // SAFETY: `uninit` is in an initialized state
             let output = unsafe { uninit.assume_init() };
-            assert_eq!(&input as *const _, output as *const _);
+            assert!(core::ptr::eq(&input, output));
             assert_eq!(input, *output);
         }
 
@@ -1010,7 +1010,7 @@ mod tests {
             let uninit = MaybeUninit::new(&input[..]);
             // SAFETY: `uninit` is in an initialized state
             let output = unsafe { uninit.assume_init() };
-            assert_eq!(&input[..] as *const _, output as *const _);
+            assert!(core::ptr::eq(&input[..], output));
             assert_eq!(input, *output);
         }
     }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#borrow_as_ptr
