### PR TITLE
Skip Anneal benchmark storage outside canonical main

### DIFF
--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -149,6 +149,11 @@ jobs:
             ]' > output.json
 
       - name: Store CI duration benchmarks
+        # Only trusted main-branch pushes to the canonical repository can
+        # update the benchmark-data branch. Pull requests from forks receive a
+        # read-only GITHUB_TOKEN, and forks running this workflow should not try
+        # to publish benchmark history for google/zerocopy.
+        if: github.event_name == 'push' && github.repository == 'google/zerocopy' && github.ref == 'refs/heads/main'
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: CI Durations
@@ -156,7 +161,7 @@ jobs:
           output-file-path: output.json
           gh-pages-branch: benchmark-data
           auto-push: true
-          save-data-file: ${{ github.ref == 'refs/heads/main' }}
+          save-data-file: true
           benchmark-data-dir-path: dashboard
           fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent the Anneal workflow from attempting to publish benchmark data when the run is not a trusted push to the canonical repository (e.g., fork/PR runs) which can fail due to read-only `GITHUB_TOKEN` or insufficient permissions.

### Description
- Restrict the "Store CI duration benchmarks" step by adding `if: github.event_name == 'push' && github.repository == 'google/zerocopy' && github.ref == 'refs/heads/main'` and make `save-data-file: true` so only trusted main-branch pushes publish benchmark history.

### Testing
- Verified YAML parsing with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/anneal.yml")'` (succeeded), linting with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/anneal.yml` (succeeded), and `git diff --check` (succeeded), while a Python YAML load using `PyYAML` could not be run in the environment due to missing `PyYAML` (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26cd7b16348333800da8ee1bd317ad)