### PR TITLE
Make `ByteOrder::ORDER` and `Order` public; release 0.8.54

### DIFF
--- a/zerocopy/Cargo.lock
+++ b/zerocopy/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 dependencies = [
  "elain",
  "itertools",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 dependencies = [
  "dissimilar",
  "prettyplease",

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 edition = "2021"
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 authors = [
     "Joshua Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
@@ -124,13 +124,13 @@ __internal_use_only_features_that_work_on_stable = [
 ]
 
 [dependencies]
-zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive", optional = true }
+zerocopy-derive = { version = "=0.8.54", path = "zerocopy-derive", optional = true }
 
 # The "associated proc macro pattern" ensures that the versions of zerocopy and
 # zerocopy-derive remain equal, even if the 'derive' feature isn't used.
 # See: https://github.com/matklad/macro-dep-test
 [target.'cfg(any())'.dependencies]
-zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.54", path = "zerocopy-derive" }
 
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
@@ -142,4 +142,4 @@ rustversion = "1.0"
 static_assertions = "1.1"
 testutil = { path = "testutil" }
 # In tests, unlike in production, zerocopy-derive is not optional
-zerocopy-derive = { version = "=0.8.53", path = "zerocopy-derive" }
+zerocopy-derive = { version = "=0.8.54", path = "zerocopy-derive" }

--- a/zerocopy/src/byteorder.rs
+++ b/zerocopy/src/byteorder.rs
@@ -87,7 +87,7 @@ use super::*;
 pub trait ByteOrder:
     Copy + Clone + Debug + Display + Eq + PartialEq + Ord + PartialOrd + Hash + private::Sealed
 {
-    #[doc(hidden)]
+    /// A value-level representation of byte order.
     const ORDER: Order;
 }
 
@@ -98,11 +98,12 @@ mod private {
     impl Sealed for super::LittleEndian {}
 }
 
-#[allow(missing_copy_implementations, missing_debug_implementations)]
-#[doc(hidden)]
-#[derive(PartialEq)]
+/// A value-level representation of [`ByteOrder`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Order {
+    /// A value-level representation of [`BigEndian`].
     BigEndian,
+    /// A value-level representation of [`LittleEndian`].
     LittleEndian,
 }
 

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -9,7 +9,7 @@
 [package]
 edition = "2021"
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3475

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c && git checkout -b pr-Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gd9e350a7c6d7eef44a2d2f32e00a2325b6413f7c", "parent": null, "child": null}" -->