### PR TITLE
Introduce 'Code Generation' documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,7 +90,7 @@ jobs:
             #
             # TODO(#1228): Use `jq` to parse these from `Cargo.toml` instead of
             # hard-coding them once we've gotten it working again.
-            METADATA_DOCS_RS_RUSTDOC_ARGS='--cfg doc_cfg --generate-link-to-definition'
+            METADATA_DOCS_RS_RUSTDOC_ARGS='--cfg doc_cfg --generate-link-to-definition --extend-css rustdoc/style.css'
             export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS"
 
             # TODO: Use `./cargo.sh` instead once we've debugged why it won't work.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ pinned-nightly = "nightly-2026-01-25"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition", "--extend-css", "rustdoc/style.css"]
 
 [package.metadata.playground]
 features = ["__internal_use_only_features_that_work_on_stable"]

--- a/benches/formats/coco.rs
+++ b/benches/formats/coco.rs
@@ -1,24 +1,3 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-//! This modules defines two formats similar to the one used to illustrate the
-//! examples of [`zerocopy::TryFromBytes`]. The basic structure of these formats
-//! is a [`Packet`], which has a parameterizable leading field, followed by
-//! two-fixed byte fields, followed by a dynamically sized field. This format is
-//! consumed by our benchmarks either as a [`CocoPacket`] (which begins with the
-//! leading bytes `0xC0C0`), or a [`LocoPacket`] (which begins two bytes of any
-//! value). Both formats share the following qualities which stress-test our
-//! benchmarks:
-//!
-//! - They have a minimum alignment of two.
-//! - They have a minimum size of four bytes.
-//! - They have an even size.
-
 use zerocopy_derive::*;
 
 // The only valid value of this type are the bytes `0xC0C0`.

--- a/benches/ref_from_bytes.rs
+++ b/benches/ref_from_bytes.rs
@@ -1,17 +1,7 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
-    FromBytes::ref_from_bytes(source).ok()
+    zerocopy::FromBytes::ref_from_bytes(source).ok()
 }

--- a/benches/ref_from_bytes_with_elems.rs
+++ b/benches/ref_from_bytes_with_elems.rs
@@ -1,17 +1,7 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
-    FromBytes::ref_from_bytes_with_elems(source, count).ok()
+    zerocopy::FromBytes::ref_from_bytes_with_elems(source, count).ok()
 }

--- a/benches/ref_from_prefix.rs
+++ b/benches/ref_from_prefix.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
-    match FromBytes::ref_from_prefix(source) {
+    match zerocopy::FromBytes::ref_from_prefix(source) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,
     }

--- a/benches/ref_from_prefix_with_elems.rs
+++ b/benches/ref_from_prefix_with_elems.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
-    match FromBytes::ref_from_prefix_with_elems(source, count) {
+    match zerocopy::FromBytes::ref_from_prefix_with_elems(source, count) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,
     }

--- a/benches/ref_from_suffix.rs
+++ b/benches/ref_from_suffix.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
-    match FromBytes::ref_from_suffix(source) {
+    match zerocopy::FromBytes::ref_from_suffix(source) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,
     }

--- a/benches/ref_from_suffix_with_elems.rs
+++ b/benches/ref_from_suffix_with_elems.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::FromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
-    match FromBytes::ref_from_suffix_with_elems(source, count) {
+    match zerocopy::FromBytes::ref_from_suffix_with_elems(source, count) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,
     }

--- a/benches/transmute_ref.rs
+++ b/benches/transmute_ref.rs
@@ -1,12 +1,3 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::transmute_ref;
 use zerocopy_derive::*;
 
 #[path = "formats/coco.rs"]
@@ -21,5 +12,5 @@ struct MinimalViableSource {
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &MinimalViableSource) -> &format::LocoPacket {
-    transmute_ref!(source)
+    zerocopy::transmute_ref!(source)
 }

--- a/benches/try_ref_from_bytes.rs
+++ b/benches/try_ref_from_bytes.rs
@@ -1,17 +1,7 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
-    TryFromBytes::try_ref_from_bytes(source).ok()
+    zerocopy::TryFromBytes::try_ref_from_bytes(source).ok()
 }

--- a/benches/try_ref_from_bytes_with_elems.rs
+++ b/benches/try_ref_from_bytes_with_elems.rs
@@ -1,17 +1,7 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
-    TryFromBytes::try_ref_from_bytes_with_elems(source, count).ok()
+    zerocopy::TryFromBytes::try_ref_from_bytes_with_elems(source, count).ok()
 }

--- a/benches/try_ref_from_prefix.rs
+++ b/benches/try_ref_from_prefix.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
-    match TryFromBytes::try_ref_from_prefix(source) {
+    match zerocopy::TryFromBytes::try_ref_from_prefix(source) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,
     }

--- a/benches/try_ref_from_prefix_with_elems.rs
+++ b/benches/try_ref_from_prefix_with_elems.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
-    match TryFromBytes::try_ref_from_prefix_with_elems(source, count) {
+    match zerocopy::TryFromBytes::try_ref_from_prefix_with_elems(source, count) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,
     }

--- a/benches/try_ref_from_suffix.rs
+++ b/benches/try_ref_from_suffix.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
-    match TryFromBytes::try_ref_from_suffix(source) {
+    match zerocopy::TryFromBytes::try_ref_from_suffix(source) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,
     }

--- a/benches/try_ref_from_suffix_with_elems.rs
+++ b/benches/try_ref_from_suffix_with_elems.rs
@@ -1,19 +1,9 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::TryFromBytes;
-
 #[path = "formats/coco.rs"]
 mod format;
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
-    match TryFromBytes::try_ref_from_suffix_with_elems(source, count) {
+    match zerocopy::TryFromBytes::try_ref_from_suffix_with_elems(source, count) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,
     }

--- a/benches/try_transmute_ref.rs
+++ b/benches/try_transmute_ref.rs
@@ -1,12 +1,3 @@
-// Copyright 2026 The Fuchsia Authors
-//
-// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
-// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
-// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
-// This file may not be copied, modified, or distributed except according to
-// those terms.
-
-use zerocopy::try_transmute_ref;
 use zerocopy_derive::*;
 
 #[path = "formats/coco.rs"]
@@ -21,5 +12,5 @@ struct MinimalViableSource {
 
 #[unsafe(no_mangle)]
 fn codegen_test(source: &MinimalViableSource) -> Option<&format::CocoPacket> {
-    try_transmute_ref!(source).ok()
+    zerocopy::try_transmute_ref!(source).ok()
 }

--- a/rustdoc/style.css
+++ b/rustdoc/style.css
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Fuchsia Authors
+
+Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+<LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+This file may not be copied, modified, or distributed except according to
+those terms.
+*/
+
+.codegen-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(200px, 1fr));
+    grid-template-rows: auto 1fr;
+    column-gap: 1rem;
+}
+
+.codegen-tabs:not(:has(details[open]))::after {
+    grid-column: 1/-1;
+    content: 'Click one of the above headers to expand its contents.';
+    font-style: italic;
+}
+
+.codegen-tabs details {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-row: 1 / span 2;
+    grid-template-columns: subgrid;
+    grid-template-rows: subgrid;
+}
+
+.codegen-tabs summary {
+    display: grid;
+    grid-column: var(--n) / span 1;
+    grid-row: 1;
+    z-index: 1;
+    border-bottom: 2px solid var(--headings-border-bottom-color);
+    cursor: pointer;
+}
+
+.codegen-tabs details[open] :is(summary) {
+    background-color: var(--code-block-background-color);
+    border-bottom-color: var(--target-border-color);
+}
+
+.codegen-tabs details::details-content {
+    grid-column: 1 / -1;
+    grid-row: 2;
+}
+
+.codegen-tabs details:not([open])::details-content {
+    display: none;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1790,6 +1790,25 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &[0x10, 0xC0, 240, 77, 0, 1, 2, 3, 4, 5][..];
     /// assert!(Packet::try_ref_from_bytes(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_ref_from_bytes")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a minimum length of 4 bytes
+    /// - the source has a total length divisible by 2
+    /// - the source begins with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_bytes")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_bytes(source: &[u8]) -> Result<&Self, TryCastError<&[u8], Self>>
@@ -1889,6 +1908,24 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &[0x10, 0xC0, 240, 77, 0, 1, 2, 3, 4, 5, 6][..];
     /// assert!(Packet::try_ref_from_prefix(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_ref_from_prefix")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a minimum length of 4 bytes
+    /// - the source begins with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_prefix")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_prefix(source: &[u8]) -> Result<(&Self, &[u8]), TryCastError<&[u8], Self>>
@@ -1975,6 +2012,26 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &[0, 1, 2, 3, 4, 5, 6, 77, 240, 0xC0, 0x10][..];
     /// assert!(Packet::try_ref_from_suffix(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_ref_from_suffix")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source's largest [valid-size] suffix for `Self`, which must:
+    ///
+    /// - begin at an even memory address
+    /// - have a minimum length of 4 bytes
+    /// - begin with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    /// [valid-size]: crate::KnownLayout#what-is-a-valid-size
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_suffix")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_suffix(source: &[u8]) -> Result<(&[u8], &Self), TryCastError<&[u8], Self>>
@@ -2064,6 +2121,10 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &mut [0x10, 0xC0, 240, 77, 0, 1, 2, 3, 4, 5, 6][..];
     /// assert!(Packet::try_mut_from_bytes(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_mut_from_bytes")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_bytes`](#method.try_ref_from_bytes.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_bytes(bytes: &mut [u8]) -> Result<&mut Self, TryCastError<&mut [u8], Self>>
@@ -2168,6 +2229,10 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &mut [0x10, 0xC0, 240, 77, 0, 1, 2, 3, 4, 5, 6][..];
     /// assert!(Packet::try_mut_from_prefix(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_mut_from_prefix")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_prefix`](#method.try_ref_from_prefix.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_prefix(
@@ -2263,6 +2328,10 @@ pub unsafe trait TryFromBytes {
     /// let bytes = &mut [0, 1, 2, 3, 4, 5, 6, 77, 240, 0xC0, 0x10][..];
     /// assert!(Packet::try_mut_from_suffix(bytes).is_err());
     /// ```
+    ///
+    #[doc = codegen_header!("try_mut_from_suffix")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_suffix`](#method.try_ref_from_suffix.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_suffix(
@@ -2349,6 +2418,26 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_ref_from_bytes`]: TryFromBytes::try_ref_from_bytes
+    ///
+    #[doc = codegen_header!("try_ref_from_bytes_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a total length that exactly fits a `Self` with a
+    ///   trailing slice length of `elems`
+    /// - the source begins with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_bytes_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_bytes_with_elems(
@@ -2451,6 +2540,25 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_ref_from_prefix`]: TryFromBytes::try_ref_from_prefix
+    ///
+    #[doc = codegen_header!("try_ref_from_prefix_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a prefix that fits a `Self` with a trailing slice
+    ///   length of `count`
+    /// - the source begins with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_prefix_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_prefix_with_elems(
@@ -2540,6 +2648,27 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_ref_from_prefix`]: TryFromBytes::try_ref_from_prefix
+    ///
+    #[doc = codegen_header!("try_ref_from_suffix_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// [valid-size] suffix for a `Self` of trailing slice length `count`, which
+    /// must:
+    ///
+    /// - begin at an even memory address
+    /// - have a minimum length of 4 bytes
+    /// - begin with the bytes `0xC0C0`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    /// [valid-size]: crate::KnownLayout#what-is-a-valid-size
+    #[doc = codegen_tabs!(format = "coco", bench = "try_ref_from_suffix_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn try_ref_from_suffix_with_elems(
@@ -2631,6 +2760,10 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_mut_from_bytes`]: TryFromBytes::try_mut_from_bytes
+    ///  
+    #[doc = codegen_header!("try_mut_from_bytes_with_elems")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_bytes_with_elems`](#method.try_ref_from_bytes_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_bytes_with_elems(
@@ -2737,6 +2870,10 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_mut_from_prefix`]: TryFromBytes::try_mut_from_prefix
+    ///
+    #[doc = codegen_header!("try_mut_from_prefix_with_elems")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_prefix_with_elems`](#method.try_ref_from_prefix_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_prefix_with_elems(
@@ -2832,6 +2969,10 @@ pub unsafe trait TryFromBytes {
     /// ```
     ///
     /// [`try_mut_from_prefix`]: TryFromBytes::try_mut_from_prefix
+    ///
+    #[doc = codegen_header!("try_mut_from_suffix_with_elems")]
+    ///
+    /// See [`TryFromBytes::try_ref_from_suffix_with_elems`](#method.try_ref_from_suffix_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn try_mut_from_suffix_with_elems(
@@ -3816,6 +3957,24 @@ pub unsafe trait FromBytes: FromZeros {
     /// assert_eq!(packet.header.checksum, [6, 7]);
     /// assert_eq!(packet.body, [8, 9, 10, 11]);
     /// ```
+    ///
+    #[doc = codegen_header!("ref_from_bytes")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a minimum length of 4 bytes
+    /// - the source has a total length divisible by 2
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_bytes")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_bytes(source: &[u8]) -> Result<&Self, CastError<&[u8], Self>>
@@ -3904,6 +4063,23 @@ pub unsafe trait FromBytes: FromZeros {
     /// assert_eq!(packet.body, [[8, 9], [10, 11], [12, 13]]);
     /// assert_eq!(suffix, &[14u8][..]);
     /// ```
+    ///
+    #[doc = codegen_header!("ref_from_prefix")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a minimum length of 4 bytes
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_prefix")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_prefix(source: &[u8]) -> Result<(&Self, &[u8]), CastError<&[u8], Self>>
@@ -3974,6 +4150,25 @@ pub unsafe trait FromBytes: FromZeros {
     /// assert_eq!(prefix, &[0, 1, 2, 3, 4, 5][..]);
     /// assert_eq!(trailer.frame_check_sequence, [6, 7, 8, 9]);
     /// ```
+    ///
+    #[doc = codegen_header!("ref_from_suffix")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source's largest [valid-size] suffix for `Self`, which must:
+    ///
+    /// - begin at an even memory address
+    /// - have a minimum length of 4 bytes
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    /// [valid-size]: crate::KnownLayout#what-is-a-valid-size
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_suffix")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_suffix(source: &[u8]) -> Result<(&[u8], &Self), CastError<&[u8], Self>>
@@ -4051,7 +4246,12 @@ pub unsafe trait FromBytes: FromZeros {
     /// header.checksum = [0, 0];
     ///
     /// assert_eq!(bytes, [0, 1, 2, 3, 4, 5, 0, 0]);
+    ///
     /// ```
+    ///
+    #[doc = codegen_header!("mut_from_bytes")]
+    ///
+    /// See [`FromBytes::ref_from_bytes`](#method.ref_from_bytes.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_bytes(source: &mut [u8]) -> Result<&mut Self, CastError<&mut [u8], Self>>
@@ -4138,6 +4338,10 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// assert_eq!(bytes, [0, 1, 2, 3, 4, 5, 0, 0, 1, 1]);
     /// ```
+    ///
+    #[doc = codegen_header!("mut_from_prefix")]
+    ///
+    /// See [`FromBytes::ref_from_prefix`](#method.ref_from_prefix.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_prefix(
@@ -4214,6 +4418,10 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// assert_eq!(bytes, [0, 0, 0, 0, 0, 0, 1, 1, 1, 1]);
     /// ```
+    ///
+    #[doc = codegen_header!("mut_from_suffix")]
+    ///
+    /// See [`FromBytes::ref_from_suffix`](#method.ref_from_suffix.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_suffix(
@@ -4287,6 +4495,25 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`ref_from_bytes`]: FromBytes::ref_from_bytes
+    ///
+    #[doc = codegen_header!("ref_from_bytes_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a total length that exactly fits a `Self` with a
+    ///   trailing slice length of `elems`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_bytes_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_bytes_with_elems(
@@ -4367,6 +4594,24 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`ref_from_prefix`]: FromBytes::ref_from_prefix
+    ///
+    #[doc = codegen_header!("ref_from_prefix_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// source:
+    ///
+    /// - the source must begin an even memory address
+    /// - the source has a prefix that fits a `Self` with a trailing slice
+    ///   length of `count`
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_prefix_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_prefix_with_elems(
@@ -4442,6 +4687,26 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`ref_from_suffix`]: FromBytes::ref_from_suffix
+    ///
+    #[doc = codegen_header!("ref_from_suffix_with_elems")]
+    ///
+    /// This abstraction for reinterpreting a buffer of bytes as a structured
+    /// type is safe and cheap, but does not necessarily have zero runtime cost.
+    /// The below code generation benchmark exercises this routine on a
+    /// destination type whose complex layout places complex requirements on the
+    /// [valid-size] suffix for a `Self` of trailing slice length `count`, which
+    /// must:
+    ///
+    /// - begin at an even memory address
+    /// - have a minimum length of 4 bytes
+    ///
+    /// These conditions must all be checked at runtime in this example, but the
+    /// codegen you experience in practice will depend on optimization level,
+    /// the layout of the destination type, and what the compiler can prove
+    /// about the source.
+    ///
+    /// [valid-size]: crate::KnownLayout#what-is-a-valid-size
+    #[doc = codegen_tabs!(format = "coco", bench = "ref_from_suffix_with_elems")]
     #[must_use = "has no side effects"]
     #[inline]
     fn ref_from_suffix_with_elems(
@@ -4518,6 +4783,10 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`mut_from_bytes`]: FromBytes::mut_from_bytes
+    ///
+    #[doc = codegen_header!("mut_from_bytes_with_elems")]
+    ///
+    /// See [`TryFromBytes::ref_from_bytes_with_elems`](#method.ref_from_bytes_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_bytes_with_elems(
@@ -4603,6 +4872,10 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`mut_from_prefix`]: FromBytes::mut_from_prefix
+    ///
+    #[doc = codegen_header!("mut_from_prefix_with_elems")]
+    ///
+    /// See [`TryFromBytes::ref_from_prefix_with_elems`](#method.ref_from_prefix_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_prefix_with_elems(
@@ -4683,6 +4956,10 @@ pub unsafe trait FromBytes: FromZeros {
     /// ```
     ///
     /// [`mut_from_suffix`]: FromBytes::mut_from_suffix
+    ///
+    #[doc = codegen_header!("mut_from_suffix_with_elems")]
+    ///
+    /// See [`TryFromBytes::ref_from_suffix_with_elems`](#method.ref_from_suffix_with_elems.codegen).
     #[must_use = "has no side effects"]
     #[inline]
     fn mut_from_suffix_with_elems(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -312,6 +312,19 @@ macro_rules! transmute {
 ///
 /// This macro can be invoked in `const` contexts only when `Src: Sized` and
 /// `Dst: Sized`.
+///
+/// # Code Generation
+///
+/// The below code generation benchmark exercises this routine on a
+/// destination type whose complex layout places complex requirements on the
+/// source:
+///
+/// - the source must begin an even memory address
+/// - the source has a minimum length of 4 bytes
+/// - the source has a total length divisible by 2
+///
+/// These conditions are all checked at compile time.
+#[doc = codegen_tabs!(format = "coco", bench = "transmute_ref")]
 #[macro_export]
 macro_rules! transmute_ref {
     ($e:expr) => {{
@@ -714,6 +727,20 @@ macro_rules! try_transmute {
 /// assert_eq!(dst.t.as_bytes(), [0, 1]);
 /// assert_eq!(dst.u, [false, true, false, true, false, true]);
 /// ```
+///
+/// # Code Generation
+///
+/// The below code generation benchmark exercises this routine on a
+/// destination type whose complex layout places complex requirements on the
+/// source:
+///
+/// - the source must begin an even memory address
+/// - the source has a minimum length of 4 bytes
+/// - the source has a total length divisible by 2
+/// - the source begins with the bytes `0xC0C0`
+///
+/// All except the final condition are checked at compile time.
+#[doc = codegen_tabs!(format = "coco", bench = "try_transmute_ref")]
 #[macro_export]
 macro_rules! try_transmute_ref {
     ($e:expr) => {{

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -835,3 +835,96 @@ macro_rules! impl_transitive_transmute_from {
 /// must wrap the call in `unsafe { ... }`.
 #[inline(always)]
 pub(crate) const unsafe fn __unsafe() {}
+
+/// Generate a rustdoc-style header with `$name` as the HTML ID for the 'Code
+/// Generation' section of documentation.
+#[allow(unused)]
+macro_rules! codegen_header {
+    ($name:expr) => {
+        concat!(
+            "
+<h5 id='method.",
+            $name,
+            ".codegen'>
+    <a class='doc-anchor' href='#method.",
+            $name,
+            ".codegen'>§</a>
+    Code Generation
+</h5>
+"
+        )
+    };
+}
+
+/// Generate the HTML for the tabulated portion of the 'Code Generation'
+/// documentation. Consumes the name of the format file and benchmark.
+#[allow(unused)]
+macro_rules! codegen_tabs {
+    (format = $format:expr, bench = $name:expr) => {
+        concat!(
+            "
+<div class='codegen-tabs'>
+    <details name='tab-",
+            $name,
+            "' style='--n: 1'>
+        <summary>
+            <h6>Format</h6>
+        </summary>
+        <div>
+
+```ignore
+",
+            include_str!(concat!("../benches/formats/", $format, ".rs")),
+            "```
+\
+        </div>
+    </details>
+    <details name='tab-",
+            $name,
+            "' style='--n: 2'>
+        <summary>
+            <h6>Benchmark</h6>
+        </summary>
+        <div>
+
+```ignore
+",
+            include_str!(concat!("../benches/", $name, ".rs")),
+            "```
+\
+        </div>
+    </details>
+        <details name='tab-",
+            $name,
+            "' style='--n: 3'>
+        <summary>
+            <h6>Machine Code Analysis</h6>
+        </summary>
+        <div>
+
+### Replication
+
+You may replicate this analysis on your device with [`cargo-show-asm`] by running:
+
+[`cargo-show-asm`]: https://github.com/pacak/cargo-show-asm
+
+```bash
+cargo asm --bench ",
+            $name,
+            " codegen_test --mca
+```
+
+### Results
+```plain
+",
+            include_str!(concat!("../benches/", $name, ".x86-64.mca")),
+            "```
+\
+        </div>
+    </details>
+</div>
+
+"
+        )
+    };
+}

--- a/tools/doc.sh
+++ b/tools/doc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# Generate documentation useful for local development.
+
+set -eo pipefail
+
+./cargo.sh +nightly rustdoc -- \
+    -Z unstable-options \
+    --document-hidden-items \
+    --document-private-items \
+    --generate-macro-expansion \
+    --extend-css rustdoc/style.css
+


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Threads each of the codegen benchmarks introduced in #3042 into the
rustdoc of the corresponding item.




---

- 👉 #3078


**Latest Update:** v8 — [Compare vs v7](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v8|[vs v7](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v6](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v5](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v4](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v3](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v8)|
|v7||[vs v6](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs v5](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs v4](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs v3](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v7)|
|v6|||[vs v5](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|[vs v4](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|[vs v3](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v6)|
|v5||||[vs v4](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5)|[vs v3](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5)|[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v5)|
|v4|||||[vs v3](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4)|[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v4)|
|v3||||||[vs v2](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3)|[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v3)|
|v2|||||||[vs v1](/google/zerocopy/compare/gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v2)|
|v1||||||||[vs Base](/google/zerocopy/compare/main..gherrit/G490f3d0c05cc9f6db9c019ac73da4215f51dc627/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G490f3d0c05cc9f6db9c019ac73da4215f51dc627 && git checkout -b pr-G490f3d0c05cc9f6db9c019ac73da4215f51dc627 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G490f3d0c05cc9f6db9c019ac73da4215f51dc627 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G490f3d0c05cc9f6db9c019ac73da4215f51dc627 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G490f3d0c05cc9f6db9c019ac73da4215f51dc627
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G490f3d0c05cc9f6db9c019ac73da4215f51dc627", "parent": null, "child": null}" -->