### PR TITLE
[docs] Generate rustdoc for explicit targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,13 @@ pinned-nightly = "nightly-2026-01-25"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition", "--extend-css", "rustdoc/style.css"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+    "i686-unknown-linux-gnu",
+    "i686-pc-windows-msvc"
+]
 
 [package.metadata.playground]
 features = ["__internal_use_only_features_that_work_on_stable"]


### PR DESCRIPTION
On 2026-05-01, these will need to be listed explicitly [1].

[1] https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
