### PR TITLE
[ci][anneal] Add manual trigger to publish precompiled artifacts

### DIFF
--- a/.github/workflows/anneal-release.yml
+++ b/.github/workflows/anneal-release.yml
@@ -17,6 +17,10 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      aeneas_version:
+        description: 'Aeneas version to roll to'
+        required: false
+        default: 'PROMPT: Enter Aeneas version'
       version:
         description: 'Anneal version'
         required: true
@@ -121,14 +125,31 @@ jobs:
           TAG="anneal-v$VERSION"
           gh release create "$TAG" --generate-notes
 
+  create-release:
+    name: Create Release for Artifacts
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to create a GitHub release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AENEAS_VERSION: ${{ github.event.inputs.aeneas_version }}
+        run: |
+          gh release create "anneal-artifacts-$AENEAS_VERSION" --generate-notes --prerelease || true
+
   publish-artifacts:
     name: Publish Artifacts (${{ matrix.target }})
-    needs: [check-version, release]
+    needs: [check-version, release, create-release]
     # We use `always()` to ensure this job runs even if the `release` job is
     # skipped (which happens on PRs). We still require `check-version` to
     # succeed to avoid running on failures.
-    # This job is also skipped on manual triggers (workflow_dispatch).
-    if: always() && (needs.check-version.result == 'success') && github.event_name != 'workflow_dispatch'
+    if: always() && (needs.check-version.result == 'success' || needs.create-release.result == 'success')
     permissions:
       contents: write # This is required to upload assets to a release.
     runs-on: ${{ matrix.os }}
@@ -186,13 +207,20 @@ jobs:
           ./tools/build-prebuilt.sh "$RUST_TRIPLE"
           
       - name: Upload Artifact
-        if: github.event_name != 'pull_request' && needs.release.result == 'success'
+        if: github.event_name == 'workflow_dispatch' || (github.event_name != 'pull_request' && needs.release.result == 'success')
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.check-version.outputs.version }}
+          AENEAS_VERSION: ${{ github.event.inputs.aeneas_version }}
           TARGET: ${{ matrix.target }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          gh release upload "anneal-v$VERSION" anneal/anneal-toolchain-$TARGET.tar.zst --clobber
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="anneal-artifacts-$AENEAS_VERSION"
+          else
+            TAG="anneal-v$VERSION"
+          fi
+          gh release upload "$TAG" anneal/anneal-toolchain-$TARGET.tar.zst --clobber
 
   release-version-action:
     # This job handles manual release triggers. It updates version numbers and


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This is part of a soft migration to the new system. It allows us to
publish precompiled artifacts that will let us land a subsequent commit
which makes use of them in `cargo-anneal`.




---

- 👉 #3286


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v1..gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v1..gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw && git checkout -b pr-Grdbltxkqkgnaqxnlrx4425qspr7nqrmw FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Grdbltxkqkgnaqxnlrx4425qspr7nqrmw
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Grdbltxkqkgnaqxnlrx4425qspr7nqrmw", "parent": null, "child": null}" -->