### PR TITLE
[ci] Run Miri tests on beefier GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ name: Build & Tests
 on:
   pull_request:
   merge_group:
+  # Useful for manually testing changes to this workflow. Because we check for
+  # the merge queue by doing `github.event_name != 'pull_request'` rather than
+  # `github.event_name == 'merge_group'`, triggering via workflow dispatch has
+  # the effect of running all jobs, including those which would normally only be
+  # run in the merge queue.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -31,7 +37,10 @@ env:
 
 jobs:
   build_test:
-    runs-on: ubuntu-latest
+    # Default to `ubuntu-latest`, but when running Miri tests, use the beefier
+    # `ubuntu-24.04-64core`. Miri tests are very expensive and parallelizable.
+    # Note that Miri tests are only run in the merge queue.
+    runs-on: ${{ (matrix.crate == 'zerocopy' && matrix.toolchain == 'nightly' && github.event_name != 'pull_request') && 'ubuntu-24.04-64core' || 'ubuntu-latest' }}
     # We pre-compute a Docker image containing most dependencies. Each job in
     # the matrix runs in parallel, so without this pre-computation, most jobs
     # would duplicate the work of downloading crates from the internet.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Compare [1], which took 49m2s with 8m7s for the "Build Docker image"
step (which runs before the matrix) with [2] (manually triggered based
on the content of this commit), which took 28m46s with 12m4s for the
"Build Docker image" step. This is a savings of:

  (49m2s - 8m7s) - (28m46s - 12m4s) = 24m13s

[1] https://github.com/google/zerocopy/actions/runs/23776658855
[2] https://github.com/google/zerocopy/actions/runs/23779309303




---

- 　  #3178
- 👉 #3177


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|[vs v4](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|[vs v3](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|[vs v2](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|[vs v1](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5)|[vs v3](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5)|[vs v2](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5)|[vs v1](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4)|[vs v2](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4)|[vs v1](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3)|[vs v1](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/main..gherrit/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b && git checkout -b pr-G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G3rwwdyu7l7jtpdzzu2rjltonfg52yu3b", "parent": null, "child": "G6ytk3lhfbvylhux6xf5jzx3rzscgi56u"}" -->