### PR TITLE
[ci] Fix bug in releasing script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,13 +130,15 @@ jobs:
       - name: Create git tag
         env:
           VERSION: ${{ needs.check-version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eo pipefail
           TAG="v$VERSION"
           git config user.name "Google PR Creation Bot"
           git config user.email "github-pull-request-creation-bot@google.com"
           git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          git push https://x-access-token:$GH_TOKEN@github.com/$GH_REPO.git "$TAG"
         
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy-derive


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The `persist-credentials: false` settings prevents the workflow from
being able to create tags. We replace the generic `git push --tags` with
a more targeted command that manually propagates the proper credentials.




---

- 　  #3243
- 👉 #3242


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v2..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v2..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v3)|[vs v1](/google/zerocopy/compare/gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v1..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v1..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Ge5exhiocyn6fohfug54jno7xi2ndb7wy/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Ge5exhiocyn6fohfug54jno7xi2ndb7wy && git checkout -b pr-Ge5exhiocyn6fohfug54jno7xi2ndb7wy FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Ge5exhiocyn6fohfug54jno7xi2ndb7wy && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Ge5exhiocyn6fohfug54jno7xi2ndb7wy && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Ge5exhiocyn6fohfug54jno7xi2ndb7wy
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Ge5exhiocyn6fohfug54jno7xi2ndb7wy", "parent": null, "child": "G2v2dkrrgsofpedlsfshdjs7u3mgkgzm5"}" -->