### PR TITLE
Change ref_from_bytes() to inline(always).

### DIFF
--- a/benches/ref_from_bytes_dynamic_padding.x86-64
+++ b/benches/ref_from_bytes_dynamic_padding.x86-64
@@ -1,22 +1,28 @@
 bench_ref_from_bytes_dynamic_padding:
 	test dil, 3
-	jne .LBB5_3
+	je .LBB5_2
+	xor eax, eax
+	mov rdx, rsi
+	ret
+.LBB5_2:
 	movabs rax, 9223372036854775804
 	and rax, rsi
 	cmp rax, 9
-	jb .LBB5_3
+	jae .LBB5_4
+	xor eax, eax
+	mov rdx, rsi
+	ret
+.LBB5_4:
 	add rax, -9
 	movabs rcx, -6148914691236517205
 	mul rcx
 	shr rdx
-	lea rax, [rdx + 2*rdx]
-	or rax, 3
-	add rax, 9
-	cmp rsi, rax
-	je .LBB5_4
-.LBB5_3:
-	xor edi, edi
+	lea rcx, [rdx + 2*rdx]
+	or rcx, 3
+	add rcx, 9
+	xor eax, eax
+	cmp rsi, rcx
+	cmove rsi, rdx
+	cmove rax, rdi
 	mov rdx, rsi
-.LBB5_4:
-	mov rax, rdi
 	ret

--- a/benches/ref_from_bytes_dynamic_padding.x86-64.mca
+++ b/benches/ref_from_bytes_dynamic_padding.x86-64.mca
@@ -1,12 +1,12 @@
 Iterations:        100
-Instructions:      1900
-Total Cycles:      645
-Total uOps:        2000
+Instructions:      2500
+Total Cycles:      849
+Total uOps:        2800
 
 Dispatch Width:    4
-uOps Per Cycle:    3.10
-IPC:               2.95
-Block RThroughput: 5.0
+uOps Per Cycle:    3.30
+IPC:               2.94
+Block RThroughput: 7.0
 
 
 Instruction Info:
@@ -19,23 +19,29 @@ Instruction Info:
 
 [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
  1      1     0.33                        test	dil, 3
- 1      1     1.00                        jne	.LBB5_3
+ 1      1     1.00                        je	.LBB5_2
+ 1      0     0.25                        xor	eax, eax
+ 1      1     0.33                        mov	rdx, rsi
+ 1      1     1.00                  U     ret
  1      1     0.33                        movabs	rax, 9223372036854775804
  1      1     0.33                        and	rax, rsi
  1      1     0.33                        cmp	rax, 9
- 1      1     1.00                        jb	.LBB5_3
+ 1      1     1.00                        jae	.LBB5_4
+ 1      0     0.25                        xor	eax, eax
+ 1      1     0.33                        mov	rdx, rsi
+ 1      1     1.00                  U     ret
  1      1     0.33                        add	rax, -9
  1      1     0.33                        movabs	rcx, -6148914691236517205
  2      4     1.00                        mul	rcx
  1      1     0.50                        shr	rdx
- 1      1     0.50                        lea	rax, [rdx + 2*rdx]
- 1      1     0.33                        or	rax, 3
- 1      1     0.33                        add	rax, 9
- 1      1     0.33                        cmp	rsi, rax
- 1      1     1.00                        je	.LBB5_4
- 1      0     0.25                        xor	edi, edi
+ 1      1     0.50                        lea	rcx, [rdx + 2*rdx]
+ 1      1     0.33                        or	rcx, 3
+ 1      1     0.33                        add	rcx, 9
+ 1      0     0.25                        xor	eax, eax
+ 1      1     0.33                        cmp	rsi, rcx
+ 2      2     0.67                        cmove	rsi, rdx
+ 2      2     0.67                        cmove	rax, rdi
  1      1     0.33                        mov	rdx, rsi
- 1      1     0.33                        mov	rax, rdi
  1      1     1.00                  U     ret
 
 
@@ -52,26 +58,32 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     6.32   6.33    -     6.35    -      -     
+ -      -     8.33   8.32    -     8.35    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
- -      -     0.64   0.35    -     0.01    -      -     test	dil, 3
- -      -      -      -      -     1.00    -      -     jne	.LBB5_3
- -      -     0.34   0.65    -     0.01    -      -     movabs	rax, 9223372036854775804
- -      -     0.35   0.65    -      -      -      -     and	rax, rsi
- -      -     0.33   0.34    -     0.33    -      -     cmp	rax, 9
- -      -      -      -      -     1.00    -      -     jb	.LBB5_3
- -      -     0.35    -      -     0.65    -      -     add	rax, -9
- -      -     0.97   0.01    -     0.02    -      -     movabs	rcx, -6148914691236517205
+ -      -     0.35   0.33    -     0.32    -      -     test	dil, 3
+ -      -      -      -      -     1.00    -      -     je	.LBB5_2
+ -      -      -      -      -      -      -      -     xor	eax, eax
+ -      -     0.92   0.04    -     0.04    -      -     mov	rdx, rsi
+ -      -      -      -      -     1.00    -      -     ret
+ -      -     0.32   0.15    -     0.53    -      -     movabs	rax, 9223372036854775804
+ -      -     0.03   0.06    -     0.91    -      -     and	rax, rsi
+ -      -     0.05   0.93    -     0.02    -      -     cmp	rax, 9
+ -      -      -      -      -     1.00    -      -     jae	.LBB5_4
+ -      -      -      -      -      -      -      -     xor	eax, eax
+ -      -     0.93   0.04    -     0.03    -      -     mov	rdx, rsi
+ -      -      -      -      -     1.00    -      -     ret
+ -      -     0.37   0.33    -     0.30    -      -     add	rax, -9
+ -      -     0.61   0.09    -     0.30    -      -     movabs	rcx, -6148914691236517205
  -      -     1.00   1.00    -      -      -      -     mul	rcx
- -      -     0.99    -      -     0.01    -      -     shr	rdx
- -      -     0.33   0.67    -      -      -      -     lea	rax, [rdx + 2*rdx]
- -      -     0.34   0.66    -      -      -      -     or	rax, 3
- -      -     0.33   0.66    -     0.01    -      -     add	rax, 9
- -      -     0.01   0.99    -      -      -      -     cmp	rsi, rax
- -      -      -      -      -     1.00    -      -     je	.LBB5_4
- -      -      -      -      -      -      -      -     xor	edi, edi
- -      -     0.32   0.01    -     0.67    -      -     mov	rdx, rsi
- -      -     0.02   0.34    -     0.64    -      -     mov	rax, rdi
+ -      -     0.67    -      -     0.33    -      -     shr	rdx
+ -      -     0.33   0.67    -      -      -      -     lea	rcx, [rdx + 2*rdx]
+ -      -     0.34   0.61    -     0.05    -      -     or	rcx, 3
+ -      -     0.36   0.61    -     0.03    -      -     add	rcx, 9
+ -      -      -      -      -      -      -      -     xor	eax, eax
+ -      -     0.04   0.63    -     0.33    -      -     cmp	rsi, rcx
+ -      -     0.98   0.97    -     0.05    -      -     cmove	rsi, rdx
+ -      -     0.98   0.94    -     0.08    -      -     cmove	rax, rdi
+ -      -     0.05   0.92    -     0.03    -      -     mov	rdx, rsi
  -      -      -      -      -     1.00    -      -     ret

--- a/benches/ref_from_bytes_dynamic_size.x86-64
+++ b/benches/ref_from_bytes_dynamic_size.x86-64
@@ -10,11 +10,11 @@ bench_ref_from_bytes_dynamic_size:
 .LBB5_2:
 	lea rcx, [rdx - 4]
 	mov rsi, rcx
-	and rsi, -2
-	add rsi, 4
-	shr rcx
+	shr rsi
+	and rcx, -2
+	add rcx, 4
 	xor eax, eax
-	cmp rdx, rsi
-	cmove rdx, rcx
+	cmp rdx, rcx
+	cmove rdx, rsi
 	cmove rax, rdi
 	ret

--- a/benches/ref_from_bytes_dynamic_size.x86-64.mca
+++ b/benches/ref_from_bytes_dynamic_size.x86-64.mca
@@ -1,11 +1,11 @@
 Iterations:        100
 Instructions:      1800
-Total Cycles:      704
+Total Cycles:      606
 Total uOps:        2000
 
 Dispatch Width:    4
-uOps Per Cycle:    2.84
-IPC:               2.56
+uOps Per Cycle:    3.30
+IPC:               2.97
 Block RThroughput: 5.0
 
 
@@ -28,12 +28,12 @@ Instruction Info:
  1      1     1.00                  U     ret
  1      1     0.50                        lea	rcx, [rdx - 4]
  1      1     0.33                        mov	rsi, rcx
- 1      1     0.33                        and	rsi, -2
- 1      1     0.33                        add	rsi, 4
- 1      1     0.50                        shr	rcx
+ 1      1     0.50                        shr	rsi
+ 1      1     0.33                        and	rcx, -2
+ 1      1     0.33                        add	rcx, 4
  1      0     0.25                        xor	eax, eax
- 1      1     0.33                        cmp	rdx, rsi
- 2      2     0.67                        cmove	rdx, rcx
+ 1      1     0.33                        cmp	rdx, rcx
+ 2      2     0.67                        cmove	rdx, rsi
  2      2     0.67                        cmove	rax, rdi
  1      1     1.00                  U     ret
 
@@ -51,25 +51,25 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     5.97   5.98    -     6.05    -      -     
+ -      -     6.00   6.00    -     6.00    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
- -      -     0.97   0.01    -     0.02    -      -     mov	rdx, rsi
- -      -     0.01   0.02    -     0.97    -      -     cmp	rsi, 4
- -      -     0.03    -      -     0.97    -      -     setb	al
- -      -     0.01   0.02    -     0.97    -      -     or	al, dil
- -      -      -     0.98    -     0.02    -      -     test	al, 1
+ -      -      -     0.99    -     0.01    -      -     mov	rdx, rsi
+ -      -     0.99   0.01    -      -      -      -     cmp	rsi, 4
+ -      -     1.00    -      -      -      -      -     setb	al
+ -      -     0.99   0.01    -      -      -      -     or	al, dil
+ -      -      -     0.99    -     0.01    -      -     test	al, 1
  -      -      -      -      -     1.00    -      -     je	.LBB5_2
  -      -      -      -      -      -      -      -     xor	eax, eax
  -      -      -      -      -     1.00    -      -     ret
- -      -     0.98   0.02    -      -      -      -     lea	rcx, [rdx - 4]
- -      -     0.01   0.99    -      -      -      -     mov	rsi, rcx
- -      -      -     0.98    -     0.02    -      -     and	rsi, -2
- -      -     0.98   0.01    -     0.01    -      -     add	rsi, 4
- -      -     0.99    -      -     0.01    -      -     shr	rcx
+ -      -     1.00    -      -      -      -      -     lea	rcx, [rdx - 4]
+ -      -      -     1.00    -      -      -      -     mov	rsi, rcx
+ -      -     1.00    -      -      -      -      -     shr	rsi
+ -      -     1.00    -      -      -      -      -     and	rcx, -2
+ -      -      -     1.00    -      -      -      -     add	rcx, 4
  -      -      -      -      -      -      -      -     xor	eax, eax
- -      -     0.02   0.97    -     0.01    -      -     cmp	rdx, rsi
- -      -     0.99   0.99    -     0.02    -      -     cmove	rdx, rcx
- -      -     0.98   0.99    -     0.03    -      -     cmove	rax, rdi
+ -      -      -      -      -     1.00    -      -     cmp	rdx, rcx
+ -      -     0.01   1.00    -     0.99    -      -     cmove	rdx, rsi
+ -      -     0.01   1.00    -     0.99    -      -     cmove	rax, rdi
  -      -      -      -      -     1.00    -      -     ret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4005,7 +4005,7 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[inline(always)]
     fn ref_from_bytes(source: &[u8]) -> Result<&Self, CastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,


### PR DESCRIPTION
When building my firmware for rv32imc with lto=fat, changing codegen-units from 16 to 1 influences the compiler heuristics enough to *not* inline this function, causing code bloat and unnecessary panic logic.
