### PR TITLE
[ci] In releasing script, pass `--allow-dirty`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,11 @@ jobs:
           # live registry and resolve workspace dependencies correctly.
           mv .cargo/config.toml .cargo/config.toml.bak
 
-          ./cargo.sh +stable publish --dry-run --package zerocopy-derive --registry crates-io
+          ./cargo.sh +stable publish --dry-run --allow-dirty --package zerocopy-derive --registry crates-io
           # Pass `--no-verify` since `zerocopy-derive` (at this new version)
           # isn't on crates.io yet, and thus resolution would fail during
           # verification.
-          ./cargo.sh +stable publish --dry-run --no-verify --package zerocopy --registry crates-io
+          ./cargo.sh +stable publish --dry-run --no-verify --allow-dirty --package zerocopy --registry crates-io
 
           mv .cargo/config.toml.bak .cargo/config.toml
 
@@ -140,7 +140,7 @@ jobs:
         run: |
           set -eo pipefail
           mv .cargo/config.toml .cargo/config.toml.bak
-          ./cargo.sh +stable publish --package zerocopy-derive --registry crates-io
+          ./cargo.sh +stable publish --allow-dirty --package zerocopy-derive --registry crates-io
           mv .cargo/config.toml.bak .cargo/config.toml
 
       # This should *technically* be unnecessary since `cargo publish` blocks
@@ -155,7 +155,7 @@ jobs:
         run: |
           set -eo pipefail
           mv .cargo/config.toml .cargo/config.toml.bak
-          ./cargo.sh +stable publish --package zerocopy --registry crates-io
+          ./cargo.sh +stable publish --allow-dirty --package zerocopy --registry crates-io
           mv .cargo/config.toml.bak .cargo/config.toml
 
       - name: Create GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.46-alpha.1"
+version = "0.8.46-alpha.2"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.46-alpha.1"
+version = "0.8.46-alpha.2"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.46-alpha.1"
+version = "0.8.46-alpha.2"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.46-alpha.1", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.46-alpha.1"
+version = "0.8.46-alpha.2"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This is required because we temporarily move `.cargo/config.toml` in
order to permit using the real crates.io instead of the local vendor
which our Cargo config sets.

Release 0.8.46-alpha.2 to test.




---

- 　  #3119
- 👉 #3125


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v1..gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v1..gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G3k34nwr3k3rr4klzas3jz3bhgn63thzz/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G3k34nwr3k3rr4klzas3jz3bhgn63thzz && git checkout -b pr-G3k34nwr3k3rr4klzas3jz3bhgn63thzz FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G3k34nwr3k3rr4klzas3jz3bhgn63thzz && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G3k34nwr3k3rr4klzas3jz3bhgn63thzz && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G3k34nwr3k3rr4klzas3jz3bhgn63thzz
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3k34nwr3k3rr4klzas3jz3bhgn63thzz", "parent": null, "child": "Gih3nhc66bp3h3tzot25f35snlcxhepun"}" -->