### PR TITLE
Add PartialEq derive to Order

### DIFF
--- a/zerocopy/src/byteorder.rs
+++ b/zerocopy/src/byteorder.rs
@@ -100,6 +100,7 @@ mod private {
 
 #[allow(missing_copy_implementations, missing_debug_implementations)]
 #[doc(hidden)]
+#[derive(PartialEq)]
 pub enum Order {
     BigEndian,
     LittleEndian,


### PR DESCRIPTION
This pull request adds a `PartialEq` derive on `Order` in `byteorder.rs`.

While `Order` is marked hidden in documentation, the below use case illustrates why it would be helpful for it to implement `PartialEq`:

```rust
use std::borrow::Cow;

use zerocopy::{ByteOrder, U16, U32, transmute_ref};

enum Value<'a, O: ByteOrder> {
    Word(Cow<'a, [U16<O>]>),
    DWord(Cow<'a, [U32<O>]>),
}

impl<'a, O: ByteOrder> Value<'a, O> {
    pub fn to<P: ByteOrder>(&self) -> Value<'a, P> {
        if O::ORDER == P::ORDER {
            return match self {
                Self::Word(words) => Value::Word(Cow::Borrowed(transmute_ref!(&**words))),
                Self::DWord(dwords) => Value::DWord(Cow::Borrowed(transmute_ref!(&**dwords))),
            };
        }

        match self {
            Self::Word(words) => Value::Word(Cow::Owned(
                words.into_iter().map(|word| U16::new(word.get())).collect(),
            )),
            Self::DWord(dwords) => Value::DWord(Cow::Owned(
                dwords
                    .into_iter()
                    .map(|dword| U32::new(dword.get()))
                    .collect(),
            )),
        }
    }
}
```