### PR TITLE
[hermes] Add auto-approval for `Cargo.lock` and `vendor`

### DIFF
--- a/.github/auto-approvers.json
+++ b/.github/auto-approvers.json
@@ -2,6 +2,12 @@
   "tools/hermes/": [
     "joshlf"
   ],
+  "tools/Cargo.lock": [
+    "joshlf"
+  ],
+  "tools/vendor/": [
+    "joshlf"
+  ],
   ".github/workflows/hermes.yml": [
     "joshlf"
   ]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

These need to be updated when modifying dependencies of Hermes itself.




---

- 　  #3149
- 👉 #3150


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v1..gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v1..gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo && git checkout -b pr-Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gcbnkgi7gxha3r6bk7l5fbkagklqv6hmo", "parent": null, "child": "Gbyp37ljqp6htpfgdgjdillrhw3ssr5xy"}" -->