### PR TITLE
[codegen] Use descriptive benchmark target fn name.

### DIFF
--- a/benches/ref_from_bytes.rs
+++ b/benches/ref_from_bytes.rs
@@ -2,6 +2,6 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
+fn bench_ref_from_bytes(source: &[u8]) -> Option<&format::LocoPacket> {
     zerocopy::FromBytes::ref_from_bytes(source).ok()
 }

--- a/benches/ref_from_bytes.x86-64
+++ b/benches/ref_from_bytes.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_bytes:
 	mov rdx, rsi
 	cmp rsi, 4
 	setb al

--- a/benches/ref_from_bytes_with_elems.rs
+++ b/benches/ref_from_bytes_with_elems.rs
@@ -2,6 +2,6 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
+fn bench_ref_from_bytes_with_elems(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
     zerocopy::FromBytes::ref_from_bytes_with_elems(source, count).ok()
 }

--- a/benches/ref_from_bytes_with_elems.x86-64
+++ b/benches/ref_from_bytes_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_bytes_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	seta cl

--- a/benches/ref_from_prefix.rs
+++ b/benches/ref_from_prefix.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
+fn bench_ref_from_prefix(source: &[u8]) -> Option<&format::LocoPacket> {
     match zerocopy::FromBytes::ref_from_prefix(source) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,

--- a/benches/ref_from_prefix.x86-64
+++ b/benches/ref_from_prefix.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_prefix:
 	xor edx, edx
 	mov eax, 0
 	test dil, 1

--- a/benches/ref_from_prefix_with_elems.rs
+++ b/benches/ref_from_prefix_with_elems.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
+fn bench_ref_from_prefix_with_elems(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
     match zerocopy::FromBytes::ref_from_prefix_with_elems(source, count) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,

--- a/benches/ref_from_prefix_with_elems.x86-64
+++ b/benches/ref_from_prefix_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_prefix_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	ja .LBB5_1

--- a/benches/ref_from_suffix.rs
+++ b/benches/ref_from_suffix.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::LocoPacket> {
+fn bench_ref_from_suffix(source: &[u8]) -> Option<&format::LocoPacket> {
     match zerocopy::FromBytes::ref_from_suffix(source) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,

--- a/benches/ref_from_suffix.x86-64
+++ b/benches/ref_from_suffix.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_suffix:
 	mov rdx, rsi
 	lea ecx, [rsi + rdi]
 	mov eax, edx

--- a/benches/ref_from_suffix_with_elems.rs
+++ b/benches/ref_from_suffix_with_elems.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
+fn bench_ref_from_suffix_with_elems(source: &[u8], count: usize) -> Option<&format::LocoPacket> {
     match zerocopy::FromBytes::ref_from_suffix_with_elems(source, count) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,

--- a/benches/ref_from_suffix_with_elems.x86-64
+++ b/benches/ref_from_suffix_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_ref_from_suffix_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	ja .LBB5_1

--- a/benches/transmute_ref.rs
+++ b/benches/transmute_ref.rs
@@ -11,6 +11,6 @@ struct MinimalViableSource {
 }
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &MinimalViableSource) -> &format::LocoPacket {
+fn bench_transmute_ref(source: &MinimalViableSource) -> &format::LocoPacket {
     zerocopy::transmute_ref!(source)
 }

--- a/benches/transmute_ref.x86-64
+++ b/benches/transmute_ref.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_transmute_ref:
 	mov rdx, rsi
 	mov rax, rdi
 	ret

--- a/benches/try_ref_from_bytes.rs
+++ b/benches/try_ref_from_bytes.rs
@@ -2,6 +2,6 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_bytes(source: &[u8]) -> Option<&format::CocoPacket> {
     zerocopy::TryFromBytes::try_ref_from_bytes(source).ok()
 }

--- a/benches/try_ref_from_bytes.x86-64
+++ b/benches/try_ref_from_bytes.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_bytes:
 	mov rdx, rsi
 	mov rax, rdi
 	cmp rsi, 4

--- a/benches/try_ref_from_bytes_with_elems.rs
+++ b/benches/try_ref_from_bytes_with_elems.rs
@@ -2,6 +2,6 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_bytes_with_elems(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
     zerocopy::TryFromBytes::try_ref_from_bytes_with_elems(source, count).ok()
 }

--- a/benches/try_ref_from_bytes_with_elems.x86-64
+++ b/benches/try_ref_from_bytes_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_bytes_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	seta cl

--- a/benches/try_ref_from_prefix.rs
+++ b/benches/try_ref_from_prefix.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_prefix(source: &[u8]) -> Option<&format::CocoPacket> {
     match zerocopy::TryFromBytes::try_ref_from_prefix(source) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,

--- a/benches/try_ref_from_prefix.x86-64
+++ b/benches/try_ref_from_prefix.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_prefix:
 	xor edx, edx
 	mov eax, 0
 	test dil, 1

--- a/benches/try_ref_from_prefix_with_elems.rs
+++ b/benches/try_ref_from_prefix_with_elems.rs
@@ -2,7 +2,10 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_prefix_with_elems(
+    source: &[u8],
+    count: usize,
+) -> Option<&format::CocoPacket> {
     match zerocopy::TryFromBytes::try_ref_from_prefix_with_elems(source, count) {
         Ok((packet, _rest)) => Some(packet),
         _ => None,

--- a/benches/try_ref_from_prefix_with_elems.x86-64
+++ b/benches/try_ref_from_prefix_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_prefix_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	ja .LBB5_1

--- a/benches/try_ref_from_suffix.rs
+++ b/benches/try_ref_from_suffix.rs
@@ -2,7 +2,7 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8]) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_suffix(source: &[u8]) -> Option<&format::CocoPacket> {
     match zerocopy::TryFromBytes::try_ref_from_suffix(source) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,

--- a/benches/try_ref_from_suffix.x86-64
+++ b/benches/try_ref_from_suffix.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_suffix:
 	lea eax, [rsi + rdi]
 	cmp rsi, 4
 	setb cl

--- a/benches/try_ref_from_suffix_with_elems.rs
+++ b/benches/try_ref_from_suffix_with_elems.rs
@@ -2,7 +2,10 @@
 mod format;
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &[u8], count: usize) -> Option<&format::CocoPacket> {
+fn bench_try_ref_from_suffix_with_elems(
+    source: &[u8],
+    count: usize,
+) -> Option<&format::CocoPacket> {
     match zerocopy::TryFromBytes::try_ref_from_suffix_with_elems(source, count) {
         Ok((_rest, packet)) => Some(packet),
         _ => None,

--- a/benches/try_ref_from_suffix_with_elems.x86-64
+++ b/benches/try_ref_from_suffix_with_elems.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_ref_from_suffix_with_elems:
 	movabs rax, 9223372036854775805
 	cmp rdx, rax
 	ja .LBB5_1

--- a/benches/try_transmute_ref.rs
+++ b/benches/try_transmute_ref.rs
@@ -11,6 +11,6 @@ struct MinimalViableSource {
 }
 
 #[unsafe(no_mangle)]
-fn codegen_test(source: &MinimalViableSource) -> Option<&format::CocoPacket> {
+fn bench_try_transmute_ref(source: &MinimalViableSource) -> Option<&format::CocoPacket> {
     zerocopy::try_transmute_ref!(source).ok()
 }

--- a/benches/try_transmute_ref.x86-64
+++ b/benches/try_transmute_ref.x86-64
@@ -1,4 +1,4 @@
-codegen_test:
+bench_try_transmute_ref:
 	mov rdx, rsi
 	xor eax, eax
 	cmp word ptr [rdi], -16192

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -51,18 +51,23 @@ fn run_codegen_test(bench_name: &str, target_cpu: &str, bless: bool) {
                 target_cpu,
                 "--simplify",
                 directive.arg(),
-                "codegen_test",
+                &format!("bench_{bench_name}"),
             ])
             .output()
             .expect("failed to execute process")
     };
 
     let test_directive = |directive: Directive| {
+        println!("{bench_name}");
         let output = cargo_asm(&directive);
         let actual_result = output.stdout;
 
         if !(output.status.success()) {
-            panic!("{}", String::from_utf8_lossy(&output.stderr));
+            panic!(
+                "{}\n{}",
+                String::from_utf8_lossy(&actual_result),
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         let expected_file_path = {


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #3085
- 　  #3083
- 👉 #3082


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|[vs v4](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|[vs v3](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|[vs v2](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|[vs v1](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/main..gherrit/Gff7f5c476000b38dbce1a040586076c9ff44a8d4/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gff7f5c476000b38dbce1a040586076c9ff44a8d4 && git checkout -b pr-Gff7f5c476000b38dbce1a040586076c9ff44a8d4 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gff7f5c476000b38dbce1a040586076c9ff44a8d4 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gff7f5c476000b38dbce1a040586076c9ff44a8d4 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gff7f5c476000b38dbce1a040586076c9ff44a8d4
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gff7f5c476000b38dbce1a040586076c9ff44a8d4", "parent": null, "child": "G04affc58395810ba04b941f14dfdc20563fa850b"}" -->