### PR TITLE
[ci] Fix bug where `rustup` output was piped to `jq`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,16 @@ jobs:
           set -eo pipefail
 
           # Get current versions
+          #
+          # Pre-install toolchains so `rustup` output isn't piped to `jq`.
+          ./cargo.sh +stable help > /dev/null
           CUR_VER_ZC=$(./cargo.sh +stable metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "zerocopy").version')
           CUR_VER_DERIVE=$(./cargo.sh +stable metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "zerocopy-derive").version')
 
           # Get previous versions using cargo metadata by temporarily checking it out
           git checkout -q HEAD^
+          # Pre-install toolchains so `rustup` output isn't piped to `jq`.
+          ./cargo.sh +stable help > /dev/null
           PREV_VER_ZC=$(./cargo.sh +stable metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "zerocopy").version')
           PREV_VER_DERIVE=$(./cargo.sh +stable metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "zerocopy-derive").version')
           git checkout -q -

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.43"
+version = "0.8.44"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.43", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.43", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.43", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.43"
+version = "0.8.44"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.44 to test this fix.




---

- 👉 #3117


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v1..gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v1..gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G52gtsaacfch7cbkstfwo5n6g3odrt3ji/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G52gtsaacfch7cbkstfwo5n6g3odrt3ji && git checkout -b pr-G52gtsaacfch7cbkstfwo5n6g3odrt3ji FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G52gtsaacfch7cbkstfwo5n6g3odrt3ji && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G52gtsaacfch7cbkstfwo5n6g3odrt3ji && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G52gtsaacfch7cbkstfwo5n6g3odrt3ji
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G52gtsaacfch7cbkstfwo5n6g3odrt3ji", "parent": null, "child": null}" -->