### PR TITLE
Publish `Ptr[Inner]` behind a `--cfg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49-alpha"
 dependencies = [
  "elain",
  "itertools",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49-alpha"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49-alpha"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -124,13 +124,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.49-alpha", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.49-alpha", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -142,4 +142,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.48", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.49-alpha", path = "zerocopy-derive" }

--- a/build.rs
+++ b/build.rs
@@ -94,6 +94,7 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)");
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
         println!("cargo:rustc-check-cfg=cfg(zerocopy_inline_always)");
+        println!("cargo:rustc-check-cfg=cfg(zerocopy_unstable_ptr)");
     }
 
     for version_cfg in version_cfgs {

--- a/src/error.rs
+++ b/src/error.rs
@@ -662,6 +662,7 @@ where
 {
     type Inner = Src;
     type Mapped = crate::ValidityError<NewSrc, Dst>;
+    #[inline]
     fn map<F: FnOnce(Src) -> NewSrc>(self, f: F) -> Self::Mapped {
         self.map_src(f)
     }
@@ -800,6 +801,7 @@ where
     type Inner = Src;
     type Mapped = crate::CastError<NewSrc, Dst>;
 
+    #[inline]
     fn map<F: FnOnce(Src) -> NewSrc>(self, f: F) -> Self::Mapped {
         self.map_src(f)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,7 +359,7 @@ mod impls;
 #[doc(hidden)]
 pub mod layout;
 mod macros;
-#[doc(hidden)]
+#[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))]
 pub mod pointer;
 mod r#ref;
 mod split_at;
@@ -385,9 +385,10 @@ use core::{
 use std::io;
 
 #[doc(hidden)]
-pub use crate::pointer::invariant::{self, BecauseExclusive};
-#[doc(hidden)]
-pub use crate::pointer::PtrInner;
+pub use crate::pointer::{
+    invariant::{self, BecauseExclusive},
+    PtrInner,
+};
 pub use crate::{
     byte_slice::*,
     byteorder::*,
@@ -404,8 +405,6 @@ use alloc::{boxed::Box, vec::Vec};
 #[cfg(any(feature = "alloc", test))]
 use core::alloc::Layout;
 
-use util::MetadataOf;
-
 // Used by `KnownLayout`.
 #[doc(hidden)]
 pub use crate::layout::*;
@@ -420,6 +419,8 @@ pub use crate::pointer::{invariant::BecauseImmutable, Maybe, Ptr};
 // See the documentation on `util::polyfills` for more information.
 #[allow(unused_imports)]
 use crate::util::polyfills::{self, NonNullExt as _, NumExt as _};
+#[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))]
+pub use crate::util::MetadataOf;
 
 #[cfg(all(test, not(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)))]
 const _: () = {

--- a/src/pointer/inner.rs
+++ b/src/pointer/inner.rs
@@ -126,7 +126,7 @@ mod _def {
 impl<'a, T: ?Sized> PtrInner<'a, T> {
     /// Constructs a `PtrInner` from a reference.
     #[inline]
-    pub(crate) fn from_ref(ptr: &'a T) -> Self {
+    pub fn from_ref(ptr: &'a T) -> Self {
         let ptr = NonNull::from(ptr);
         // SAFETY:
         // 0. If `ptr`'s referent is not zero sized, then `ptr`, by invariant on
@@ -152,7 +152,7 @@ impl<'a, T: ?Sized> PtrInner<'a, T> {
 
     /// Constructs a `PtrInner` from a mutable reference.
     #[inline]
-    pub(crate) fn from_mut(ptr: &'a mut T) -> Self {
+    pub fn from_mut(ptr: &'a mut T) -> Self {
         let ptr = NonNull::from(ptr);
         // SAFETY:
         // 0. If `ptr`'s referent is not zero sized, then `ptr`, by invariant on
@@ -218,7 +218,9 @@ where
     T: ?Sized + KnownLayout,
 {
     /// Extracts the metadata of this `ptr`.
-    pub(crate) fn meta(self) -> MetadataOf<T> {
+    #[inline]
+    #[must_use]
+    pub fn meta(self) -> MetadataOf<T> {
         let meta = T::pointer_to_metadata(self.as_ptr());
         // SAFETY: By invariant on `PtrInner`, `self.as_non_null()` addresses no
         // more than `isize::MAX` bytes.
@@ -234,7 +236,8 @@ where
     /// a pointer constructed from its address with the given `meta` metadata
     /// will address a subset of the allocation pointed to by `self`.
     #[inline]
-    pub(crate) unsafe fn with_meta(self, meta: T::PointerMetadata) -> Self
+    #[must_use]
+    pub unsafe fn with_meta(self, meta: T::PointerMetadata) -> Self
     where
         T: KnownLayout,
     {
@@ -288,7 +291,9 @@ where
     ///
     /// If `l_len.padding_needed_for() != 0`, then the left pointer will overlap
     /// the right pointer to satisfy `T`'s padding requirements.
-    pub(crate) unsafe fn split_at_unchecked(
+    #[inline]
+    #[must_use]
+    pub unsafe fn split_at_unchecked(
         self,
         l_len: crate::util::MetadataOf<T>,
     ) -> (Self, PtrInner<'a, [T::Elem]>)
@@ -323,7 +328,9 @@ where
     }
 
     /// Produces the trailing slice of `self`.
-    pub(crate) fn trailing_slice(self) -> PtrInner<'a, [T::Elem]>
+    #[inline]
+    #[must_use]
+    pub fn trailing_slice(self) -> PtrInner<'a, [T::Elem]>
     where
         T: SplitAt,
     {
@@ -379,7 +386,9 @@ impl<'a, T> PtrInner<'a, [T]> {
     /// # Safety
     ///
     /// `range` is a valid range (`start <= end`) and `end <= self.meta()`.
-    pub(crate) unsafe fn slice_unchecked(self, range: Range<usize>) -> Self {
+    #[inline]
+    #[must_use]
+    pub unsafe fn slice_unchecked(self, range: Range<usize>) -> Self {
         let base = self.as_non_null().cast::<T>().as_ptr();
 
         // SAFETY: The caller promises that `start <= end <= self.meta()`. By
@@ -424,7 +433,8 @@ impl<'a, T> PtrInner<'a, [T]> {
     }
 
     /// Iteratively projects the elements `PtrInner<T>` from `PtrInner<[T]>`.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = PtrInner<'a, T>> {
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = PtrInner<'a, T>> {
         // FIXME(#429): Once `NonNull::cast` documents that it preserves
         // provenance, cite those docs.
         let base = self.as_non_null().cast::<T>().as_ptr();
@@ -498,7 +508,9 @@ impl<'a, T, const N: usize> PtrInner<'a, [T; N]> {
     /// Callers may assume that the returned `PtrInner` references the same
     /// address and length as `self`.
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn as_slice(self) -> PtrInner<'a, [T]> {
+    #[inline]
+    #[must_use]
+    pub fn as_slice(self) -> PtrInner<'a, [T]> {
         let start = self.as_non_null().cast::<T>().as_ptr();
         let slice = core::ptr::slice_from_raw_parts_mut(start, N);
         // SAFETY: `slice` is not null, because it is derived from `start`
@@ -546,7 +558,7 @@ impl<'a> PtrInner<'a, [u8]> {
     /// - If this is a prefix cast, `ptr` has the same address as `self`.
     /// - If this is a suffix cast, `remainder` has the same address as `self`.
     #[inline]
-    pub(crate) fn try_cast_into<U>(
+    pub fn try_cast_into<U>(
         self,
         cast_type: CastType,
         meta: Option<U::PointerMetadata>,

--- a/src/pointer/invariant.rs
+++ b/src/pointer/invariant.rs
@@ -6,7 +6,7 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-#![allow(missing_copy_implementations, missing_debug_implementations)]
+#![allow(missing_copy_implementations, missing_debug_implementations, missing_docs)]
 
 //! The parameterized invariants of a [`Ptr`][super::Ptr].
 //!
@@ -265,13 +265,11 @@ impl<T: ?Sized> Read<Exclusive, BecauseExclusive> for T {}
 /// Unsynchronized reads are permitted because only one live [`Ptr`](crate::Ptr)
 /// or reference may exist to the referent bytes at a time.
 #[derive(Copy, Clone, Debug)]
-#[doc(hidden)]
 pub enum BecauseExclusive {}
 
 /// Unsynchronized reads are permitted because no live [`Ptr`](crate::Ptr)s or
 /// references permit interior mutation.
 #[derive(Copy, Clone, Debug)]
-#[doc(hidden)]
 pub enum BecauseImmutable {}
 
 use sealed::Sealed;

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -8,19 +8,17 @@
 
 //! Abstractions over raw pointers.
 
+#![allow(missing_docs)]
+
 mod inner;
-#[doc(hidden)]
 pub mod invariant;
 mod ptr;
-mod transmute;
+pub mod transmute;
 
-#[doc(hidden)]
-pub use {inner::PtrInner, transmute::*};
-#[doc(hidden)]
-pub use {
-    invariant::{BecauseExclusive, BecauseImmutable, Read},
-    ptr::*,
-};
+pub use inner::PtrInner;
+pub use invariant::{BecauseExclusive, BecauseImmutable, Read};
+pub use ptr::{Ptr, TryWithError};
+pub use transmute::*;
 
 use crate::wrappers::ReadOnly;
 
@@ -44,7 +42,6 @@ where
     )
 }
 
-#[doc(hidden)]
 pub mod cast {
     use core::{marker::PhantomData, mem};
 

--- a/src/pointer/ptr.rs
+++ b/src/pointer/ptr.rs
@@ -6,6 +6,8 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
+#![allow(missing_docs)]
+
 use core::{
     fmt::{Debug, Formatter},
     marker::PhantomData,
@@ -96,7 +98,9 @@ mod def {
         /// Note that this method does not consume `self`. The caller should
         /// watch out for `unsafe` code which uses the returned value in a way
         /// that violates the safety invariants of `self`.
-        pub(crate) fn as_inner(&self) -> PtrInner<'a, T> {
+        #[inline]
+        #[must_use]
+        pub fn as_inner(&self) -> PtrInner<'a, T> {
             self.ptr
         }
     }
@@ -168,7 +172,6 @@ mod _conversions {
         T: 'a + ?Sized,
     {
         /// Constructs a `Ptr` from a shared reference.
-        #[doc(hidden)]
         #[inline(always)]
         pub fn from_ref(ptr: &'a T) -> Self {
             let inner = PtrInner::from_ref(ptr);
@@ -196,7 +199,6 @@ mod _conversions {
         T: 'a + ?Sized,
     {
         /// Constructs a `Ptr` from an exclusive reference.
-        #[doc(hidden)]
         #[inline(always)]
         pub fn from_mut(ptr: &'a mut T) -> Self {
             let inner = PtrInner::from_mut(ptr);
@@ -229,7 +231,9 @@ mod _conversions {
         // this doesn't prevent the caller from still using the pointer after
         // calling `as_ref`.
         #[allow(clippy::wrong_self_convention)]
-        pub(crate) fn as_ref(self) -> &'a T {
+        #[inline]
+        #[must_use]
+        pub fn as_ref(self) -> &'a T {
             let raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
@@ -282,8 +286,8 @@ mod _conversions {
         ///
         /// Since `self` is borrowed mutably, this prevents any methods from
         /// being called on `self` as long as the returned `Ptr` exists.
-        #[doc(hidden)]
         #[inline]
+        #[must_use]
         #[allow(clippy::needless_lifetimes)] // Allows us to name the lifetime in the safety comment below.
         pub fn reborrow<'b>(&'b mut self) -> Ptr<'b, T, I>
         where
@@ -328,8 +332,8 @@ mod _conversions {
         ///
         /// Since `self` is borrowed mutably, this prevents any methods from
         /// being called on `self` as long as the returned `Ptr` exists.
-        #[doc(hidden)]
         #[inline]
+        #[must_use]
         #[allow(clippy::needless_lifetimes)] // Allows us to name the lifetime in the safety comment below.
         pub fn reborrow_shared<'b>(&'b mut self) -> Ptr<'b, T, (Shared, I::Alignment, I::Validity)>
         where
@@ -377,7 +381,9 @@ mod _conversions {
     {
         /// Converts `self` to a mutable reference.
         #[allow(clippy::wrong_self_convention)]
-        pub(crate) fn as_mut(self) -> &'a mut T {
+        #[inline]
+        #[must_use]
+        pub fn as_mut(self) -> &'a mut T {
             let mut raw = self.as_inner().as_non_null();
             // SAFETY: `self` satisfies the `Aligned` invariant, so we know that
             // `raw` is validly-aligned for `T`.
@@ -435,7 +441,9 @@ mod _conversions {
             self.transmute_with::<U, V, <U as SizeEq<T>>::CastFrom, R>()
         }
 
-        pub(crate) fn transmute_with<U, V, C, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
+        #[inline]
+        #[must_use]
+        pub fn transmute_with<U, V, C, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, V)>
         where
             V: Validity,
             U: TransmuteFromPtr<T, I::Aliasing, I::Validity, V, C, R> + ?Sized,
@@ -457,8 +465,7 @@ mod _conversions {
             unsafe { self.project_transmute_unchecked::<_, _, C>() }
         }
 
-        #[doc(hidden)]
-        #[inline(always)]
+        #[inline]
         #[must_use]
         pub fn recall_validity<V, R>(self) -> Ptr<'a, T, (I::Aliasing, I::Alignment, V)>
         where
@@ -495,8 +502,7 @@ mod _conversions {
         ///   presence, absence, or specific location of `UnsafeCell`s in `T`
         ///   and/or `U`, and on whether interior mutation is ever permitted via
         ///   those `UnsafeCell`s. See [`Validity`] for more details.
-        #[doc(hidden)]
-        #[inline(always)]
+        #[inline]
         #[must_use]
         pub unsafe fn project_transmute_unchecked<U: ?Sized, V, P>(
             self,
@@ -546,7 +552,9 @@ mod _conversions {
     {
         /// Converts a `Ptr` an unaligned `T` into a `Ptr` to an aligned
         /// `Unalign<T>`.
-        pub(crate) fn into_unalign(
+        #[inline]
+        #[must_use]
+        pub fn into_unalign(
             self,
         ) -> Ptr<'a, crate::Unalign<T>, (I::Aliasing, Aligned, I::Validity)> {
             // FIXME(#1359): This should be a `transmute_with` call.
@@ -634,7 +642,9 @@ mod _transitions {
 
         /// Helps the type system unify two distinct invariant types which are
         /// actually the same.
-        pub(crate) fn unify_invariants<
+        #[inline]
+        #[must_use]
+        pub fn unify_invariants<
             H: Invariants<Aliasing = I::Aliasing, Alignment = I::Alignment, Validity = I::Validity>,
         >(
             self,
@@ -662,7 +672,8 @@ mod _transitions {
 
         /// Checks the `self`'s alignment at runtime, returning an aligned `Ptr`
         /// on success.
-        pub(crate) fn try_into_aligned(
+        #[inline]
+        pub fn try_into_aligned(
             self,
         ) -> Result<Ptr<'a, T, (I::Aliasing, Aligned, I::Validity)>, AlignmentError<Self, T>>
         where
@@ -682,9 +693,8 @@ mod _transitions {
         #[inline]
         // FIXME(#859): Reconsider the name of this method before making it
         // public.
-        pub(crate) fn bikeshed_recall_aligned(
-            self,
-        ) -> Ptr<'a, T, (I::Aliasing, Aligned, I::Validity)>
+        #[must_use]
+        pub fn bikeshed_recall_aligned(self) -> Ptr<'a, T, (I::Aliasing, Aligned, I::Validity)>
         where
             T: crate::Unaligned,
         {
@@ -700,7 +710,6 @@ mod _transitions {
         ///
         /// The caller promises that `self`'s referent conforms to the validity
         /// requirement of `V`.
-        #[doc(hidden)]
         #[must_use]
         #[inline]
         pub unsafe fn assume_validity<V: Validity>(
@@ -717,7 +726,6 @@ mod _transitions {
         ///
         /// The caller promises to uphold the safety preconditions of
         /// `self.assume_validity<invariant::Initialized>()`.
-        #[doc(hidden)]
         #[must_use]
         #[inline]
         pub unsafe fn assume_initialized(
@@ -734,7 +742,6 @@ mod _transitions {
         ///
         /// The caller promises to uphold the safety preconditions of
         /// `self.assume_validity<Valid>()`.
-        #[doc(hidden)]
         #[must_use]
         #[inline]
         pub unsafe fn assume_valid(self) -> Ptr<'a, T, (I::Aliasing, I::Alignment, Valid)> {
@@ -756,7 +763,7 @@ mod _transitions {
         /// On error, unsafe code may rely on this method's returned
         /// `ValidityError` containing `self`.
         #[inline]
-        pub(crate) fn try_into_valid<R, S>(
+        pub fn try_into_valid<R, S>(
             mut self,
         ) -> Result<Ptr<'a, T, (I::Aliasing, I::Alignment, Valid)>, ValidityError<Self, T>>
         where
@@ -784,9 +791,8 @@ mod _transitions {
         }
 
         /// Forgets that `self`'s referent is validly-aligned for `T`.
-        #[doc(hidden)]
-        #[must_use]
         #[inline]
+        #[must_use]
         pub fn forget_aligned(self) -> Ptr<'a, T, (I::Aliasing, Unaligned, I::Validity)> {
             // SAFETY: `Unaligned` is less restrictive than `Aligned`.
             unsafe { self.assume_invariants() }
@@ -795,7 +801,8 @@ mod _transitions {
 }
 
 /// Casts of the referent type.
-pub(crate) use _casts::TryWithError;
+#[cfg_attr(not(zerocopy_unstable_ptr), allow(unreachable_pub))]
+pub use _casts::TryWithError;
 mod _casts {
     use core::cell::UnsafeCell;
 
@@ -820,8 +827,7 @@ mod _casts {
         /// If `I::Aliasing` is [`Shared`], it must not be possible for safe
         /// code, operating on a `&T` and `&U` with the same referent
         /// simultaneously, to cause undefined behavior.
-        #[doc(hidden)]
-        #[inline(always)]
+        #[inline]
         #[must_use]
         pub unsafe fn cast_unchecked<U, C: Cast<T, U>>(
             self,
@@ -847,8 +853,7 @@ mod _casts {
         }
 
         /// Casts to a different referent type.
-        #[doc(hidden)]
-        #[inline(always)]
+        #[inline]
         #[must_use]
         pub fn cast<U, C, R>(self) -> Ptr<'a, U, (I::Aliasing, Unaligned, I::Validity)>
         where
@@ -972,7 +977,7 @@ mod _casts {
         /// Attempts to transform the pointer, restoring the original on
         /// failure.
         #[inline(always)]
-        pub(crate) fn try_with<U, J, E, F>(self, f: F) -> Result<Ptr<'a, U, J>, E::Mapped>
+        pub fn try_with<U, J, E, F>(self, f: F) -> Result<Ptr<'a, U, J>, E::Mapped>
         where
             U: 'a + ?Sized,
             J: Invariants<Aliasing = I::Aliasing>,
@@ -993,7 +998,7 @@ mod _casts {
     /// `Self::Mapped` contain no non-ZST fields.
     ///
     /// `map` must pass ownership of `self`'s sole `Self::Inner` to `f`.
-    pub(crate) unsafe trait TryWithError<MappedInner> {
+    pub unsafe trait TryWithError<MappedInner> {
         type Inner;
         type Mapped;
         fn map<F: FnOnce(Self::Inner) -> MappedInner>(self, f: F) -> Self::Mapped;
@@ -1023,7 +1028,9 @@ mod _casts {
     {
         /// Casts this pointer-to-array into a slice.
         #[allow(clippy::wrong_self_convention)]
-        pub(crate) fn as_slice(self) -> Ptr<'a, [T], I> {
+        #[inline]
+        #[must_use]
+        pub fn as_slice(self) -> Ptr<'a, [T], I> {
             let slice = self.as_inner().as_slice();
             // SAFETY: Note that, by post-condition on `PtrInner::as_slice`,
             // `slice` refers to the same byte range as `self.as_inner()`.
@@ -1087,7 +1094,7 @@ mod _casts {
         /// - If this is a suffix cast, `remainder` has the same address as
         ///   `self`.
         #[inline(always)]
-        pub(crate) fn try_cast_into<U, R>(
+        pub fn try_cast_into<U, R>(
             self,
             cast_type: CastType,
             meta: Option<U::PointerMetadata>,
@@ -1159,7 +1166,7 @@ mod _casts {
         /// references the same byte range as `self`.
         #[allow(unused)]
         #[inline(always)]
-        pub(crate) fn try_cast_into_no_leftover<U, R>(
+        pub fn try_cast_into_no_leftover<U, R>(
             self,
             meta: Option<U::PointerMetadata>,
         ) -> Result<Ptr<'a, U, (I::Aliasing, Aligned, Initialized)>, CastError<Self, U>>
@@ -1174,7 +1181,7 @@ mod _casts {
                     #[inline(always)]
                     |slf| match slf.try_cast_into(CastType::Prefix, meta) {
                         Ok((slf, remainder)) => {
-                            if remainder.len() == 0 {
+                            if remainder.is_empty() {
                                 Ok(slf)
                             } else {
                                 Err(CastError::Size(SizeError::<_, U>::new(())))
@@ -1260,7 +1267,8 @@ mod _project {
         I::Aliasing: Reference,
     {
         /// Iteratively projects the elements `Ptr<T>` from `Ptr<[T]>`.
-        pub(crate) fn iter(&self) -> impl Iterator<Item = Ptr<'a, T, I>> {
+        #[inline]
+        pub fn iter(&self) -> impl Iterator<Item = Ptr<'a, T, I>> {
             // SAFETY:
             // 0. `elem` conforms to the aliasing invariant of `I::Aliasing`
             //    because projection does not impact the aliasing invariant.
@@ -1292,8 +1300,17 @@ mod _project {
         I: Invariants,
     {
         /// The number of slice elements in the object referenced by `self`.
-        pub(crate) fn len(&self) -> usize {
+        #[inline]
+        #[must_use]
+        pub fn len(&self) -> usize {
             self.as_inner().meta().get()
+        }
+
+        /// Returns `true` if the slice pointer has a length of 0.
+        #[inline]
+        #[must_use]
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
         }
     }
 }

--- a/src/pointer/transmute.rs
+++ b/src/pointer/transmute.rs
@@ -6,6 +6,8 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
+#![allow(missing_docs)]
+
 use core::{
     cell::{Cell, UnsafeCell},
     mem::{ManuallyDrop, MaybeUninit},
@@ -223,7 +225,6 @@ where
 }
 
 #[allow(missing_debug_implementations, missing_copy_implementations)]
-#[doc(hidden)]
 pub enum BecauseInvariantsEq {}
 
 macro_rules! unsafe_impl_invariants_eq {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -463,7 +463,7 @@ mod len_of {
     use super::*;
 
     /// A witness type for metadata of a valid instance of `&T`.
-    pub(crate) struct MetadataOf<T: ?Sized + KnownLayout> {
+    pub struct MetadataOf<T: ?Sized + KnownLayout> {
         /// # Safety
         ///
         /// The size of an instance of `&T` with the given metadata is not
@@ -474,8 +474,19 @@ mod len_of {
 
     impl<T: ?Sized + KnownLayout> Copy for MetadataOf<T> {}
     impl<T: ?Sized + KnownLayout> Clone for MetadataOf<T> {
+        #[inline]
         fn clone(&self) -> Self {
             *self
+        }
+    }
+
+    impl<T: ?Sized + KnownLayout> core::fmt::Debug for MetadataOf<T>
+    where
+        T::PointerMetadata: core::fmt::Debug,
+    {
+        #[inline]
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("MetadataOf").field("meta", &self.meta).finish()
         }
     }
 
@@ -654,7 +665,7 @@ mod len_of {
     }
 }
 
-pub(crate) use len_of::MetadataOf;
+pub use len_of::MetadataOf;
 
 /// Since we support multiple versions of Rust, there are often features which
 /// have been stabilized in the most recent stable release which do not yet

--- a/tests/ui/ptr-is-invariant-over-v.nightly.stderr
+++ b/tests/ui/ptr-is-invariant-over-v.nightly.stderr
@@ -10,7 +10,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, zerocopy::invariant::Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -26,7 +26,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Shared, zerocopy::invariant::Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/zerocopy-derive/Cargo.toml
+++ b/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49-alpha"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Release 0.8.49-alpha.




---

- 👉 #3387


**Latest Update:** v8 — [Compare vs v7](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v8|[vs v7](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v6](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v5](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v4](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v3](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v8)|
|v7||[vs v6](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs v5](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs v4](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs v3](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v7)|
|v6|||[vs v5](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|[vs v4](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|[vs v3](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v6)|
|v5||||[vs v4](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v5)|
|v4|||||[vs v3](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v4)|
|v3||||||[vs v2](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v3)|
|v2|||||||[vs v1](/google/zerocopy/compare/gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v2)|
|v1||||||||[vs Base](/google/zerocopy/compare/main..gherrit/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf && git checkout -b pr-Gblc7dfltwcey7wvtj3gjkseaqcltgwvf FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gblc7dfltwcey7wvtj3gjkseaqcltgwvf
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gblc7dfltwcey7wvtj3gjkseaqcltgwvf", "parent": null, "child": null}" -->