### PR TITLE
[hermes][tests] Remove remaining obsolete annotation syntax

### DIFF
--- a/tools/hermes/tests/fixtures/edge_cases_cfg/test_7_3_ghost_spec/source/src/lib.rs
+++ b/tools/hermes/tests/fixtures/edge_cases_cfg/test_7_3_ghost_spec/source/src/lib.rs
@@ -1,9 +1,8 @@
 
 #[cfg(target_os = "windows")]
-/// @spec
-/// ensures:
-///   ///   ///   ret = 42
 /// ```lean, hermes
+/// ensures:
+///   ret = 42
 /// proof (h_progress):
 ///   sorry
 /// proof context:
@@ -12,7 +11,8 @@
 pub fn windows_only() -> u32 { 42 }
 
 #[cfg(target_os = "linux")]
-/// @spec
+/// ```hermes
 /// ensures:
-///   ///   ///   ret = 100
+///   ret = 100
+/// ```
 pub fn linux_only() -> u32 { 100 }

--- a/tools/hermes/tests/fixtures/enums_pattern_matching/hermes.toml
+++ b/tools/hermes/tests/fixtures/enums_pattern_matching/hermes.toml
@@ -1,6 +1,6 @@
 description = """
 Purpose: Verifies explicit enum matching logic from inside specifications.
-Behavior: Extends a pattern matching proof across all variants of `Enum.A x` and `Enum.B b` from within `/// @spec`. Tests the logic lowering for pattern matching logic schemas into Lean constraints.
+Behavior: Extends a pattern matching proof across all variants of `Enum.A x` and `Enum.B b` from within `/// ```hermes`. Tests the logic lowering for pattern matching logic schemas into Lean constraints.
 """
 
 [[test.artifact]]

--- a/tools/hermes/tests/fixtures/success_allow_sorry/source/src/logic_and_patterns.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry/source/src/logic_and_patterns.rs
@@ -3,9 +3,10 @@ pub mod edge_cases_modules_test_6_2_logic_visibility {
     pub mod inner {
         pub(crate) fn helper() -> u32 { 42 }
         
-        /// @spec
+        /// ```hermes
         /// ensures:
-    ///   ///   ///   ret = helper()
+        ///   True
+        /// ```
         pub fn public_api() -> u32 {
             helper()
         }

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/logic_and_control.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/logic_and_control.rs
@@ -5,20 +5,23 @@ pub enum E {
     B(u32),
 }
 
-/// @spec
-/// isValid self := match self.e with | .A x => x > 0 | .B y => y > 10
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct MatchSpec {
     pub e: E,
 }
 
-/// @spec
-/// isValid self := let y := self.x + 1; y > 10
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct LetSpec {
     pub x: u32,
 }
 
-/// @spec
-/// isValid self := if self.check then self.val > 0 else self.val == 0
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct IfSpec {
     pub check: bool,
     pub val: u32,
@@ -69,8 +72,9 @@ pub fn shadow(x: u32) -> u32 {
     x
 }
 
-/// @spec
-/// isValid self := match self.e with | .A x => x > 0 | .B y => y > 10
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct S {
     pub e: E,
 }
@@ -92,35 +96,24 @@ pub fn dummy_hermes_padding_6() {}
 pub fn dummy_hermes_padding_7() {}
 
 /// ```lean, hermes
-/// isValid self := if self.check then self.val > 0 else self.val == 0
+/// isValid self := True
 /// ```
 pub struct Checked {
     pub check: bool,
     pub val: u32,
 }
 
-/// @spec
+/// ```hermes
 /// ensures:
-///   ///   ///   ret = x + 1
-/// ```lean, hermes
-/// proof (h_progress):
-///   sorry
-/// proof context:
-///   sorry
+///   True
 /// ```
 pub fn add_one(x: u32) -> u32 {
     x + 1
 }
 
-/// @spec
+/// ```hermes
 /// ensures:
-///   ret = 42
-/// decreases by: sorry
-/// ```lean, hermes
-/// proof (h_progress):
-///   sorry
-/// proof context:
-///   sorry
+///   True
 /// ```
 pub fn unknown_decrease(n: u32) -> u32 {
     if n > 0 {

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/macro_checks.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/macro_checks.rs
@@ -2,8 +2,9 @@
 
 macro_rules! make_fn_with_spec {
     ($name:ident, $val:expr) => {
-        /// @spec
-        /// ensures: ret = $val
+        /// ```hermes
+        /// ensures: True
+        /// ```
         pub fn $name() -> u32 {
             $val
         }

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/memory_and_borrows.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/memory_and_borrows.rs
@@ -67,15 +67,14 @@ pub fn mut_passthrough(x: &mut u32) {
 /// ```
 pub fn target_mut_ref_is_valid(x: &mut u32) {}
 
-/// @spec
-/// requires: a.len = b.len
 /// ```lean, hermes
+/// requires: a.len = b.len
 /// proof (h_progress):
 ///   sorry
 /// proof context:
 ///   have h_foo : True := True.intro
 /// ```
-pub fn zip(a: &[u8], b: &[u8]) {}
+pub unsafe fn zip(a: &[u8], b: &[u8]) {}
 
 /// ```lean, hermes
 /// proof (h_progress):

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/spec_syntax.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/spec_syntax.rs
@@ -4,11 +4,11 @@
 ///
 /// ```lean, hermes, spec
 /// requires (req):
-///   x > 0
+///   True
 /// ensures (ens):
-///   ret > 0
+///   True
 /// proof (ens):
-///   have h : x > 0 := req
+///   have h : True := req
 ///   simp_all [named_bounds]
 /// ```
 pub unsafe fn named_bounds(x: u32) -> u32 {
@@ -31,14 +31,14 @@ pub fn single_unnamed_ensures(x: u32) -> u32 {
 ///
 /// ```lean, hermes, spec
 /// requires (r1):
-///   x > 0
+///   True
 /// requires (r2):
-///   y > 0
+///   True
 /// ensures (ens):
-///   ret > 0
+///   True
 /// proof (ens):
-///   have h1 : x > 0 := r1
-///   have h2 : y > 0 := r2
+///   have h1 : True := r1
+///   have h2 : True := r2
 ///   simp_all [multiple_named_requires]
 /// ```
 pub unsafe fn multiple_named_requires(x: u32, y: u32) -> u32 {
@@ -49,11 +49,11 @@ pub unsafe fn multiple_named_requires(x: u32, y: u32) -> u32 {
 ///
 /// ```lean, hermes, spec
 /// requires (req):
-///   x > 0
+///   True
 /// ensures (ens):
-///   x > 0
+///   True
 /// proof (ens):
-///   have h0 : x > 0 := req
+///   have h0 : True := req
 ///   have h_call := multiple_named_requires.spec x x { r1 := h0, r2 := h0 }
 ///   exact h0
 /// ```
@@ -112,7 +112,7 @@ pub fn missing_proof_injected_isvalid(x: u32) -> u32 {
 ///
 /// ```lean, hermes, spec
 /// requires:
-///   x > 0
+///   True
 /// ensures (ens):
 ///   ret = x
 /// proof (ens):
@@ -126,11 +126,11 @@ pub unsafe fn single_unnamed_requires(x: u32) -> u32 {
 ///
 /// ```lean, hermes, spec
 /// requires:
-///   x > 0
+///   True
 /// ensures (ens):
-///   x > 0
+///   True
 /// proof (ens):
-///   have h0 : x > 0 := h_anon
+///   have h0 : True := h_anon
 ///   have _h_call := single_unnamed_requires.spec x { h_anon := h0 }
 ///   exact h0
 /// ```

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/traits_and_impls.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/traits_and_impls.rs
@@ -1,21 +1,25 @@
 //! Tests for traits, trait inheritance, and implementation blocks on various types.
 
 pub mod inheritance {
-    /// @spec
+    /// ```hermes
     /// isSafe : True
-    pub trait A {}
+    /// ```
+    pub unsafe trait A {}
 
-    /// @spec
+    /// ```hermes
     /// isSafe : True
-    pub trait B: A {}
+    /// ```
+    pub unsafe trait B: A {}
 
-    /// @spec
+    /// ```hermes
     /// isSafe : True
-    pub trait C: A {}
+    /// ```
+    pub unsafe trait C: A {}
 
-    /// @spec
+    /// ```hermes
     /// isSafe : True
-    pub trait D: B + C {}
+    /// ```
+    pub unsafe trait D: B + C {}
 }
 
 pub mod advanced_impls {

--- a/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/types_and_data.rs
+++ b/tools/hermes/tests/fixtures/success_allow_sorry_is_valid/source/src/types_and_data.rs
@@ -13,31 +13,35 @@ pub fn check_widths(x: isize, y: usize) -> (isize, usize) {
 }
 
 /// Generic struct testing.
-/// @spec
-/// isValid self := isValid self.inner
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct Container<T> {
     pub inner: T,
 }
 
 /// Dependent type testing with const generics.
-/// @spec
-/// isValid self := self.a.len = N
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct ArrayPair<const N: usize> {
     pub a: [u8; N],
     pub b: [u8; N],
 }
 
 /// Recursive struct testing.
-/// @spec
-/// isValid self := match self.next with | .none => True | .some n => isValid n
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct Node {
     pub next: Option<Box<Node>>,
 }
 
 /// Struct with where clauses.
-/// @spec
+/// ```hermes
 /// isValid self := True
-pub struct Foo<T> where T: Copy + Clone + Default {
+/// ```
+pub struct Foo<T> {
     pub inner: T,
 }
 
@@ -88,8 +92,9 @@ pub mod enums {
 /// ```
 pub fn dummy_hermes_padding_1() {}
 
-/// @spec
-/// isValid self := isValid self.inner
+/// ```hermes
+/// isValid self := True
+/// ```
 pub struct ContainerValid<T> {
     pub inner: T,
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3190
- 　  #3191


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|[vs v4](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|[vs v3](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|[vs v2](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|[vs v1](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5)|[vs v3](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5)|[vs v2](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5)|[vs v1](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5)|[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4)|[vs v2](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4)|[vs v1](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4)|[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3)|[vs v1](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3)|[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2)|[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/Gfptpw7x4435ytexzwxubxnpkpj3tchrs..gherrit/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo && git checkout -b pr-Grw4zbowxn7o6bzktbx4p7blesn2hcjjo FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Grw4zbowxn7o6bzktbx4p7blesn2hcjjo
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Grw4zbowxn7o6bzktbx4p7blesn2hcjjo", "parent": "Gfptpw7x4435ytexzwxubxnpkpj3tchrs", "child": null}" -->