### PR TITLE
[ci][auto-approvers] Expect mismatch in file count

### DIFF
--- a/ci/validate_auto_approvers.py
+++ b/ci/validate_auto_approvers.py
@@ -87,10 +87,13 @@ def main():
             sys.exit(TECHNICAL_ERROR)
 
         if not file_objects or len(file_objects) != args.expected_count:
+            # This can happen when a PR contains a large number of files. It
+            # doesn't necessarily represent a bug, so we treat this as
+            # `NOT_APPROVED` rather than `TECHNICAL_ERROR`.
             print(
                 f"::error::❌ File truncation mismatch or empty PR. Expected {args.expected_count}, got {len(file_objects) if file_objects else 0}."
             )
-            sys.exit(TECHNICAL_ERROR)
+            sys.exit(NOT_APPROVED)
 
         if not all(isinstance(obj, list) for obj in file_objects):
             print("::error::❌ Invalid payload format. Expected a list of lists.")


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This error condition does not necessarily represent a bug – it can
happen when a PR contains a large number of files. Treating it as a bug
causes any PR with a large number of files to fail CI.




---

- 　  #3194
- 　  #3192
- 👉 #3193


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v2..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v2..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v3)|[vs v1](/google/zerocopy/compare/gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v1..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v1..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn && git checkout -b pr-G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G4r7ugzrhxwn4uc7chqtx4m5ooxqnnzkn", "parent": null, "child": "Gcc4q572sgyiglnf43z6by36ux4scgqec"}" -->