### PR TITLE
[ci] When releasing, don't dry-run zerocopy publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,13 +106,7 @@ jobs:
           # Temporarily disable vendoring so that `cargo publish` can see the
           # live registry and resolve workspace dependencies correctly.
           mv .cargo/config.toml .cargo/config.toml.bak
-
           ./cargo.sh +stable publish --dry-run --allow-dirty --package zerocopy-derive --registry crates-io
-          # Pass `--no-verify` since `zerocopy-derive` (at this new version)
-          # isn't on crates.io yet, and thus resolution would fail during
-          # verification.
-          ./cargo.sh +stable publish --dry-run --no-verify --allow-dirty --package zerocopy --registry crates-io
-
           mv .cargo/config.toml.bak .cargo/config.toml
 
       - name: Check if tag already exists
@@ -155,6 +149,11 @@ jobs:
         run: |
           set -eo pipefail
           mv .cargo/config.toml .cargo/config.toml.bak
+
+          # Dry-run first to catch any last-minute issues now that
+          # `zerocopy-derive` is on crates.io.
+          ./cargo.sh +stable publish --dry-run --allow-dirty --package zerocopy --registry crates-io
+
           ./cargo.sh +stable publish --allow-dirty --package zerocopy --registry crates-io
           mv .cargo/config.toml.bak .cargo/config.toml
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.46-alpha.2"
+version = "0.8.46-alpha.3"
 dependencies = [
  "elain",
  "itertools",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.46-alpha.2"
+version = "0.8.46-alpha.3"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.46-alpha.2"
+version = "0.8.46-alpha.3"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -112,13 +112,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.46-alpha.3", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.3", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -129,4 +129,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.46-alpha.2", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.46-alpha.3", path = "zerocopy-derive" }

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.46-alpha.2"
+version = "0.8.46-alpha.3"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

We can dry-run publishing zerocopy-derive, but dry-running publishing
zerocopy requires zerocopy-derive to already be published. Thus, we
instead do:
- Dry run and then publish zerocopy-derive
- Dry run and then publish zerocopy

Release 0.8.46-alpha.3 to test.




---

- 　  #3119
- 👉 #3126

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5rb3zfqizimx5hy4yal4jg4okuhdlwin && git checkout -b pr-G5rb3zfqizimx5hy4yal4jg4okuhdlwin FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5rb3zfqizimx5hy4yal4jg4okuhdlwin && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5rb3zfqizimx5hy4yal4jg4okuhdlwin && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5rb3zfqizimx5hy4yal4jg4okuhdlwin
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G5rb3zfqizimx5hy4yal4jg4okuhdlwin", "parent": null, "child": "Gih3nhc66bp3h3tzot25f35snlcxhepun"}" -->