### PR TITLE
Only use `layout_for_ptr` feature for zerocopy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,15 @@ jobs:
         THREADS=$(echo "$(nproc) * 2" | bc)
         echo "Running Miri tests with $THREADS threads" | tee -a $GITHUB_STEP_SUMMARY
 
+        # The internal miri tests use unstable rust features, so we want to make sure zerocopy
+        # still compiles without those features for downstream users. We'll use cargo directly since
+        # `cargo.sh` sets `__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS`, which turns on
+        # the unstable features.
+        RUSTFLAGS="--cfg miri -Zallow-features=" \
+          cargo \
+          +$(./cargo.sh --version $TOOLCHAIN) \
+          check
+
         # Run under both the stacked borrows model (default) and under the tree 
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 dependencies = [
  "elain",
  "itertools",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -124,13 +124,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.49", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.49", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -142,4 +142,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.49", path = "zerocopy-derive" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,10 +324,7 @@
 #![cfg_attr(feature = "float-nightly", feature(f16, f128))]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![cfg_attr(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, feature(coverage_attribute))]
-#![cfg_attr(
-    any(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, miri),
-    feature(layout_for_ptr)
-)]
+#![cfg_attr(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, feature(layout_for_ptr))]
 #![cfg_attr(all(test, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), feature(test))]
 
 // This is a hack to allow zerocopy-derive derives to work in this crate. They

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -233,7 +233,7 @@ mod _conversions {
             let raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
-            #[cfg(miri)]
+            #[cfg(all(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, miri))]
             unsafe {
                 crate::util::miri_promise_symbolic_alignment(
                     raw.as_ptr().cast(),
@@ -381,7 +381,7 @@ mod _conversions {
             let mut raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
-            #[cfg(miri)]
+            #[cfg(all(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, miri))]
             unsafe {
                 crate::util::miri_promise_symbolic_alignment(
                     raw.as_ptr().cast(),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -56,7 +56,7 @@ impl<T: ?Sized> Clone for SendSyncPhantomData<T> {
     }
 }
 
-#[cfg(miri)]
+#[cfg(all(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, miri))]
 extern "Rust" {
     /// Miri-provided intrinsic that marks the pointer `ptr` as aligned to
     /// `align`.

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This puts the use of the unstable feature `layout_for_ptr` behind
`all(test, miri)`, since it is only necessary for zerocopy tests, not
for downstream users.

Release 0.8.49.




---

- 👉 #3365


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v1..gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v1..gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gouy5nmgied3joawzp6mdecm3nuhi35jh/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gouy5nmgied3joawzp6mdecm3nuhi35jh && git checkout -b pr-Gouy5nmgied3joawzp6mdecm3nuhi35jh FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gouy5nmgied3joawzp6mdecm3nuhi35jh && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gouy5nmgied3joawzp6mdecm3nuhi35jh && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gouy5nmgied3joawzp6mdecm3nuhi35jh
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gouy5nmgied3joawzp6mdecm3nuhi35jh", "parent": null, "child": null}" -->