### PR TITLE
Add experimental `ptr` crate to workspace re-exporting zerocopy pointer APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr"
+version = "0.1.0"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@
 # avoids issues like:
 # https://github.com/dtolnay/trybuild/issues/207#issuecomment-131227.594
 [workspace]
+members = [".", "ptr", "testutil", "zerocopy-derive"]
 
 [package]
 edition = "2021"

--- a/ptr/Cargo.toml
+++ b/ptr/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ptr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+zerocopy = { path = "..", features = ["__internal_use_only_features_that_work_on_stable"] }

--- a/ptr/src/lib.rs
+++ b/ptr/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+//! Experimental crate which re-exports zerocopy pointer APIs.
+
+pub use zerocopy::pointer::*;
+


### PR DESCRIPTION
### Motivation
- Provide an experimental crate that re-exports the `zerocopy` pointer APIs so downstream consumers can depend on a focused `ptr` crate.
- Add the crate to the workspace to stabilize crate paths for workspace-aware tooling such as `trybuild` and to keep local dev/test artifacts consistent.

### Description
- Added a new workspace member `ptr` in `Cargo.toml` via `members = [".", "ptr", "testutil", "zerocopy-derive"]`.
- Introduced the `ptr` crate with `ptr/Cargo.toml` declaring a dependency on the local `zerocopy` crate and `ptr/src/lib.rs` which re-exports `zerocopy::pointer::*`.
- Updated `Cargo.lock` to include the new `ptr` package entry and its dependency on `zerocopy`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e425d94e883338856b209509a3e8b)