### PR TITLE
Hide unstable `derive(most_traits)` in documentation

### DIFF
--- a/zerocopy/Cargo.lock
+++ b/zerocopy/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 dependencies = [
  "elain",
  "itertools",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -124,13 +124,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.52", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.52", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -142,4 +142,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.52", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive" }

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -435,7 +435,6 @@ const _: () = {
     WARNING
 };
 
-#[doc(hidden)]
 #[cfg(all(any(feature = "derive", test), zerocopy_unstable_linux))]
 pub use zerocopy_derive::most_traits;
 /// Implements [`KnownLayout`].

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"

--- a/zerocopy/zerocopy-derive/src/lib.rs
+++ b/zerocopy/zerocopy-derive/src/lib.rs
@@ -129,7 +129,7 @@ derive!(ByteHash => derive_hash => crate::derive::derive_hash);
 derive!(ByteEq => derive_eq => crate::derive::derive_eq);
 derive!(SplitAt => derive_split_at => crate::derive::derive_split_at);
 
-#[cfg_attr(zerocopy_unstable_linux, doc(hidden))]
+#[cfg_attr(not(zerocopy_unstable_linux), doc(hidden))]
 #[proc_macro_derive(most_traits, attributes(zerocopy))]
 pub fn most_traits(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = syn::parse_macro_input!(ts as DeriveInput);


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Fixes #3466




---

- 👉 #3470

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G304df306ff9b25d6a30a8c91906232a439cf2ba4 && git checkout -b pr-G304df306ff9b25d6a30a8c91906232a439cf2ba4 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G304df306ff9b25d6a30a8c91906232a439cf2ba4 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G304df306ff9b25d6a30a8c91906232a439cf2ba4 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G304df306ff9b25d6a30a8c91906232a439cf2ba4
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G304df306ff9b25d6a30a8c91906232a439cf2ba4", "parent": null, "child": null}" -->