### PR TITLE
Fixed section reference

### DIFF
--- a/anneal/docs/design/design.md
+++ b/anneal/docs/design/design.md
@@ -71,7 +71,7 @@ Anneal abstracts away the need to manually author Lean specifications in separat
 
 ## 5\. Architecture
 
-Once a programmer has annotated their Rust code with Anneal annotations (whose syntax is described in Section 5), interacting with Anneal is just a matter of running `cargo anneal verify`. Like the familiar `cargo check`, `cargo anneal verify` will exit cleanly on successful verification, or will print error messages describing verification failures.
+Once a programmer has annotated their Rust code with Anneal annotations (whose syntax is described in Section 6), interacting with Anneal is just a matter of running `cargo anneal verify`. Like the familiar `cargo check`, `cargo anneal verify` will exit cleanly on successful verification, or will print error messages describing verification failures.
 
 Anneal primarily operates by orchestrating the Charon, Aeneas, and Lean verification tools, managing the flow between Rust source, LLBC, and Lean through distinct stages:
 


### PR DESCRIPTION
Syntax description is in Section 6, not Section 5

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
