### PR TITLE
[hermes] Pre-build Lean libraries during `setup`

### DIFF
--- a/hermes/src/aeneas.rs
+++ b/hermes/src/aeneas.rs
@@ -449,9 +449,7 @@ fn run_lake(roots: &LockedRoots, artifacts: &[HermesArtifact]) -> Result<()> {
         std::thread::spawn(move || {
             let reader = BufReader::new(stderr);
             for line in reader.lines().map_while(Result::ok) {
-                if !line.contains("declaration uses `sorry`") {
-                    stderr_clone.lock().unwrap().push(line);
-                }
+                stderr_clone.lock().unwrap().push(line);
             }
         })
     });
@@ -471,9 +469,7 @@ fn run_lake(roots: &LockedRoots, artifacts: &[HermesArtifact]) -> Result<()> {
         std::thread::spawn(move || {
             let reader = BufReader::new(stdout);
             for line in reader.lines().map_while(Result::ok) {
-                if !line.contains("declaration uses `sorry`") {
-                    stdout_clone.lock().unwrap().push(line);
-                }
+                stdout_clone.lock().unwrap().push(line);
                 pb_clone.tick();
             }
         })
@@ -795,6 +791,10 @@ fn patch_discriminants(content: &str) -> String {
 /// Patches the generated Funs.lean file to suppress bytecode compilation errors
 /// for functions that invoke opaque axioms (such as `core::mem::size_of`).
 fn patch_funs(content: &str) -> String {
+    // Aeneas misses `show` keyword when renaming arguments in Lean.
+    // We manually rename it to `show1` to match Aeneas's convention for other keywords.
+    let content = content.replace("(show :", "(show1 :");
+
     let mut lines: Vec<&str> = content.split('\n').collect();
     let mut insert_idx = 0;
     for (i, line) in lines.iter().enumerate() {

--- a/hermes/src/generate.rs
+++ b/hermes/src/generate.rs
@@ -1256,6 +1256,17 @@ fn map_type(ty: &crate::parse::hkd::SafeType) -> String {
 /// pass-by-value bindings that are merely declared as mutable (`mut x: T`).
 /// Only true `&mut T` references are flagged with `is_mut_ref = true` to inform
 /// `generate_function` that it needs to unpack a tuple output from Aeneas.
+fn escape_lean_keyword(name: &str) -> String {
+    match name {
+        "theorem" | "axiom" | "variable" | "lemma" | "def" | "class" | "instance" | "structure"
+        | "inductive" | "from" | "have" | "show" | "calc" | "then" | "with" | "section"
+        | "namespace" | "end" | "import" | "open" | "attribute" | "universe" => {
+            format!("{}1", name)
+        }
+        _ => name.to_string(),
+    }
+}
+
 fn extract_args_metadata(
     func: &FunctionItem<crate::parse::hkd::Safe>,
     impl_struct_name: &Option<crate::parse::hkd::AstNode<syn::Type, crate::parse::hkd::Safe>>,
@@ -1271,7 +1282,7 @@ fn extract_args_metadata(
                 if let SafeType::Reference { mutability, .. } = ty {
                     is_mut_ref = *mutability;
                 }
-                ArgInfo { name: name.clone(), lean_type: map_type(ty), is_mut_ref }
+                ArgInfo { name: escape_lean_keyword(name), lean_type: map_type(ty), is_mut_ref }
             }
             SafeFnArg::Receiver { mutability, reference } => {
                 let lean_type = if let Some(t) = impl_struct_name {

--- a/hermes/src/main.rs
+++ b/hermes/src/main.rs
@@ -229,8 +229,23 @@ mod util {
                     format!("Failed to create directory for lock file: {:?}", parent)
                 })?;
             }
-            std::fs::File::create(&lock_path)
-                .with_context(|| format!("Failed to create lock file at {:?}", lock_path))
+            // If the lock file already exists, we open it in read-only mode.
+            // This prevents failures if the file is read-only (e.g., after
+            // making the toolchain directory read-only), while still allowing
+            // us to acquire shared and exclusive locks on the file descriptor.
+            if lock_path.exists() {
+                std::fs::OpenOptions::new()
+                    .read(true)
+                    .open(&lock_path)
+                    .with_context(|| format!("Failed to open lock file at {:?}", lock_path))
+            } else {
+                std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .open(&lock_path)
+                    .with_context(|| format!("Failed to create lock file at {:?}", lock_path))
+            }
         }
     }
 }

--- a/hermes/src/setup.rs
+++ b/hermes/src/setup.rs
@@ -152,11 +152,13 @@ impl Toolchain {
     /// Resolves the toolchain manager and acquires a shared lock.
     pub fn resolve() -> Result<Self> {
         let home = if std::env::var("__ZEROCOPY_LOCAL_DEV").is_ok() {
-            std::path::PathBuf::from(
-                std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string()),
-            )
-            .join("target")
-            .join("hermes-home")
+            let base = std::env::var("CARGO_MANIFEST_DIR")
+                .map(std::path::PathBuf::from)
+                // Fall back to current directory if CARGO_MANIFEST_DIR is not set,
+                // which can happen if the binary is executed directly rather than
+                // via `cargo run`.
+                .unwrap_or_else(|_| std::env::current_dir().unwrap());
+            base.join("target").join("hermes-home")
         } else {
             dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?
         };
@@ -312,8 +314,158 @@ fn extract_artifact(data: &[u8], target_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Ensures that `elan` (the Lean toolchain manager) is installed on the
+/// system. If it is not found in the system `PATH`, it downloads the latest
+/// release from GitHub and runs `elan-init` to install it for the current
+/// user. It also attempts to add the `elan` bin directory to the current
+/// process's `PATH` to ensure subsequent commands can find it immediately.
+fn ensure_elan_installed() -> Result<()> {
+    println!("Checking for elan...");
+    let status = std::process::Command::new("elan")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    if status.is_ok() && status.unwrap().success() {
+        println!("elan is already installed.");
+        return Ok(());
+    }
+
+    println!("elan not found. Installing elan...");
+    let platform = Platform::detect()?;
+    let arch = match platform {
+        Platform::LinuxX86_64 => "x86_64-unknown-linux-gnu",
+        Platform::LinuxAArch64 => "aarch64-unknown-linux-gnu",
+        Platform::MacosAArch64 => "aarch64-apple-darwin",
+        Platform::MacosX86_64 => "x86_64-apple-darwin",
+    };
+
+    let url =
+        format!("https://github.com/leanprover/elan/releases/latest/download/elan-{}.tar.gz", arch);
+
+    println!("Downloading elan from {}...", url);
+    let response = reqwest::blocking::get(&url).context("Failed to download elan")?;
+    if !response.status().is_success() {
+        bail!("Failed to download elan: HTTP {}", response.status());
+    }
+    let data = response.bytes().context("Failed to read elan response")?;
+
+    let temp_dir = std::env::temp_dir();
+    let elan_extract_dir = temp_dir.join("elan-extract-hermes");
+    fs::create_dir_all(&elan_extract_dir).context("Failed to create elan extract dir")?;
+
+    extract_artifact(&data, &elan_extract_dir)?;
+
+    let elan_init_path = elan_extract_dir.join("elan-init");
+
+    let status = std::process::Command::new(&elan_init_path)
+        .args(["-y", "--default-toolchain", "none"])
+        .status()
+        .context("Failed to run elan-init")?;
+
+    let _ = fs::remove_dir_all(&elan_extract_dir);
+
+    if !status.success() {
+        bail!("elan-init failed");
+    }
+
+    // Add elan to PATH for current process
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
+    let elan_bin = home.join(".elan").join("bin");
+    if elan_bin.exists() {
+        let path = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = std::env::split_paths(&path).collect::<Vec<_>>();
+        if !paths.contains(&elan_bin) {
+            paths.insert(0, elan_bin);
+            let new_path = std::env::join_paths(paths)?;
+            // SAFETY: This is a single-threaded setup context.
+            unsafe {
+                std::env::set_var("PATH", new_path);
+            }
+        }
+    }
+
+    println!("elan installed successfully.");
+    Ok(())
+}
+
+/// Installs the pinned Lean toolchain required by Hermes using `elan`.
+/// It checks the environment variable `HERMES_LEAN_TOOLCHAIN` to determine
+/// which version to install. If the version is already listed in `elan
+/// toolchain list`, it skips installation to save time.
+fn install_lean_toolchain() -> Result<()> {
+    let version = env!("HERMES_LEAN_TOOLCHAIN");
+    println!("Installing Lean toolchain {}...", version);
+
+    // Check if already installed
+    let output = std::process::Command::new("elan")
+        .args(["toolchain", "list"])
+        .output()
+        .context("Failed to run elan toolchain list")?;
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.lines().any(|line| line.contains(version)) {
+            println!("Lean toolchain {} is already installed.", version);
+            return Ok(());
+        }
+    }
+
+    let status = std::process::Command::new("elan")
+        .args(["toolchain", "install", version])
+        .status()
+        .context("Failed to run elan toolchain install")?;
+
+    if !status.success() {
+        bail!("Failed to install Lean toolchain");
+    }
+
+    println!("Lean toolchain {} installed successfully.", version);
+    Ok(())
+}
+
+/// Pre-builds the Aeneas Lean library in the extracted toolchain directory.
+/// This prevents compiling the library from source when users verify their
+/// projects, which is slow and disk-heavy. It first attempts to fetch
+/// pre-compiled Mathlib artifacts using `lake exe cache get` to avoid
+/// compiling Mathlib from source, and then runs `lake build`.
+fn prebuild_lean_library(lean_dir: &Path) -> Result<()> {
+    println!("Pre-building Aeneas Lean library at {:?}...", lean_dir);
+
+    // Fetch Mathlib cache
+    println!("Fetching Mathlib cache...");
+    let status = std::process::Command::new("lake")
+        .args(["exe", "cache", "get"])
+        .current_dir(lean_dir)
+        .status()
+        .context("Failed to run `lake exe cache get`")?;
+
+    if !status.success() {
+        bail!("Failed to fetch Mathlib cache; refusing to build from scratch");
+    }
+
+    // Build the library
+    println!("Building Aeneas Lean library...");
+    let status = std::process::Command::new("lake")
+        .arg("build")
+        .current_dir(lean_dir)
+        .status()
+        .context("Failed to run `lake build`")?;
+
+    if !status.success() {
+        bail!("Failed to build Aeneas Lean library");
+    }
+
+    println!("Successfully pre-built Aeneas Lean library.");
+    Ok(())
+}
+
 /// Sets up the Hermes toolchain by downloading and extracting dependencies.
 pub fn run_setup() -> Result<()> {
+    ensure_elan_installed()?;
+    install_lean_toolchain()?;
+
     let mut toolchain = Toolchain::resolve()?;
     // Drop the shared lock acquired by resolve() so we can acquire an
     // exclusive one.
@@ -384,6 +536,13 @@ pub fn run_setup() -> Result<()> {
         let data = download_artifact(&url, &expected_archive_hash)?;
 
         extract_artifact(&data, &toolchain.root)?;
+
+        let lean_dir = toolchain.root.join("backends").join("lean");
+        if lean_dir.exists() {
+            prebuild_lean_library(&lean_dir)?;
+        } else {
+            log::warn!("Lean directory not found at {:?}", lean_dir);
+        }
 
         println!("Successfully installed toolchain v{tag}");
     } else {

--- a/hermes/tests/fixtures/edge_cases_charon/test_8_2_unions/expected.stderr
+++ b/hermes/tests/fixtures/edge_cases_charon/test_8_2_unions/expected.stderr
@@ -1,6 +1,5 @@
 Error: Aeneas failed for package 'test_8_2_unions' with status: exit status: 2
 stderr:
-Applied prepasses:  [----------------------------------------------------] 0/2 ⠋Applied prepasses:  [##########################--------------------------] 1/2 ⠙Applied prepasses:  [####################################################] 2/2 ✔️
 Uncaught exception:
   
   (Failure

--- a/hermes/tests/fixtures/edge_cases_naming/test_1_2_lean_keywords_args/expected.stderr
+++ b/hermes/tests/fixtures/edge_cases_naming/test_1_2_lean_keywords_args/expected.stderr
@@ -218,14 +218,12 @@
     ╰────
   help: if this is intentional, prefix it with an underscore
 
-Error: Lean build failed
-STDOUT:
-trace: .> LEAN_PATH=[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/Cli/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/batteries/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/Qq/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/aesop/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/proofwidgets/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/importGraph/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/LeanSearchClient/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/plausible/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/lean_lake/packages/mathlib/.lake/build/lib/lean:[TARGET_DIR]/worker_caches/<ID>/aeneas/backends/lean/.lake/build/lib/lean:[PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/build/lib/lean [ELAN_TOOLCHAIN]/bin/lean [PROJECT_ROOT]/target/hermes/hermes_test_target/lean/generated/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.lean -o [PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/build/lib/lean/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.olean -i [PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/build/lib/lean/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.ilean -c [PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/build/ir/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.c --setup [PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/build/ir/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.setup.json --json
-error: generated/Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891/Funs.lean:24:21: unexpected token 'show'; expected '_' or identifier
-error: Lean exited with code 1
-Some required targets logged failures:
-- Test12LeanKeywordsArgsTest12LeanKeywordsArgsbfc34253d33aa891.Funs
-STDERR:
-warning: mathlib: repository '[PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/packages/mathlib' has local changes
-warning: batteries: repository '[PROJECT_ROOT]/target/hermes/hermes_test_target/lean/.lake/packages/batteries' has local changes
-error: build failed
+  ⚠ declaration uses `sorry`
+   ╭─[[PROJECT_ROOT]/src/lib.rs:7:4]
+ 6 │ /// proof context:
+ 7 │ ///   have h_foo : True := True.intro
+   ·    ─────────────────┬────────────────
+   ·                     ╰── here
+ 8 │ /// ```
+   ╰────
+

--- a/hermes/tests/fixtures/edge_cases_naming/test_1_2_lean_keywords_args/hermes.toml
+++ b/hermes/tests/fixtures/edge_cases_naming/test_1_2_lean_keywords_args/hermes.toml
@@ -4,6 +4,6 @@ Behavior: Tests translation of function arguments bearing keyword names (e.g. `t
 """
 
 [test]
-expected_status = "failure"
+expected_status = "success"
 stderr_file = "expected.stderr"
 args = ["verify", "--allow-sorry"]

--- a/hermes/tests/fixtures/setup_e2e/expected.stdout
+++ b/hermes/tests/fixtures/setup_e2e/expected.stdout
@@ -1,2 +1,9 @@
+Checking for elan...
+elan is already installed.
+Installing Lean toolchain leanprover/lean4:v4.28.0-rc1...
+
+leanprover/lean4:v4.28.0-rc1 installed - Lean (version 4.28.0-rc1, x86_64-unknown-linux-gnu, commit 3b0f2862196c6a8af9eb0025ee650252694013dd, Release)
+
+Lean toolchain leanprover/lean4:v4.28.0-rc1 installed successfully.
 Downloading: http://127.0.0.1:<PORT>/build-2026.04.07.112215-42c0e90dacf486f7d3ed5b6cde3a9a81f04915a4/aeneas-linux-x86_64.tar.gz
 Successfully installed toolchain vbuild-2026.04.07.112215-42c0e90dacf486f7d3ed5b6cde3a9a81f04915a4

--- a/hermes/tests/fixtures/unions/expected.stderr
+++ b/hermes/tests/fixtures/unions/expected.stderr
@@ -1,6 +1,5 @@
 Error: Aeneas failed for package 'transform_lib' with status: exit status: 2
 stderr:
-Applied prepasses:  [----------------------------------------------------] 0/1 ⠋Applied prepasses:  [####################################################] 1/1 ⠋Applied prepasses:  [####################################################] 1/1 ✔️
 Uncaught exception:
   
   (Failure

--- a/hermes/tests/integration.rs
+++ b/hermes/tests/integration.rs
@@ -180,9 +180,15 @@ fn ensure_cache_ready(cache_dir: &Path) -> Result<(), anyhow::Error> {
 
         // 1. Resolve global pinned toolchain path
         let cargo_bin = env!("CARGO_BIN_EXE_cargo-hermes");
+        // We use a separate home directory for tests to avoid polluting the
+        // user's `~/.hermes` directory and to ensure a clean environment.
+        let test_home = cache_dir.parent().unwrap().join("hermes-test-home");
+        fs::create_dir_all(&test_home).unwrap();
+
         let setup_status = Command::new(cargo_bin)
             .arg("setup")
             .env_remove("__ZEROCOPY_LOCAL_DEV") // So that Hermes looks in `$HOME` for toolchains, not `target`
+            .env("HOME", &test_home)
             .status()
             .expect("Failed to execute cargo-hermes setup");
         if !setup_status.success() {
@@ -192,6 +198,7 @@ fn ensure_cache_ready(cache_dir: &Path) -> Result<(), anyhow::Error> {
         let output = Command::new(cargo_bin)
             .arg("toolchain-path")
             .env_remove("__ZEROCOPY_LOCAL_DEV") // So that Hermes looks in `$HOME` for toolchains, not `target`
+            .env("HOME", &test_home)
             .output()
             .expect("Failed to execute cargo-hermes toolchain-path");
         if !output.status.success() {
@@ -1409,6 +1416,7 @@ fn assert_output_file(
             .replace(cache_path_str, "[CACHE_ROOT]")
             .replace(home_path_str, "[HOME]")
             .replace(target_path_str, "[TARGET_DIR]"),
+        test_name == "setup_e2e",
     );
 
     if bless {
@@ -1879,7 +1887,7 @@ fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
 // - Local IP/port combinations used in mock servers (replaced with
 //   `127.0.0.1:<PORT>`)
 // - Rustup toolchain paths (replaced with `[RUSTUP_TOOLCHAIN]`)
-fn sanitize_output(output: &str) -> String {
+fn sanitize_output(output: &str, sanitize_sorry: bool) -> String {
     let re_thread_id = regex::Regex::new(r"thread '([^']+)' \(\d+\) panicked").unwrap();
     let re_file_lock =
         regex::Regex::new(r"(?m)^.*Blocking waiting for file lock on.*$\n?").unwrap();
@@ -1896,6 +1904,15 @@ fn sanitize_output(output: &str) -> String {
     // Lake's build progress indicators are volatile as they depend on the hit/miss
     // state of the persistent `worker_caches/<ID>/` directory. We strip the entire line.
     let re_lake_progress = regex::Regex::new(r"(?m)^.*\[\d+/\d+\].*$\n?").unwrap();
+    // Aeneas pre-built library might produce warnings about `sorry` usage.
+    // We strip them to make test output deterministic.
+    let re_sorry_warning = regex::Regex::new(r"(?m)^.*declaration uses `sorry`.*$\n?").unwrap();
+    // Aeneas progress bars contain volatile spinner characters. We strip them.
+    let re_applied_prepasses = regex::Regex::new(r"(?m)^.*Applied prepasses:.*$\n?").unwrap();
+    // Pre-building Aeneas Lean library produces volatile output depending on cache state.
+    let re_prebuild_output = regex::Regex::new(r"(?m)^(Pre-building Aeneas Lean library|Fetching Mathlib cache|installing leantar|Fetching ProofWidgets|Current branch:|Using cache|Attempting to download|Decompressing|Unpacked in|Completed successfully!|Building Aeneas Lean library|Build completed successfully|Successfully pre-built).*$\n?").unwrap();
+    // Strip ANSI escape codes.
+    let re_ansi_escape = regex::Regex::new(r"\x1B\[[0-9;]*[a-zA-Z]").unwrap();
 
     let mut clean = output.to_string();
 
@@ -1911,6 +1928,12 @@ fn sanitize_output(output: &str) -> String {
     clean = re_rustup.replace_all(&clean, "[RUSTUP_TOOLCHAIN]").into_owned();
     clean = re_elan.replace_all(&clean, "[ELAN_TOOLCHAIN]").into_owned();
     clean = re_lake_progress.replace_all(&clean, "").into_owned();
+    clean = re_applied_prepasses.replace_all(&clean, "").into_owned();
+    clean = re_prebuild_output.replace_all(&clean, "").into_owned();
+    clean = re_ansi_escape.replace_all(&clean, "").into_owned();
+    if sanitize_sorry {
+        clean = re_sorry_warning.replace_all(&clean, "").into_owned();
+    }
 
     clean
 }


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

During `cargo hermes setup`, download and install the compiled Mathlib
artifact (via `lake exe cache get`) and build the Aeneas Lean library,
installing it in `~/.hermes`. This has a number of benefits:
- Improves verification time since the Aeneas Lean library doesn't have
  to be built
- Removes complexity from verification – currently, we rely on Lake's
  caching of built artifacts to speed up subsequent verifications
- Cuts down on stdout/stderr noise during verification (caused by
  building Aeneas)
- Allows us (in a future commit) to simplify local development and CI,
  which currently perform complex caching to improve performance

Closes #3233




---

- 　  #3236
- 👉 #3234


**Latest Update:** v6 — [Compare vs v5](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|
|v6|[vs v5](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|[vs v4](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|[vs v3](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|[vs v2](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|[vs v1](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v6)|
|v5||[vs v4](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5)|[vs v3](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5)|[vs v2](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5)|[vs v1](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v5)|
|v4|||[vs v3](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4)|[vs v2](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4)|[vs v1](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v4)|
|v3||||[vs v2](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3)|[vs v1](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v3)|
|v2|||||[vs v1](/google/zerocopy/compare/gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v2)|
|v1||||||[vs Base](/google/zerocopy/compare/main..gherrit/G22sseffy6pm4qru4t73cwsmtzlks36bq/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G22sseffy6pm4qru4t73cwsmtzlks36bq && git checkout -b pr-G22sseffy6pm4qru4t73cwsmtzlks36bq FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G22sseffy6pm4qru4t73cwsmtzlks36bq && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G22sseffy6pm4qru4t73cwsmtzlks36bq && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G22sseffy6pm4qru4t73cwsmtzlks36bq
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G22sseffy6pm4qru4t73cwsmtzlks36bq", "parent": null, "child": "Gimnjq2dz4vyuoa3jek7wvbwvdafgngq7"}" -->