### PR TITLE
Prevent external PRs from pushing benchmark data in anneal CI workflow

### DIFF
--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -110,7 +110,9 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: build_time.json
           gh-pages-branch: benchmark-data
-          auto-push: true
+          # External pull requests cannot push benchmark data to the
+          # `benchmark-data` branch.
+          auto-push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}
           benchmark-data-dir-path: dashboard
           fail-on-alert: false


### PR DESCRIPTION
### Motivation
- Prevent external pull requests from attempting to push benchmark data to the `benchmark-data` branch (which they do not have permission to do), avoiding push failures and accidental updates.

### Description
- Change `auto-push` for the `benchmark-action/github-action-benchmark` step to a conditional: `auto-push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}` and add a comment explaining the restriction.

### Testing
- Validated the modified workflow YAML for syntax correctness and ensured the updated conditional compiles in the workflow; no unit tests were changed or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2079a5445c833381302b7bf4bd34d0)