### PR TITLE
[test] Fix mis-run UI tests

### DIFF
--- a/testutil/src/lib.rs
+++ b/testutil/src/lib.rs
@@ -125,16 +125,23 @@ impl UiTestRunner {
 
         let mut command = Command::new("cargo");
         command.current_dir(workspace_root.clone());
-        // We strip `--cfg zerocopy_derive_union_into_bytes` from `RUSTFLAGS` so
-        // that the `zerocopy-derive` proc macro is built without it. This ensures
-        // it generates the `#[cfg(not(zerocopy_derive_union_into_bytes))]` checks
-        // into the UI tests, which we can then explicitly enable or disable via
-        // `rustc_args`.
+        // We strip `--cfg zerocopy_derive_union_into_bytes` and `--cfg
+        // zerocopy_unstable_derive_on_error` from `RUSTFLAGS` so that the
+        // `zerocopy-derive` proc macro is built without them. This ensures it
+        // generates the feature-gate checks into the UI tests, which we can
+        // then explicitly enable or disable via `rustc_args`.
         let mut rustflags = env::var("RUSTFLAGS").unwrap_or_default();
-        rustflags = rustflags.replace("--cfg zerocopy_derive_union_into_bytes", "");
+        let cfgs_to_strip =
+            ["--cfg zerocopy_derive_union_into_bytes", "--cfg zerocopy_unstable_derive_on_error"];
+        for &cfg in &cfgs_to_strip {
+            rustflags = rustflags.replace(cfg, "");
+        }
         if let Ok(flags) = env::var("RUSTDOCFLAGS") {
-            command
-                .env("RUSTDOCFLAGS", flags.replace("--cfg zerocopy_derive_union_into_bytes", ""));
+            let mut new_flags = flags;
+            for &cfg in &cfgs_to_strip {
+                new_flags = new_flags.replace(cfg, "");
+            }
+            command.env("RUSTDOCFLAGS", new_flags);
         }
         command.env("RUSTFLAGS", rustflags);
         command.env_remove("CARGO_ENCODED_RUSTFLAGS");

--- a/zerocopy-derive/tests/ui.rs
+++ b/zerocopy-derive/tests/ui.rs
@@ -19,10 +19,9 @@ fn ui() {
         .rustc_arg("-Wwarnings") // To ensure .stderr files reflect typical user encounter
         .run();
 
-    // This tests the behavior when `--cfg zerocopy_derive_union_into_bytes` is
-    // not present.
+    // This tests the behavior when various `--cfg` flags are not present.
     UiTestRunner::new()
-        .subdir("union_into_bytes_cfg")
+        .subdir("cfgs")
         .rustc_arg("-Wwarnings") // To ensure .stderr files reflect typical user encounter
         .run();
 }

--- a/zerocopy-derive/tests/ui/cfgs/on_error.msrv.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/on_error.msrv.stderr
@@ -1,5 +1,5 @@
 error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error' to enable
-  --> tests/ui-msrv/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^
@@ -7,10 +7,14 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-  --> tests/ui-msrv/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
    |
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui/cfgs/on_error.nightly.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/on_error.nightly.stderr
@@ -1,5 +1,5 @@
 error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error' to enable
-  --> tests/ui-nightly/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^
@@ -7,7 +7,7 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-  --> tests/ui-nightly/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
@@ -22,10 +22,14 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and $N others
+           and 79 others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
  9 + #![feature(trivial_bounds)]
    |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui/cfgs/on_error.rs
+++ b/zerocopy-derive/tests/ui/cfgs/on_error.rs
@@ -11,6 +11,8 @@ extern crate zerocopy_renamed;
 use zerocopy_renamed::FromBytes;
 
 #[derive(FromBytes)]
+//~^ ERROR: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error' to enable
+//~| ERROR: the trait bound `bool: FromBytes` is not satisfied
 #[zerocopy(crate = "zerocopy_renamed")]
 #[zerocopy(on_error = "skip")]
 #[repr(C)]

--- a/zerocopy-derive/tests/ui/cfgs/on_error.stable.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/on_error.stable.stderr
@@ -1,5 +1,5 @@
 error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error' to enable
-  --> tests/ui-stable/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^
@@ -7,7 +7,7 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_derive_on_error
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
-  --> tests/ui-stable/cfgs/on_error.rs:13:10
+  --> $DIR/on_error.rs:13:10
    |
 13 | #[derive(FromBytes)]
    |          ^^^^^^^^^ the trait `FromBytes` is not implemented for `bool`
@@ -22,6 +22,10 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and $N others
+           and 79 others
    = help: see issue #48214
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.msrv.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.msrv.stderr
@@ -1,10 +1,6 @@
 error: requires --cfg zerocopy_derive_union_into_bytes;
 please let us know you use this feature: https://github.com/google/zerocopy/discussions/1802
-<<<<<<< HEAD:zerocopy-derive/tests/ui-msrv/cfgs/union_into_bytes_cfg.stderr
-  --> tests/ui-msrv/cfgs/union_into_bytes_cfg.rs:20:10
-=======
   --> $DIR/union_into_bytes_cfg.rs:20:10
->>>>>>> af201b89 ([tests] Migrate from trybuild to ui-test):zerocopy-derive/tests/ui-msrv/union_into_bytes_cfg/union_into_bytes_cfg.stderr
    |
 20 | #[derive(IntoBytes)]
    |          ^^^^^^^^^

--- a/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.nightly.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.nightly.stderr
@@ -1,8 +1,11 @@
 error: requires --cfg zerocopy_derive_union_into_bytes;
        please let us know you use this feature: https://github.com/google/zerocopy/discussions/1802
-  --> tests/ui-nightly/cfgs/union_into_bytes_cfg.rs:20:10
+  --> $DIR/union_into_bytes_cfg.rs:20:10
    |
 20 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.rs
+++ b/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.rs
@@ -18,6 +18,7 @@ extern crate zerocopy_renamed;
 use zerocopy_renamed::IntoBytes;
 
 #[derive(IntoBytes)]
+//~^ ERROR: requires --cfg zerocopy_derive_union_into_bytes
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 union Foo {

--- a/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.stable.stderr
+++ b/zerocopy-derive/tests/ui/cfgs/union_into_bytes_cfg.stable.stderr
@@ -1,8 +1,11 @@
 error: requires --cfg zerocopy_derive_union_into_bytes;
        please let us know you use this feature: https://github.com/google/zerocopy/discussions/1802
-  --> tests/ui-stable/cfgs/union_into_bytes_cfg.rs:20:10
+  --> $DIR/union_into_bytes_cfg.rs:20:10
    |
 20 | #[derive(IntoBytes)]
    |          ^^^^^^^^^
    |
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The tests in `zerocopy-derive/tests/ui/cfgs` were not being run after
being moved to that directory. Furthermore, the environment variable
`--cfg zerocopy_unstable_derive_on_error` was not stripped when running
these tests.




---

- 👉 #3134


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v3..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v3..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v2..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v1..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v2..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v1..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v1..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gb36998432d9a3fe259055359df13130c28ebca6a/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gb36998432d9a3fe259055359df13130c28ebca6a && git checkout -b pr-Gb36998432d9a3fe259055359df13130c28ebca6a FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gb36998432d9a3fe259055359df13130c28ebca6a && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gb36998432d9a3fe259055359df13130c28ebca6a && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gb36998432d9a3fe259055359df13130c28ebca6a
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gb36998432d9a3fe259055359df13130c28ebca6a", "parent": null, "child": null}" -->