### PR TITLE
[ci] In auto-approve, concatenate JSON arrays

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -60,7 +60,7 @@ jobs:
           set -eo pipefail
 
           API_ENDPOINT="repos/$REPOSITORY/pulls/$PR_NUMBER/files"
-          gh api "$API_ENDPOINT" --paginate --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > /tmp/changed_files.json
+          gh api "$API_ENDPOINT" --paginate --jq 'map([.filename, .previous_filename] | map(select(. != null)))' | jq -s 'add' > /tmp/changed_files.json
 
       - name: Optimistic Evaluation
         id: evaluation
@@ -228,7 +228,7 @@ jobs:
         run: |
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
             --paginate \
-            --jq 'map([.filename, .previous_filename] | map(select(. != null)))' > /tmp/changed_files.json
+            --jq 'map([.filename, .previous_filename] | map(select(. != null)))' | jq -s 'add' > /tmp/changed_files.json
 
       - name: Strict Identity & File Validation
         if: steps.gate.outputs.is_auto_pr != 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,7 +929,7 @@ jobs:
           # Fetch changed files (including renames for move-tracking)
           gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
             --paginate \
-            --jq 'map([.filename, .previous_filename] | map(select(.)))' > changed_files.json
+            --jq 'map([.filename, .previous_filename] | map(select(.)))' | jq -s 'add' > changed_files.json
 
           # Fetch unique contributors (logins)
           CONTRIBUTORS=$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/commits" \


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The `validate_auto_approvers.py` script expects a single JSON array.
When GitHub API results are paginated, returning multiple JSON arrays,
this breaks that script unless we first concatenate them before passing
them to the script.




---

- 👉 #3141

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Glejkxn6s2idc57zgeyxhqk7tmqk3sphy && git checkout -b pr-Glejkxn6s2idc57zgeyxhqk7tmqk3sphy FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Glejkxn6s2idc57zgeyxhqk7tmqk3sphy && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Glejkxn6s2idc57zgeyxhqk7tmqk3sphy && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Glejkxn6s2idc57zgeyxhqk7tmqk3sphy
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Glejkxn6s2idc57zgeyxhqk7tmqk3sphy", "parent": null, "child": null}" -->