### PR TITLE
Use rustc's --diagnostic-width flag in UI tests

### DIFF
--- a/anneal/tests/ui.rs
+++ b/anneal/tests/ui.rs
@@ -7,6 +7,7 @@ fn ui() {
     unsafe { std::env::set_var("ANNEAL_UI_TEST_MODE", "true") };
 
     let mut config = Config::rustc(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/ui"));
+    config.program.args.push("--diagnostic-width=100".into());
 
     let args = Args::test().unwrap();
     config.with_args(&args);

--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -119,8 +119,22 @@ fn main() {
     // Ignoring `RUSTFLAGS` and specifying our own flags here makes these
     // tests more reproducible.
 
-    // FIXME: These seem to have no effect (ie, rustc seems to still discover
-    // the real terminal width).
+    // The `--diagnostic-width` flag is the most reliable way to ensure that
+    // rustc's error messages are wrapped at a consistent width. This avoids
+    // flakiness in UI tests where the output might otherwise depend on the
+    // terminal width of the environment in which the tests are run.
+    //
+    // However, this flag was only stabilized in Rust 1.70.0 (and was unstable
+    // starting in 1.62.0), so we only pass it if we're not on our MSRV
+    // toolchain (which is 1.56.0).
+    if toolchain_meta_name != "msrv" {
+        config.program.args.push("--diagnostic-width=100".into());
+    }
+
+    // These environment variables are usually respected by CLI tools (including
+    // rustc) to determine the terminal width. As of this writing, rustc sometimes
+    // ignores them and discovers the real terminal width anyway; the
+    // `--diagnostic-width` flag above is more reliable.
     config.program.envs.push(("TERM".into(), Some("dumb".into())));
     config.program.envs.push(("COLUMNS".into(), Some("100".into())));
 

--- a/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
@@ -25,6 +25,8 @@ note: required by a bound in `takes_from_bytes`
    |
 77 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:18:24
@@ -53,6 +55,8 @@ note: required by a bound in `takes_from_zeros`
    |
 78 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:20:23
@@ -81,6 +85,8 @@ note: required by a bound in `takes_immutable`
    |
 79 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:22:24
@@ -165,6 +171,8 @@ note: required by a bound in `takes_try_from_bytes`
    |
 82 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:28:23

--- a/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
@@ -25,6 +25,8 @@ note: required by a bound in `takes_from_bytes`
    |
 77 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:18:24
@@ -53,6 +55,8 @@ note: required by a bound in `takes_from_zeros`
    |
 78 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:20:23
@@ -81,6 +85,8 @@ note: required by a bound in `takes_immutable`
    |
 79 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:22:24
@@ -165,6 +171,8 @@ note: required by a bound in `takes_try_from_bytes`
    |
 82 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:28:23

--- a/zerocopy/tests/ui/include_value.nightly.stderr
+++ b/zerocopy/tests/ui/include_value.nightly.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `NOT_FROM_BYTES::transmute`
    |     |
    |     required by a bound in this function
    |     required by this bound in `transmute`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/zerocopy/tests/ui/include_value.stable.stderr
+++ b/zerocopy/tests/ui/include_value.stable.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `NOT_FROM_BYTES::transmute`
    |     |
    |     required by a bound in this function
    |     required by this bound in `transmute`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/zerocopy/tests/ui/late-compile-pass.nightly.stderr
+++ b/zerocopy/tests/ui/late-compile-pass.nightly.stderr
@@ -58,8 +58,8 @@ error[E0015]: cannot call non-const method `zerocopy::util::macro_util::Wrap::<&
 error[E0080]: transmuting from 4-byte type to 8-byte type: `[u8; 4]` -> `u64`
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
+50 | ...IZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
    |
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -96,8 +96,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 | ...G_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `[u8; 4]` (32 bits)
    = note: target type: `u64` (64 bits)

--- a/zerocopy/tests/ui/late-compile-pass.stable.stderr
+++ b/zerocopy/tests/ui/late-compile-pass.stable.stderr
@@ -58,8 +58,8 @@ error[E0015]: cannot call non-const method `Wrap::<&mut [u8; 2], &mut [u8; 2]>::
 error[E0080]: transmuting from 4-byte type to 8-byte type: `[u8; 4]` -> `u64`
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
+50 | ...IZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
    |
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -96,8 +96,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 | ...G_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `[u8; 4]` (32 bits)
    = note: target type: `u64` (64 bits)

--- a/zerocopy/tests/ui/transmute.nightly.stderr
+++ b/zerocopy/tests/ui/transmute.nightly.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
    |                                         |
    |                                         required by a bound in this function
    |                                         required by this bound in `transmute`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute.stable.stderr
+++ b/zerocopy/tests/ui/transmute.stable.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
    |                                         |
    |                                         required by a bound in this function
    |                                         required by this bound in `transmute`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -48,6 +48,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 ...
 814 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: IntoBytes` is not satisfied
@@ -156,6 +158,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 812 |     where
 813 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcD: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -48,6 +48,8 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
 ...
 814 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: IntoBytes` is not satisfied
@@ -156,6 +158,8 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
 812 |     where
 813 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcD: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -108,6 +108,8 @@ note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
    |
 40 | const DST_NOT_FROM_BYTES: &DstA = transmute_ref!(&AU16(0));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: Immutable` is not satisfied
@@ -140,6 +142,8 @@ note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
    |
 48 | const DST_NOT_IMMUTABLE: &DstB = transmute_ref!(&AU16(0));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -305,6 +309,8 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcB: Immutable` is not satisfied
@@ -334,6 +340,8 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `transmute_ref` exists for struct `zerocopy::util::macro_util::Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -108,6 +108,8 @@ note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
    |
 40 | const DST_NOT_FROM_BYTES: &DstA = transmute_ref!(&AU16(0));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: Immutable` is not satisfied
@@ -140,6 +142,8 @@ note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
    |
 48 | const DST_NOT_IMMUTABLE: &DstB = transmute_ref!(&AU16(0));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -305,6 +309,8 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcB: Immutable` is not satisfied
@@ -334,6 +340,8 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -25,6 +25,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute.rs:15:58
@@ -56,6 +58,8 @@ note: required by a bound in `zerocopy::util::macro_util::try_transmute`
 ...
 528 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -85,6 +89,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -25,6 +25,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute.rs:15:58
@@ -56,6 +58,8 @@ note: required by a bound in `try_transmute`
 ...
 528 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -85,6 +89,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 ...
 837 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
@@ -89,6 +91,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_mut.rs:18:63
@@ -117,6 +121,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcA: FromBytes` is not satisfied
@@ -149,6 +155,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 835 |     where
 836 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstA: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -28,6 +28,8 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mu
 ...
 837 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
@@ -89,6 +91,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_mut.rs:18:63
@@ -117,6 +121,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcA: FromBytes` is not satisfied
@@ -149,6 +155,8 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mu
 835 |     where
 836 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstA: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -45,6 +45,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
@@ -77,6 +79,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -106,6 +110,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_ref.rs:25:59
@@ -134,6 +140,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
@@ -198,6 +206,8 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 755 |     where
 756 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -45,6 +45,8 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
@@ -77,6 +79,8 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -106,6 +110,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_ref.rs:25:59
@@ -134,6 +140,8 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
@@ -198,6 +206,8 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 755 |     where
 756 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
@@ -35,6 +35,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
    | ------------------------------------------------------------------- in this macro invocation
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
@@ -74,6 +76,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ---------------------------------------------------------------- in this macro invocation
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
@@ -113,6 +117,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ---------------------------------------------------------------- in this macro invocation
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
@@ -30,6 +30,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 35 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: TryFromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
@@ -64,6 +66,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 38 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromZeros);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
@@ -98,6 +102,8 @@ note: required by a bound in `_::{closure#0}::_::{closure#0}::assert_impl_all`
    |
 41 | util_assert_impl_all!(TransparentStruct<NotZerocopy>: FromBytes);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_impl_all`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` which comes from the expansion of the macro `util_assert_impl_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -336,6 +336,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D, E, F)
            and 137 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -360,6 +362,8 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D, E, F)
            and 137 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -389,6 +393,8 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F, G, H)
             and 157 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
@@ -418,6 +424,8 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F, G, H)
             and 157 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
@@ -447,6 +455,8 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F, G, H)
             and 142 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
@@ -471,6 +481,8 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F, G, H)
             and 79 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
@@ -593,6 +605,8 @@ note: required by a bound in `assert_is_from_bytes`
     |
 247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 52 previous errors

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -312,6 +312,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D, E, F)
            and 137 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
@@ -332,6 +334,8 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D, E, F)
            and 137 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotTryFromBytes: TryFromBytes` is not satisfied
@@ -357,6 +361,8 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F, G, H)
             and 157 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: TryFromBytes` is not satisfied
@@ -382,6 +388,8 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F, G, H)
             and 157 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotFromZeros: FromZeros` is not satisfied
@@ -407,6 +415,8 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F, G, H)
             and 142 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `bool: FromBytes` is not satisfied
@@ -427,6 +437,8 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F, G, H)
             and 79 others
     = help: see issue #48214
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
@@ -541,6 +553,8 @@ note: required by a bound in `assert_is_from_bytes`
     |
 247 | #[derive(FromBytes)]
     |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
+    = note: the full name for the type has been written to '/long-type-HASH.txt'
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 52 previous errors

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
@@ -29,6 +29,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -58,6 +60,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -87,6 +91,8 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 143 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -116,6 +122,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -145,6 +153,8 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 143 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -174,6 +184,8 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F, G, H)
            and 80 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -328,6 +340,8 @@ note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for Fro
    |
 54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 11 previous errors; 1 warning emitted

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
@@ -29,6 +29,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
@@ -54,6 +56,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
@@ -79,6 +83,8 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 143 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromZeros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::TryFromBytes` is not satisfied
@@ -104,6 +110,8 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F, G, H)
            and 156 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
@@ -129,6 +137,8 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F, G, H)
            and 143 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::FromBytes` is not satisfied
@@ -154,6 +164,8 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F, G, H)
            and 80 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy_renamed::IntoBytes` is not satisfied
@@ -288,6 +300,8 @@ note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for Fro
    |
 54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ required by this bound in `assert_is_from_bytes`
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 11 previous errors; 1 warning emitted

--- a/zerocopy/zerocopy-derive/tests/ui/privacy.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/privacy.nightly.stderr
@@ -25,7 +25,7 @@ error: type `private::_::_::_::ẕ1` is private
 error: type `private::_::_::_::ẕb` is private
    --> $DIR/privacy.rs:138:49
     |
-138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>:...
     |                                                 ^ private type
 
 error: aborting due to 3 previous errors; 1 warning emitted

--- a/zerocopy/zerocopy-derive/tests/ui/privacy.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/privacy.stable.stderr
@@ -25,7 +25,7 @@ error: type `private::_::_::_::ẕ1` is private
 error: type `private::_::_::_::ẕb` is private
    --> $DIR/privacy.rs:138:49
     |
-138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>::Type =
+138 |     let _: <Union as zerocopy_renamed::HasField<_, _, { zerocopy_renamed::ident_id!(b) }>>:...
     |                                                 ^ private type
 
 error: aborting due to 3 previous errors; 1 warning emitted

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -205,6 +205,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D, E, F)
            and 130 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
@@ -230,6 +232,8 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
            and 130 others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -184,6 +184,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D, E, F)
            and 130 others
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is not satisfied
@@ -205,6 +207,8 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
            and 130 others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type

--- a/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
@@ -81,6 +81,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
            and 129 others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |

--- a/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
@@ -81,6 +81,8 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
            and 129 others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the derive macro `Immutable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `IntoBytes2` has 1 total byte(s) of padding


### PR DESCRIPTION
Pass --diagnostic-width=100 to rustc in UI tests to ensure consistent error message line-wrapping regardless of the terminal width of the environment in which the tests are run.

The flag is skipped for the 'msrv' toolchain (Rust 1.56.0) since it was only stabilized in Rust 1.70.0.

The TERM/COLUMNS environment variables are retained since they can still influence other tools, but a comment is updated to clarify that --diagnostic-width is now the primary and more reliable mechanism.

Fixes #3113

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
