### PR TITLE
[derive] Remove unnecessary clones

### DIFF
--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     let root = env::current_dir().unwrap();
     let mut config = Config::rustc(tests_dir.clone());
     config.out_dir = root.join("target").join("ui-test-artifacts");
-    config.program.envs.push(("RUSTUP_TOOLCHAIN".into(), Some(toolchain.clone().into())));
+    config.program.envs.push(("RUSTUP_TOOLCHAIN".into(), Some(toolchain.into())));
 
     let toolchain_meta_name = env::var("ZEROCOPY_UI_TEST_TOOLCHAIN_META_NAME")
         .expect("ZEROCOPY_UI_TEST_TOOLCHAIN_META_NAME must be set by tests/ui.rs");

--- a/zerocopy/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy/zerocopy-derive/src/derive/known_layout.rs
@@ -85,7 +85,6 @@ fn derive_known_layout_for_repr_c_struct<'a>(
     };
 
     let inner_extras = {
-        let leading_fields_tys = leading_fields_tys.clone();
         let methods = make_methods(*trailing_field_ty);
         let (_, ty_generics, _) = ctx.ast.generics.split_for_impl();
 

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -529,8 +529,8 @@ fn derive_has_field_struct_union(ctx: &Ctx, data: &dyn DataExt) -> TokenStream {
                 data,
                 Trait::ProjectField {
                     variant_id: variant_id.clone(),
-                    field: field.clone(),
-                    field_id: field_id.clone(),
+                    field,
+                    field_id,
                     invariants: parse_quote!((Aliasing, Alignment, #zerocopy_crate::invariant::Initialized)),
                 },
                 FieldBounds::None,


### PR DESCRIPTION
If I am not overlooking anything, many of these clones can be removed as the receiver's type implements `Copy`, or can simply be moved.

CC @nunoplopes