### PR TITLE
[ci] Fix bugs in `auto-approvers.yml`

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_ENDPOINT: repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files
-        run: gh api "$API_ENDPOINT" --paginate --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > changed_files.json
+        run: gh api "$API_ENDPOINT" --paginate --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > /tmp/changed_files.json
 
       - name: Optimistic Evaluation
         env:
@@ -57,6 +57,7 @@ jobs:
           python3 ci/validate_auto_approvers.py \
             --expected-count "$TOTAL_PR_FILES" \
             --contributors "$ACTOR"
+            --changed-files /tmp/changed_files.json
 
       - name: Approve PR Atomically
         if: success()
@@ -132,7 +133,7 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/commits \
             --paginate \
-            --jq '[.[] | {author: .author.login, committer: .committer.login}]' > commits.json
+            --jq '[.[] | {author: .author.login, committer: .committer.login}]' > /tmp/commits.json
 
       - name: Fetch Changed Files
         env:
@@ -140,24 +141,25 @@ jobs:
         run: |
           gh api repos/${{ github.repository }}/pulls/$PR_NUMBER/files \
             --paginate \
-            --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > changed_files.json
+            --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > /tmp/changed_files.json
 
       - name: Strict Identity & File Validation
         run: |
           set -eo pipefail
 
           # Ensure no commits are unlinked to a GitHub account
-          NULL_COUNT=$(jq '[.[] | select(.author == null or .committer == null)] | length' commits.json)
+          NULL_COUNT=$(jq '[.[] | select(.author == null or .committer == null)] | length' /tmp/commits.json)
           if [ "$NULL_COUNT" -gt 0 ]; then
             echo "::error::❌ A commit belongs to an email not linked to a GitHub account."
             exit 1
           fi
 
           # Extract unique authors and committers into a space-separated string
-          CONTRIBUTORS=$(jq -r '.[] | .author, .committer' commits.json | sort -u)
-          
+          CONTRIBUTORS=$(jq -r '.[] | .author, .committer' /tmp/commits.json | sort -u)
+
           # Pass the unquoted $CONTRIBUTORS variable to python so argparse
           # correctly receives each name as a separate item in the list.
           python3 ci/validate_auto_approvers.py \
             --expected-count "$TOTAL_PR_FILES" \
             --contributors $CONTRIBUTORS
+            --changed-files /tmp/changed_files.json


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Store working files in `/tmp` to avoid potential future conflicts with
files checked into the repo. Pass `--changed-files
/tmp/changed_files.json` to `validate_auto_approvers.py`, which was
accidentally omitted before.




---

- 　  #3119
- 👉 #3128

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gxc3mluav6zwlo4nuepiwsfj2p5o467n6 && git checkout -b pr-Gxc3mluav6zwlo4nuepiwsfj2p5o467n6 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gxc3mluav6zwlo4nuepiwsfj2p5o467n6 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gxc3mluav6zwlo4nuepiwsfj2p5o467n6 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gxc3mluav6zwlo4nuepiwsfj2p5o467n6
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gxc3mluav6zwlo4nuepiwsfj2p5o467n6", "parent": null, "child": "Gih3nhc66bp3h3tzot25f35snlcxhepun"}" -->