### PR TITLE
Apply `#[inline(always)]` to more closures

### DIFF
--- a/benches/ref_from_bytes_static_size.x86-64
+++ b/benches/ref_from_bytes_static_size.x86-64
@@ -1,8 +1,9 @@
 bench_ref_from_bytes_static_size:
-	mov ecx, edi
-	and ecx, 1
-	xor rsi, 6
 	xor eax, eax
-	or rsi, rcx
-	cmove rax, rdi
+	cmp rsi, 6
+	mov rcx, rdi
+	cmovne rcx, rax
+	cmovb rcx, rax
+	test dil, 1
+	cmove rax, rcx
 	ret

--- a/benches/ref_from_bytes_static_size.x86-64.mca
+++ b/benches/ref_from_bytes_static_size.x86-64.mca
@@ -1,12 +1,12 @@
 Iterations:        100
-Instructions:      700
-Total Cycles:      240
-Total uOps:        800
+Instructions:      800
+Total Cycles:      341
+Total uOps:        1100
 
 Dispatch Width:    4
-uOps Per Cycle:    3.33
-IPC:               2.92
-Block RThroughput: 2.0
+uOps Per Cycle:    3.23
+IPC:               2.35
+Block RThroughput: 2.8
 
 
 Instruction Info:
@@ -18,12 +18,13 @@ Instruction Info:
 [6]: HasSideEffects (U)
 
 [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
- 1      1     0.33                        mov	ecx, edi
- 1      1     0.33                        and	ecx, 1
- 1      1     0.33                        xor	rsi, 6
  1      0     0.25                        xor	eax, eax
- 1      1     0.33                        or	rsi, rcx
- 2      2     0.67                        cmove	rax, rdi
+ 1      1     0.33                        cmp	rsi, 6
+ 1      1     0.33                        mov	rcx, rdi
+ 2      2     0.67                        cmovne	rcx, rax
+ 2      2     0.67                        cmovb	rcx, rax
+ 1      1     0.33                        test	dil, 1
+ 2      2     0.67                        cmove	rax, rcx
  1      1     1.00                  U     ret
 
 
@@ -40,14 +41,15 @@ Resources:
 
 Resource pressure per iteration:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  
- -      -     2.33   2.33    -     2.34    -      -     
+ -      -     3.32   3.34    -     3.34    -      -     
 
 Resource pressure by instruction:
 [0]    [1]    [2]    [3]    [4]    [5]    [6.0]  [6.1]  Instructions:
- -      -     0.01   0.98    -     0.01    -      -     mov	ecx, edi
- -      -     0.02   0.66    -     0.32    -      -     and	ecx, 1
- -      -     0.33   0.66    -     0.01    -      -     xor	rsi, 6
  -      -      -      -      -      -      -      -     xor	eax, eax
- -      -     0.98   0.02    -      -      -      -     or	rsi, rcx
- -      -     0.99   0.01    -     1.00    -      -     cmove	rax, rdi
+ -      -      -     0.17    -     0.83    -      -     cmp	rsi, 6
+ -      -     0.17   0.18    -     0.65    -      -     mov	rcx, rdi
+ -      -     1.00   0.98    -     0.02    -      -     cmovne	rcx, rax
+ -      -     1.00   1.00    -      -      -      -     cmovb	rcx, rax
+ -      -     0.16   0.02    -     0.82    -      -     test	dil, 1
+ -      -     0.99   0.99    -     0.02    -      -     cmove	rax, rcx
  -      -      -      -      -     1.00    -      -     ret

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -657,14 +657,20 @@ mod tests {
                 let l_sum: usize = l
                     .trailing_slice()
                     .iter()
-                    .map(|ptr| unsafe { core::ptr::read_unaligned(ptr.as_ptr()) } as usize)
+                    .map(
+                        #[inline(always)]
+                        |ptr| unsafe { core::ptr::read_unaligned(ptr.as_ptr()) } as usize,
+                    )
                     .sum();
                 // SAFETY: Points to a valid value by construction.
                 #[allow(clippy::undocumented_unsafe_blocks, clippy::as_conversions)]
                 // Clippy false positive
                 let r_sum: usize = r
                     .iter()
-                    .map(|ptr| unsafe { core::ptr::read_unaligned(ptr.as_ptr()) } as usize)
+                    .map(
+                        #[inline(always)]
+                        |ptr| unsafe { core::ptr::read_unaligned(ptr.as_ptr()) } as usize,
+                    )
                     .sum();
                 assert_eq!(l_sum, i.get());
                 assert_eq!(r_sum, n - i.get());

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -38,7 +38,10 @@ where
     I: invariant::Invariants<Validity = invariant::Initialized>,
     I::Aliasing: invariant::Reference,
 {
-    ptr.as_bytes().as_ref().iter().all(|&byte| byte == 0)
+    ptr.as_bytes().as_ref().iter().all(
+        #[inline(always)]
+        |&byte| byte == 0,
+    )
 }
 
 #[doc(hidden)]

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -971,6 +971,7 @@ mod _casts {
 
         /// Attempts to transform the pointer, restoring the original on
         /// failure.
+        #[inline(always)]
         pub(crate) fn try_with<U, J, E, F>(self, f: F) -> Result<Ptr<'a, U, J>, E::Mapped>
         where
             U: 'a + ?Sized,
@@ -1098,15 +1099,20 @@ mod _casts {
             I::Aliasing: Reference,
             U: 'a + ?Sized + KnownLayout + Read<I::Aliasing, R>,
         {
-            let (inner, remainder) =
-                self.as_inner().try_cast_into(cast_type, meta).map_err(|err| {
-                    err.map_src(|inner|
+            let (inner, remainder) = self.as_inner().try_cast_into(cast_type, meta).map_err(
+                #[inline(always)]
+                |err| {
+                    err.map_src(
+                        #[inline(always)]
+                        |inner|
                     // SAFETY: `PtrInner::try_cast_into` promises to return its
                     // original argument on error, which was originally produced
                     // by `self.as_inner()`, which is guaranteed to satisfy
                     // `Ptr`'s invariants.
-                    unsafe { Ptr::from_inner(inner) })
-                })?;
+                    unsafe { Ptr::from_inner(inner) },
+                    )
+                },
+            )?;
 
             // SAFETY:
             // 0. Since `U: Read<I::Aliasing, _>`, either:
@@ -1164,16 +1170,22 @@ mod _casts {
         {
             // SAFETY: The provided closure returns the only copy of `slf`.
             unsafe {
-                self.try_with_unchecked(|slf| match slf.try_cast_into(CastType::Prefix, meta) {
-                    Ok((slf, remainder)) => {
-                        if remainder.len() == 0 {
-                            Ok(slf)
-                        } else {
-                            Err(CastError::Size(SizeError::<_, U>::new(())))
+                self.try_with_unchecked(
+                    #[inline(always)]
+                    |slf| match slf.try_cast_into(CastType::Prefix, meta) {
+                        Ok((slf, remainder)) => {
+                            if remainder.len() == 0 {
+                                Ok(slf)
+                            } else {
+                                Err(CastError::Size(SizeError::<_, U>::new(())))
+                            }
                         }
-                    }
-                    Err(err) => Err(err.map_src(|_slf| ())),
-                })
+                        Err(err) => Err(err.map_src(
+                            #[inline(always)]
+                            |_slf| (),
+                        )),
+                    },
+                )
             }
         }
     }
@@ -1266,7 +1278,10 @@ mod _project {
             //    size_of::<T>()` bytes. Thus, `elem` addresses a valid `T`
             //    within the slice. Since `self` satisfies `I::Validity`, `elem`
             //    also satisfies `I::Validity`.
-            self.as_inner().iter().map(|elem| unsafe { Ptr::from_inner(elem) })
+            self.as_inner().iter().map(
+                #[inline(always)]
+                |elem| unsafe { Ptr::from_inner(elem) },
+            )
         }
     }
 

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -230,8 +230,10 @@ where
         if let Err(err) = util::validate_aligned_to::<_, T>(bytes.deref()) {
             return Err(err.with_src(bytes).into());
         }
-        let (bytes, suffix) =
-            bytes.split_at(mem::size_of::<T>()).map_err(|b| SizeError::new(b).into())?;
+        let (bytes, suffix) = bytes.split_at(mem::size_of::<T>()).map_err(
+            #[inline(always)]
+            |b| SizeError::new(b).into(),
+        )?;
         // SAFETY: We just validated alignment and that `bytes` is at least as
         // large as `T`. `bytes.split_at(mem::size_of::<T>())?` ensures that the
         // new `bytes` is exactly the size of `T`. By safety postcondition on

--- a/src/util/macro_util.rs
+++ b/src/util/macro_util.rs
@@ -765,16 +765,22 @@ impl<'a, Src, Dst> Wrap<&'a Src, &'a Dst> {
         <Wrap<&'a Wrapping<Src>, &'a Wrapping<Dst>> as TryTransmuteRefDst<'a>>::try_transmute_ref(
             src,
         )
-        // SAFETY: By the preceding assert, `Dst` and `Wrapping<Dst>` have the
-        // same alignment.
-        .map(|dst| unsafe { crate::util::transmute_ref::<_, _, BecauseImmutable>(dst) })
-        .map_err(|err| {
-            // SAFETY: By the preceding assert, `Src` and `Wrapping<Src>` have the
-            // same alignment.
-            ValidityError::new(unsafe {
-                crate::util::transmute_ref::<_, _, BecauseImmutable>(err.into_src())
-            })
-        })
+        .map(
+            // SAFETY: By the preceding assert, `Dst` and `Wrapping<Dst>` have
+            // the same alignment.
+            #[inline(always)]
+            |dst| unsafe { crate::util::transmute_ref::<_, _, BecauseImmutable>(dst) },
+        )
+        .map_err(
+            #[inline(always)]
+            |err| {
+                // SAFETY: By the preceding assert, `Src` and `Wrapping<Src>` have the
+                // same alignment.
+                ValidityError::new(unsafe {
+                    crate::util::transmute_ref::<_, _, BecauseImmutable>(err.into_src())
+                })
+            },
+        )
     }
 }
 

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -201,7 +201,10 @@ impl<T> Unalign<T> {
         let inner = Ptr::from_ref(self).transmute();
         match inner.try_into_aligned() {
             Ok(aligned) => Ok(aligned.as_ref()),
-            Err(err) => Err(err.map_src(|src| src.into_unalign().as_ref())),
+            Err(err) => Err(err.map_src(
+                #[inline(always)]
+                |src| src.into_unalign().as_ref(),
+            )),
         }
     }
 

--- a/tests/ui/transmute_mut.nightly.stderr
+++ b/tests/ui/transmute_mut.nightly.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and 85 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:806:14
+   --> src/util/macro_util.rs:812:14
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-806 |         Dst: FromBytes + IntoBytes,
+812 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -73,12 +73,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and 74 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:806:26
+   --> src/util/macro_util.rs:812:26
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-806 |         Dst: FromBytes + IntoBytes,
+812 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -149,12 +149,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and 85 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:805:14
+   --> src/util/macro_util.rs:811:14
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-804 |     where
-805 |         Src: FromBytes + IntoBytes,
+810 |     where
+811 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -181,12 +181,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and 74 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:805:26
+   --> src/util/macro_util.rs:811:26
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-804 |     where
-805 |         Src: FromBytes + IntoBytes,
+810 |     where
+811 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/transmute_mut.stable.stderr
+++ b/tests/ui/transmute_mut.stable.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and 85 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:806:14
+   --> $WORKSPACE/src/util/macro_util.rs:812:14
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-806 |         Dst: FromBytes + IntoBytes,
+812 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -73,12 +73,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and 74 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:806:26
+   --> $WORKSPACE/src/util/macro_util.rs:812:26
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-806 |         Dst: FromBytes + IntoBytes,
+812 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -149,12 +149,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and 85 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:805:14
+   --> $WORKSPACE/src/util/macro_util.rs:811:14
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-804 |     where
-805 |         Src: FromBytes + IntoBytes,
+810 |     where
+811 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -181,12 +181,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and 74 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:805:26
+   --> $WORKSPACE/src/util/macro_util.rs:811:26
     |
-803 |     pub fn transmute_mut(self) -> &'a mut Dst
+809 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-804 |     where
-805 |         Src: FromBytes + IntoBytes,
+810 |     where
+811 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/try_transmute_mut.nightly.stderr
+++ b/tests/ui/try_transmute_mut.nightly.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and 156 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:829:14
+   --> src/util/macro_util.rs:835:14
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -53,12 +53,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and 69 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:829:29
+   --> src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -142,12 +142,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and 80 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:828:14
+   --> src/util/macro_util.rs:834:14
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-827 |     where
-828 |         Src: FromBytes + IntoBytes,
+833 |     where
+834 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -174,12 +174,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and 69 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:829:29
+   --> src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -206,12 +206,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and 69 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:828:26
+   --> src/util/macro_util.rs:834:26
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-827 |     where
-828 |         Src: FromBytes + IntoBytes,
+833 |     where
+834 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -238,12 +238,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and 69 others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:829:29
+   --> src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/try_transmute_mut.stable.stderr
+++ b/tests/ui/try_transmute_mut.stable.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and 156 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:829:14
+   --> $WORKSPACE/src/util/macro_util.rs:835:14
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -53,12 +53,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and 69 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:829:29
+   --> $WORKSPACE/src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -142,12 +142,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and 80 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:828:14
+   --> $WORKSPACE/src/util/macro_util.rs:834:14
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-827 |     where
-828 |         Src: FromBytes + IntoBytes,
+833 |     where
+834 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -174,12 +174,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and 69 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:829:29
+   --> $WORKSPACE/src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -206,12 +206,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and 69 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:828:26
+   --> $WORKSPACE/src/util/macro_util.rs:834:26
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-827 |     where
-828 |         Src: FromBytes + IntoBytes,
+833 |     where
+834 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -238,12 +238,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and 69 others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:829:29
+   --> $WORKSPACE/src/util/macro_util.rs:835:29
     |
-826 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+832 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-829 |         Dst: TryFromBytes + IntoBytes,
+835 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3140


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v2..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v2..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v1..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v1..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Gff0fac1332c8d87cd462e82e44fa573fb6678db3/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gff0fac1332c8d87cd462e82e44fa573fb6678db3 && git checkout -b pr-Gff0fac1332c8d87cd462e82e44fa573fb6678db3 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gff0fac1332c8d87cd462e82e44fa573fb6678db3 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gff0fac1332c8d87cd462e82e44fa573fb6678db3 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gff0fac1332c8d87cd462e82e44fa573fb6678db3
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gff0fac1332c8d87cd462e82e44fa573fb6678db3", "parent": null, "child": null}" -->