### PR TITLE
[derive] Support `IntoBytes` on homogeneous generic structs

### DIFF
--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -5602,6 +5602,10 @@ fn mut_from_prefix_suffix<T: FromBytes + IntoBytes + KnownLayout + ?Sized>(
 ///       if its field is [`IntoBytes`]; else,
 ///     - if the type has no generic parameters, it is [`IntoBytes`] if the type
 ///       is sized and has no padding bytes; else,
+///     - if the type is `repr(C)` without an `align(N)` modifier for `N > 1`
+///       (it may have `align(1)` or `packed(N)`), and every field is `T`,
+///       `[T; N]`, or a final `[T]` for the same type parameter `T`, it is
+///       [`IntoBytes`]; else,
 ///     - if the type is `repr(C)`, its fields must be [`Unaligned`].
 /// - If the type is an enum:
 ///   - It must have a defined representation (`repr`s `C`, `u8`, `u16`, `u32`,

--- a/zerocopy/src/util/macro_util.rs
+++ b/zerocopy/src/util/macro_util.rs
@@ -946,6 +946,22 @@ pub mod core_reexport {
     }
 }
 
+/// Projects `Self` to itself.
+///
+/// This is used by macros to have the compiler verify that two syntactically
+/// similar types actually resolve to the same type. The blanket implementation
+/// ensures that no other implementation can project a type to anything other
+/// than itself.
+#[doc(hidden)]
+pub trait Identity {
+    /// `Self`.
+    type Type: ?Sized;
+}
+
+impl<T: ?Sized> Identity for T {
+    type Type = T;
+}
+
 #[cfg(test)]
 mod tests {
     use core::num::NonZeroUsize;

--- a/zerocopy/testutil/src/lib.rs
+++ b/zerocopy/testutil/src/lib.rs
@@ -148,6 +148,52 @@ impl UiTestRunner {
         command.env_remove("CARGO_ENCODED_RUSTFLAGS");
         command.env_remove("CARGO_ENCODED_RUSTDOCFLAGS");
 
+        // `cargo-zerocopy` includes
+        // `--cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS` in
+        // `RUSTFLAGS` for the pinned nightly. That cfg enables a test-only proc
+        // macro which requires `proc_macro::Span::def_site`, a nightly feature.
+        //
+        // Cargo historically treats host artifacts inconsistently depending
+        // on whether `--target` is present. Without `--target`, `RUSTFLAGS`
+        // apply to host artifacts such as proc macros and build scripts. With
+        // `--target`, they do not. Consequently, relying only on `RUSTFLAGS`
+        // would omit the test proc macro from the host `zerocopy-derive`
+        // artifact in explicit-target UI tests, even when the explicit target
+        // happens to equal the host triple.
+        //
+        // Configure target and host flags separately so that the test behaves
+        // consistently with and without `--target`:
+        //
+        // - `-Ztarget-applies-to-host` enables the `target-applies-to-host`
+        //   configuration key.
+        // - `target-applies-to-host=false` prevents ordinary `RUSTFLAGS` and
+        //   target/build configuration from also being applied to host
+        //   artifacts.
+        // - `-Zhost-config` enables the `host` configuration table.
+        // - `host.rustflags` supplies just the nightly-test cfg to host
+        //   artifacts, including the `zerocopy-derive` proc macro. It applies
+        //   to every host artifact in this build, but the uniquely-named cfg is
+        //   inert in crates which do not inspect it.
+        //
+        // Both `-Z` options are nightly-only, so they must not be passed during
+        // the MSRV or stable UI tests. Keep this configuration inline rather
+        // than in `.cargo/config.toml` so that ordinary stable Cargo commands
+        // never encounter it. See:
+        // https://doc.rust-lang.org/cargo/reference/unstable.html#host-config
+        if matches!(&self.toolchain, ToolchainVersion::PinnedNightly) {
+            command.args([
+                "-Ztarget-applies-to-host",
+                "-Zhost-config",
+                "--config",
+                "target-applies-to-host=false",
+                "--config",
+                // A `--config` value uses TOML syntax. The embedded quotes are
+                // part of that syntax; `Command::args` passes the entire raw
+                // string as one OS argument, so no shell quoting is needed.
+                r#"host.rustflags=["--cfg", "__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS"]"#,
+            ]);
+        }
+
         let mut args = vec![
             "build",
             "-p",

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [".*", "tests/enum_from_bytes.rs", "tests/ui-nightly/enum_from_bytes_u
 [lints.rust]
 # See #1792 for more context.
 unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)',
   'cfg(zerocopy_derive_union_into_bytes)',
   'cfg(zerocopy_unstable_linux)',
 ] }

--- a/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
@@ -2,7 +2,7 @@
 //
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DataUnion, Error, Type};
+use syn::{parse_quote, Data, DataEnum, DataStruct, DataUnion, Error, Ident, Type, WherePredicate};
 
 use crate::{
     repr::{EnumRepr, StructUnionRepr},
@@ -18,6 +18,74 @@ pub(crate) fn derive_into_bytes(ctx: &Ctx, _top_level: Trait) -> Result<TokenStr
         Data::Union(unn) => derive_into_bytes_union(ctx, unn),
     }
 }
+
+/// If every field is exactly `T`, `[T; _]`, or a final `[T]` for the same type
+/// parameter `T`, returns the bounds required to prove this to rustc.
+fn homogeneous_field_bounds(ctx: &Ctx, strct: &DataStruct) -> Option<Vec<WherePredicate>> {
+    fn strip_parens_and_groups(mut ty: &Type) -> &Type {
+        loop {
+            ty = match ty {
+                Type::Group(group) => &group.elem,
+                Type::Paren(paren) => &paren.elem,
+                ty => return ty,
+            };
+        }
+    }
+
+    fn type_is_parameter(ty: &Type, parameter: &Ident) -> bool {
+        match strip_parens_and_groups(ty) {
+            Type::Path(path) => path.qself.is_none() && path.path.is_ident(parameter),
+            _ => false,
+        }
+    }
+
+    let fields = strct.fields();
+    ctx.ast.generics.type_params().find_map(|parameter| {
+        let parameter = &parameter.ident;
+        let elements = fields
+            .iter()
+            .enumerate()
+            .map(|(index, (_, _, ty))| match strip_parens_and_groups(ty) {
+                Type::Array(array) => Some(&*array.elem),
+                Type::Slice(slice) if index + 1 == fields.len() => Some(&*slice.elem),
+                Type::Slice(_) => None,
+                ty => Some(ty),
+            })
+            .collect::<Option<Vec<_>>>()?;
+
+        if !elements.iter().all(|element| type_is_parameter(element, parameter)) {
+            return None;
+        }
+
+        let zerocopy_crate = &ctx.zerocopy_crate;
+        let mut bounds = fields
+            .iter()
+            .map(|(_, _, ty)| parse_quote!(#ty: #zerocopy_crate::IntoBytes))
+            .collect::<Vec<WherePredicate>>();
+
+        // `Ident` equality is only a syntactic prefilter above. In
+        // macro-generated input, two identifiers can both print as `T` and
+        // compare equal here while having different hygiene contexts. For
+        // example, a call-site `T` could resolve to a `u8` type alias while a
+        // def-site `T` resolves to this struct's type parameter. Instantiating
+        // that parameter with `u16` would make the fields actually be `u8` and
+        // `u16`; treating them as homogeneous could overlook padding and cause
+        // us to emit an unsound `IntoBytes` impl.
+        //
+        // Quote every element type from its original field AST so that its
+        // hygiene context is retained, then use `Identity` to have rustc verify
+        // that it resolves to `parameter`. Do not deduplicate these predicates:
+        // identically-printed types may have different hygiene contexts and
+        // must each be checked by rustc.
+        bounds.extend(elements.into_iter().map(|element| {
+            parse_quote! {
+                #element: #zerocopy_crate::util::macro_util::Identity<Type = #parameter>
+            }
+        }));
+        Some(bounds)
+    })
+}
+
 fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream, Error> {
     let repr = StructUnionRepr::from_attrs(&ctx.ast.attrs)?;
 
@@ -25,8 +93,12 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
     let is_c = repr.is_c();
     let is_packed_1 = repr.is_packed_1();
     let num_fields = strct.fields().len();
+    let mut homogeneous_bounds =
+        if is_c && !repr.is_align_gt_1() { homogeneous_field_bounds(ctx, strct) } else { None };
 
-    let (padding_check, require_unaligned_fields) = if is_transparent || is_packed_1 {
+    let (padding_check, require_unaligned_fields, explicit_field_bounds) = if is_transparent
+        || is_packed_1
+    {
         // No padding check needed.
         // - repr(transparent): The layout and ABI of the whole struct is the
         //   same as its only non-ZST field (meaning there's no padding outside
@@ -43,12 +115,12 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         //   An important consequence of these rules is that a type with
         //   `#[repr(packed(1))]`` (or `#[repr(packed)]``) will have no
         //   inter-field padding.
-        (None, false)
+        (None, false, None)
     } else if is_c && !repr.is_align_gt_1() && num_fields <= 1 {
         // No padding check needed. A repr(C) struct with zero or one field has
         // no padding unless #[repr(align)] explicitly adds padding, which we
         // check for in this branch's condition.
-        (None, false)
+        (None, false, None)
     } else if ctx.ast.generics.params.is_empty() {
         // Is the last field a syntactic slice, i.e., `[SomeType]`.
         let is_syntactic_dst =
@@ -66,10 +138,31 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         //   2. The fields do not overlap.
         //   ...
         if is_c && is_syntactic_dst {
-            (Some(PaddingCheck::ReprCStruct), false)
+            (Some(PaddingCheck::ReprCStruct), false, None)
         } else {
-            (Some(PaddingCheck::Struct), false)
+            (Some(PaddingCheck::Struct), false, None)
         }
+    } else if let Some(bounds) = homogeneous_bounds.take() {
+        // Let `a` be the alignment of `T` and `s` be its size. Rust guarantees
+        // that `s` is a multiple of `a`. `T`, `[T; N]`, and `[T]` all have
+        // alignment `a`, and their sizes are `s`, `N * s`, and `len * s`,
+        // respectively.
+        //
+        // Without a `packed` modifier, each field and the struct have
+        // alignment `a`. `align(1)` does not change that because every Rust
+        // type already has alignment at least 1. With `packed(P)`, each field
+        // and the struct instead have alignment `b = min(a, P)`. Rust
+        // alignments and valid values of `P` are powers of two, so `b` divides
+        // `a`; every field size is therefore also a multiple of `b`.
+        //
+        // Thus, after placing any field, the running offset is already aligned
+        // for the next field, and the final offset is already aligned for the
+        // struct. A repr(C) without an `align` modifier greater than 1
+        // therefore introduces neither inter-field nor trailing padding,
+        // including for a slice DST. The bounds returned by
+        // `homogeneous_field_bounds` require rustc to verify that the element
+        // type of every field is the same type `T`.
+        (None, false, Some(bounds))
     } else if is_c && !repr.is_align_gt_1() {
         // We can't use a padding check since there are generic type arguments.
         // Instead, we require all field types to implement `Unaligned`. This
@@ -79,7 +172,7 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         //
         // FIXME(#10): Support type parameters for non-transparent, non-packed
         // structs without requiring `Unaligned`.
-        (None, true)
+        (None, true, None)
     } else {
         return ctx.error_or_skip(Error::new(
             Span::call_site(),
@@ -87,7 +180,9 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         ));
     };
 
-    let field_bounds = if require_unaligned_fields {
+    let field_bounds = if let Some(bounds) = explicit_field_bounds {
+        FieldBounds::Explicit(bounds)
+    } else if require_unaligned_fields {
         FieldBounds::All(&[TraitBound::Slf, TraitBound::Other(Trait::Unaligned)])
     } else {
         FieldBounds::ALL_SELF

--- a/zerocopy/zerocopy-derive/src/lib.rs
+++ b/zerocopy/zerocopy-derive/src/lib.rs
@@ -28,6 +28,10 @@
 #![allow(clippy::type_complexity)]
 // Inlining format args isn't supported on our MSRV.
 #![allow(clippy::uninlined_format_args)]
+// `cargo-zerocopy` supplies this cfg for pinned-nightly tests. During UI tests,
+// `testutil::UiTestRunner` explicitly supplies it to the host-built proc macro;
+// ordinary `RUSTFLAGS` are not sufficient when Cargo receives `--target`.
+#![cfg_attr(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS, feature(proc_macro_def_site))]
 #![deny(
     rustdoc::bare_urls,
     rustdoc::broken_intra_doc_links,
@@ -128,6 +132,47 @@ derive!(Unaligned => derive_unaligned => crate::derive::unaligned::derive_unalig
 derive!(ByteHash => derive_hash => crate::derive::derive_hash);
 derive!(ByteEq => derive_eq => crate::derive::derive_eq);
 derive!(SplitAt => derive_split_at => crate::derive::derive_split_at);
+
+/// Generates a struct whose two identically-printed field types resolve to
+/// different types. This is used to test that derives preserve type identity
+/// across macro hygiene contexts.
+#[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]
+#[doc(hidden)]
+#[proc_macro]
+pub fn __test_hygienically_mixed_into_bytes(
+    _input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    use proc_macro::{Group, Ident, Span, TokenStream, TokenTree};
+
+    fn rewrite(input: TokenStream) -> TokenStream {
+        input
+            .into_iter()
+            .map(|token| match token {
+                TokenTree::Ident(ident) if ident.to_string() == "CallT" => {
+                    TokenTree::Ident(Ident::new("T", Span::call_site()))
+                }
+                TokenTree::Ident(ident) if ident.to_string() == "DefT" => {
+                    TokenTree::Ident(Ident::new("T", Span::def_site()))
+                }
+                TokenTree::Group(group) => {
+                    let mut rewritten = Group::new(group.delimiter(), rewrite(group.stream()));
+                    rewritten.set_span(group.span());
+                    TokenTree::Group(rewritten)
+                }
+                token => token,
+            })
+            .collect()
+    }
+
+    rewrite(
+        "#[derive(zerocopy_renamed::IntoBytes)] \
+         #[zerocopy(crate = \"zerocopy_renamed\")] \
+         #[repr(C)] \
+         struct IntoBytes15<DefT>(CallT, DefT);"
+            .parse()
+            .expect("test input must parse"),
+    )
+}
 
 #[cfg_attr(not(zerocopy_unstable_linux), doc(hidden))]
 #[proc_macro_derive(most_traits, attributes(zerocopy))]

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_struct_homogeneous_generic.expected.rs
@@ -1,0 +1,25 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    unsafe impl<T, const N: usize> ::zerocopy::IntoBytes for Foo<T, { N }>
+    where
+        T: ::zerocopy::IntoBytes,
+        [T; N]: ::zerocopy::IntoBytes,
+        [T]: ::zerocopy::IntoBytes,
+        T: ::zerocopy::util::macro_util::Identity<Type = T>,
+        T: ::zerocopy::util::macro_util::Identity<Type = T>,
+        T: ::zerocopy::util::macro_util::Identity<Type = T>,
+    {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -246,6 +246,16 @@ fn test_into_bytes_struct_trailing_generic() {
 }
 
 #[test]
+fn test_into_bytes_struct_homogeneous_generic() {
+    test! {
+        IntoBytes {
+            #[repr(C)]
+            struct Foo<T, const N: usize>(T, [T; N], [T]);
+        } expands to "expected/into_bytes_struct_homogeneous_generic.expected.rs"
+    }
+}
+
+#[test]
 fn test_into_bytes_enum() {
     macro_rules! test_repr {
         ($(#[$attr:meta])*) => {

--- a/zerocopy/zerocopy-derive/tests/struct_to_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/struct_to_bytes.rs
@@ -12,11 +12,14 @@
 
 include!("include.rs");
 
-// A struct is `IntoBytes` if:
-// - all fields are `IntoBytes`
-// - `repr(C)` or `repr(transparent)` and
-//   - no padding (size of struct equals sum of size of field types)
-// - `repr(packed)`
+// A struct can derive `IntoBytes` if all of its fields implement `IntoBytes`
+// and its representation lets the derive prove that the struct introduces no
+// uninitialized outer padding. The cases below are grouped by representation
+// and by the proof strategy used by the derive.
+
+//
+// Non-generic `repr(C)`
+//
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -24,6 +27,20 @@ include!("include.rs");
 struct CZst;
 
 util_assert_impl_all!(CZst: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(8))]
+struct ReprCAlignedZst;
+
+util_assert_impl_all!(ReprCAlignedZst: imp::IntoBytes);
+
+#[derive(imp::IntoBytes, Copy, Clone)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(8))]
+struct ReprCAligned8([u8; 8]);
+
+util_assert_impl_all!(ReprCAligned8: imp::IntoBytes);
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -39,13 +56,230 @@ util_assert_impl_all!(C: imp::IntoBytes);
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
-struct SyntacticUnsized {
+struct ReprCSyntacticDst {
     a: u8,
     b: u8,
     c: [util::AU16],
 }
 
-util_assert_impl_all!(C: imp::IntoBytes);
+util_assert_impl_all!(ReprCSyntacticDst: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(2))]
+struct ReprCSyntacticDstAligned {
+    a: [[u8; 2]],
+}
+
+util_assert_impl_all!(ReprCSyntacticDstAligned: imp::IntoBytes);
+
+//
+// Generic `repr(C)`
+//
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCGenericOneField<T: ?imp::Sized> {
+    t: T,
+}
+
+// Even though `ReprCGenericOneField` has generic type arguments, its one-field
+// layout never requires an `Unaligned` bound. Sized, array, and slice
+// instantiations are asserted in `assert_repr_c_homogeneous` below.
+
+// Given `T: Sized + IntoBytes`, a plain `repr(C)` struct whose fields are all
+// `T`, `[T; N]`, or a final `[T]` introduces no outer padding. `T` and all of
+// its arrays and slices have the same alignment. The size of `T`, every array,
+// and every slice value is a multiple of that alignment; bytes within each `T`
+// are covered by `T`'s `IntoBytes` implementation.
+//
+// The following six declarations exhaustively enumerate the direct two-field
+// shape combinations in this grammar. A slice may only be the final field, so
+// the first field is either `T` or `[T; N]`, while the second is `T`, `[T; M]`,
+// or `[T]`. The one-field case is covered by `ReprCGenericOneField` above.
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousTThenT<T>(T, T);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousTThenArray<T, const N: usize>(T, [T; N]);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousArrayThenT<T, const N: usize>([T; N], T);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousArrayThenArray<T, const N: usize, const M: usize>([T; N], [T; M]);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousTThenSlice<T>(T, [T]);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousArrayThenSlice<T, const N: usize>([T; N], [T]);
+
+// Exercise longer named-field structs containing every allowed sized field
+// shape, both with and without a trailing slice. Together with the two-field
+// matrix above, these ensure that the derive handles repeated transitions and
+// both of its sized/DST paths rather than special-casing a particular arity.
+// The literal-length field also ensures that recognition does not depend on
+// the array length being a const parameter.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousMixedSized<T, const N: usize, const M: usize> {
+    literal: [T; 0],
+    array0: [T; N],
+    t0: T,
+    array1: [T; M],
+    t1: T,
+}
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHomogeneousMixedDst<T, const N: usize, const M: usize> {
+    t0: T,
+    array0: [T; N],
+    t1: T,
+    array1: [T; M],
+    tail: [T],
+}
+
+// `align(1)` cannot increase a type's alignment, so it preserves the same
+// no-padding argument as an unmodified `repr(C)`. Test both the sized and DST
+// paths.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(1))]
+struct ReprCHomogeneousAlign1Sized<T, const N: usize>(T, [T; N], T);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(1))]
+struct ReprCHomogeneousAlign1Dst<T, const N: usize>(T, [T; N], [T]);
+
+// `packed(2)` caps every field's alignment at the same value. Since every
+// field's size is still a multiple of that capped alignment, it likewise
+// preserves the no-padding argument. A packed DST may only contain elements
+// which do not need drop, so the DST declaration additionally requires
+// `Copy`.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, packed(2))]
+struct ReprCHomogeneousPacked2Sized<T, const N: usize>(T, [T; N], T);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, packed(2))]
+struct ReprCHomogeneousPacked2Dst<T: imp::Copy, const N: usize>(T, [T; N], [T]);
+
+// This generic assertion is stronger than checking a finite set of concrete
+// element types and array lengths: its body only assumes `T: IntoBytes`, and
+// is type-checked for every `N` and `M`.
+fn assert_repr_c_homogeneous<T: imp::IntoBytes, const N: usize, const M: usize>() {
+    fn assert_into_bytes<T: ?imp::Sized + imp::IntoBytes>() {}
+
+    assert_into_bytes::<ReprCGenericOneField<T>>();
+    assert_into_bytes::<ReprCGenericOneField<[T; N]>>();
+    assert_into_bytes::<ReprCGenericOneField<[T]>>();
+    assert_into_bytes::<ReprCHomogeneousTThenT<T>>();
+    assert_into_bytes::<ReprCHomogeneousTThenArray<T, N>>();
+    assert_into_bytes::<ReprCHomogeneousArrayThenT<T, N>>();
+    assert_into_bytes::<ReprCHomogeneousArrayThenArray<T, N, M>>();
+    assert_into_bytes::<ReprCHomogeneousTThenSlice<T>>();
+    assert_into_bytes::<ReprCHomogeneousArrayThenSlice<T, N>>();
+    assert_into_bytes::<ReprCHomogeneousMixedSized<T, N, M>>();
+    assert_into_bytes::<ReprCHomogeneousMixedDst<T, N, M>>();
+    assert_into_bytes::<ReprCHomogeneousAlign1Sized<T, N>>();
+    assert_into_bytes::<ReprCHomogeneousAlign1Dst<T, N>>();
+    assert_into_bytes::<ReprCHomogeneousPacked2Sized<T, N>>();
+}
+
+fn assert_repr_c_homogeneous_packed_dst<T: imp::Copy + imp::IntoBytes, const N: usize>() {
+    fn assert_into_bytes<T: ?imp::Sized + imp::IntoBytes>() {}
+
+    assert_into_bytes::<ReprCHomogeneousPacked2Dst<T, N>>();
+}
+
+// `AU16` is guaranteed to have alignment 2 and not implement `Unaligned`, so
+// these assertions distinguish the homogeneous case from the existing
+// `Unaligned` fallback. The witnesses cover every field shape, zero and
+// nonzero arrays in both positions, and both the sized and DST paths.
+util_assert_impl_all!(ReprCHomogeneousTThenT<util::AU16>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousTThenArray<util::AU16, 0>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousArrayThenT<util::AU16, 3>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousArrayThenArray<util::AU16, 0, 3>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousTThenSlice<util::AU16>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousArrayThenSlice<util::AU16, 0>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousArrayThenSlice<util::AU16, 3>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousMixedSized<util::AU16, 0, 3>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousMixedDst<util::AU16, 0, 3>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousAlign1Sized<util::AU16, 0>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousAlign1Dst<util::AU16, 3>: imp::IntoBytes);
+// This exercises the case in which `packed(2)` actually lowers the element
+// alignment rather than merely leaving it unchanged.
+util_assert_impl_all!(ReprCHomogeneousPacked2Sized<ReprCAligned8, 0>: imp::IntoBytes);
+util_assert_impl_all!(ReprCHomogeneousPacked2Dst<ReprCAligned8, 3>: imp::IntoBytes);
+
+// Zero-sized element types still carry alignment. In particular, a derive
+// must not assume that an aligned field occupies any bytes.
+util_assert_impl_all!(ReprCHomogeneousArrayThenSlice<ReprCAlignedZst, 0>: imp::IntoBytes);
+
+// `IntoBytes` does not imply `Immutable`; interior-mutable element types are
+// therefore part of the supported set too.
+util_assert_impl_all!(
+    ReprCHomogeneousArrayThenSlice<imp::UnsafeCell<util::AU16>, 3>: imp::IntoBytes
+);
+
+// A zero-length array does not eliminate the `T: IntoBytes` requirement: the
+// trailing slice can still contain elements. `MaybeUninit<u8>` implements
+// `Unaligned` but not `IntoBytes`, isolating the bound under test.
+util_assert_not_impl_any!(
+    ReprCHomogeneousArrayThenSlice<imp::MaybeUninit<u8>, 0>: imp::IntoBytes
+);
+
+// Generic `repr(C)` structs outside of the homogeneous family fall back to
+// requiring every field type to be `Unaligned`.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCIndependentFields<T, U: ?imp::Sized> {
+    t: T,
+    u: U,
+}
+
+util_assert_impl_all!(ReprCIndependentFields<u8, [u8; 2]>: imp::IntoBytes);
+util_assert_impl_all!(ReprCIndependentFields<u8, [[u8; 2]]>: imp::IntoBytes);
+util_assert_not_impl_any!(ReprCIndependentFields<u8, util::AU16>: imp::IntoBytes);
+util_assert_not_impl_any!(ReprCIndependentFields<u8, [util::AU16]>: imp::IntoBytes);
+
+// The common element type is essential. Here, the zero-length `AU16` array
+// gives the struct alignment 2, while an odd-length `[u8]` tail requires a
+// trailing padding byte.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct ReprCHeterogeneousArrayThenSlice<T, U, const N: usize>([T; N], [U]);
+
+util_assert_not_impl_any!(
+    ReprCHeterogeneousArrayThenSlice<util::AU16, u8, 0>: imp::IntoBytes
+);
+
+//
+// `repr(transparent)`
+//
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -67,6 +301,35 @@ struct TransparentGeneric<T: ?imp::Sized> {
 
 util_assert_impl_all!(TransparentGeneric<u64>: imp::IntoBytes);
 util_assert_impl_all!(TransparentGeneric<[u64]>: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(transparent)]
+struct Unsized {
+    a: [u8],
+}
+
+util_assert_impl_all!(Unsized: imp::IntoBytes);
+
+// Deriving `IntoBytes` should work if the struct has bounded parameters.
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(transparent)]
+struct WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::IntoBytes, const N: usize>(
+    [T; N],
+    imp::PhantomData<&'a &'b ()>,
+)
+where
+    'a: 'b,
+    'b: 'a,
+    T: 'a + 'b + imp::IntoBytes;
+
+util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::IntoBytes);
+
+//
+// Packed representations
+//
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -137,78 +400,6 @@ struct PackedGeneric<T, U: ?imp::Sized> {
 util_assert_impl_all!(PackedGeneric<u8, util::AU16>: imp::IntoBytes);
 util_assert_impl_all!(PackedGeneric<u8, [util::AU16]>: imp::IntoBytes);
 
-// This test is non-portable, but works so long as Rust happens to lay this
-// struct out with no padding.
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-struct Unpacked {
-    a: u8,
-    b: u8,
-}
-
-util_assert_impl_all!(Unpacked: imp::IntoBytes);
-
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(C)]
-struct ReprCGenericOneField<T: ?imp::Sized> {
-    t: T,
-}
-
-// Even though `ReprCGenericOneField` has generic type arguments, since it only
-// has one field, we don't require that its field types implement `Unaligned`.
-util_assert_impl_all!(ReprCGenericOneField<util::AU16>: imp::IntoBytes);
-util_assert_impl_all!(ReprCGenericOneField<[util::AU16]>: imp::IntoBytes);
-
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(C)]
-struct ReprCGenericMultipleFields<T, U: ?imp::Sized> {
-    t: T,
-    u: U,
-}
-
-// Since `ReprCGenericMultipleFields` is generic and has more than one field,
-// all field types must implement `Unaligned`.
-util_assert_impl_all!(ReprCGenericMultipleFields<u8, [u8; 2]>: imp::IntoBytes);
-util_assert_impl_all!(ReprCGenericMultipleFields<u8, [[u8; 2]]>: imp::IntoBytes);
-util_assert_not_impl_any!(ReprCGenericMultipleFields<u8, util::AU16>: imp::IntoBytes);
-util_assert_not_impl_any!(ReprCGenericMultipleFields<u8, [util::AU16]>: imp::IntoBytes);
-
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(transparent)]
-struct Unsized {
-    a: [u8],
-}
-
-util_assert_impl_all!(Unsized: imp::IntoBytes);
-
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(C, align(2))]
-struct UnsizedAligned {
-    a: [[u8; 2]],
-}
-
-util_assert_impl_all!(UnsizedAligned: imp::IntoBytes);
-
-// Deriving `IntoBytes` should work if the struct has bounded parameters.
-
-#[derive(imp::IntoBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(transparent)]
-struct WithParams<'a: 'b, 'b: 'a, T: 'a + 'b + imp::IntoBytes, const N: usize>(
-    [T; N],
-    imp::PhantomData<&'a &'b ()>,
-)
-where
-    'a: 'b,
-    'b: 'a,
-    T: 'a + 'b + imp::IntoBytes;
-
-util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::IntoBytes);
-
 // Test for the failure reported in #1182.
 
 #[derive(imp::IntoBytes)]
@@ -227,3 +418,18 @@ pub struct IndexEntry<const SIZE_BLOCK_ID: usize> {
 
 util_assert_impl_all!(IndexEntry<0>: imp::IntoBytes);
 util_assert_impl_all!(IndexEntry<1>: imp::IntoBytes);
+
+//
+// Rust representation
+//
+
+// This test is non-portable, but works so long as Rust happens to lay this
+// struct out with no padding.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Unpacked {
+    a: u8,
+    b: u8,
+}
+
+util_assert_impl_all!(Unpacked: imp::IntoBytes);

--- a/zerocopy/zerocopy-derive/tests/ui/msrv_specific.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/msrv_specific.rs
@@ -21,15 +21,15 @@ use self::util::util::AU16;
 
 fn main() {}
 
-// `repr(C, packed(2))` is not equivalent to `repr(C, packed)`.
+// `repr(C, packed(2))` can still have padding between heterogeneous fields.
 #[derive(IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C, packed(2))]
 struct IntoBytes1<T> {
-    t0: T,
-    // Add a second field to avoid triggering the "repr(C) struct with one
-    // field" special case.
-    t1: T,
+    byte: u8,
+    // For `T = AU16`, this field remains 2-aligned and leaves a padding byte
+    // after `byte`.
+    t: T,
 }
 
 fn is_into_bytes_1<T: IntoBytes>() {

--- a/zerocopy/zerocopy-derive/tests/ui/struct.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.msrv.stderr
@@ -51,9 +51,9 @@ error[E0277]: the trait bound `(): DynamicPaddingFree<IntoBytes13, true>` is not
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:328:10
+   --> $DIR/struct.rs:357:10
     |
-328 | #[derive(SplitAt)]
+357 | #[derive(SplitAt)]
     |          ^^^^^^^ the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
     |
 note: required by a bound in `SplitAt`
@@ -64,24 +64,24 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:334:10
+   --> $DIR/struct.rs:363:10
     |
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<u8 as zerocopy_renamed::KnownLayout>::PointerMetadata == usize`
-   --> $DIR/struct.rs:334:10
+   --> $DIR/struct.rs:363:10
     |
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ expected `()`, found `usize`
     |
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 31 previous errors
+error: aborting due to 32 previous errors
 
 Some errors have detailed explanations: E0271, E0277, E0692.
 For more information about an error, try `rustc --explain E0271`.

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -28,67 +28,75 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/struct.rs:273:11
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+   --> $DIR/struct.rs:270:10
     |
-273 | #[repr(C, align(2))]
+270 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> $DIR/struct.rs:302:11
+    |
+302 | #[repr(C, align(2))]
     |           ^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:279:8
+   --> $DIR/struct.rs:308:8
     |
-279 | #[repr(transparent, align(2))]
+308 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:288:8
+   --> $DIR/struct.rs:317:8
     |
-288 | #[repr(packed, align(2))]
+317 | #[repr(packed, align(2))]
     |        ^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:295:8
+   --> $DIR/struct.rs:324:8
     |
-295 | #[repr(align(1), align(2))]
+324 | #[repr(align(1), align(2))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:301:8
+   --> $DIR/struct.rs:330:8
     |
-301 | #[repr(align(2), align(4))]
+330 | #[repr(align(2), align(4))]
     |        ^^^^^^^^^^^^^^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:305:10
+   --> $DIR/struct.rs:334:10
     |
-305 | #[derive(Unaligned)]
+334 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:310:10
+   --> $DIR/struct.rs:339:10
     |
-310 | #[derive(Unaligned)]
+339 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:320:19
+   --> $DIR/struct.rs:349:19
     |
-320 |   #[repr(packed(2), C)]
+349 |   #[repr(packed(2), C)]
     |  ___________________^
-321 | |
-322 | | #[derive(Unaligned)]
-323 | | #[zerocopy(crate = "zerocopy_renamed")]
-324 | | #[repr(C, packed(2))]
+350 | |
+351 | | #[derive(Unaligned)]
+352 | | #[zerocopy(crate = "zerocopy_renamed")]
+353 | | #[repr(C, packed(2))]
     | |________^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> $DIR/struct.rs:279:8
+   --> $DIR/struct.rs:308:8
     |
-279 | #[repr(transparent, align(2))]
+308 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -462,21 +470,21 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
     |
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> $DIR/struct.rs:290:1
+   --> $DIR/struct.rs:319:1
     |
-290 | struct Unaligned3;
+319 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:328:10
+   --> $DIR/struct.rs:357:10
     |
-328 | #[derive(SplitAt)]
+357 | #[derive(SplitAt)]
     |          ^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
-   --> $DIR/struct.rs:332:1
+   --> $DIR/struct.rs:361:1
     |
-332 | struct SplitAtNotKnownLayout([u8]);
+361 | struct SplitAtNotKnownLayout([u8]);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
     = help: the following other types implement trait `zerocopy_renamed::KnownLayout`:
@@ -494,19 +502,19 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:334:10
+   --> $DIR/struct.rs:363:10
     |
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
 help: the following other types implement trait `SplitAt`
-   --> $DIR/struct.rs:328:10
+   --> $DIR/struct.rs:357:10
     |
-328 | #[derive(SplitAt)]
+357 | #[derive(SplitAt)]
     |          ^^^^^^^ `SplitAtNotKnownLayout`
 ...
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ `SplitAtSized`
    --> src/split_at.rs:253:0
     |
@@ -552,7 +560,29 @@ note: required by a bound in `is_into_bytes_11`
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 36 previous errors
+error[E0271]: type mismatch resolving `<u8 as Identity>::Type == u16`
+   --> $DIR/struct.rs:290:33
+    |
+290 |             assert_into_bytes::<IntoBytes15<u16>>();
+    |                                 ^^^^^^^^^^^^^^^^ expected `u16`, found `u8`
+    |
+note: required for `IntoBytes15<u16>` to implement `zerocopy_renamed::IntoBytes`
+   --> $DIR/struct.rs:285:5
+    |
+285 |     zerocopy_derive::__test_hygienically_mixed_into_bytes!();
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+note: required by a bound in `assert_into_bytes`
+   --> $DIR/struct.rs:287:29
+    |
+287 |     fn assert_into_bytes<T: IntoBytes>() {
+    |                             ^^^^^^^^^ required by this bound in `assert_into_bytes`
+    = note: this error originates in the derive macro `zerocopy_renamed::IntoBytes` which comes from the expansion of the macro `zerocopy_derive::__test_hygienically_mixed_into_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Some errors have detailed explanations: E0277, E0587, E0588, E0692.
-For more information about an error, try `rustc --explain E0277`.
+error: aborting due to 38 previous errors
+
+Some errors have detailed explanations: E0271, E0277, E0587, E0588, E0692.
+For more information about an error, try `rustc --explain E0271`.

--- a/zerocopy/zerocopy-derive/tests/ui/struct.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.rs
@@ -228,15 +228,15 @@ struct IntoBytes10<T> {
     t: T,
 }
 
-// `repr(C, packed(2))` is not equivalent to `repr(C, packed)`.
+// `repr(C, packed(2))` can still have padding between heterogeneous fields.
 #[derive(IntoBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C, packed(2))]
 struct IntoBytes11<T> {
-    t0: T,
-    // Add a second field to avoid triggering the "repr(C) struct with one
-    // field" special case.
-    t1: T,
+    byte: u8,
+    // For `T = AU16`, this field remains 2-aligned and leaves a padding byte
+    // after `byte`.
+    t: T,
 }
 
 fn is_into_bytes_11<T: IntoBytes>() {
@@ -263,6 +263,35 @@ struct IntoBytes12<T> {
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C, align(2))]
 struct IntoBytes13([u8]);
+
+// A homogeneous multi-field optimization must still account for an explicit
+// outer alignment. For `T = u8` and `N = 0`, odd-length tails have trailing
+// padding.
+#[derive(IntoBytes)]
+//~[msrv, stable, nightly]^ ERROR: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(2))]
+struct IntoBytes14<T, const N: usize>([T; N], [T]);
+
+// A type captured at a macro invocation site can have the same spelling as a
+// type parameter introduced by the macro while resolving to a different type.
+// The homogeneous `repr(C)` optimization must not treat them as the same type.
+#[cfg(nightly)]
+mod into_bytes_15 {
+    use super::IntoBytes;
+
+    type T = u8;
+
+    zerocopy_derive::__test_hygienically_mixed_into_bytes!();
+
+    fn assert_into_bytes<T: IntoBytes>() {
+        if false {
+            assert_into_bytes::<IntoBytes15<u8>>();
+            assert_into_bytes::<IntoBytes15<u16>>();
+            //~[nightly]^ ERROR: type mismatch resolving `<u8 as Identity>::Type == u16`
+        }
+    }
+}
 
 //
 // Unaligned errors

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -28,62 +28,70 @@ error: must have a non-align #[repr(...)] attribute in order to guarantee this t
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: cannot derive `Unaligned` on type with alignment greater than 1
-   --> $DIR/struct.rs:273:11
+error: must have a non-align #[repr(...)] attribute in order to guarantee this type's memory layout
+   --> $DIR/struct.rs:270:10
     |
-273 | #[repr(C, align(2))]
+270 | #[derive(IntoBytes)]
+    |          ^^^^^^^^^
+    |
+    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot derive `Unaligned` on type with alignment greater than 1
+   --> $DIR/struct.rs:302:11
+    |
+302 | #[repr(C, align(2))]
     |           ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:279:8
+   --> $DIR/struct.rs:308:8
     |
-279 | #[repr(transparent, align(2))]
+308 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:288:16
+   --> $DIR/struct.rs:317:16
     |
-288 | #[repr(packed, align(2))]
+317 | #[repr(packed, align(2))]
     |                ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:295:18
+   --> $DIR/struct.rs:324:18
     |
-295 | #[repr(align(1), align(2))]
+324 | #[repr(align(1), align(2))]
     |                  ^^^^^
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:301:18
+   --> $DIR/struct.rs:330:18
     |
-301 | #[repr(align(2), align(4))]
+330 | #[repr(align(2), align(4))]
     |                  ^^^^^
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:305:10
+   --> $DIR/struct.rs:334:10
     |
-305 | #[derive(Unaligned)]
+334 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: must have #[repr(C)], #[repr(transparent)], or #[repr(packed)] attribute in order to guarantee this type's alignment
-   --> $DIR/struct.rs:310:10
+   --> $DIR/struct.rs:339:10
     |
-310 | #[derive(Unaligned)]
+339 | #[derive(Unaligned)]
     |          ^^^^^^^^^
     |
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this conflicts with another representation hint
-   --> $DIR/struct.rs:324:8
+   --> $DIR/struct.rs:353:8
     |
-324 | #[repr(C, packed(2))]
+353 | #[repr(C, packed(2))]
     |        ^
 
 error[E0692]: transparent struct cannot have other repr hints
-   --> $DIR/struct.rs:279:8
+   --> $DIR/struct.rs:308:8
     |
-279 | #[repr(transparent, align(2))]
+308 | #[repr(transparent, align(2))]
     |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -429,21 +437,21 @@ help: the trait `DynamicPaddingFree<IntoBytes13, true>` is not implemented for `
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0587]: type has conflicting packed and align representation hints
-   --> $DIR/struct.rs:290:1
+   --> $DIR/struct.rs:319:1
     |
-290 | struct Unaligned3;
+319 | struct Unaligned3;
     | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SplitAtNotKnownLayout: zerocopy_renamed::KnownLayout` is not satisfied
-   --> $DIR/struct.rs:328:10
+   --> $DIR/struct.rs:357:10
     |
-328 | #[derive(SplitAt)]
+357 | #[derive(SplitAt)]
     |          ^^^^^^^ unsatisfied trait bound
     |
 help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtNotKnownLayout`
-   --> $DIR/struct.rs:332:1
+   --> $DIR/struct.rs:361:1
     |
-332 | struct SplitAtNotKnownLayout([u8]);
+361 | struct SplitAtNotKnownLayout([u8]);
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: Consider adding `#[derive(KnownLayout)]` to `SplitAtNotKnownLayout`
     = help: the following other types implement trait `zerocopy_renamed::KnownLayout`:
@@ -464,19 +472,19 @@ note: required by a bound in `SplitAt`
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `u8: SplitAt` is not satisfied
-   --> $DIR/struct.rs:334:10
+   --> $DIR/struct.rs:363:10
     |
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ the trait `SplitAt` is not implemented for `u8`
     |
     = note: Consider adding `#[derive(SplitAt)]` to `u8`
 help: the following other types implement trait `SplitAt`
-   --> $DIR/struct.rs:328:10
+   --> $DIR/struct.rs:357:10
     |
-328 | #[derive(SplitAt)]
+357 | #[derive(SplitAt)]
     |          ^^^^^^^ `SplitAtNotKnownLayout`
 ...
-334 | #[derive(SplitAt, KnownLayout)]
+363 | #[derive(SplitAt, KnownLayout)]
     |          ^^^^^^^ `SplitAtSized`
     |
    ::: $WORKSPACE/src/split_at.rs:253:1
@@ -520,7 +528,7 @@ note: required by a bound in `is_into_bytes_11`
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 36 previous errors
+error: aborting due to 37 previous errors
 
 Some errors have detailed explanations: E0277, E0587, E0588, E0692.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Support deriving `IntoBytes` on unmodified `repr(C)` structs whose
fields are all `T`, `[T; N]`, or a final `[T]` for the same generic type
parameter `T`.

All such fields have the same alignment, and each field's size is a
multiple of that alignment. Thus, `repr(C)` introduces neither
inter-field nor trailing padding.

Use an `Identity<Type = T>` bound to have rustc verify that each field's
element type actually resolves to `T`. This guards against
macro-generated identifiers which compare equal in the derive but have
different hygiene contexts.




---

- 👉 #3488


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v3..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v3..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v2..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v1..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v2..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v1..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v1..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gsxxjwwhqbpepd5p73rd6libcy7n44svt/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gsxxjwwhqbpepd5p73rd6libcy7n44svt && git checkout -b pr-Gsxxjwwhqbpepd5p73rd6libcy7n44svt FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gsxxjwwhqbpepd5p73rd6libcy7n44svt && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gsxxjwwhqbpepd5p73rd6libcy7n44svt && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gsxxjwwhqbpepd5p73rd6libcy7n44svt
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gsxxjwwhqbpepd5p73rd6libcy7n44svt", "parent": null, "child": null}" -->