### PR TITLE
[ci][anneal] Install fewer, smaller Rust toolchains

### DIFF
--- a/anneal/Dockerfile
+++ b/anneal/Dockerfile
@@ -38,11 +38,8 @@ RUN if [ -z "$UID" ]; then echo "UID build arg is required" && exit 1; fi && \
 # Switch to non-root user for the rest of the build.
 USER anneal
 
-# Install Rust and the specific nightly toolchain required by Charon.
-# This version string is hardcoded here and must be kept in sync with
-# `Cargo.toml`.
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
- && rustup toolchain install --no-self-update nightly-2026-02-07 --profile minimal
+# Install Rust.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal
 
 # Direct Anneal tests to write ephemeral integration targets here to leverage
 # overlayfs.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Now that `cargo anneal setup` downloads Rust toolchains (specifically,
the toolchain pinned by Charon), we no longer need to separately install
these when setting up the Docker image. We also pass `--minimal` when
installing the default toolchain.




---

- 👉 #3277

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gtk6iuxmege4csoh6ypqysrrdt47l6luz && git checkout -b pr-Gtk6iuxmege4csoh6ypqysrrdt47l6luz FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gtk6iuxmege4csoh6ypqysrrdt47l6luz && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gtk6iuxmege4csoh6ypqysrrdt47l6luz && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gtk6iuxmege4csoh6ypqysrrdt47l6luz
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gtk6iuxmege4csoh6ypqysrrdt47l6luz", "parent": null, "child": null}" -->