### PR TITLE
[ci][anneal] Overhaul release process to support manual trigger and PR generation

### DIFF
--- a/.github/workflows/anneal-release.yml
+++ b/.github/workflows/anneal-release.yml
@@ -6,6 +6,32 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+# This workflow implements a complex release process for precompiled artifacts
+# of the Anneal toolchain.
+#
+# Motivation:
+# Previously, we relied solely on upstream prebuilts (from Aeneas and Rust).
+# To provide a better user experience, we want to distribute our own "fat"
+# artifacts that include these dependencies and pre-compiled Lean libraries.
+#
+# Obvious approaches like building locally and pushing binaries are rejected
+# because they require trusting developer machines. Building in CI and pushing
+# directly back to `main` is also rejected because it complicates protected
+# branch rules and can lead to concurrent modification issues.
+#
+# Design Outline:
+# - A manual GitHub Action (workflow_dispatch) is used to roll Aeneas.
+# - It builds our fat artifacts on trusted CI runners.
+# - It publishes them to a GitHub Pre-release with a unique tag.
+# - It automatically generates a PR that updates Cargo.toml with the new
+#   URLs and hashes of OUR artifacts.
+# - A local script remains available for simple version bumps without
+#   pinning updates.
+#
+# This ensures atomicity on `main` and keeps the process automated and
+# secure. We keep the workflows together in this file using conditional
+# logic to determine behavior.
+
 name: Anneal Release
 
 on:
@@ -17,12 +43,17 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Anneal version'
-        required: true
+      aeneas_version:
+        description: 'Aeneas version to roll to (optional)'
+        required: false
+        default: 'PROMPT: Enter Aeneas version'
+      crate_version:
+        description: 'New version for cargo-anneal (optional)'
+        required: false
+        default: 'PROMPT: Enter Cargo version'
       branch:
-        description: 'Branch to update'
-        required: true
+        description: 'Branch to target'
+        required: false
         default: 'main'
 
 permissions: {}
@@ -38,7 +69,7 @@ jobs:
     # Don't run this on forks. Also skip it on workflow_dispatch because that
     # trigger is specifically for creating the version-bumping PR, not for
     # checking if it was already done.
-    if: github.repository == 'google/zerocopy' && github.event_name != 'workflow_dispatch'
+    if: github.repository == 'google/zerocopy'
     outputs:
       changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
@@ -57,18 +88,53 @@ jobs:
           
           CUR_VER=$(cargo metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "cargo-anneal").version')
           
-          git checkout -q HEAD^
-          PREV_VER=$(cargo metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "cargo-anneal").version')
-          git checkout -q -
-          
-          if [ "$CUR_VER" != "$PREV_VER" ]; then
-            echo "Version change detected."
+          # If triggered manually, we assume the version has changed or we want
+          # to force a release/PR generation.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Triggered manually."
             echo "changed=true" >> $GITHUB_OUTPUT
-            echo "version=$CUR_VER" >> $GITHUB_OUTPUT
+            IN_VER="${{ github.event.inputs.crate_version }}"
+            if [ -n "$IN_VER" ] && [ "$IN_VER" != "PROMPT: Enter Cargo version" ]; then
+              echo "version=$IN_VER" >> $GITHUB_OUTPUT
+            else
+              echo "version=$CUR_VER" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "Version unchanged."
-            echo "changed=false" >> $GITHUB_OUTPUT
+            git checkout -q HEAD^
+            PREV_VER=$(cargo metadata -q --format-version 1 | jq -r '.packages[] | select(.name == "cargo-anneal").version')
+            git checkout -q -
+            
+            if [ "$CUR_VER" != "$PREV_VER" ]; then
+              echo "Version change detected."
+              echo "changed=true" >> $GITHUB_OUTPUT
+              echo "version=$CUR_VER" >> $GITHUB_OUTPUT
+            else
+              echo "Version unchanged."
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
           fi
+
+  prepare-release:
+    name: Prepare Release
+    needs: check-version
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+    steps:
+      - name: Generate Tag
+        id: tag
+        run: |
+          set -eo pipefail
+          # We use a unique tag for manual artifact builds to avoid overwriting
+          # existing releases, and to allow uploading artifacts for the same
+          # version multiple times during development.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_NAME="anneal-artifacts-$(date +'%Y.%m.%d.%H%M%S')-${{ github.sha }}"
+          else
+            # For standard releases, we use the version as the tag.
+            TAG_NAME="anneal-v${{ needs.check-version.outputs.version }}"
+          fi
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
   release:
     name: Release to crates.io and GitHub
@@ -123,12 +189,11 @@ jobs:
 
   publish-artifacts:
     name: Publish Artifacts (${{ matrix.target }})
-    needs: [check-version, release]
+    needs: [check-version, release, prepare-release]
     # We use `always()` to ensure this job runs even if the `release` job is
     # skipped (which happens on PRs). We still require `check-version` to
     # succeed to avoid running on failures.
-    # This job is also skipped on manual triggers (workflow_dispatch).
-    if: always() && (needs.check-version.result == 'success') && github.event_name != 'workflow_dispatch'
+    if: always() && (needs.check-version.result == 'success')
     permissions:
       contents: write # This is required to upload assets to a release.
     runs-on: ${{ matrix.os }}
@@ -186,22 +251,21 @@ jobs:
           ./tools/build-prebuilt.sh "$RUST_TRIPLE"
           
       - name: Upload Artifact
-        if: github.event_name != 'pull_request' && needs.release.result == 'success'
+        if: github.event_name == 'workflow_dispatch' || (github.event_name != 'pull_request' && needs.release.result == 'success')
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.check-version.outputs.version }}
+          TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
           TARGET: ${{ matrix.target }}
         run: |
-          gh release upload "anneal-v$VERSION" anneal/anneal-toolchain-$TARGET.tar.zst --clobber
+          gh release upload "$TAG_NAME" anneal/anneal-toolchain-$TARGET.tar.zst --clobber
 
-  release-version-action:
-    # This job handles manual release triggers. It updates version numbers and
-    # creates a PR for review. It does not perform actual publishing.
-    name: Release new Anneal versions
-    if: github.event_name == 'workflow_dispatch'
+  create-release-pr:
+    name: Create Release PR
+    needs: [publish-artifacts, prepare-release]
+    if: github.event_name == 'workflow_dispatch' && needs.publish-artifacts.result == 'success'
     permissions:
-      contents: read
-      pull-requests: write # Required to create pull requests
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -209,22 +273,32 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
-      - name: Overwrite Anneal files
+
+      - name: Install Python dependencies
+        run: pip install tomlkit
+
+      # This step closes the loop by downloading the artifacts we just
+      # published, computing their hashes, and baking them into Cargo.toml.
+      - name: Update Cargo.toml with hashes
         env:
-          VERSION: ${{ github.event.inputs.version }}
-        run: ./ci/release_anneal_version.sh "$VERSION"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./anneal/tools/prepare-release-pr.py \
+            --tag "${{ needs.prepare-release.outputs.tag_name }}" \
+            --aeneas-version "${{ github.event.inputs.aeneas_version }}" \
+            --crate-version "${{ github.event.inputs.crate_version }}"
 
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0
         with:
-          commit-message: "Release Anneal ${{ github.event.inputs.version }}"
+          commit-message: "Release Anneal ${{ github.event.inputs.crate_version }}"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
           committer: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
-          title: "Release Anneal ${{ github.event.inputs.version }}"
-          branch: anneal-release-${{ github.event.inputs.version }}
+          title: "Release Anneal ${{ github.event.inputs.crate_version }}"
+          branch: anneal-release-${{ github.event.inputs.crate_version }}
           push-to-fork: google-pr-creation-bot/zerocopy
-          token: ${{ secrets.GOOGLE_PR_CREATION_BOT_TOKEN }} # zizmor: ignore[secrets-outside-env]
+          token: ${{ secrets.GOOGLE_PR_CREATION_BOT_TOKEN }}
 
       - name: Add labels
         if: steps.submit-pr.outputs.pull-request-operation == 'created'

--- a/anneal/tools/prepare-release-pr.py
+++ b/anneal/tools/prepare-release-pr.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Updates Cargo.toml with artifact hashes.
+
+This script is used in the manual release workflow to close the loop: it
+downloads the artifacts published to a unique release, computes their
+hashes, and updates Cargo.toml with these hashes and URLs.
+"""
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tomlkit
+
+CARGO_TOML_PATH = (Path(__file__).parent.parent / "Cargo.toml").resolve()
+
+def get_file_sha256(path):
+    """Computes the SHA256 hash of a file.
+
+    This is used to verify the integrity of artifacts downloaded by users.
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(8192):
+            h.update(chunk)
+    return h.hexdigest()
+
+def main():
+    parser = argparse.ArgumentParser(description="Update Cargo.toml with artifact hashes")
+    parser.add_argument("--tag", required=True, help="Release tag")
+    parser.add_argument("--aeneas-version", required=True, help="Aeneas version")
+    parser.add_argument("--crate-version", help="New crate version")
+    args = parser.parse_args()
+
+    # 1. Download artifacts.
+    # We download the artifacts from the unique release tag generated in the
+    # previous step of the workflow. This ensures we are getting the exact
+    # binaries built by that run.
+    print(f"Downloading artifacts from release {args.tag}...")
+    try:
+        # Ensure output directory exists
+        os.makedirs("dist_download", exist_ok=True)
+        subprocess.run([
+            "gh", "release", "download", args.tag,
+            "-D", "dist_download",
+            "-R", "google/zerocopy",
+            "--clobber"
+        ], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: Failed to download artifacts: {e}")
+        sys.exit(1)
+
+    # 2. Compute hashes.
+    # We compute hashes for all downloaded artifacts to bake them into
+    # Cargo.toml. This allows `cargo anneal setup` to verify integrity.
+    checksums = {}
+    dist_dir = Path("dist_download")
+    for path in dist_dir.glob("*.tar.zst"):
+        name = path.name
+        target = name.replace("anneal-toolchain-", "").replace(".tar.zst", "")
+        checksums[target] = get_file_sha256(path)
+        print(f"Hash for {target}: {checksums[target]}")
+
+    # 3. Update Cargo.toml.
+    # We use tomlkit to parse and modify the document, which ensures
+    # that all existing comments and formatting in the original file are
+    # preserved.
+    print(f"Updating {CARGO_TOML_PATH}...")
+    try:
+        content = CARGO_TOML_PATH.read_text()
+        doc = tomlkit.parse(content)
+    except Exception as e:
+        print(f"ERROR: Failed to parse Cargo.toml: {e}")
+        sys.exit(1)
+
+    try:
+        metadata = doc["package"]["metadata"]
+        deps = metadata["anneal"]["dependencies"]
+
+        deps["aeneas"]["tag"] = args.tag
+        deps["aeneas"]["checksums"] = tomlkit.table()
+        for k, v in sorted(checksums.items()):
+            deps["aeneas"]["checksums"][k] = v
+
+        metadata["build_rs"]["aeneas_rev"] = args.aeneas_version
+
+        if args.crate_version and args.crate_version != "PROMPT: Enter Cargo version":
+            doc["package"]["version"] = args.crate_version
+            
+    except KeyError as e:
+        print(f"ERROR: Cargo.toml missing expected metadata section: {e}")
+        sys.exit(1)
+
+    try:
+        CARGO_TOML_PATH.write_text(tomlkit.dumps(doc))
+    except Exception as e:
+        print(f"ERROR: Failed to write to Cargo.toml: {e}")
+        sys.exit(1)
+
+    print("Cargo.toml updated successfully.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This design addresses a complex chicken-and-egg problem in releasing
precompiled artifacts for the Anneal toolchain. Previously, we relied
solely on upstream prebuilts (from Aeneas and Rust). To provide a better
user experience, we want to distribute our own "fat" artifacts that
include these dependencies and pre-compiled Lean libraries.

Obvious approaches like building locally and pushing binaries are
rejected because they require trusting developer machines. Building in
CI and pushing directly back to `main` is also rejected because it
complicates protected branch rules and can lead to concurrent
modification issues.

This commit overhauls the release process to support a new design:
- A manual GitHub Action (workflow_dispatch) is used to roll Aeneas.
- It builds our fat artifacts on trusted CI runners.
- It publishes them to a GitHub Pre-release with a unique tag.
- It automatically generates a PR that updates Cargo.toml with the new
  URLs and hashes of OUR artifacts.
- A local script remains available for simple version bumps without
  pinning updates.

This ensures atomicity on `main` and keeps the process automated and
secure. We keep the workflows together in `anneal-release.yml` as
suggested, using conditional logic to determine behavior.




---

- 👉 #3285


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v1..gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v1..gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma && git checkout -b pr-Gsfuzkz4u5vy5ps2egbs6bortsksfbpma FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gsfuzkz4u5vy5ps2egbs6bortsksfbpma
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gsfuzkz4u5vy5ps2egbs6bortsksfbpma", "parent": null, "child": null}" -->