### PR TITLE
ci: update step-security/harden-runner to v2.16.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 


### PR DESCRIPTION
Updates `step-security/harden-runner` in `.github/workflows/dependency-review.yml` to v2.16.0 to resolve known vulnerabilities identified by the `zizmor` CLI tool. (GHSA-46g3-37rh-v698 and GHSA-g699-3x6g-wm3g).

---
*PR created automatically by Jules for task [9834569690814950485](https://jules.google.com/task/9834569690814950485) started by @joshlf*