### PR TITLE
anneal-setup-v2: switch from shelling out to tar to managing archives with libraries

### DIFF
--- a/anneal/v2/setup/Cargo.toml
+++ b/anneal/v2/setup/Cargo.toml
@@ -8,3 +8,5 @@ log = "0.4"
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls"] }
 sha2 = "0.10"
 tempfile = "3.27.0"
+tar = "0.4"
+zstd = "0.13"

--- a/anneal/v2/setup/src/lib.rs
+++ b/anneal/v2/setup/src/lib.rs
@@ -119,7 +119,7 @@ impl ArchiveFormat {
     fn new_extractor(&self) -> impl Extractor {
         use ArchiveFormat::*;
         match self {
-            TarZst => TarZstExtractor,
+            TarZst => TarZstLibraryExtractor,
         }
     }
 }
@@ -164,60 +164,130 @@ pub trait Extractor {
     fn extract(&self, dst: &std::path::Path) -> std::io::Result<Box<dyn ArchiveWriter>>;
 }
 
-/// A concrete [`Extractor`] implementation delegating archive extraction duties to the host system's
-/// native `tar` executable.
-///
-/// This abstraction leverages highly optimized external OS tools to unpack data streams efficiently
-/// without swelling the compilation binary footprint with dense offline dependencies.
-pub struct TarZstExtractor;
-
-/// An [`ArchiveWriter`] bridging zstd-compressed byte streams into an actively running external
-/// `tar` subprocess.
-///
-/// This writer retains exclusive ownership over the spawned child process handle and directly feeds
-/// incoming bytes into its standard input stream.
-pub struct TarZstSubprocessWriter {
-    child: std::process::Child,
-    stdin: Option<std::process::ChildStdin>,
+struct PipeState {
+    buf: Vec<u8>,
+    closed: bool,
+    err: Option<String>,
 }
 
-impl std::io::Write for TarZstSubprocessWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.stdin.as_mut().unwrap().write(buf)
-    }
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.stdin.as_mut().unwrap().flush()
-    }
+#[derive(Clone)]
+struct SharedPipe {
+    state: std::sync::Arc<std::sync::Mutex<PipeState>>,
+    cvar: std::sync::Arc<std::sync::Condvar>,
+    cap: usize,
 }
 
-impl ArchiveWriter for TarZstSubprocessWriter {
-    fn finish(mut self: Box<Self>) -> std::io::Result<()> {
-        self.stdin = None;
-        let status = self.child.wait()?;
-        if !status.success() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("tar extraction failed with status: {status}"),
-            ));
+impl SharedPipe {
+    fn new(cap: usize) -> Self {
+        Self {
+            state: std::sync::Arc::new(std::sync::Mutex::new(PipeState {
+                buf: Vec::new(),
+                closed: false,
+                err: None,
+            })),
+            cvar: std::sync::Arc::new(std::sync::Condvar::new()),
+            cap,
         }
+    }
+}
+
+struct PipeWriter {
+    shared: SharedPipe,
+    join_handle: Option<std::thread::JoinHandle<std::io::Result<()>>>,
+}
+
+impl std::io::Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut state = self.shared.state.lock().unwrap();
+        while state.buf.len() >= self.shared.cap && !state.closed && state.err.is_none() {
+            state = self.shared.cvar.wait(state).unwrap();
+        }
+        if let Some(ref err) = state.err {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, err.clone()));
+        }
+        if state.closed {
+            return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "Pipe closed"));
+        }
+        let space = self.shared.cap.saturating_sub(state.buf.len()).max(1);
+        let n = buf.len().min(space);
+        state.buf.extend_from_slice(&buf[..n]);
+        self.shared.cvar.notify_all();
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
 }
 
-impl Extractor for TarZstExtractor {
-    fn extract(&self, dst: &std::path::Path) -> std::io::Result<Box<dyn ArchiveWriter>> {
-        let mut child = std::process::Command::new("tar")
-            .arg("--zstd")
-            .arg("-x")
-            .arg("-C")
-            .arg(dst)
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()?;
+impl ArchiveWriter for PipeWriter {
+    fn finish(mut self: Box<Self>) -> std::io::Result<()> {
+        {
+            let mut state = self.shared.state.lock().unwrap();
+            state.closed = true;
+            self.shared.cvar.notify_all();
+        }
+        let handle = self.join_handle.take().unwrap();
+        handle.join().map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Extraction thread panicked"))??;
+        Ok(())
+    }
+}
 
-        let stdin = child.stdin.take().expect("Failed to open stdin");
-        Ok(Box::new(TarZstSubprocessWriter { child, stdin: Some(stdin) }))
+struct PipeReader {
+    shared: SharedPipe,
+}
+
+impl std::io::Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut state = self.shared.state.lock().unwrap();
+        while state.buf.is_empty() && !state.closed && state.err.is_none() {
+            state = self.shared.cvar.wait(state).unwrap();
+        }
+        if let Some(ref err) = state.err {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, err.clone()));
+        }
+        if state.buf.is_empty() && state.closed {
+            return Ok(0);
+        }
+        let n = buf.len().min(state.buf.len());
+        let drained: Vec<u8> = state.buf.drain(..n).collect();
+        buf[..n].copy_from_slice(&drained);
+        self.shared.cvar.notify_all();
+        Ok(n)
+    }
+}
+
+/// A concrete [`Extractor`] implementation delegating archive extraction duties entirely in-process
+/// via concurrent multi-threaded streaming pipelines using the `tar` and `zstd` library crates.
+pub struct TarZstLibraryExtractor;
+
+impl Extractor for TarZstLibraryExtractor {
+    fn extract(&self, dst: &std::path::Path) -> std::io::Result<Box<dyn ArchiveWriter>> {
+        let shared = SharedPipe::new(65536);
+        let reader = PipeReader { shared: shared.clone() };
+        let dst = dst.to_path_buf();
+        let shared_clone = shared.clone();
+
+        let join_handle = std::thread::spawn(move || {
+            let res = (|| -> std::io::Result<()> {
+                let decoder = zstd::Decoder::new(reader)?;
+                let mut archive = tar::Archive::new(decoder);
+                archive.unpack(&dst)?;
+                Ok(())
+            })();
+
+            if let Err(ref e) = res {
+                let mut state = shared_clone.state.lock().unwrap();
+                state.err = Some(e.to_string());
+                shared_clone.cvar.notify_all();
+            }
+            res
+        });
+
+        Ok(Box::new(PipeWriter {
+            shared,
+            join_handle: Some(join_handle),
+        }))
     }
 }
 
@@ -433,16 +503,12 @@ mod tests {
     use super::*;
 
     fn create_test_archive(src_dir: &std::path::Path, archive_path: &std::path::Path) {
-        let status = std::process::Command::new("tar")
-            .arg("--zstd")
-            .arg("-cf")
-            .arg(archive_path)
-            .arg("-C")
-            .arg(src_dir)
-            .arg(".")
-            .status()
-            .expect("Failed to execute tar archive creation");
-        assert!(status.success());
+        let file = std::fs::File::create(archive_path).unwrap();
+        let encoder = zstd::Encoder::new(file, 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+        builder.append_dir_all(".", src_dir).unwrap();
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
     }
 
     fn compute_sha256(path: &std::path::Path) -> [u8; 32] {
@@ -487,7 +553,7 @@ mod tests {
 
         let dst = temp.path().join("dst");
         let file = std::fs::File::open(&archive_path).unwrap();
-        let hash = setup_from_archive(file, &dst, &TarZstExtractor).unwrap();
+        let hash = setup_from_archive(file, &dst, &TarZstLibraryExtractor).unwrap();
 
         assert_eq!(hash, compute_sha256(&archive_path));
         assert_eq!(std::fs::read_to_string(dst.join("data.txt")).unwrap(), "archive_content");


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #3360
- 　  #3359
- 　  #3358
- 　  #3357
- 👉 #3356
- 　  #3355
- 　  #3354
- 　  #3353
- 　  #3352


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v1..gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v1..gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v2)|[vs Base](/google/zerocopy/compare/Gtdgv7maeahl7cskivexxr5m2v4ehhzix..gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v2)|
|v1||[vs Base](/google/zerocopy/compare/Gtdgv7maeahl7cskivexxr5m2v4ehhzix..gherrit/Gion2gin42evzb4uuuean4jsthrgm2srm/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gion2gin42evzb4uuuean4jsthrgm2srm && git checkout -b pr-Gion2gin42evzb4uuuean4jsthrgm2srm FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gion2gin42evzb4uuuean4jsthrgm2srm && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gion2gin42evzb4uuuean4jsthrgm2srm && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gion2gin42evzb4uuuean4jsthrgm2srm
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gion2gin42evzb4uuuean4jsthrgm2srm", "parent": "Gtdgv7maeahl7cskivexxr5m2v4ehhzix", "child": "Gcik3rgbblmm5ws5wf6ceozrmgc5wu2oo"}" -->