### PR TITLE
Only use `layout_for_ptr` feature for zerocopy tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, feature(coverage_attribute))]
 #![cfg_attr(
-    any(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, miri),
+    any(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, all(test, miri)),
     feature(layout_for_ptr)
 )]
 #![cfg_attr(all(test, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), feature(test))]

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -233,7 +233,7 @@ mod _conversions {
             let raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
-            #[cfg(miri)]
+            #[cfg(all(test, miri))]
             unsafe {
                 crate::util::miri_promise_symbolic_alignment(
                     raw.as_ptr().cast(),
@@ -381,7 +381,7 @@ mod _conversions {
             let mut raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
-            #[cfg(miri)]
+            #[cfg(all(test, miri))]
             unsafe {
                 crate::util::miri_promise_symbolic_alignment(
                     raw.as_ptr().cast(),


### PR DESCRIPTION
This puts the use of the unstable feature `layout_for_ptr` behind `all(test, miri)`, since it is only necessary for zerocopy tests, not for downstream users.