### PR TITLE
In `test_ptr_try_cast_into_soundness`, skip `u128`/`i128`

### DIFF
--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -1473,8 +1473,8 @@ mod tests {
         }
 
         test!(empty_tuple: ());
-        test!(u8, u16, u32, u64, u128, usize, AU64);
-        test!(i8, i16, i32, i64, i128, isize);
+        test!(u8, u16, u32, u64, usize, AU64);
+        test!(i8, i16, i32, i64, isize);
         test!(f32, f64);
     }
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

These account for the majority of the time to execute this set of tests
under Miri, which in turn accounts for the majority of the time to
execute all tests in the merge queue. Worse, they often represent a
significant long tail which cannot be parallelized (in other words, most
time spent executing Miri tests – even on our current, 64-core runners
– is spent after all *other* test cases have completed and the `u128`
and `i128` cases are the only ones remaining, leaving all but 2 cores
idle).

Compre [1] (manually triggered based on the content of the parent
commit), which took 28m46s with 12m4s for the "Build Docker image" step
(which runs before the matrix) with [2] (manually triggered based on the
content of this commit), which took 17m59s with 8m38s for the "Build
Docker image" step. This is a savings of:

  (28m46s - 12m4s) - (17m59s - 8m38s) = 7m21s

[1] https://github.com/google/zerocopy/actions/runs/23779309303
[2] https://github.com/google/zerocopy/actions/runs/23780205408




---

- 👉 #3178


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v3..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v3..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v4)|[vs v2](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v2..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v4)|[vs v1](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v1..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v2..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v3)|[vs v1](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v1..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v1..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u && git checkout -b pr-G6ytk3lhfbvylhux6xf5jzx3rzscgi56u FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G6ytk3lhfbvylhux6xf5jzx3rzscgi56u
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G6ytk3lhfbvylhux6xf5jzx3rzscgi56u", "parent": null, "child": null}" -->