### PR TITLE
[ci] Pass `--no-verify` when running release dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,9 @@ jobs:
           set -eo pipefail
 
           ./cargo.sh +stable publish --dry-run --package zerocopy-derive --registry crates-io
-          ./cargo.sh +stable publish --dry-run --package zerocopy --registry crates-io
+          # Pass `--no-verify` since `zerocopy-derive` (at this new version)
+          # isn't available on crates.io yet, and so otherwise this will fail.
+          ./cargo.sh +stable publish --dry-run --no-verify --package zerocopy --registry crates-io
 
       - name: Check if tag already exists
         run: |
@@ -131,8 +133,12 @@ jobs:
       - name: Publish zerocopy-derive
         run: ./cargo.sh +stable publish --package zerocopy-derive --registry crates-io
 
+      # This should *technically* be unnecessary since `cargo publish` blocks
+      # until the published crate is available in the API, but we have observed
+      # this failing occasionally, presumably due to eventual consistency. 60
+      # seconds is likely overkill, but better safe than sorry.
       - name: Wait for crates.io index propagation
-        run: sleep 30
+        run: sleep 60
 
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.45"
+version = "0.8.46-alpha"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.45"
+version = "0.8.46-alpha"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.45"
+version = "0.8.46-alpha"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.45", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive" }

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -390,7 +390,7 @@ fn delegate_cargo() -> Result<(), Error> {
                     let output = rustup(["run", version, "cargo", "pkgid", "-p"], None)
                         .arg(p)
                         .output_or_exit();
-                    String::from_utf8(output.stdout).unwrap()
+                    String::from_utf8(output.stdout).unwrap().trim().to_string()
                 };
 
                 // Replace `-p<package>`, `-p <package>` and `--package <package`

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.45"
+version = "0.8.46-alpha"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This is necessary since zerocopy-derive (at the new version) isn't on
crates.io, and so without `--no-verify`, the dry-run will fail.

Also make `cargo-zerocopy` robust to leading and trailing whitespace in
the output of subcommands.

Release 0.8.46-alpha to test this.




---

- 　  #3119
- 👉 #3122

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gc7agvrsvdamujyamxo2p5ue556qkfbhg && git checkout -b pr-Gc7agvrsvdamujyamxo2p5ue556qkfbhg FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gc7agvrsvdamujyamxo2p5ue556qkfbhg && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gc7agvrsvdamujyamxo2p5ue556qkfbhg && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gc7agvrsvdamujyamxo2p5ue556qkfbhg
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gc7agvrsvdamujyamxo2p5ue556qkfbhg", "parent": null, "child": "Gih3nhc66bp3h3tzot25f35snlcxhepun"}" -->