### PR TITLE
[hermes] Release 0.1.0-alpha.8

### DIFF
--- a/hermes/Cargo.lock
+++ b/hermes/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-hermes"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/hermes/Cargo.toml
+++ b/hermes/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "tools/doc_gen"]
 [package]
 name = "cargo-hermes"
 edition = "2024"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 description = "Formally verify that your safety comments are correct."
 categories = [
   "development-tools::cargo-plugins",

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -11,7 +11,7 @@ The [main design document](docs/design/design.md) motivates Hermes and describes
 Install Hermes:
 
 ```
-cargo install cargo-hermes@0.1.0-alpha.7
+cargo install cargo-hermes@0.1.0-alpha.8
 ```
 
 Optionally, install the Charon and Aeneas toolchains from pre-built binaries:

--- a/hermes/tests/fixtures/edge_cases_charon/test_8_2_unions/expected.stderr
+++ b/hermes/tests/fixtures/edge_cases_charon/test_8_2_unions/expected.stderr
@@ -1,6 +1,6 @@
 Error: Aeneas failed for package 'test_8_2_unions' with status: exit status: 2
 stderr:
-Applied prepasses:  [----------------------------------------------------] 0/2 ⠋Applied prepasses:  [##########################--------------------------] 1/2 ⠋Applied prepasses:  [####################################################] 2/2 ✔️
+Applied prepasses:  [----------------------------------------------------] 0/2 ⠋Applied prepasses:  [##########################--------------------------] 1/2 ⠙Applied prepasses:  [####################################################] 2/2 ✔️
 Uncaught exception:
   
   (Failure


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #3234
- 👉 #3235


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v1..gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v1..gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G2eixo2fa3qqpdwsjldp75psn23d4gwdo/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G2eixo2fa3qqpdwsjldp75psn23d4gwdo && git checkout -b pr-G2eixo2fa3qqpdwsjldp75psn23d4gwdo FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G2eixo2fa3qqpdwsjldp75psn23d4gwdo && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G2eixo2fa3qqpdwsjldp75psn23d4gwdo && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G2eixo2fa3qqpdwsjldp75psn23d4gwdo
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G2eixo2fa3qqpdwsjldp75psn23d4gwdo", "parent": null, "child": "G22sseffy6pm4qru4t73cwsmtzlks36bq"}" -->