### PR TITLE
[ci] Fix releasing script bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,8 +140,14 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push https://x-access-token:$GH_TOKEN@github.com/$GH_REPO.git "$TAG"
         
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy-derive
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -eo pipefail
           mv .cargo/config.toml .cargo/config.toml.bak
@@ -157,6 +163,8 @@ jobs:
 
       # NOTE: Relies on OIDC to be configured for this GHA workflow.
       - name: Publish zerocopy
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -eo pipefail
           mv .cargo/config.toml .cargo/config.toml.bak


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Add step to authenticate to crates.io in exchange for an ephemeral
token.




---

- 👉 #3250


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v2..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v2..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v1..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v1..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24 && git checkout -b pr-Gwkfpkazx3xdrqmthrk4sk5npjr3kti24 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gwkfpkazx3xdrqmthrk4sk5npjr3kti24
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gwkfpkazx3xdrqmthrk4sk5npjr3kti24", "parent": null, "child": null}" -->