### PR TITLE
[codegen] Track unanalyzed assembly and include it in docs.

### DIFF
--- a/benches/ref_from_bytes.x86-64
+++ b/benches/ref_from_bytes.x86-64
@@ -1,0 +1,20 @@
+codegen_test:
+	mov rdx, rsi
+	cmp rsi, 4
+	setb al
+	or al, dil
+	test al, 1
+	je .LBB5_2
+	xor eax, eax
+	ret
+.LBB5_2:
+	lea rcx, [rdx - 4]
+	mov rsi, rcx
+	and rsi, -2
+	add rsi, 4
+	shr rcx
+	xor eax, eax
+	cmp rdx, rsi
+	cmove rdx, rcx
+	cmove rax, rdi
+	ret

--- a/benches/ref_from_bytes_with_elems.x86-64
+++ b/benches/ref_from_bytes_with_elems.x86-64
@@ -1,0 +1,16 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	seta cl
+	mov rax, rdi
+	or dil, cl
+	test dil, 1
+	jne .LBB5_2
+	lea rcx, [2*rdx + 4]
+	cmp rsi, rcx
+	je .LBB5_3
+.LBB5_2:
+	xor eax, eax
+	mov rdx, rsi
+.LBB5_3:
+	ret

--- a/benches/ref_from_prefix.x86-64
+++ b/benches/ref_from_prefix.x86-64
@@ -1,0 +1,17 @@
+codegen_test:
+	xor edx, edx
+	mov eax, 0
+	test dil, 1
+	jne .LBB5_4
+	cmp rsi, 4
+	jae .LBB5_3
+	mov edx, 1
+	xor eax, eax
+	ret
+.LBB5_3:
+	add rsi, -4
+	shr rsi
+	mov rdx, rsi
+	mov rax, rdi
+.LBB5_4:
+	ret

--- a/benches/ref_from_prefix_with_elems.x86-64
+++ b/benches/ref_from_prefix_with_elems.x86-64
@@ -1,0 +1,22 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	ja .LBB5_1
+	mov rcx, rdx
+	xor edx, edx
+	mov eax, 0
+	test dil, 1
+	jne .LBB5_4
+	lea rax, [2*rcx + 4]
+	xor r8d, r8d
+	cmp rax, rsi
+	mov edx, 1
+	cmovbe rdx, rcx
+	cmova rdi, r8
+	mov rax, rdi
+.LBB5_4:
+	ret
+.LBB5_1:
+	mov edx, 1
+	xor eax, eax
+	ret

--- a/benches/ref_from_suffix.x86-64
+++ b/benches/ref_from_suffix.x86-64
@@ -1,0 +1,13 @@
+codegen_test:
+	mov rdx, rsi
+	lea ecx, [rsi + rdi]
+	mov eax, edx
+	and eax, 1
+	add rax, rdi
+	xor esi, esi
+	sub rdx, 4
+	cmovb rax, rsi
+	shr rdx
+	test cl, 1
+	cmovne rax, rsi
+	ret

--- a/benches/ref_from_suffix_with_elems.x86-64
+++ b/benches/ref_from_suffix_with_elems.x86-64
@@ -1,0 +1,23 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	ja .LBB5_1
+	lea r8d, [rsi + rdi]
+	xor ecx, ecx
+	mov eax, 0
+	test r8b, 1
+	jne .LBB5_5
+	lea rax, [2*rdx + 4]
+	sub rsi, rax
+	jae .LBB5_4
+.LBB5_1:
+	xor eax, eax
+	mov edx, 1
+	ret
+.LBB5_4:
+	add rdi, rsi
+	mov rcx, rdx
+	mov rax, rdi
+.LBB5_5:
+	mov rdx, rcx
+	ret

--- a/benches/transmute_ref.x86-64
+++ b/benches/transmute_ref.x86-64
@@ -1,0 +1,4 @@
+codegen_test:
+	mov rdx, rsi
+	mov rax, rdi
+	ret

--- a/benches/try_ref_from_bytes.x86-64
+++ b/benches/try_ref_from_bytes.x86-64
@@ -1,0 +1,22 @@
+codegen_test:
+	mov rdx, rsi
+	mov rax, rdi
+	cmp rsi, 4
+	setb cl
+	or cl, al
+	test cl, 1
+	jne .LBB5_4
+	lea rcx, [rdx - 4]
+	mov rsi, rcx
+	and rsi, -2
+	add rsi, 4
+	cmp rdx, rsi
+	jne .LBB5_4
+	cmp word ptr [rax], -16192
+	jne .LBB5_4
+	shr rcx
+	mov rdx, rcx
+	ret
+.LBB5_4:
+	xor eax, eax
+	ret

--- a/benches/try_ref_from_bytes_with_elems.x86-64
+++ b/benches/try_ref_from_bytes_with_elems.x86-64
@@ -1,0 +1,18 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	seta cl
+	mov rax, rdi
+	or dil, cl
+	test dil, 1
+	jne .LBB5_3
+	lea rcx, [2*rdx + 4]
+	cmp rsi, rcx
+	jne .LBB5_3
+	cmp word ptr [rax], -16192
+	je .LBB5_4
+.LBB5_3:
+	xor eax, eax
+	mov rdx, rsi
+.LBB5_4:
+	ret

--- a/benches/try_ref_from_prefix.x86-64
+++ b/benches/try_ref_from_prefix.x86-64
@@ -1,0 +1,22 @@
+codegen_test:
+	xor edx, edx
+	mov eax, 0
+	test dil, 1
+	jne .LBB5_4
+	cmp rsi, 4
+	jae .LBB5_3
+	mov edx, 1
+	xor eax, eax
+	ret
+.LBB5_3:
+	add rsi, -4
+	shr rsi
+	movzx ecx, word ptr [rdi]
+	cmp ecx, 49344
+	mov edx, 2
+	cmove rdx, rsi
+	xor eax, eax
+	cmp cx, -16192
+	cmove rax, rdi
+.LBB5_4:
+	ret

--- a/benches/try_ref_from_prefix_with_elems.x86-64
+++ b/benches/try_ref_from_prefix_with_elems.x86-64
@@ -1,0 +1,26 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	ja .LBB5_1
+	mov rcx, rdx
+	xor edx, edx
+	mov eax, 0
+	test dil, 1
+	jne .LBB5_5
+	lea rax, [2*rcx + 4]
+	cmp rax, rsi
+	jbe .LBB5_4
+.LBB5_1:
+	xor eax, eax
+	mov edx, 1
+	ret
+.LBB5_4:
+	movzx esi, word ptr [rdi]
+	cmp si, -16192
+	mov edx, 2
+	cmove rdx, rcx
+	xor eax, eax
+	cmp esi, 49344
+	cmove rax, rdi
+.LBB5_5:
+	ret

--- a/benches/try_ref_from_suffix.x86-64
+++ b/benches/try_ref_from_suffix.x86-64
@@ -1,0 +1,18 @@
+codegen_test:
+	lea eax, [rsi + rdi]
+	cmp rsi, 4
+	setb cl
+	or cl, al
+	test cl, 1
+	je .LBB5_2
+	xor eax, eax
+	ret
+.LBB5_2:
+	lea rdx, [rsi - 4]
+	shr rdx
+	and esi, 1
+	lea rcx, [rdi + rsi]
+	xor eax, eax
+	cmp word ptr [rdi + rsi], -16192
+	cmove rax, rcx
+	ret

--- a/benches/try_ref_from_suffix_with_elems.x86-64
+++ b/benches/try_ref_from_suffix_with_elems.x86-64
@@ -1,0 +1,28 @@
+codegen_test:
+	movabs rax, 9223372036854775805
+	cmp rdx, rax
+	ja .LBB5_1
+	lea r8d, [rsi + rdi]
+	xor ecx, ecx
+	mov eax, 0
+	test r8b, 1
+	jne .LBB5_5
+	lea rax, [2*rdx + 4]
+	sub rsi, rax
+	jae .LBB5_4
+.LBB5_1:
+	xor eax, eax
+	mov edx, 1
+	ret
+.LBB5_4:
+	lea r8, [rdi + rsi]
+	movzx esi, word ptr [rdi + rsi]
+	cmp si, -16192
+	mov ecx, 2
+	cmove rcx, rdx
+	xor eax, eax
+	cmp esi, 49344
+	cmove rax, r8
+.LBB5_5:
+	mov rdx, rcx
+	ret

--- a/benches/try_transmute_ref.x86-64
+++ b/benches/try_transmute_ref.x86-64
@@ -1,0 +1,6 @@
+codegen_test:
+	mov rdx, rsi
+	xor eax, eax
+	cmp word ptr [rdi], -16192
+	cmove rax, rdi
+	ret

--- a/rustdoc/style.css
+++ b/rustdoc/style.css
@@ -10,7 +10,7 @@ those terms.
 
 .codegen-tabs {
     display: grid;
-    grid-template-columns: repeat(3, minmax(200px, 1fr));
+    grid-template-columns: repeat(4, minmax(200px, 1fr));
     grid-template-rows: auto 1fr;
     column-gap: 1rem;
 }

--- a/src/util/macros.rs
+++ b/src/util/macros.rs
@@ -894,9 +894,24 @@ macro_rules! codegen_tabs {
 \
         </div>
     </details>
-        <details name='tab-",
+    <details name='tab-",
             $name,
             "' style='--n: 3'>
+        <summary>
+            <h6>Assembly (x86-64)</h6>
+        </summary>
+        <div>
+
+```ignore
+",
+            include_str!(concat!("../benches/", $name, ".x86-64")),
+            "```
+\
+        </div>
+    </details>
+    <details name='tab-",
+            $name,
+            "' style='--n: 4'>
         <summary>
             <h6>Machine Code Analysis</h6>
         </summary>

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -10,52 +10,83 @@
 
 use std::{path::PathBuf, process::Command};
 
+enum Directive {
+    Asm,
+    Mca,
+}
+
+impl Directive {
+    fn arg(&self) -> &'static str {
+        match self {
+            Directive::Asm => "--asm",
+            Directive::Mca => "--mca",
+        }
+    }
+
+    fn ext(&self) -> &'static str {
+        match self {
+            Directive::Asm => "",
+            Directive::Mca => ".mca",
+        }
+    }
+}
+
 fn run_codegen_test(bench_name: &str, target_cpu: &str, bless: bool) {
     let manifest_path = env!("CARGO_MANIFEST_PATH");
     let target_dir = env!("CARGO_TARGET_DIR");
 
-    let output = Command::new("cargo")
-        .args([
-            "asm",
-            "-p",
-            "zerocopy",
-            "--manifest-path",
-            manifest_path,
-            "--target-dir",
-            target_dir,
-            "--bench",
-            bench_name,
-            "--target-cpu",
-            target_cpu,
-            "--mca",
-            "codegen_test",
-        ])
-        .output()
-        .expect("failed to execute process");
-
-    let actual_result = output.stdout;
-
-    if !(output.status.success()) {
-        panic!("{}", String::from_utf8_lossy(&output.stderr));
-    }
-
-    let expected_file_path = {
-        let mut path: PathBuf = env!("CARGO_MANIFEST_DIR").into();
-        path.push("benches");
-        let file_name = format!("{bench_name}.{target_cpu}.mca");
-        path.push(file_name);
-        path
+    let cargo_asm = |directive: &Directive| {
+        Command::new("cargo")
+            .args([
+                "asm",
+                "-p",
+                "zerocopy",
+                "--manifest-path",
+                manifest_path,
+                "--target-dir",
+                target_dir,
+                "--bench",
+                bench_name,
+                "--target-cpu",
+                target_cpu,
+                "--simplify",
+                directive.arg(),
+                "codegen_test",
+            ])
+            .output()
+            .expect("failed to execute process")
     };
 
-    if bless {
-        std::fs::write(expected_file_path, &actual_result).unwrap();
-    } else {
-        let expected_result = std::fs::read(expected_file_path).unwrap_or_default();
-        if actual_result != expected_result {
-            let expected = String::from_utf8_lossy(&expected_result[..]);
-            panic!("Bless codegen tests with BLESS=1\nGot unexpected output:\n{}", expected);
+    let test_directive = |directive: Directive| {
+        let output = cargo_asm(&directive);
+        let actual_result = output.stdout;
+
+        if !(output.status.success()) {
+            panic!("{}", String::from_utf8_lossy(&output.stderr));
         }
-    }
+
+        let expected_file_path = {
+            let ext = directive.ext();
+            let mut path: PathBuf = env!("CARGO_MANIFEST_DIR").into();
+            path.push("benches");
+            let file_name = format!("{bench_name}.{target_cpu}{ext}",);
+            path.push(file_name);
+            path
+        };
+
+        if bless {
+            std::fs::write(expected_file_path, &actual_result).unwrap();
+        } else {
+            let expected_result = std::fs::read(expected_file_path).unwrap_or_default();
+            if actual_result != expected_result {
+                let expected = String::from_utf8_lossy(&expected_result[..]);
+                panic!("Bless codegen tests with BLESS=1\nGot unexpected output:\n{}", expected);
+            }
+        }
+    };
+
+    test_directive(Directive::Asm);
+    test_directive(Directive::Mca);
 }
 
 #[test]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This is more approachable than the full llvm-mca analysis.




---

- 　  #3085
- 　  #3083
- 　  #3082
- 👉 #3081


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|[vs v4](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|[vs v3](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|[vs v2](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|[vs v1](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5)|[vs v3](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5)|[vs v2](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5)|[vs v1](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4)|[vs v2](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4)|[vs v1](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3)|[vs v1](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/main..gherrit/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008 && git checkout -b pr-Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Ged67b8f5ad7d38d9f2eb40adebea8894a1a6a008", "parent": null, "child": "Gff7f5c476000b38dbce1a040586076c9ff44a8d4"}" -->