### PR TITLE
Use wider diagnostic output in UI tests

### DIFF
--- a/anneal/tests/ui.rs
+++ b/anneal/tests/ui.rs
@@ -7,7 +7,7 @@ fn ui() {
     unsafe { std::env::set_var("ANNEAL_UI_TEST_MODE", "true") };
 
     let mut config = Config::rustc(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/ui"));
-    config.program.args.push("--diagnostic-width=100".into());
+    config.program.args.push("--diagnostic-width=1000".into());
 
     let args = Args::test().unwrap();
     config.with_args(&args);

--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
     // starting in 1.62.0), so we only pass it if we're not on our MSRV
     // toolchain (which is 1.56.0).
     if toolchain_meta_name != "msrv" {
-        config.program.args.push("--diagnostic-width=100".into());
+        config.program.args.push("--diagnostic-width=1000".into());
     }
 
     // These environment variables are usually respected by CLI tools (including
@@ -136,7 +136,7 @@ fn main() {
     // ignores them and discovers the real terminal width anyway; the
     // `--diagnostic-width` flag above is more reliable.
     config.program.envs.push(("TERM".into(), Some("dumb".into())));
-    config.program.envs.push(("COLUMNS".into(), Some("100".into())));
+    config.program.envs.push(("COLUMNS".into(), Some("1000".into())));
 
     // Set `-Wwarnings` in the `RUSTFLAGS` environment variable to ensure that
     // `.stderr` files reflect what the typical user would encounter.

--- a/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
@@ -25,8 +25,6 @@ note: required by a bound in `takes_from_bytes`
    |
 77 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:18:24
@@ -55,8 +53,6 @@ note: required by a bound in `takes_from_zeros`
    |
 78 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:20:23
@@ -85,8 +81,6 @@ note: required by a bound in `takes_immutable`
    |
 79 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:22:24
@@ -171,8 +165,6 @@ note: required by a bound in `takes_try_from_bytes`
    |
 82 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:28:23

--- a/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
@@ -25,8 +25,6 @@ note: required by a bound in `takes_from_bytes`
    |
 77 | fn takes_from_bytes<T: FromBytes>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_bytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: FromZeros` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:18:24
@@ -55,8 +53,6 @@ note: required by a bound in `takes_from_zeros`
    |
 78 | fn takes_from_zeros<T: FromZeros>() {}
    |                        ^^^^^^^^^ required by this bound in `takes_from_zeros`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:20:23
@@ -85,8 +81,6 @@ note: required by a bound in `takes_immutable`
    |
 79 | fn takes_immutable<T: Immutable>() {}
    |                       ^^^^^^^^^ required by this bound in `takes_immutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:22:24
@@ -171,8 +165,6 @@ note: required by a bound in `takes_try_from_bytes`
    |
 82 | fn takes_try_from_bytes<T: TryFromBytes>() {}
    |                            ^^^^^^^^^^^^ required by this bound in `takes_try_from_bytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: zerocopy::Unaligned` is not satisfied
   --> $DIR/diagnostic-not-implemented.rs:28:23

--- a/zerocopy/tests/ui/include_value.nightly.stderr
+++ b/zerocopy/tests/ui/include_value.nightly.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `NOT_FROM_BYTES::transmute`
    |     |
    |     required by a bound in this function
    |     required by this bound in `transmute`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/zerocopy/tests/ui/include_value.stable.stderr
+++ b/zerocopy/tests/ui/include_value.stable.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `NOT_FROM_BYTES::transmute`
    |     |
    |     required by a bound in this function
    |     required by this bound in `transmute`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/zerocopy/tests/ui/late-compile-pass.nightly.stderr
+++ b/zerocopy/tests/ui/late-compile-pass.nightly.stderr
@@ -58,8 +58,8 @@ error[E0015]: cannot call non-const method `zerocopy::util::macro_util::Wrap::<&
 error[E0080]: transmuting from 4-byte type to 8-byte type: `[u8; 4]` -> `u64`
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | ...IZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
+50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
    |
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -96,8 +96,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | ...G_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `[u8; 4]` (32 bits)
    = note: target type: `u64` (64 bits)

--- a/zerocopy/tests/ui/late-compile-pass.stable.stderr
+++ b/zerocopy/tests/ui/late-compile-pass.stable.stderr
@@ -58,8 +58,8 @@ error[E0015]: cannot call non-const method `Wrap::<&mut [u8; 2], &mut [u8; 2]>::
 error[E0080]: transmuting from 4-byte type to 8-byte type: `[u8; 4]` -> `u64`
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | ...IZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
+50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `INCLUDE_VALUE_WRONG_SIZE` failed here
    |
    = note: this error originates in the macro `$crate::transmute` which comes from the expansion of the macro `zerocopy::include_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -96,8 +96,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/late-compile-pass.rs:50:39
    |
-50 | ...G_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+50 | const INCLUDE_VALUE_WRONG_SIZE: u64 = zerocopy::include_value!("../../testdata/include_value/data");
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `[u8; 4]` (32 bits)
    = note: target type: `u64` (64 bits)

--- a/zerocopy/tests/ui/transmute.nightly.stderr
+++ b/zerocopy/tests/ui/transmute.nightly.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
    |                                         |
    |                                         required by a bound in this function
    |                                         required by this bound in `transmute`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute.stable.stderr
+++ b/zerocopy/tests/ui/transmute.stable.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
    |                                         |
    |                                         required by a bound in this function
    |                                         required by this bound in `transmute`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -48,8 +48,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 ...
 814 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: IntoBytes` is not satisfied
@@ -158,8 +156,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 812 |     where
 813 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcD: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -48,8 +48,6 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
 ...
 814 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: IntoBytes` is not satisfied
@@ -158,8 +156,6 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
 812 |     where
 813 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcD: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -108,8 +108,6 @@ note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
    |
 40 | const DST_NOT_FROM_BYTES: &DstA = transmute_ref!(&AU16(0));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: Immutable` is not satisfied
@@ -142,8 +140,6 @@ note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
    |
 48 | const DST_NOT_IMMUTABLE: &DstB = transmute_ref!(&AU16(0));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -309,8 +305,6 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcB: Immutable` is not satisfied
@@ -340,8 +334,6 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `transmute_ref` exists for struct `zerocopy::util::macro_util::Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -108,8 +108,6 @@ note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
    |
 40 | const DST_NOT_FROM_BYTES: &DstA = transmute_ref!(&AU16(0));
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsFromBytes`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstB: Immutable` is not satisfied
@@ -142,8 +140,6 @@ note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
    |
 48 | const DST_NOT_IMMUTABLE: &DstB = transmute_ref!(&AU16(0));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertDstIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
@@ -309,8 +305,6 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcB: Immutable` is not satisfied
@@ -340,8 +334,6 @@ note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
    |
 79 | const SRC_NOT_IMMUTABLE: &AU16 = transmute_ref!(&SrcB(AU16(0)));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `AssertSrcIsImmutable`
-   = note: the full name for the type has been written to '/long-type-HASH.txt'
-   = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]>`, but its trait bounds were not satisfied

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -25,8 +25,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute.rs:15:58
@@ -58,8 +56,6 @@ note: required by a bound in `zerocopy::util::macro_util::try_transmute`
 ...
 528 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -89,8 +85,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -25,8 +25,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute.rs:15:58
@@ -58,8 +56,6 @@ note: required by a bound in `try_transmute`
 ...
 528 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -89,8 +85,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 ...
 837 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
@@ -91,8 +89,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_mut.rs:18:63
@@ -121,8 +117,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcA: FromBytes` is not satisfied
@@ -155,8 +149,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'
 835 |     where
 836 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstA: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -28,8 +28,6 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mu
 ...
 837 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: IntoBytes` is not satisfied
@@ -91,8 +89,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_mut.rs:18:63
@@ -121,8 +117,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SrcA: FromBytes` is not satisfied
@@ -155,8 +149,6 @@ note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mu
 835 |     where
 836 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `DstA: IntoBytes` is not satisfied

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -45,8 +45,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
@@ -79,8 +77,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -110,8 +106,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_ref.rs:25:59
@@ -140,8 +134,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
@@ -206,8 +198,6 @@ note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Ds
 755 |     where
 756 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -45,8 +45,6 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: Immutable` is not satisfied
@@ -79,8 +77,6 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 ...
 757 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
@@ -110,8 +106,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
 
 error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
    --> $DIR/try_transmute_ref.rs:25:59
@@ -140,8 +134,6 @@ note: required by a bound in `ValidityError`
     |
 590 | pub struct ValidityError<Src, Dst: ?Sized + TryFromBytes> {
     |                                             ^^^^^^^^^^^^ required by this bound in `ValidityError`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
@@ -206,8 +198,6 @@ note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
 755 |     where
 756 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
-    = note: the full name for the type has been written to '/long-type-HASH.txt'
-    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors


### PR DESCRIPTION
### Motivation
- UI tests were intermittently showing truncation notes (long-type files) and spurious wrapping due to a narrow diagnostic width, causing brittle snapshots and extra noise.
- Making the runner request a much wider diagnostic width and matching `COLUMNS` produces full diagnostics and more stable/meaningful `.stderr` snapshots.

### Description
- Increase the `--diagnostic-width` argument from `100` to `1000` in `tools/ui-runner/src/main.rs` and `anneal/tests/ui.rs` so rustc emits wider, less-truncated diagnostics.
- Update the `COLUMNS` environment variable in `tools/ui-runner` to `1000` to match the requested diagnostic width.
- Re-bless numerous UI `.stderr` snapshots in `zerocopy/tests/ui/` (stable and nightly variants) to remove `/long-type-HASH.txt` truncation notes and reflect wider source spans.

### Testing
- Ran `CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN=1 BLESS=1 ./cargo.sh +stable test --test ui -p zerocopy --features=__internal_use_only_features_that_work_on_stable` and the UI tests completed successfully.
- Ran `CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN=1 BLESS=1 ./cargo.sh +nightly test --test ui -p zerocopy --all-features` and the UI tests completed successfully.
- Ran `CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN=1 BLESS=1 ./cargo.sh +msrv test --test ui -p zerocopy --features=__internal_use_only_features_that_work_on_stable` and the UI tests completed successfully.
- Attempted the full snapshot update script `../tools/update-expected-test-output.sh`, but it failed early because `cargo-asm` was not available in this environment and that prevented the `codegen` step from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e778133e48333989002b85d6a95de)