### PR TITLE
[hermes] Fix example warnings

### DIFF
--- a/hermes/examples/size_of_align_of.rs
+++ b/hermes/examples/size_of_align_of.rs
@@ -40,8 +40,8 @@ pub fn get_align_of_empty_tuple() -> usize {
 ///     have h_align_pos : 0 < (Hermes.HasStaticLayout.layout T).align.val.val := (Hermes.HasStaticLayout.layout T).align.isValid.left
 ///     have h_align_nz : (Hermes.HasStaticLayout.layout T).align.val.val ≠ 0 := by omega
 ///     simp_all
-///     progress
-///     progress
+///     step
+///     step
 ///     · rw [i_post]
 ///       simp
 ///     · rw [i_post] at r_post
@@ -56,8 +56,8 @@ pub fn get_align_of_empty_tuple() -> usize {
 ///     have h_align_pos : 0 < (Hermes.HasStaticLayout.layout T).align.val.val := (Hermes.HasStaticLayout.layout T).align.isValid.left
 ///     have h_align_nz : (Hermes.HasStaticLayout.layout T).align.val.val ≠ 0 := by omega
 ///     simp_all
-///     progress
-///     progress
+///     step
+///     step
 ///     · rw [i_post]
 ///       simp
 ///   have ⟨y, hy1, _⟩ := Aeneas.Std.WP.spec_imp_exists h_wp


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #3204
- 👉 #3205


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v2..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v2..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v1..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v1..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg && git checkout -b pr-Gwh2eghunjfnouro4hyj3wt3xhteyrqxg FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gwh2eghunjfnouro4hyj3wt3xhteyrqxg
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gwh2eghunjfnouro4hyj3wt3xhteyrqxg", "parent": null, "child": "Go47kyyj6ojyz5dbcvuuavbfyxdlpsdyb"}" -->