### PR TITLE
Support structs with same type

### DIFF
--- a/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy-derive/src/derive/into_bytes.rs
@@ -114,8 +114,8 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
 }
 
 fn all_fields_same_type(strct: &DataStruct) -> bool {
-    let mut fields =
-        strct.fields().into_iter().map(|(_, _, ty)| ty.into_token_stream().to_string());
+    let fields = strct.fields();
+    let mut fields = fields.into_iter().map(|(_, _, ty)| ty.into_token_stream().to_string());
     if let Some(first) = fields.next() {
         fields.all(|field| field == first)
     } else {

--- a/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy-derive/src/derive/into_bytes.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{Data, DataEnum, DataStruct, DataUnion, Error, Type};
 
 use crate::{
@@ -68,6 +68,23 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         } else {
             (Some(PaddingCheck::Struct), false)
         }
+    } else if is_c && !repr.is_align_gt_1() && all_fields_same_type(strct) {
+        // All fields have the same syntactic type `T`, which under
+        // `repr(C)` without `#[repr(align)]` is sufficient to prove no
+        // padding. The `repr(C)` layout algorithm places each field at
+        // an offset that is a multiple of that field's alignment; with
+        // every field having the same type, the struct's alignment
+        // equals `align_of::<T>()`, field `i` sits at offset `i *
+        // size_of::<T>()` (always a multiple of `align_of::<T>()`), and
+        // the struct's total size is `N * size_of::<T>()` (also a
+        // multiple of its alignment). Hence there is no inter-field or
+        // trailing padding, and requiring `T: IntoBytes` (so that `T`
+        // itself is padding-free) proves the struct is padding-free.
+        //
+        // We prefer this to the `Unaligned`-requiring branch below
+        // because it accepts strictly more types without giving up any
+        // soundness guarantees.
+        (None, false)
     } else if is_c && !repr.is_align_gt_1() {
         // We can't use a padding check since there are generic type arguments.
         // Instead, we require all field types to implement `Unaligned`. This
@@ -94,6 +111,30 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
     Ok(ImplBlockBuilder::new(ctx, strct, Trait::IntoBytes, field_bounds)
         .padding_check(padding_check)
         .build())
+}
+
+/// Returns `true` iff `strct` has two or more fields which all share the
+/// same syntactic type token tree.
+///
+/// Comparison is syntactic (tokens only), not semantic: `T` and
+/// `<T as Trait>::Self_` compare unequal even if they resolve to the
+/// same type. This is deliberate. A proc macro has no type resolution,
+/// and the soundness argument the caller relies on (that `N` copies of
+/// the same type under `repr(C)` contain no padding) only holds when
+/// the types are actually the same at the Rust-layout level. Being
+/// strict about token equality keeps the rule trivially sound.
+fn all_fields_same_type(strct: &DataStruct) -> bool {
+    let fields = strct.fields();
+    if fields.len() < 2 {
+        // Zero- and one-field cases are already handled by an earlier
+        // branch in `derive_into_bytes_struct`. Returning `false` here
+        // ensures those cases cannot reach this branch even if the
+        // order of checks is later rearranged.
+        return false;
+    }
+    let mut tokens = fields.iter().map(|(_, _, ty)| ty.to_token_stream().to_string());
+    let first = tokens.next().expect("len >= 2");
+    tokens.all(|t| t == first)
 }
 
 fn derive_into_bytes_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Error> {

--- a/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy-derive/src/derive/into_bytes.rs
@@ -125,16 +125,13 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
 /// strict about token equality keeps the rule trivially sound.
 fn all_fields_same_type(strct: &DataStruct) -> bool {
     let fields = strct.fields();
-    if fields.len() < 2 {
-        // Zero- and one-field cases are already handled by an earlier
-        // branch in `derive_into_bytes_struct`. Returning `false` here
-        // ensures those cases cannot reach this branch even if the
-        // order of checks is later rearranged.
-        return false;
+    let mut fields =
+        strct.fields().into_iter().map(|(_, _, ty)| ty.into_token_stream().to_string());
+    if let Some(first) = fields.next() {
+        fields.all(|field| field == first)
+    } else {
+        true
     }
-    let mut tokens = fields.iter().map(|(_, _, ty)| ty.to_token_stream().to_string());
-    let first = tokens.next().expect("len >= 2");
-    tokens.all(|t| t == first)
 }
 
 fn derive_into_bytes_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Error> {

--- a/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy-derive/src/derive/into_bytes.rs
@@ -113,18 +113,7 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         .build())
 }
 
-/// Returns `true` iff `strct` has two or more fields which all share the
-/// same syntactic type token tree.
-///
-/// Comparison is syntactic (tokens only), not semantic: `T` and
-/// `<T as Trait>::Self_` compare unequal even if they resolve to the
-/// same type. This is deliberate. A proc macro has no type resolution,
-/// and the soundness argument the caller relies on (that `N` copies of
-/// the same type under `repr(C)` contain no padding) only holds when
-/// the types are actually the same at the Rust-layout level. Being
-/// strict about token equality keeps the rule trivially sound.
 fn all_fields_same_type(strct: &DataStruct) -> bool {
-    let fields = strct.fields();
     let mut fields =
         strct.fields().into_iter().map(|(_, _, ty)| ty.into_token_stream().to_string());
     if let Some(first) = fields.next() {

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic.expected.rs
@@ -1,0 +1,21 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<T> ::zerocopy::IntoBytes for Foo<T>
+    where
+        T: ::zerocopy::IntoBytes,
+        T: ::zerocopy::IntoBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+};

--- a/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic_assoc_ty.expected.rs
+++ b/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic_assoc_ty.expected.rs
@@ -1,0 +1,22 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<P: Config> ::zerocopy::IntoBytes for Foo<P>
+    where
+        P::BaseField: ::zerocopy::IntoBytes,
+        P::BaseField: ::zerocopy::IntoBytes,
+        P::BaseField: ::zerocopy::IntoBytes,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+};

--- a/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy-derive/src/output_tests/mod.rs
@@ -233,6 +233,41 @@ fn test_into_bytes_struct_trailing() {
 }
 
 #[test]
+fn test_into_bytes_struct_homogeneous_generic() {
+    // A `#[repr(C)]` generic struct whose fields all share the same
+    // syntactic type has no padding, so the emitted `IntoBytes` impl
+    // bounds only on `IntoBytes` for the shared type and omits the
+    // `Unaligned` bound that the fallback branch would otherwise add.
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo<T> {
+                a: T,
+                b: T,
+            }
+        } expands to "expected/into_bytes_struct_homogeneous_generic.expected.rs"
+    }
+}
+
+#[test]
+fn test_into_bytes_struct_homogeneous_generic_assoc_ty() {
+    // Exercises the case in which every field is an associated-type
+    // projection of the single type parameter. Token comparison sees
+    // the same sequence `P :: BaseField` for every field, so the
+    // homogeneous branch applies.
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo<P: Config> {
+                c0: P::BaseField,
+                c1: P::BaseField,
+                c2: P::BaseField,
+            }
+        } expands to "expected/into_bytes_struct_homogeneous_generic_assoc_ty.expected.rs"
+    }
+}
+
+#[test]
 fn test_into_bytes_struct_trailing_generic() {
     test! {
         IntoBytes {

--- a/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy-derive/tests/struct_to_bytes.rs
@@ -172,10 +172,6 @@ struct ReprCGenericHomogeneousTuple<T>(T, T);
 
 util_assert_impl_all!(ReprCGenericHomogeneousTuple<u8>: imp::IntoBytes);
 util_assert_impl_all!(ReprCGenericHomogeneousTuple<u64>: imp::IntoBytes);
-// `AU16` has alignment 2, so the fallback branch for generic `repr(C)`
-// would have required `AU16: Unaligned` and been rejected. See the
-// corresponding `util_assert_not_impl_any!` on
-// `ReprCGenericMultipleFields<_, AU16>` below.
 util_assert_impl_all!(ReprCGenericHomogeneousTuple<util::AU16>: imp::IntoBytes);
 
 #[derive(imp::IntoBytes)]

--- a/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy-derive/tests/struct_to_bytes.rs
@@ -160,6 +160,37 @@ struct ReprCGenericOneField<T: ?imp::Sized> {
 util_assert_impl_all!(ReprCGenericOneField<util::AU16>: imp::IntoBytes);
 util_assert_impl_all!(ReprCGenericOneField<[util::AU16]>: imp::IntoBytes);
 
+// When every field of a generic `repr(C)` struct has the same syntactic
+// type, the struct has no padding regardless of the alignment of that
+// type, so `IntoBytes` can be derived requiring only that the shared
+// type itself is `IntoBytes` (no `Unaligned` bound needed).
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCGenericHomogeneousTuple<T>(T, T);
+
+util_assert_impl_all!(ReprCGenericHomogeneousTuple<u8>: imp::IntoBytes);
+util_assert_impl_all!(ReprCGenericHomogeneousTuple<u64>: imp::IntoBytes);
+// `AU16` has alignment 2, so the fallback branch for generic `repr(C)`
+// would have required `AU16: Unaligned` and been rejected. See the
+// corresponding `util_assert_not_impl_any!` on
+// `ReprCGenericMultipleFields<_, AU16>` below.
+util_assert_impl_all!(ReprCGenericHomogeneousTuple<util::AU16>: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCGenericHomogeneousNamed<T> {
+    x: T,
+    y: T,
+    z: T,
+}
+
+util_assert_impl_all!(ReprCGenericHomogeneousNamed<u8>: imp::IntoBytes);
+util_assert_impl_all!(ReprCGenericHomogeneousNamed<u64>: imp::IntoBytes);
+util_assert_impl_all!(ReprCGenericHomogeneousNamed<util::AU16>: imp::IntoBytes);
+
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]


### PR DESCRIPTION
## What

Let `derive(IntoBytes)` accept `#[repr(C)]` generic structs when every
field has the same type. Only requires `T: IntoBytes` — no `Unaligned`
bound.

## Why it's sound

`#[repr(C)]` struct, N fields all of type `T`, no `#[repr(align)]`:
field `i` sits at `i * size_of::<T>()`, size is `N * size_of::<T>()`,
struct alignment is `align_of::<T>()`. Everything's a multiple of
alignment, so no padding. If `T: IntoBytes`, so is the struct.

## Why I want it

arkworks has things like:

```rust
#[repr(C)]
pub struct QuadExtField<P: QuadExtConfig> {
    pub c0: P::BaseField,
    pub c1: P::BaseField,
}
```
Can't use repr(transparent) (two fields). Existing generic branch
wants P::BaseField: Unaligned, which it isn't (Montgomery form,
align 8). So today the only way to treat &[Fq2] as bytes is a
hand-written unsafe transmute.

With this, elems.as_bytes() just works.

Partially addresses [#10](https://github.com/google/zerocopy/issues/10)
