### PR TITLE
Introduce `--cfg zerocopy_inline_always`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ for network parsing.
 [duplicate-import-errors]: https://github.com/google/zerocopy/issues/1587
 [simd-layout]: https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
 
+## Build Tuning
+
+### `--cfg zerocopy_inline_always`
+
+Upgrades `#[inline]` to `#[inline(always)]` on many of zerocopy's public
+functions and methods. This provides a narrowly-scoped alternative that
+*may* improve the optimization of hot paths using zerocopy without the broad
+compile-time penalties of configuring `codegen-units=1`.
+
 ## Security Ethos
 
 Zerocopy is expressly designed for use in security-critical contexts. We

--- a/benches/ref_from_bytes_dynamic_padding.x86-64
+++ b/benches/ref_from_bytes_dynamic_padding.x86-64
@@ -1,28 +1,22 @@
 bench_ref_from_bytes_dynamic_padding:
 	test dil, 3
-	je .LBB5_2
-	xor eax, eax
-	mov rdx, rsi
-	ret
-.LBB5_2:
+	jne .LBB5_3
 	movabs rax, 9223372036854775804
 	and rax, rsi
 	cmp rax, 9
-	jae .LBB5_4
-	xor eax, eax
-	mov rdx, rsi
-	ret
-.LBB5_4:
+	jb .LBB5_3
 	add rax, -9
 	movabs rcx, -6148914691236517205
 	mul rcx
 	shr rdx
-	lea rcx, [rdx + 2*rdx]
-	or rcx, 3
-	add rcx, 9
-	xor eax, eax
-	cmp rsi, rcx
-	cmove rsi, rdx
-	cmove rax, rdi
+	lea rax, [rdx + 2*rdx]
+	or rax, 3
+	add rax, 9
+	cmp rsi, rax
+	je .LBB5_4
+.LBB5_3:
+	xor edi, edi
 	mov rdx, rsi
+.LBB5_4:
+	mov rax, rdi
 	ret

--- a/benches/ref_from_bytes_dynamic_padding.x86-64.mca
+++ b/benches/ref_from_bytes_dynamic_padding.x86-64.mca
@@ -1,12 +1,12 @@
 Iterations:        100
-Instructions:      2500
-Total Cycles:      849
-Total uOps:        2800
+Instructions:      1900
+Total Cycles:      645
+Total uOps:        2000
 
 Dispatch Width:    4
-uOps Per Cycle:    3.30
-IPC:               2.94
-Block RThroughput: 7.0
+uOps Per Cycle:    3.10
+IPC:               2.95
+Block RThroughput: 5.0
 
 
 Instruction Info:
@@ -19,29 +19,23 @@ Instruction Info:
 
 [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
  1      1     0.33                        test	dil, 3
- 1      1     1.00                        je	.LBB5_2
- 1      0     0.25                        xor	eax, eax
- 1      1     0.33                        mov	rdx, rsi
- 1      1     1.00                  U     ret
+ 1      1     1.00                        jne	.LBB5_3
  1      1     0.33                        movabs	rax, 9223372036854775804
  1      1     0.33                        and	rax, rsi
  1      1     0.33                        cmp	rax, 9
- 1      1     1.00                        jae	.LBB5_4
- 1      0     0.25                        xor	eax, eax
- 1      1     0.33                        mov	rdx, rsi
- 1      1     1.00                  U     ret
+ 1      1     1.00                        jb	.LBB5_3
  1      1     0.33                        add	rax, -9
  1      1     0.33                        movabs	rcx, -6148914691236517205
  2      4     1.00                        mul	rcx
  1      1     0.50                        shr	rdx
- 1      1     0.50                        lea	rcx, [rdx + 2*rdx]
- 1      1     0.33                        or	rcx, 3
- 1      1     0.33                        add	rcx, 9
- 1      0     0.25                        xor	eax, eax
- 1      1     0.33                        cmp	rsi, rcx
- 2      2     0.67                        cmove	rsi, rdx
- 2      2     0.67                        cmove	rax, rdi
+ 1      1     0.50                        lea	rax, [rdx + 2*rdx]
+ 1      1     0.33                        or	rax, 3
+ 1      1     0.33                        add	rax, 9
+ 1      1     0.33                        cmp	rsi, rax
+ 1      1     1.00                        je	.LBB5_4
+ 1      0     0.25                        xor	edi, edi
  1      1     0.33                        mov	rdx, rsi
+ 1      1     0.33                        mov	rax, rdi
  1      1     1.00                  U     ret
 
 
@@ -58,32 +52,26 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     8.33   8.32    -     8.35    -      -     
+ -      -     6.32   6.33    -     6.35    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
- -      -     0.35   0.33    -     0.32    -      -     test	dil, 3
- -      -      -      -      -     1.00    -      -     je	.LBB5_2
- -      -      -      -      -      -      -      -     xor	eax, eax
- -      -     0.92   0.04    -     0.04    -      -     mov	rdx, rsi
- -      -      -      -      -     1.00    -      -     ret
- -      -     0.32   0.15    -     0.53    -      -     movabs	rax, 9223372036854775804
- -      -     0.03   0.06    -     0.91    -      -     and	rax, rsi
- -      -     0.05   0.93    -     0.02    -      -     cmp	rax, 9
- -      -      -      -      -     1.00    -      -     jae	.LBB5_4
- -      -      -      -      -      -      -      -     xor	eax, eax
- -      -     0.93   0.04    -     0.03    -      -     mov	rdx, rsi
- -      -      -      -      -     1.00    -      -     ret
- -      -     0.37   0.33    -     0.30    -      -     add	rax, -9
- -      -     0.61   0.09    -     0.30    -      -     movabs	rcx, -6148914691236517205
+ -      -     0.64   0.35    -     0.01    -      -     test	dil, 3
+ -      -      -      -      -     1.00    -      -     jne	.LBB5_3
+ -      -     0.34   0.65    -     0.01    -      -     movabs	rax, 9223372036854775804
+ -      -     0.35   0.65    -      -      -      -     and	rax, rsi
+ -      -     0.33   0.34    -     0.33    -      -     cmp	rax, 9
+ -      -      -      -      -     1.00    -      -     jb	.LBB5_3
+ -      -     0.35    -      -     0.65    -      -     add	rax, -9
+ -      -     0.97   0.01    -     0.02    -      -     movabs	rcx, -6148914691236517205
  -      -     1.00   1.00    -      -      -      -     mul	rcx
- -      -     0.67    -      -     0.33    -      -     shr	rdx
- -      -     0.33   0.67    -      -      -      -     lea	rcx, [rdx + 2*rdx]
- -      -     0.34   0.61    -     0.05    -      -     or	rcx, 3
- -      -     0.36   0.61    -     0.03    -      -     add	rcx, 9
- -      -      -      -      -      -      -      -     xor	eax, eax
- -      -     0.04   0.63    -     0.33    -      -     cmp	rsi, rcx
- -      -     0.98   0.97    -     0.05    -      -     cmove	rsi, rdx
- -      -     0.98   0.94    -     0.08    -      -     cmove	rax, rdi
- -      -     0.05   0.92    -     0.03    -      -     mov	rdx, rsi
+ -      -     0.99    -      -     0.01    -      -     shr	rdx
+ -      -     0.33   0.67    -      -      -      -     lea	rax, [rdx + 2*rdx]
+ -      -     0.34   0.66    -      -      -      -     or	rax, 3
+ -      -     0.33   0.66    -     0.01    -      -     add	rax, 9
+ -      -     0.01   0.99    -      -      -      -     cmp	rsi, rax
+ -      -      -      -      -     1.00    -      -     je	.LBB5_4
+ -      -      -      -      -      -      -      -     xor	edi, edi
+ -      -     0.32   0.01    -     0.67    -      -     mov	rdx, rsi
+ -      -     0.02   0.34    -     0.64    -      -     mov	rax, rdi
  -      -      -      -      -     1.00    -      -     ret

--- a/benches/ref_from_bytes_dynamic_size.x86-64
+++ b/benches/ref_from_bytes_dynamic_size.x86-64
@@ -10,11 +10,11 @@ bench_ref_from_bytes_dynamic_size:
 .LBB5_2:
 	lea rcx, [rdx - 4]
 	mov rsi, rcx
-	shr rsi
-	and rcx, -2
-	add rcx, 4
+	and rsi, -2
+	add rsi, 4
+	shr rcx
 	xor eax, eax
-	cmp rdx, rcx
-	cmove rdx, rsi
+	cmp rdx, rsi
+	cmove rdx, rcx
 	cmove rax, rdi
 	ret

--- a/benches/ref_from_bytes_dynamic_size.x86-64.mca
+++ b/benches/ref_from_bytes_dynamic_size.x86-64.mca
@@ -1,11 +1,11 @@
 Iterations:        100
 Instructions:      1800
-Total Cycles:      606
+Total Cycles:      704
 Total uOps:        2000
 
 Dispatch Width:    4
-uOps Per Cycle:    3.30
-IPC:               2.97
+uOps Per Cycle:    2.84
+IPC:               2.56
 Block RThroughput: 5.0
 
 
@@ -28,12 +28,12 @@ Instruction Info:
  1      1     1.00                  U     ret
  1      1     0.50                        lea	rcx, [rdx - 4]
  1      1     0.33                        mov	rsi, rcx
- 1      1     0.50                        shr	rsi
- 1      1     0.33                        and	rcx, -2
- 1      1     0.33                        add	rcx, 4
+ 1      1     0.33                        and	rsi, -2
+ 1      1     0.33                        add	rsi, 4
+ 1      1     0.50                        shr	rcx
  1      0     0.25                        xor	eax, eax
- 1      1     0.33                        cmp	rdx, rcx
- 2      2     0.67                        cmove	rdx, rsi
+ 1      1     0.33                        cmp	rdx, rsi
+ 2      2     0.67                        cmove	rdx, rcx
  2      2     0.67                        cmove	rax, rdi
  1      1     1.00                  U     ret
 
@@ -51,25 +51,25 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     6.00   6.00    -     6.00    -      -     
+ -      -     5.97   5.98    -     6.05    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
- -      -      -     0.99    -     0.01    -      -     mov	rdx, rsi
- -      -     0.99   0.01    -      -      -      -     cmp	rsi, 4
- -      -     1.00    -      -      -      -      -     setb	al
- -      -     0.99   0.01    -      -      -      -     or	al, dil
- -      -      -     0.99    -     0.01    -      -     test	al, 1
+ -      -     0.97   0.01    -     0.02    -      -     mov	rdx, rsi
+ -      -     0.01   0.02    -     0.97    -      -     cmp	rsi, 4
+ -      -     0.03    -      -     0.97    -      -     setb	al
+ -      -     0.01   0.02    -     0.97    -      -     or	al, dil
+ -      -      -     0.98    -     0.02    -      -     test	al, 1
  -      -      -      -      -     1.00    -      -     je	.LBB5_2
  -      -      -      -      -      -      -      -     xor	eax, eax
  -      -      -      -      -     1.00    -      -     ret
- -      -     1.00    -      -      -      -      -     lea	rcx, [rdx - 4]
- -      -      -     1.00    -      -      -      -     mov	rsi, rcx
- -      -     1.00    -      -      -      -      -     shr	rsi
- -      -     1.00    -      -      -      -      -     and	rcx, -2
- -      -      -     1.00    -      -      -      -     add	rcx, 4
+ -      -     0.98   0.02    -      -      -      -     lea	rcx, [rdx - 4]
+ -      -     0.01   0.99    -      -      -      -     mov	rsi, rcx
+ -      -      -     0.98    -     0.02    -      -     and	rsi, -2
+ -      -     0.98   0.01    -     0.01    -      -     add	rsi, 4
+ -      -     0.99    -      -     0.01    -      -     shr	rcx
  -      -      -      -      -      -      -      -     xor	eax, eax
- -      -      -      -      -     1.00    -      -     cmp	rdx, rcx
- -      -     0.01   1.00    -     0.99    -      -     cmove	rdx, rsi
- -      -     0.01   1.00    -     0.99    -      -     cmove	rax, rdi
+ -      -     0.02   0.97    -     0.01    -      -     cmp	rdx, rsi
+ -      -     0.99   0.99    -     0.02    -      -     cmove	rdx, rcx
+ -      -     0.98   0.99    -     0.03    -      -     cmove	rax, rdi
  -      -      -      -      -     1.00    -      -     ret

--- a/benches/ref_from_bytes_static_size.x86-64
+++ b/benches/ref_from_bytes_static_size.x86-64
@@ -1,9 +1,8 @@
 bench_ref_from_bytes_static_size:
+	mov ecx, edi
+	and ecx, 1
+	xor rsi, 6
 	xor eax, eax
-	cmp rsi, 6
-	mov rcx, rdi
-	cmovne rcx, rax
-	cmovb rcx, rax
-	test dil, 1
-	cmove rax, rcx
+	or rsi, rcx
+	cmove rax, rdi
 	ret

--- a/benches/ref_from_bytes_static_size.x86-64.mca
+++ b/benches/ref_from_bytes_static_size.x86-64.mca
@@ -1,12 +1,12 @@
 Iterations:        100
-Instructions:      800
-Total Cycles:      341
-Total uOps:        1100
+Instructions:      700
+Total Cycles:      240
+Total uOps:        800
 
 Dispatch Width:    4
-uOps Per Cycle:    3.23
-IPC:               2.35
-Block RThroughput: 2.8
+uOps Per Cycle:    3.33
+IPC:               2.92
+Block RThroughput: 2.0
 
 
 Instruction Info:
@@ -18,13 +18,12 @@ Instruction Info:
 [6]: HasSideEffects (U)
 
 [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
+ 1      1     0.33                        mov	ecx, edi
+ 1      1     0.33                        and	ecx, 1
+ 1      1     0.33                        xor	rsi, 6
  1      0     0.25                        xor	eax, eax
- 1      1     0.33                        cmp	rsi, 6
- 1      1     0.33                        mov	rcx, rdi
- 2      2     0.67                        cmovne	rcx, rax
- 2      2     0.67                        cmovb	rcx, rax
- 1      1     0.33                        test	dil, 1
- 2      2     0.67                        cmove	rax, rcx
+ 1      1     0.33                        or	rsi, rcx
+ 2      2     0.67                        cmove	rax, rdi
  1      1     1.00                  U     ret
 
 
@@ -41,15 +40,14 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     3.32   3.34    -     3.34    -      -     
+ -      -     2.33   2.33    -     2.34    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
+ -      -     0.01   0.98    -     0.01    -      -     mov	ecx, edi
+ -      -     0.02   0.66    -     0.32    -      -     and	ecx, 1
+ -      -     0.33   0.66    -     0.01    -      -     xor	rsi, 6
  -      -      -      -      -      -      -      -     xor	eax, eax
- -      -      -     0.17    -     0.83    -      -     cmp	rsi, 6
- -      -     0.17   0.18    -     0.65    -      -     mov	rcx, rdi
- -      -     1.00   0.98    -     0.02    -      -     cmovne	rcx, rax
- -      -     1.00   1.00    -      -      -      -     cmovb	rcx, rax
- -      -     0.16   0.02    -     0.82    -      -     test	dil, 1
- -      -     0.99   0.99    -     0.02    -      -     cmove	rax, rcx
+ -      -     0.98   0.02    -      -      -      -     or	rsi, rcx
+ -      -     0.99   0.01    -     1.00    -      -     cmove	rax, rdi
  -      -      -      -      -     1.00    -      -     ret

--- a/build.rs
+++ b/build.rs
@@ -93,6 +93,7 @@ fn main() {
         );
         println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)");
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
+        println!("cargo:rustc-check-cfg=cfg(zerocopy_inline_always)");
     }
 
     for version_cfg in version_cfgs {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,15 @@
 //! [duplicate-import-errors]: https://github.com/google/zerocopy/issues/1587
 //! [simd-layout]: https://rust-lang.github.io/unsafe-code-guidelines/layout/packed-simd-vectors.html
 //!
+//! # Build Tuning
+//!
+//! ## `--cfg zerocopy_inline_always`
+//!
+//! Upgrades `#[inline]` to `#[inline(always)]` on many of zerocopy's public
+//! functions and methods. This provides a narrowly-scoped alternative that
+//! *may* improve the optimization of hot paths using zerocopy without the broad
+//! compile-time penalties of configuring `codegen-units=1`.
+//!
 //! # Security Ethos
 //!
 //! Zerocopy is expressly designed for use in security-critical contexts. We
@@ -1814,7 +1823,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_bytes(source: &[u8]) -> Result<&Self, TryCastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,
@@ -1936,7 +1946,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_prefix(source: &[u8]) -> Result<(&Self, &[u8]), TryCastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,
@@ -2045,7 +2056,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_suffix(source: &[u8]) -> Result<(&[u8], &Self), TryCastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,
@@ -2138,7 +2150,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_bytes`](#method.try_ref_from_bytes.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_bytes(bytes: &mut [u8]) -> Result<&mut Self, TryCastError<&mut [u8], Self>>
     where
         Self: KnownLayout + IntoBytes,
@@ -2246,7 +2259,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_prefix`](#method.try_ref_from_prefix.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_prefix(
         source: &mut [u8],
     ) -> Result<(&mut Self, &mut [u8]), TryCastError<&mut [u8], Self>>
@@ -2345,7 +2359,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_suffix`](#method.try_ref_from_suffix.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_suffix(
         source: &mut [u8],
     ) -> Result<(&mut [u8], &mut Self), TryCastError<&mut [u8], Self>>
@@ -2449,7 +2464,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_bytes_with_elems(
         source: &[u8],
         count: usize,
@@ -2569,7 +2585,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_prefix_with_elems(
         source: &[u8],
         count: usize,
@@ -2676,7 +2693,8 @@ pub unsafe trait TryFromBytes {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_ref_from_suffix_with_elems(
         source: &[u8],
         count: usize,
@@ -2771,7 +2789,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_bytes_with_elems`](#method.try_ref_from_bytes_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_bytes_with_elems(
         source: &mut [u8],
         count: usize,
@@ -2881,7 +2900,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_prefix_with_elems`](#method.try_ref_from_prefix_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_prefix_with_elems(
         source: &mut [u8],
         count: usize,
@@ -2980,7 +3000,8 @@ pub unsafe trait TryFromBytes {
     ///
     /// See [`TryFromBytes::try_ref_from_suffix_with_elems`](#method.try_ref_from_suffix_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_mut_from_suffix_with_elems(
         source: &mut [u8],
         count: usize,
@@ -3046,7 +3067,8 @@ pub unsafe trait TryFromBytes {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_read_from_bytes(source: &[u8]) -> Result<Self, TryReadError<&[u8], Self>>
     where
         Self: Sized,
@@ -3123,7 +3145,8 @@ pub unsafe trait TryFromBytes {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_read_from_prefix(source: &[u8]) -> Result<(Self, &[u8]), TryReadError<&[u8], Self>>
     where
         Self: Sized,
@@ -3201,7 +3224,8 @@ pub unsafe trait TryFromBytes {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn try_read_from_suffix(source: &[u8]) -> Result<(&[u8], Self), TryReadError<&[u8], Self>>
     where
         Self: Sized,
@@ -4005,7 +4029,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline(always)]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_bytes(source: &[u8]) -> Result<&Self, CastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,
@@ -4116,7 +4141,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_prefix(source: &[u8]) -> Result<(&Self, &[u8]), CastError<&[u8], Self>>
     where
         Self: KnownLayout + Immutable,
@@ -4209,7 +4235,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_suffix(source: &[u8]) -> Result<(&[u8], &Self), CastError<&[u8], Self>>
     where
         Self: Immutable + KnownLayout,
@@ -4292,7 +4319,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`FromBytes::ref_from_bytes`](#method.ref_from_bytes.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_bytes(source: &mut [u8]) -> Result<&mut Self, CastError<&mut [u8], Self>>
     where
         Self: IntoBytes + KnownLayout,
@@ -4382,7 +4410,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`FromBytes::ref_from_prefix`](#method.ref_from_prefix.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_prefix(
         source: &mut [u8],
     ) -> Result<(&mut Self, &mut [u8]), CastError<&mut [u8], Self>>
@@ -4462,7 +4491,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`FromBytes::ref_from_suffix`](#method.ref_from_suffix.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_suffix(
         source: &mut [u8],
     ) -> Result<(&mut [u8], &mut Self), CastError<&mut [u8], Self>>
@@ -4553,7 +4583,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_bytes_with_elems(
         source: &[u8],
         count: usize,
@@ -4651,7 +4682,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_prefix_with_elems(
         source: &[u8],
         count: usize,
@@ -4744,7 +4776,8 @@ pub unsafe trait FromBytes: FromZeros {
         ]
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn ref_from_suffix_with_elems(
         source: &[u8],
         count: usize,
@@ -4824,7 +4857,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`TryFromBytes::ref_from_bytes_with_elems`](#method.ref_from_bytes_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_bytes_with_elems(
         source: &mut [u8],
         count: usize,
@@ -4913,7 +4947,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`TryFromBytes::ref_from_prefix_with_elems`](#method.ref_from_prefix_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_prefix_with_elems(
         source: &mut [u8],
         count: usize,
@@ -4997,7 +5032,8 @@ pub unsafe trait FromBytes: FromZeros {
     ///
     /// See [`TryFromBytes::ref_from_suffix_with_elems`](#method.ref_from_suffix_with_elems.codegen).
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn mut_from_suffix_with_elems(
         source: &mut [u8],
         count: usize,
@@ -5044,7 +5080,8 @@ pub unsafe trait FromBytes: FromZeros {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn read_from_bytes(source: &[u8]) -> Result<Self, SizeError<&[u8], Self>>
     where
         Self: Sized,
@@ -5101,7 +5138,8 @@ pub unsafe trait FromBytes: FromZeros {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn read_from_prefix(source: &[u8]) -> Result<(Self, &[u8]), SizeError<&[u8], Self>>
     where
         Self: Sized,
@@ -5152,7 +5190,8 @@ pub unsafe trait FromBytes: FromZeros {
         format = "coco_static_size",
     )]
     #[must_use = "has no side effects"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     fn read_from_suffix(source: &[u8]) -> Result<(&[u8], Self), SizeError<&[u8], Self>>
     where
         Self: Sized,
@@ -5756,7 +5795,8 @@ pub unsafe trait IntoBytes {
         ]
     )]
     #[must_use = "callers should check the return value to see if the operation succeeded"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     #[allow(clippy::mut_from_ref)] // False positive: `&self -> &mut [u8]`
     fn write_to(&self, dst: &mut [u8]) -> Result<(), SizeError<&Self, &mut [u8]>>
     where
@@ -5841,7 +5881,8 @@ pub unsafe trait IntoBytes {
         ]
     )]
     #[must_use = "callers should check the return value to see if the operation succeeded"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     #[allow(clippy::mut_from_ref)] // False positive: `&self -> &mut [u8]`
     fn write_to_prefix(&self, dst: &mut [u8]) -> Result<(), SizeError<&Self, &mut [u8]>>
     where
@@ -5935,7 +5976,8 @@ pub unsafe trait IntoBytes {
         ]
     )]
     #[must_use = "callers should check the return value to see if the operation succeeded"]
-    #[inline]
+    #[cfg_attr(zerocopy_inline_always, inline(always))]
+    #[cfg_attr(not(zerocopy_inline_always), inline)]
     #[allow(clippy::mut_from_ref)] // False positive: `&self -> &mut [u8]`
     fn write_to_suffix(&self, dst: &mut [u8]) -> Result<(), SizeError<&Self, &mut [u8]>>
     where


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Enables customers to tune inlining aggressiveness of many of zerocopy's
public functions. At higher `codegen-units`, the Rust compiler may fail
to inline invocations of conversion functions. Applying the
`#[inline(always)]` attribute (as in #3137) forces inlining, but that
might not be desirable for all monomorphizations or invocations.
Dynamically padded types, for instance, require much more complex
codegen than statically sized for unpadded dynamically sized types.

While reducing `codegen-units` for a build can improve codegen, it
carries a large penalty in build times. The `--cfg zerocopy_inline_always`
flag provides a narrowly-scoped lever for achieving some of the
benefits of `codegen-units=1` without the broad build time penalties.




---

- 👉 #3139


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|[vs v4](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|[vs v3](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|[vs v2](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|[vs v1](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5)|[vs v3](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5)|[vs v2](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5)|[vs v1](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4)|[vs v2](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4)|[vs v1](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3)|[vs v1](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/main..gherrit/G750518420a745aec19276f7a24bcd0f66584bb2c/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G750518420a745aec19276f7a24bcd0f66584bb2c && git checkout -b pr-G750518420a745aec19276f7a24bcd0f66584bb2c FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G750518420a745aec19276f7a24bcd0f66584bb2c && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G750518420a745aec19276f7a24bcd0f66584bb2c && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G750518420a745aec19276f7a24bcd0f66584bb2c
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G750518420a745aec19276f7a24bcd0f66584bb2c", "parent": null, "child": null}" -->