### PR TITLE
[byteorder] Add cfg no_fp_fmt_parse

### DIFF
--- a/zerocopy/build.rs
+++ b/zerocopy/build.rs
@@ -95,6 +95,7 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
         println!("cargo:rustc-check-cfg=cfg(zerocopy_inline_always)");
         println!("cargo:rustc-check-cfg=cfg(zerocopy_unstable_ptr)");
+        println!("cargo:rustc-check-cfg=cfg(no_fp_fmt_parse)");
     }
 
     for version_cfg in version_cfgs {

--- a/zerocopy/src/byteorder.rs
+++ b/zerocopy/src/byteorder.rs
@@ -162,6 +162,42 @@ pub type BE = BigEndian;
 /// A type alias for [`LittleEndian`].
 pub type LE = LittleEndian;
 
+macro_rules! impl_dbg_trait {
+    ($name:ident, $native:ident) => {
+        impl<O: ByteOrder> Debug for $name<O> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                // This results in a format like "U16(42)".
+                f.debug_tuple(stringify!($name)).field(&self.get()).finish()
+            }
+        }
+    };
+}
+
+macro_rules! impl_dbg_traits {
+    ($name:ident, $native:ident, "floating point number") => {
+        #[cfg(not(no_fp_fmt_parse))]
+        impl_dbg_trait!($name, $native);
+
+        #[cfg(no_fp_fmt_parse)]
+        impl<O: ByteOrder> Debug for $name<O> {
+            #[inline]
+            fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
+                panic!("floating point support is turned off");
+            }
+        }
+    };
+    ($name:ident, $native:ident, "unsigned integer") => {
+        impl_dbg_traits!($name, $native, @all_types);
+    };
+    ($name:ident, $native:ident, "signed integer") => {
+        impl_dbg_traits!($name, $native, @all_types);
+    };
+    ($name:ident, $native:ident, @all_types) => {
+        impl_dbg_trait!($name, $native);
+    };
+}
+
 macro_rules! impl_fmt_trait {
     ($name:ident, $native:ident, $trait:ident) => {
         impl<O: ByteOrder> $trait for $name<O> {
@@ -175,6 +211,7 @@ macro_rules! impl_fmt_trait {
 
 macro_rules! impl_fmt_traits {
     ($name:ident, $native:ident, "floating point number") => {
+        #[cfg(not(no_fp_fmt_parse))]
         impl_fmt_trait!($name, $native, Display);
     };
     ($name:ident, $native:ident, "unsigned integer") => {
@@ -686,16 +723,9 @@ example of how it can be used for parsing UDP packets.
             }
         }
 
+        impl_dbg_traits!($name, $native, $number_kind);
         impl_fmt_traits!($name, $native, $number_kind);
         impl_ops_traits!($name, $native, $number_kind);
-
-        impl<O: ByteOrder> Debug for $name<O> {
-            #[inline]
-            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-                // This results in a format like "U16(42)".
-                f.debug_tuple(stringify!($name)).field(&self.get()).finish()
-            }
-        }
     };
 }
 


### PR DESCRIPTION
This cfg deactivates Debug and Display for floatting point numbers, this is particluarly useful in kernel context.
The implementation is inspired by:
https://github.com/rust-lang/rust/commit/ec7292ad3c35

Fixes #3426