### PR TITLE
  [tests] Add regression tests for Fuchsia packet types with large arrays (#2445)

### DIFF
--- a/zerocopy-derive/tests/struct_no_cell.rs
+++ b/zerocopy-derive/tests/struct_no_cell.rs
@@ -107,7 +107,6 @@ util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::Immutable);
 // Regression test for #2445: Fuchsia has `repr(C)` packet types with a large
 // computed array field, and they should still be `Immutable`.
 const FX_LOG_MAX_DATAGRAM_LEN: usize = 2032;
-const FX_LOG_METADATA_SIZE: usize = 32;
 
 #[derive(imp::Immutable)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -119,6 +118,8 @@ struct FxLogMetadata {
     severity: i32,
     dropped_logs: u32,
 }
+
+const FX_LOG_METADATA_SIZE: usize = imp::core::mem::size_of::<FxLogMetadata>();
 
 #[derive(imp::Immutable)]
 #[zerocopy(crate = "zerocopy_renamed")]

--- a/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy-derive/tests/struct_to_bytes.rs
@@ -231,7 +231,6 @@ util_assert_impl_all!(IndexEntry<1>: imp::IntoBytes);
 // Regression test for #2445: Fuchsia has `repr(C)` packet types with a large
 // computed array field, and they should still be serializable with zerocopy.
 const FX_LOG_MAX_DATAGRAM_LEN: usize = 2032;
-const FX_LOG_METADATA_SIZE: usize = 32;
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -243,6 +242,8 @@ struct FxLogMetadata {
     severity: i32,
     dropped_logs: u32,
 }
+
+const FX_LOG_METADATA_SIZE: usize = imp::core::mem::size_of::<FxLogMetadata>();
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]


### PR DESCRIPTION
This PR adds regression tests to verify that `zerocopy` correctly handles `repr(C)` structs containing large computed array fields (e.g., `[u8; 2000]`), as seen in Fuchsia's `FxLogPacket` and similar datagram types.
    
    Specifically, it ensures that these types correctly derive and implement:
    - `KnownLayout`
    - `Immutable`
    - `IntoBytes`
 
   These tests confirm that `zerocopy`'s const-generic implementation for arrays correctly scales to large sizes without hitting compiler limits or logic errors in the derive macros.
    
   ### Verification:
   Tests were verified locally on the `stable` toolchain:
   - `./cargo.sh +stable test -p zerocopy-derive --test struct_known_layout`
   - `./cargo.sh +stable test -p zerocopy-derive --test struct_no_cell`
   - `./cargo.sh +stable test -p zerocopy-derive --test struct_to_bytes`
   
   The tests passed successfully and were confirmed to fail if the derives were manually removed from the test cases.