### PR TITLE
[docs] Document `--cfg=zerocopy_unstable_ptr` on internal rendered docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  RUSTDOCFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings --cfg=zerocopy_unstable_ptr
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly
   # toolchain.
   ZC_NIGHTLY_RUSTFLAGS: -Zrandomize-layout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
             #
             # TODO(#1228): Use `jq` to parse these from `Cargo.toml` instead of
             # hard-coding them once we've gotten it working again.
-            METADATA_DOCS_RS_RUSTDOC_ARGS="--cfg doc_cfg --generate-link-to-definition --extend-css $PWD/rustdoc/style.css"
+            METADATA_DOCS_RS_RUSTDOC_ARGS="--cfg doc_cfg --cfg zerocopy_unstable_ptr --generate-link-to-definition --extend-css $PWD/rustdoc/style.css"
             export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS"
 
             # TODO: Use `./cargo.sh` instead once we've debugged why it won't work.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,7 @@ mod impls;
 pub mod layout;
 mod macros;
 #[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(zerocopy_unstable_ptr)))]
 pub mod pointer;
 mod r#ref;
 mod split_at;
@@ -420,6 +421,7 @@ pub use crate::pointer::{invariant::BecauseImmutable, Maybe, Ptr};
 #[allow(unused_imports)]
 use crate::util::polyfills::{self, NonNullExt as _, NumExt as _};
 #[cfg_attr(not(zerocopy_unstable_ptr), doc(hidden))]
+#[cfg_attr(doc_cfg, doc(cfg(zerocopy_unstable_ptr)))]
 pub use crate::util::MetadataOf;
 
 #[cfg(all(test, not(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)))]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3388


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v2..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v2..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v3)|[vs v1](/google/zerocopy/compare/gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v1..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v1..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7 && git checkout -b pr-G7p44q5rcehvy46vrrowj5vxxkgp3xuw7 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G7p44q5rcehvy46vrrowj5vxxkgp3xuw7
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G7p44q5rcehvy46vrrowj5vxxkgp3xuw7", "parent": null, "child": null}" -->