### PR TITLE
[ci] Bypass vendoring during publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,11 +103,17 @@ jobs:
       - name: Dry-run publish
         run: |
           set -eo pipefail
+          # Temporarily disable vendoring so that `cargo publish` can see the
+          # live registry and resolve workspace dependencies correctly.
+          mv .cargo/config.toml .cargo/config.toml.bak
 
           ./cargo.sh +stable publish --dry-run --package zerocopy-derive --registry crates-io
           # Pass `--no-verify` since `zerocopy-derive` (at this new version)
-          # isn't available on crates.io yet, and so otherwise this will fail.
+          # isn't on crates.io yet, and thus resolution would fail during
+          # verification.
           ./cargo.sh +stable publish --dry-run --no-verify --package zerocopy --registry crates-io
+
+          mv .cargo/config.toml.bak .cargo/config.toml
 
       - name: Check if tag already exists
         run: |
@@ -131,7 +137,11 @@ jobs:
         
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy-derive
-        run: ./cargo.sh +stable publish --package zerocopy-derive --registry crates-io
+        run: |
+          set -eo pipefail
+          mv .cargo/config.toml .cargo/config.toml.bak
+          ./cargo.sh +stable publish --package zerocopy-derive --registry crates-io
+          mv .cargo/config.toml.bak .cargo/config.toml
 
       # This should *technically* be unnecessary since `cargo publish` blocks
       # until the published crate is available in the API, but we have observed
@@ -142,7 +152,11 @@ jobs:
 
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy
-        run: ./cargo.sh +stable publish --package zerocopy --registry crates-io
+        run: |
+          set -eo pipefail
+          mv .cargo/config.toml .cargo/config.toml.bak
+          ./cargo.sh +stable publish --package zerocopy --registry crates-io
+          mv .cargo/config.toml.bak .cargo/config.toml
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.46-alpha"
+version = "0.8.46-alpha.1"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.46-alpha"
+version = "0.8.46-alpha.1"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.46-alpha"
+version = "0.8.46-alpha.1"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.46-alpha", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.46-alpha"
+version = "0.8.46-alpha.1"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.46-alpha.1 to test.




---

- 　  #3119
- 👉 #3124

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G23zd7snz5pcqvr2rsrwwx7m57vg5slph && git checkout -b pr-G23zd7snz5pcqvr2rsrwwx7m57vg5slph FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G23zd7snz5pcqvr2rsrwwx7m57vg5slph && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G23zd7snz5pcqvr2rsrwwx7m57vg5slph && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G23zd7snz5pcqvr2rsrwwx7m57vg5slph
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G23zd7snz5pcqvr2rsrwwx7m57vg5slph", "parent": null, "child": "Gih3nhc66bp3h3tzot25f35snlcxhepun"}" -->