### PR TITLE
[ci] Fix wrong GitHub Actions hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
         run: ./cargo.sh +stable publish --package zerocopy --registry crates-io
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd5704bfa3b69f0c2a9c440319b85f3cf # v2.0.8
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.44"
+version = "0.8.45"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.44"
+version = "0.8.45"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.44"
+version = "0.8.45"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.44", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.44"
+version = "0.8.45"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.45 to test this fix.




---

- 👉 #3121


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v1..gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v1..gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gga7qjmq2iq7jfloo2gir37coepdpzrej/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gga7qjmq2iq7jfloo2gir37coepdpzrej && git checkout -b pr-Gga7qjmq2iq7jfloo2gir37coepdpzrej FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gga7qjmq2iq7jfloo2gir37coepdpzrej && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gga7qjmq2iq7jfloo2gir37coepdpzrej && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gga7qjmq2iq7jfloo2gir37coepdpzrej
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gga7qjmq2iq7jfloo2gir37coepdpzrej", "parent": null, "child": null}" -->