### PR TITLE
Introduce `doc(hidden)` `derive(Project)`

### DIFF
--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -1184,6 +1184,14 @@ pub const REPR_C_UNION_VARIANT_ID: i128 = -3;
 #[doc(hidden)]
 #[derive(Copy, Clone, Debug)]
 pub enum TryFromBytesDerive {}
+#[doc(hidden)]
+#[derive(Copy, Clone, Debug)]
+pub enum ProjectDerive {}
+
+#[cfg(any(feature = "derive", test))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
+#[doc(hidden)]
+pub use zerocopy_derive::Project;
 
 /// # Safety
 ///
@@ -1212,9 +1220,9 @@ pub unsafe trait HasTag<Client = TryFromBytesDerive> {
 
 /// Projects a given field from `Self`.
 ///
-/// All implementations of `HasField` for a particular field `f` in `Self`
-/// should use the same `Field` type; this ensures that `Field` is inferable
-/// given an explicit `VARIANT_ID` and `FIELD_ID`.
+/// All implementations of `HasField` for a particular `Client` and field `f`
+/// in `Self` should use the same `Field` type; this ensures that `Field` is
+/// inferable given an explicit `Client`, `VARIANT_ID`, and `FIELD_ID`.
 ///
 /// The `Client` parameter exists solely to disambiguate between implementations
 /// of `HasField` that would otherwise conflict.
@@ -1224,12 +1232,14 @@ pub unsafe trait HasTag<Client = TryFromBytesDerive> {
 /// A field `f` is `HasField` for `Self` if and only if:
 ///
 /// - If `Self` has the layout of a struct or union type, then `VARIANT_ID` is
-///   `STRUCT_VARIANT_ID` or `UNION_VARIANT_ID` respectively; otherwise, if
-///   `Self` has the layout of an enum type, `VARIANT_ID` is the numerical index
-///   of the enum variant in which `f` appears. Note that `Self` does not need
-///   to actually *be* such a type – it just needs to have the same layout as
-///   such a type. For example, a `#[repr(transparent)]` wrapper around an enum
-///   has the same layout as that enum.
+///   `STRUCT_VARIANT_ID` or `UNION_VARIANT_ID` respectively. For internal
+///   projections of `repr(C)` unions, `VARIANT_ID` may instead be
+///   `REPR_C_UNION_VARIANT_ID`. Otherwise, if `Self` has the layout of an enum
+///   type and `f` appears in a variant named `v`, `VARIANT_ID` is
+///   `zerocopy::ident_id!(v)`. Note that `Self` does not need to actually *be*
+///   such a type – it just needs to have the same layout as such a type. For
+///   example, a `#[repr(transparent)]` wrapper around an enum has the same
+///   layout as that enum.
 /// - If `f` has name `n`, `FIELD_ID` is `zerocopy::ident_id!(n)`; otherwise,
 ///   if `f` is at index `i`, `FIELD_ID` is `zerocopy::ident_id!(i)`.
 /// - `Field` is a type with the same visibility as `f`.
@@ -1274,7 +1284,8 @@ pub unsafe trait HasField<Client, Field, const VARIANT_ID: i128, const FIELD_ID:
 /// `Self::Invariants` comes out.
 ///
 /// The `Client` parameter exists solely to disambiguate between implementations
-/// of `HasField` that would otherwise conflict.
+/// of `ProjectField` (and their corresponding `HasField` implementations) that
+/// would otherwise conflict.
 ///
 /// # Safety
 ///
@@ -1338,7 +1349,9 @@ where
                     // referent. This default implementation of `is_projectable`
                     // is non-destructive, as it does not overwrite any part of
                     // the referent.
-                    crate::STRUCT_VARIANT_ID | crate::UNION_VARIANT_ID => true,
+                    crate::STRUCT_VARIANT_ID
+                    | crate::UNION_VARIANT_ID
+                    | crate::REPR_C_UNION_VARIANT_ID => true,
                     _enum_variant => {
                         use crate::invariant::{Validity, ValidityKind};
                         match I::Validity::KIND {

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -1244,7 +1244,14 @@ pub const REPR_C_UNION_VARIANT_ID: i128 = -3;
 #[allow(missing_copy_implementations, missing_debug_implementations)]
 pub mod project_clients {
     pub enum TryFromBytesDerive {}
+
+    pub enum ProjectDerive {}
 }
+
+#[cfg(any(feature = "derive", test))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
+#[doc(hidden)]
+pub use zerocopy_derive::Project;
 
 /// # Safety
 ///
@@ -1265,17 +1272,18 @@ pub unsafe trait HasTag<Client = project_clients::TryFromBytesDerive> {
     ///
     /// # Safety
     ///
-    /// It must be the case that, for all `slf: Ptr<'_, Self, I>`, it is sound
-    /// to project from `slf` to
-    /// `Ptr<'_, <Self as HasTag<Client>>::Tag, I>` using this projection.
+    /// It must be the case that, for all `slf: Ptr<'_, Self, I>` where
+    /// `I::Aliasing` is `Shared`, it is sound to project it using this
+    /// projection to a `Ptr<'_, Self::Tag, (Shared, I::Alignment,
+    /// I::Validity)>`.
     type ProjectToTag: pointer::cast::Project<Self, Self::Tag>;
 }
 
 /// Projects a given field from `Self`.
 ///
-/// All implementations of `HasField` for a particular field `f` in `Self`
-/// should use the same `Field` type; this ensures that `Field` is inferable
-/// given an explicit `VARIANT_ID` and `FIELD_ID`.
+/// All implementations of `HasField` for a particular `Client` and field `f`
+/// in `Self` should use the same `Field` type; this ensures that `Field` is
+/// inferable given an explicit `Client`, `VARIANT_ID`, and `FIELD_ID`.
 ///
 /// The `Client` parameter exists solely to disambiguate between implementations
 /// of `HasField` that would otherwise conflict.
@@ -1284,13 +1292,15 @@ pub unsafe trait HasTag<Client = project_clients::TryFromBytesDerive> {
 ///
 /// A field `f` is `HasField` for `Self` if and only if:
 ///
-/// - If `Self` has the layout of a struct or union type, then `VARIANT_ID` is
-///   `STRUCT_VARIANT_ID` or `UNION_VARIANT_ID` respectively; otherwise, if
-///   `Self` has the layout of an enum type, `VARIANT_ID` is the numerical index
-///   of the enum variant in which `f` appears. Note that `Self` does not need
-///   to actually *be* such a type – it just needs to have the same layout as
-///   such a type. For example, a `#[repr(transparent)]` wrapper around an enum
-///   has the same layout as that enum.
+/// - If `Self` has the layout of a struct type, `VARIANT_ID` is
+///   `STRUCT_VARIANT_ID`. If `Self` has the layout of a `repr(C)` union type,
+///   `VARIANT_ID` is `REPR_C_UNION_VARIANT_ID`; for other union layouts, it is
+///   `UNION_VARIANT_ID`. Otherwise, if `Self` has the layout of an enum type and
+///   `f` appears in a variant named `v`, `VARIANT_ID` is
+///   `zerocopy::ident_id!(v)`. Note that `Self` does not need to actually *be*
+///   such a type – it just needs to have the same layout as such a type. For
+///   example, a `#[repr(transparent)]` wrapper around an enum has the same
+///   layout as that enum.
 /// - If `f` has name `n`, `FIELD_ID` is `zerocopy::ident_id!(n)`; otherwise,
 ///   if `f` is at index `i`, `FIELD_ID` is `zerocopy::ident_id!(i)`.
 /// - `Field` is a type with the same visibility as `f`.
@@ -1335,12 +1345,14 @@ pub unsafe trait HasField<Client, Field, const VARIANT_ID: i128, const FIELD_ID:
 /// `Self::Invariants` comes out.
 ///
 /// The `Client` parameter exists solely to disambiguate between implementations
-/// of `HasField` that would otherwise conflict.
+/// of `ProjectField` (and their corresponding `HasField` implementations) that
+/// would otherwise conflict.
 ///
 /// # Safety
 ///
 /// `T: ProjectField<Client, Field, I, VARIANT_ID, FIELD_ID>` if, for a
-/// `ptr: Ptr<'_, T, I>` such that `T::is_projectable(ptr).is_ok()`,
+/// `ptr: Ptr<'_, T, I>` such that `T::is_projectable` returns `Ok(())`
+/// when passed the tag pointer projected from `ptr`,
 /// `<T as HasField<Client, Field, VARIANT_ID, FIELD_ID>>::project(ptr.as_inner())`
 /// conforms to `T::Invariants`.
 #[doc(hidden)]
@@ -1364,15 +1376,19 @@ where
 
     /// Is the given field projectable from `ptr`?
     ///
-    /// If a field with [`Self::Invariants`] is projectable from the referent,
-    /// this function produces an `Ok(ptr)` from which the projection can be
-    /// made; otherwise `Err`.
+    /// If a field with [`Self::Invariants`] is projectable from the containing
+    /// value whose projected tag is `ptr`, this function produces `Ok(())`;
+    /// otherwise it produces `Err`.
     ///
     /// This method must be overriden if the field's projectability depends on
     /// the value of the bytes in `ptr`.
     #[inline(always)]
     fn is_projectable<'a>(
-        _ptr: Ptr<'a, <Self as HasTag<Client>>::Tag, I>,
+        _ptr: Ptr<
+            'a,
+            <Self as HasTag<Client>>::Tag,
+            (invariant::Shared, I::Alignment, I::Validity),
+        >,
     ) -> Result<(), Self::Error> {
         trait IsInfallible {
             const IS_INFALLIBLE: bool;
@@ -1399,7 +1415,9 @@ where
                     // referent. This default implementation of `is_projectable`
                     // is non-destructive, as it does not overwrite any part of
                     // the referent.
-                    crate::STRUCT_VARIANT_ID | crate::UNION_VARIANT_ID => true,
+                    crate::STRUCT_VARIANT_ID
+                    | crate::UNION_VARIANT_ID
+                    | crate::REPR_C_UNION_VARIANT_ID => true,
                     _enum_variant => {
                         use crate::invariant::{Validity, ValidityKind};
                         match I::Validity::KIND {

--- a/zerocopy/src/pointer/ptr.rs
+++ b/zerocopy/src/pointer/ptr.rs
@@ -656,6 +656,22 @@ mod _transitions {
             unsafe { self.assume_invariants::<H>() }
         }
 
+        /// Downgrades `self` to shared aliasing.
+        #[inline]
+        #[must_use]
+        pub(super) fn into_shared(self) -> Ptr<'a, T, (Shared, I::Alignment, I::Validity)>
+        where
+            I::Aliasing: Reference,
+        {
+            // SAFETY: `I::Aliasing: Reference` guarantees that the source
+            // aliasing is either `Shared` or `Exclusive`. `Shared` requires no
+            // transition. If it is `Exclusive`, consuming `self` ends the only
+            // permitted access to the referent, so the returned pointer can
+            // soundly carry `Shared` aliasing. The referent type, alignment,
+            // and validity invariants are unchanged.
+            unsafe { self.assume_invariants() }
+        }
+
         /// Assumes that `self`'s referent is validly-aligned for `T` if
         /// required by `A`.
         ///
@@ -911,21 +927,22 @@ mod _casts {
 
         #[must_use]
         #[inline(always)]
-        pub(crate) fn project_tag<Client>(self) -> Ptr<'a, <T as HasTag<Client>>::Tag, I>
+        pub fn project_tag<Client>(
+            self,
+        ) -> Ptr<'a, <T as HasTag<Client>>::Tag, (Shared, I::Alignment, I::Validity)>
         where
             T: HasTag<Client>,
+            I::Aliasing: Reference,
         {
-            // SAFETY: By invariant on
-            // `<T as HasTag<Client>>::ProjectToTag`, this is a sound
-            // projection.
-            let tag = unsafe {
-                self.project_transmute_unchecked::<_, _, <T as HasTag<Client>>::ProjectToTag>()
+            let ptr = self.into_shared();
+            // SAFETY: By invariant on `ProjectToTag`, it is sound to project
+            // `ptr` to a shared tag pointer with the same validity invariant.
+            let ptr = unsafe {
+                ptr.project_transmute_unchecked::<_, _, <T as HasTag<Client>>::ProjectToTag>()
             };
-            // SAFETY: By invariant on
-            // `<T as HasTag<Client>>::ProjectToTag`, the projected pointer has
+            // SAFETY: By invariant on `ProjectToTag`, the projected pointer has
             // the same alignment as `self`.
-            let tag = unsafe { tag.assume_alignment() };
-            tag.unify_invariants()
+            unsafe { ptr.assume_alignment() }
         }
 
         /// Attempts to transform the pointer, restoring the original on
@@ -1339,6 +1356,23 @@ mod tests {
     #[allow(unused)] // Needed on our MSRV, but considered unused on later toolchains.
     use crate::util::AsAddress;
     use crate::{pointer::BecauseImmutable, util::testutil::AU64, FromBytes, Immutable};
+
+    #[test]
+    fn test_project_tag_downgrades_aliasing() {
+        #[allow(dead_code)]
+        #[derive(zerocopy_derive::Project)]
+        #[repr(u8)]
+        enum Enum {
+            Variant(u8),
+        }
+
+        let mut value = Enum::Variant(0);
+        let _: Ptr<
+            '_,
+            <Enum as crate::HasTag<crate::project_clients::ProjectDerive>>::Tag,
+            (Shared, Aligned, Valid),
+        > = Ptr::from_mut(&mut value).project_tag::<crate::project_clients::ProjectDerive>();
+    }
 
     mod test_ptr_try_cast_into_soundness {
         use super::*;

--- a/zerocopy/src/wrappers.rs
+++ b/zerocopy/src/wrappers.rs
@@ -765,8 +765,9 @@ unsafe impl<T: HasTag<Client> + ?Sized, Client> HasTag<Client> for ReadOnly<T> {
     // produces a pointer with the same referent. By invariant, for any
     // `Ptr<'_, T, I>` it is sound to use
     // `<T as HasTag<Client>>::ProjectToTag` to project to a
-    // `Ptr<'_, <T as HasTag<Client>>::Tag, I>`. Since `ReadOnly<T>` has the
-    // same layout and validity as `T`, the same is true of projecting from a
+    // shared `Ptr<'_, <T as HasTag<Client>>::Tag,
+    // (_, I::Alignment, I::Validity)>`. Since `ReadOnly<T>` has the same
+    // layout and validity as `T`, the same is true of projecting from a
     // `Ptr<'_, ReadOnly<T>, I>`.
     type ProjectToTag = crate::pointer::cast::TransitiveProject<
         T,
@@ -777,13 +778,13 @@ unsafe impl<T: HasTag<Client> + ?Sized, Client> HasTag<Client> for ReadOnly<T> {
 
 // SAFETY: `ReadOnly<T>` is a `#[repr(transparent)]` wrapper around `T`, and so
 // has the same fields at the same offsets. Thus, it satisfies the safety
-// invariants of `HasField<Client, Field, VARIANT_ID, FIELD_ID>` for field `f` exactly
-// when `T` does, as guaranteed by the `T: HasField` bound:
-// - If `VARIANT_ID` is `STRUCT_VARIANT_ID` or `UNION_VARIANT_ID`, then `T` has
-//   the layout of a struct or union type. Since `ReadOnly<T>` is a transparent
-//   wrapper around `T`, it does too. Otherwise, if `VARIANT_ID` is an enum
-//   variant index, then `T` has the layout of an enum type, and `ReadOnly<T>`
-//   does too.
+// invariants of `HasField<Client, Field, VARIANT_ID, FIELD_ID>` for field `f`
+// exactly when `T` does, as guaranteed by the `T: HasField` bound:
+// - If `VARIANT_ID` is `STRUCT_VARIANT_ID`, `UNION_VARIANT_ID`, or
+//   `REPR_C_UNION_VARIANT_ID`, then `T` has the layout of a struct, non-C union,
+//   or C union type respectively. Since `ReadOnly<T>` is a transparent wrapper
+//   around `T`, it does too. Otherwise, `VARIANT_ID` is the identifier ID of an
+//   enum variant; `T` has the layout of an enum type, and `ReadOnly<T>` does too.
 // - By `T: HasField<_, _, _, FIELD_ID>`:
 //   - `T` has a field `f` with name `n` such that
 //     `FIELD_ID = zerocopy::ident_id!(n)` or at index `i` such that
@@ -843,7 +844,7 @@ where
 
     #[inline(always)]
     fn is_projectable<'a>(
-        ptr: Ptr<'a, <Self as HasTag<Client>>::Tag, I>,
+        ptr: Ptr<'a, <Self as HasTag<Client>>::Tag, (invariant::Shared, I::Alignment, I::Validity)>,
     ) -> Result<(), Self::Error> {
         <T as ProjectField<Client, Field, I, VARIANT_ID, FIELD_ID>>::is_projectable(ptr)
     }

--- a/zerocopy/src/wrappers.rs
+++ b/zerocopy/src/wrappers.rs
@@ -777,13 +777,13 @@ unsafe impl<T: HasTag<Client> + ?Sized, Client> HasTag<Client> for ReadOnly<T> {
 
 // SAFETY: `ReadOnly<T>` is a `#[repr(transparent)]` wrapper around `T`, and so
 // has the same fields at the same offsets. Thus, it satisfies the safety
-// invariants of `HasField<Client, Field, VARIANT_ID, FIELD_ID>` for field `f` exactly
-// when `T` does, as guaranteed by the `T: HasField` bound:
-// - If `VARIANT_ID` is `STRUCT_VARIANT_ID` or `UNION_VARIANT_ID`, then `T` has
-//   the layout of a struct or union type. Since `ReadOnly<T>` is a transparent
-//   wrapper around `T`, it does too. Otherwise, if `VARIANT_ID` is an enum
-//   variant index, then `T` has the layout of an enum type, and `ReadOnly<T>`
-//   does too.
+// invariants of `HasField<Client, Field, VARIANT_ID, FIELD_ID>` for field `f`
+// exactly when `T` does, as guaranteed by the `T: HasField` bound:
+// - If `VARIANT_ID` is `STRUCT_VARIANT_ID`, `UNION_VARIANT_ID`, or
+//   `REPR_C_UNION_VARIANT_ID`, then `T` has the layout of the corresponding
+//   struct or union type. Since `ReadOnly<T>` is a transparent wrapper around
+//   `T`, it does too. Otherwise, `VARIANT_ID` is the identifier ID of an enum
+//   variant; `T` has the layout of an enum type, and `ReadOnly<T>` does too.
 // - By `T: HasField<_, _, _, FIELD_ID>`:
 //   - `T` has a field `f` with name `n` such that
 //     `FIELD_ID = zerocopy::ident_id!(n)` or at index `i` such that

--- a/zerocopy/zerocopy-derive/src/derive/mod.rs
+++ b/zerocopy/zerocopy-derive/src/derive/mod.rs
@@ -3,6 +3,7 @@
 pub mod from_bytes;
 pub mod into_bytes;
 pub mod known_layout;
+pub mod project;
 pub mod try_from_bytes;
 pub mod unaligned;
 

--- a/zerocopy/zerocopy-derive/src/derive/project.rs
+++ b/zerocopy/zerocopy-derive/src/derive/project.rs
@@ -1,0 +1,579 @@
+// SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0 OR MIT
+//
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse_quote, spanned::Spanned as _, Data, DataEnum, DeriveInput, Error, Expr, Fields, Ident,
+    Index, Type,
+};
+
+use crate::{
+    repr::{EnumRepr, StructUnionRepr},
+    util::{
+        const_block, generate_tag_enum, Client, Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait,
+    },
+};
+
+pub(crate) fn tag_ident(variant: &Ident) -> Ident {
+    ident!(("___ZEROCOPY_TAG_{}", variant), variant.span())
+}
+
+pub(crate) fn variant_struct_ident(variant: &Ident) -> Ident {
+    ident!(("___ZerocopyVariantStruct_{}", variant), variant.span())
+}
+
+pub(crate) fn variants_union_field_ident(variant: &Ident) -> Ident {
+    ident!(("__field_{}", variant), variant.span())
+}
+
+/// Generates a constant for the tag associated with each variant of the enum.
+/// When we match on the enum's tag, each arm matches one of these constants. We
+/// have to use constants here because:
+///
+/// - The type that we're matching on is not the type of the tag, it's an
+///   integer of the same size as the tag type and with the same bit patterns.
+/// - We can't read the enum tag as an enum because the bytes may not represent
+///   a valid variant.
+/// - Patterns do not currently support const expressions, so we have to assign
+///   these constants to names rather than use them inline in the `match`
+///   statement.
+pub(crate) fn generate_tag_consts(data: &DataEnum) -> TokenStream {
+    let tags = data.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let tag = tag_ident(variant_ident);
+
+        quote! {
+            // This casts the enum variant to its discriminant, and then
+            // converts the discriminant to the target integral type via a
+            // numeric cast [1].
+            //
+            // Because these are the same size, this is defined to be a no-op
+            // and therefore is a lossless conversion [2].
+            //
+            // [1] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#enum-cast:
+            //
+            //   Casts an enum to its discriminant.
+            //
+            // [2] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#numeric-cast:
+            //
+            //   Casting between two integers of the same size (e.g. i32 -> u32)
+            //   is a no-op.
+            const #tag: ___ZerocopyTagPrimitive =
+                ___ZerocopyTag::#variant_ident as ___ZerocopyTagPrimitive;
+        }
+    });
+
+    quote! {
+        #(#tags)*
+    }
+}
+
+fn field_alignment(ctx: &Ctx) -> TokenStream {
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let fields_preserve_alignment = StructUnionRepr::from_attrs(&ctx.ast.attrs)
+        .map(|repr| repr.get_packed().is_none())
+        .unwrap();
+    if fields_preserve_alignment {
+        quote! { ___ZcAlignment }
+    } else {
+        quote! { #zerocopy_crate::invariant::Unaligned }
+    }
+}
+
+#[derive(Clone)]
+struct FieldProjection {
+    variant_id: Box<Expr>,
+    field: Box<Type>,
+    field_id: Box<Expr>,
+}
+
+struct ProjectionInvariants {
+    input_validity: Type,
+    output_validity: Type,
+    output_alignment: TokenStream,
+}
+
+fn derive_project_field(
+    ctx: &Ctx,
+    data: &dyn DataExt,
+    client: Client,
+    projection: FieldProjection,
+    invariants: ProjectionInvariants,
+) -> TokenStream {
+    let FieldProjection { variant_id, field, field_id } = projection;
+    let ProjectionInvariants { input_validity, output_validity, output_alignment } = invariants;
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    ImplBlockBuilder::new(
+        ctx,
+        data,
+        Trait::ProjectField {
+            client,
+            variant_id,
+            field,
+            field_id,
+            invariants: parse_quote!((___ZcAliasing, ___ZcAlignment, #input_validity)),
+        },
+        FieldBounds::None,
+    )
+    .param_extras(vec![
+        parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Aliasing),
+        parse_quote!(___ZcAlignment: #zerocopy_crate::invariant::Alignment),
+    ])
+    .inner_extras(quote! {
+        // SAFETY: Struct and union projections do not depend on the value of
+        // the referent, and are therefore infallible.
+        type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
+
+        // SAFETY: Projection preserves aliasing. It also preserves alignment
+        // unless the containing type is packed. The caller-selected validity
+        // mapping is justified by the kind of product or sum type being
+        // projected.
+        type Invariants = (___ZcAliasing, #output_alignment, #output_validity);
+    })
+    .build()
+}
+
+/// Generates field projection implementations for a struct or union.
+///
+/// `repr_c_union` selects `REPR_C_UNION_VARIANT_ID` for unions whose
+/// projections must additionally implement `pointer::cast::Cast`.
+pub(crate) fn derive_has_field_struct_union(
+    ctx: &Ctx,
+    data: &dyn DataExt,
+    client: Client,
+    repr_c_union: bool,
+) -> TokenStream {
+    let fields = ctx.ast.data.fields();
+    if fields.is_empty() {
+        return quote! {};
+    }
+
+    let field_tokens = fields.iter().map(|(vis, ident, _)| {
+        let ident = ident!(("ẕ{}", ident), ident.span());
+        quote! {
+            #vis enum #ident {}
+        }
+    });
+
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let variant_id: Box<Expr> = match &ctx.ast.data {
+        Data::Struct(_) => parse_quote!({ #zerocopy_crate::STRUCT_VARIANT_ID }),
+        Data::Union(_) if repr_c_union => {
+            debug_assert!(StructUnionRepr::from_attrs(&ctx.ast.attrs)
+                .map(|repr| repr.is_c())
+                .unwrap_or(false));
+            parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
+        }
+        Data::Union(_) => parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID }),
+        Data::Enum(_) => unreachable!(),
+    };
+
+    let core = ctx.core_path();
+    let has_tag = ImplBlockBuilder::new(ctx, data, Trait::HasTag { client }, FieldBounds::None)
+        .inner_extras(quote! {
+            type Tag = ();
+            type ProjectToTag = #zerocopy_crate::pointer::cast::CastToUnit;
+        })
+        .build();
+
+    let output_alignment = field_alignment(ctx);
+    let has_fields = fields.iter().map(move |(_, ident, ty)| {
+        let field_token = ident!(("ẕ{}", ident), ident.span());
+        let projection = FieldProjection {
+            variant_id: variant_id.clone(),
+            field: parse_quote!(#field_token),
+            field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
+        };
+        let has_field_trait = Trait::HasField {
+            client,
+            variant_id: projection.variant_id.clone(),
+            field: projection.field.clone(),
+            field_id: projection.field_id.clone(),
+        };
+        let has_field_path = has_field_trait.crate_path(ctx);
+        let has_field = ImplBlockBuilder::new(ctx, data, has_field_trait, FieldBounds::None)
+            .inner_extras(quote! {
+                type Type = #ty;
+
+                #[inline(always)]
+                fn project(
+                    slf: #zerocopy_crate::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as #has_field_path>::Type {
+                    let slf = slf.as_ptr();
+                    // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
+                    // pointer whose referent is zero-sized or lives in a valid
+                    // allocation. Since `#ident` is a struct or union field of
+                    // `Self`, this projection preserves or shrinks the referent
+                    // size, and so the resulting referent also fits in the same
+                    // allocation.
+                    unsafe { #core::ptr::addr_of_mut!((*slf).#ident) }
+                }
+            })
+            .build();
+
+        let uninit = derive_project_field(
+            ctx,
+            data,
+            client,
+            projection.clone(),
+            ProjectionInvariants {
+                input_validity: parse_quote!(#zerocopy_crate::invariant::Uninit),
+                output_validity: parse_quote!(#zerocopy_crate::invariant::Uninit),
+                output_alignment: output_alignment.clone(),
+            },
+        );
+        let initialized = derive_project_field(
+            ctx,
+            data,
+            client,
+            projection.clone(),
+            ProjectionInvariants {
+                input_validity: parse_quote!(#zerocopy_crate::invariant::Initialized),
+                output_validity: parse_quote!(#zerocopy_crate::invariant::Initialized),
+                output_alignment: output_alignment.clone(),
+            },
+        );
+        let valid_output = if matches!(&ctx.ast.data, Data::Struct(_)) {
+            parse_quote!(#zerocopy_crate::invariant::Valid)
+        } else {
+            // A valid union need not contain a valid (or initialized) instance
+            // of any particular field. `Uninit` is the strongest validity
+            // invariant that holds for every field projection.
+            parse_quote!(#zerocopy_crate::invariant::Uninit)
+        };
+        let valid = derive_project_field(
+            ctx,
+            data,
+            client,
+            projection,
+            ProjectionInvariants {
+                input_validity: parse_quote!(#zerocopy_crate::invariant::Valid),
+                output_validity: valid_output,
+                output_alignment: output_alignment.clone(),
+            },
+        );
+
+        quote! {
+            #has_field
+            #uninit
+            #initialized
+            #valid
+        }
+    });
+
+    const_block(field_tokens.into_iter().chain(Some(has_tag)).chain(has_fields).map(Some))
+}
+
+fn generate_project_variant_structs(ctx: &Ctx, data: &DataEnum, client: Client) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = ctx.ast.generics.split_for_impl();
+    let enum_name = &ctx.ast.ident;
+    let core = ctx.core_path();
+    let phantom_ty = quote! {
+        #core::marker::PhantomData<#enum_name #ty_generics>
+    };
+    let variant_structs = data.variants.iter().filter_map(|variant| {
+        if matches!(variant.fields, Fields::Unit) {
+            return None;
+        }
+
+        let ident = variant_struct_ident(&variant.ident);
+        let field_types = variant.fields.iter().map(|field| &field.ty);
+        let variant_struct: DeriveInput = parse_quote! {
+            #[repr(C)]
+            struct #ident #impl_generics (
+                #core::mem::MaybeUninit<___ZerocopyInnerTag>,
+                #(#field_types,)*
+                #phantom_ty,
+            ) #where_clause;
+        };
+        let projections = derive_has_field_struct_union(
+            &ctx.with_input(&variant_struct),
+            &variant_struct.data,
+            client,
+            false,
+        );
+
+        Some(quote! {
+            #variant_struct
+            #projections
+        })
+    });
+
+    quote! {
+        #(#variant_structs)*
+    }
+}
+
+fn generate_project_variants_union(ctx: &Ctx, data: &DataEnum, client: Client) -> TokenStream {
+    let generics = &ctx.ast.generics;
+    let (_, ty_generics, _) = generics.split_for_impl();
+    let core = ctx.core_path();
+    let fields = data.variants.iter().filter_map(|variant| {
+        if matches!(variant.fields, Fields::Unit) {
+            return None;
+        }
+        let field_name = variants_union_field_ident(&variant.ident);
+        let variant_struct = variant_struct_ident(&variant.ident);
+        Some(quote! {
+            #field_name: #core::mem::ManuallyDrop<#variant_struct #ty_generics>,
+        })
+    });
+
+    let variants_union: DeriveInput = parse_quote! {
+        #[repr(C)]
+        union ___ZerocopyVariants #generics {
+            #(#fields)*
+            // A fieldless enum produces no variant structs, but a union must
+            // have at least one field. This unit does not affect `repr(C)`
+            // layout.
+            __nonempty: (),
+        }
+    };
+    let projections = derive_has_field_struct_union(
+        &ctx.with_input(&variants_union),
+        &variants_union.data,
+        client,
+        true,
+    );
+
+    quote! {
+        #variants_union
+        #projections
+    }
+}
+
+fn derive_enum_project_field(
+    ctx: &Ctx,
+    data: &DataEnum,
+    client: Client,
+    projection: FieldProjection,
+    validity: Type,
+    variant_tag: Option<&Ident>,
+) -> TokenStream {
+    let FieldProjection { variant_id, field, field_id } = projection;
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let project_field_trait = Trait::ProjectField {
+        client,
+        variant_id,
+        field,
+        field_id,
+        invariants: parse_quote!((___ZcAliasing, ___ZcAlignment, #validity)),
+    };
+
+    let mut params = vec![
+        parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Aliasing),
+        parse_quote!(___ZcAlignment: #zerocopy_crate::invariant::Alignment),
+    ];
+    let (error, is_projectable) = if let Some(variant_tag) = variant_tag {
+        params[0] = parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Reference);
+        let has_tag_path = Trait::HasTag { client }.crate_path(ctx);
+        let core = ctx.core_path();
+        (
+            quote! { () },
+            quote! {
+                #[inline(always)]
+                fn is_projectable(
+                    tag: #zerocopy_crate::pointer::Ptr<
+                        '_,
+                        <Self as #has_tag_path>::Tag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            #zerocopy_crate::invariant::Valid,
+                        ),
+                    >,
+                ) -> #core::result::Result<(), ()> {
+                    let tag = tag.read::<#zerocopy_crate::BecauseImmutable>()
+                        as ___ZerocopyTagPrimitive;
+                    if tag == #variant_tag {
+                        #core::result::Result::Ok(())
+                    } else {
+                        #core::result::Result::Err(())
+                    }
+                }
+            },
+        )
+    } else {
+        (
+            quote! { #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible },
+            quote! {},
+        )
+    };
+
+    ImplBlockBuilder::new(ctx, data, project_field_trait, FieldBounds::None)
+        .param_extras(params)
+        .inner_extras(quote! {
+            type Error = #error;
+            type Invariants = (___ZcAliasing, ___ZcAlignment, #validity);
+            #is_projectable
+        })
+        .build()
+}
+
+pub(crate) fn derive_has_field_enum(ctx: &Ctx, data: &DataEnum, client: Client) -> TokenStream {
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
+        let variant_ident = &variant.unwrap().ident;
+        let variants_union_field = variants_union_field_ident(variant_ident);
+        let variant_id: Box<Expr> =
+            parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) });
+        let variant_tag = tag_ident(variant_ident);
+
+        fields.into_iter().enumerate().map(move |(idx, (vis, ident, ty))| {
+            // Rust does not presently support explicit visibility modifiers on
+            // enum fields. Keep this assertion so that a future language
+            // change cannot silently invalidate the visibility invariant.
+            assert!(matches!(vis, syn::Visibility::Inherited));
+            let projection = FieldProjection {
+                variant_id: variant_id.clone(),
+                field: parse_quote!(()),
+                field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
+            };
+            let variant_struct_field_index = Index::from(idx + 1);
+            let (_, ty_generics, _) = ctx.ast.generics.split_for_impl();
+            let has_field_trait = Trait::HasField {
+                client,
+                variant_id: projection.variant_id.clone(),
+                field: projection.field.clone(),
+                field_id: projection.field_id.clone(),
+            };
+            let has_field_path = has_field_trait.crate_path(ctx);
+            let client_path = client.crate_path(ctx);
+            let has_field = ImplBlockBuilder::new(ctx, data, has_field_trait, FieldBounds::None)
+                .inner_extras(quote! {
+                    type Type = #ty;
+
+                    #[inline(always)]
+                    fn project(
+                        slf: #zerocopy_crate::pointer::PtrInner<'_, Self>,
+                    ) -> *mut <Self as #has_field_path>::Type {
+                        use #zerocopy_crate::pointer::cast::{CastSized, Projection};
+
+                        slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
+                            .as_ptr()
+                    }
+                })
+                .build();
+
+            let uninit = derive_enum_project_field(
+                ctx,
+                data,
+                client,
+                projection.clone(),
+                parse_quote!(#zerocopy_crate::invariant::Uninit),
+                None,
+            );
+            let initialized = derive_enum_project_field(
+                ctx,
+                data,
+                client,
+                projection.clone(),
+                parse_quote!(#zerocopy_crate::invariant::Initialized),
+                None,
+            );
+            let valid = derive_enum_project_field(
+                ctx,
+                data,
+                client,
+                projection,
+                parse_quote!(#zerocopy_crate::invariant::Valid),
+                Some(&variant_tag),
+            );
+
+            quote! {
+                #has_field
+                #uninit
+                #initialized
+                #valid
+            }
+        })
+    });
+
+    quote! {
+        #(#has_fields)*
+    }
+}
+
+fn derive_enum(ctx: &Ctx, data: &DataEnum, client: Client) -> Result<TokenStream, Error> {
+    // With no fields, there are no `HasField` or `ProjectField` impls to emit,
+    // and therefore no representation requirement to enforce.
+    if data.fields().is_empty() {
+        return Ok(TokenStream::new());
+    }
+
+    let repr = EnumRepr::from_attrs(&ctx.ast.attrs)?;
+    let (outer_tag_type, inner_tag_type) = if repr.is_c() {
+        (quote! { ___ZerocopyTag }, quote! { () })
+    } else if repr.is_primitive() {
+        (quote! { () }, quote! { ___ZerocopyTag })
+    } else {
+        return Err(Error::new(
+            ctx.ast.span(),
+            "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout",
+        ));
+    };
+
+    let tag_enum = generate_tag_enum(ctx, &repr, data);
+    let tag_consts = generate_tag_consts(data);
+    let variant_structs = generate_project_variant_structs(ctx, data, client);
+    let variants_union = generate_project_variants_union(ctx, data, client);
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let core = ctx.core_path();
+    let (_, ty_generics, _) = ctx.ast.generics.split_for_impl();
+    let generics = &ctx.ast.generics;
+    let raw_enum: DeriveInput = parse_quote! {
+        #[repr(C)]
+        struct ___ZerocopyRawEnum #generics {
+            tag: ___ZerocopyOuterTag,
+            variants: ___ZerocopyVariants #ty_generics,
+        }
+    };
+    let raw_projections =
+        derive_has_field_struct_union(&ctx.with_input(&raw_enum), &raw_enum.data, client, false);
+    let has_tag = ImplBlockBuilder::new(ctx, data, Trait::HasTag { client }, FieldBounds::None)
+        .inner_extras(quote! {
+            type Tag = ___ZerocopyTag;
+            type ProjectToTag = #zerocopy_crate::pointer::cast::CastSized;
+        })
+        .build();
+    let has_fields = derive_has_field_enum(ctx, data, client);
+
+    Ok(quote! {
+        #tag_enum
+
+        type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
+            { #core::mem::size_of::<___ZerocopyTag>() },
+        >;
+
+        #tag_consts
+
+        type ___ZerocopyOuterTag = #outer_tag_type;
+        type ___ZerocopyInnerTag = #inner_tag_type;
+
+        #variant_structs
+        #variants_union
+
+        #raw_enum
+        #raw_projections
+
+        #has_tag
+        #has_fields
+    })
+}
+
+pub(crate) fn derive(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error> {
+    match &ctx.ast.data {
+        Data::Struct(strct) => {
+            Ok(derive_has_field_struct_union(ctx, strct, Client::ProjectDerive, false))
+        }
+        Data::Union(unn) => {
+            Ok(derive_has_field_struct_union(ctx, unn, Client::ProjectDerive, false))
+        }
+        Data::Enum(enm) => derive_enum(ctx, enm, Client::ProjectDerive),
+    }
+}

--- a/zerocopy/zerocopy-derive/src/derive/project.rs
+++ b/zerocopy/zerocopy-derive/src/derive/project.rs
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: BSD-2-Clause OR Apache-2.0 OR MIT
+//
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    parse_quote, spanned::Spanned as _, Data, DataEnum, DeriveInput, Error, Expr, Fields, Ident,
+    Index, Type,
+};
+
+use crate::{
+    repr::{EnumRepr, StructUnionRepr},
+    util::{
+        const_block, generate_tag_enum, Client, Ctx, DataExt, FieldBounds, FieldProjection,
+        ImplBlockBuilder, Trait,
+    },
+};
+
+pub(crate) fn tag_ident(variant: &Ident) -> Ident {
+    ident!(("___ZEROCOPY_TAG_{}", variant), variant.span())
+}
+
+pub(crate) fn variant_struct_ident(variant: &Ident) -> Ident {
+    ident!(("___ZerocopyVariantStruct_{}", variant), variant.span())
+}
+
+pub(crate) fn variants_union_field_ident(variant: &Ident) -> Ident {
+    ident!(("__field_{}", variant), variant.span())
+}
+
+/// Generates a constant for the tag associated with each variant of the enum.
+/// When we match on the enum's tag, each arm matches one of these constants. We
+/// have to use constants here because:
+///
+/// - The type that we're matching on is not the type of the tag, it's an
+///   integer of the same size as the tag type and with the same bit patterns.
+/// - We can't read the enum tag as an enum because the bytes may not represent
+///   a valid variant.
+/// - Patterns do not currently support const expressions, so we have to assign
+///   these constants to names rather than use them inline in the `match`
+///   statement.
+pub(crate) fn generate_tag_consts(data: &DataEnum) -> TokenStream {
+    let tags = data.variants.iter().map(|variant| {
+        let variant_ident = &variant.ident;
+        let tag = tag_ident(variant_ident);
+
+        quote! {
+            // This casts the enum variant to its discriminant, and then
+            // converts the discriminant to the target integral type via a
+            // numeric cast [1].
+            //
+            // Because these are the same size, this is defined to be a no-op
+            // and therefore is a lossless conversion [2].
+            //
+            // [1] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#enum-cast:
+            //
+            //   Casts an enum to its discriminant.
+            //
+            // [2] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#numeric-cast:
+            //
+            //   Casting between two integers of the same size (e.g. i32 -> u32)
+            //   is a no-op.
+            const #tag: ___ZerocopyTagPrimitive =
+                ___ZerocopyTag::#variant_ident as ___ZerocopyTagPrimitive;
+        }
+    });
+
+    quote! {
+        #(#tags)*
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum Validity {
+    Uninit,
+    Initialized,
+    Valid,
+}
+
+impl Validity {
+    fn as_type(self, ctx: &Ctx) -> Type {
+        let zerocopy_crate = &ctx.zerocopy_crate;
+        match self {
+            Validity::Uninit => parse_quote!(#zerocopy_crate::invariant::Uninit),
+            Validity::Initialized => {
+                parse_quote!(#zerocopy_crate::invariant::Initialized)
+            }
+            Validity::Valid => parse_quote!(#zerocopy_crate::invariant::Valid),
+        }
+    }
+
+    /// Computes the output validity of projecting a struct or union field, or
+    /// returns `None` if that projection must not be generated.
+    ///
+    /// Struct fields preserve all three validity invariants. Union fields
+    /// preserve `Uninit` and `Initialized`. No projection is generated from a
+    /// `Valid` union.
+    fn output_validity_for_struct_or_union(self, data: &Data) -> Option<Self> {
+        match (data, self) {
+            (Data::Struct(_), validity) => Some(validity),
+            (Data::Union(_), validity @ (Validity::Uninit | Validity::Initialized)) => {
+                Some(validity)
+            }
+            (Data::Union(_), Validity::Valid) => None,
+            (Data::Enum(_), _) => unreachable!(),
+        }
+    }
+}
+
+/// Returns the projection variant ID for the struct or union described by
+/// `ctx`.
+///
+/// This intentionally does not handle enums: an enum field's variant ID
+/// identifies its source variant rather than the representation of its
+/// containing type.
+pub(crate) fn struct_union_variant_id(ctx: &Ctx) -> Box<Expr> {
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    match &ctx.ast.data {
+        Data::Struct(_) => parse_quote!({ #zerocopy_crate::STRUCT_VARIANT_ID }),
+        Data::Union(_) => {
+            if StructUnionRepr::from_attrs(&ctx.ast.attrs).map(|repr| repr.is_c()).unwrap() {
+                parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
+            } else {
+                parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID })
+            }
+        }
+        Data::Enum(_) => unreachable!("struct_union_variant_id called for enum"),
+    }
+}
+
+/// Generates field projection implementations for a struct or union.
+///
+/// `repr(C)` unions use `REPR_C_UNION_VARIANT_ID`, so their projections
+/// additionally implement `pointer::cast::Cast`. Other unions use
+/// `UNION_VARIANT_ID`.
+pub(crate) fn derive_projection_struct_union(
+    ctx: &Ctx,
+    data: &dyn DataExt,
+    client: Client,
+) -> TokenStream {
+    let fields = ctx.ast.data.fields();
+    if fields.is_empty() {
+        return quote! {};
+    }
+
+    let field_tokens = fields.iter().map(|(vis, ident, _)| {
+        let ident = ident!(("ẕ{}", ident), ident.span());
+        quote! {
+            #vis enum #ident {}
+        }
+    });
+
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let variant_id = struct_union_variant_id(ctx);
+
+    let core = ctx.core_path();
+    let has_tag = ImplBlockBuilder::new(ctx, data, Trait::HasTag { client }, FieldBounds::None)
+        .inner_extras(quote! {
+            type Tag = ();
+            type ProjectToTag = #zerocopy_crate::pointer::cast::CastToUnit;
+        })
+        .build();
+
+    let has_fields = fields.iter().map(move |(_, ident, ty)| {
+        let field_token = ident!(("ẕ{}", ident), ident.span());
+        let projection = FieldProjection {
+            variant_id: variant_id.clone(),
+            field: parse_quote!(#field_token),
+            field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
+        };
+        let has_field_trait = Trait::HasField { client, projection: projection.clone() };
+        let has_field_path = has_field_trait.crate_path(ctx);
+        let has_field = ImplBlockBuilder::new(ctx, data, has_field_trait, FieldBounds::None)
+            .inner_extras(quote! {
+                type Type = #ty;
+
+                #[inline(always)]
+                fn project(
+                    slf: #zerocopy_crate::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as #has_field_path>::Type {
+                    let slf = slf.as_ptr();
+                    // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
+                    // pointer whose referent is zero-sized or lives in a valid
+                    // allocation. Since `#ident` is a struct or union field of
+                    // `Self`, this projection preserves or shrinks the referent
+                    // size, and so the resulting referent also fits in the same
+                    // allocation.
+                    unsafe { #core::ptr::addr_of_mut!((*slf).#ident) }
+                }
+            })
+            .build();
+
+        let derive_project_field = |input_validity: Validity| {
+            let output_validity =
+                match input_validity.output_validity_for_struct_or_union(&ctx.ast.data) {
+                    Some(output_validity) => output_validity.as_type(ctx),
+                    None => return TokenStream::new(),
+                };
+            let input_validity = input_validity.as_type(ctx);
+            let projection_preserves_alignment = StructUnionRepr::from_attrs(&ctx.ast.attrs)
+                .map(|repr| repr.get_packed().is_none())
+                .unwrap();
+            let output_alignment = if projection_preserves_alignment {
+                quote! { ___ZcAlignment }
+            } else {
+                quote! { #zerocopy_crate::invariant::Unaligned }
+            };
+            ImplBlockBuilder::new(
+                ctx,
+                data,
+                Trait::ProjectField {
+                    client,
+                    projection: projection.clone(),
+                    invariants: parse_quote!((___ZcAliasing, ___ZcAlignment, #input_validity)),
+                },
+                FieldBounds::None,
+            )
+            .param_extras(vec![
+                parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Aliasing),
+                parse_quote!(___ZcAlignment: #zerocopy_crate::invariant::Alignment),
+            ])
+            .inner_extras(quote! {
+                // SAFETY: Struct and union projections do not depend on the value of
+                // the referent, and are therefore infallible.
+                type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
+
+                // SAFETY: Projection preserves aliasing. It also preserves alignment
+                // unless the containing type is packed. `Validity` determines whether
+                // a projection is emitted and, if so, computes its output validity:
+                // struct fields preserve validity; union fields preserve `Uninit` and
+                // `Initialized`, and no projection is emitted for `Valid` union input.
+                type Invariants = (___ZcAliasing, #output_alignment, #output_validity);
+            })
+            .build()
+        };
+
+        let project_uninit = derive_project_field(Validity::Uninit);
+        let project_initialized = derive_project_field(Validity::Initialized);
+        let project_valid = derive_project_field(Validity::Valid);
+
+        quote! {
+            #has_field
+            #project_uninit
+            #project_initialized
+            #project_valid
+        }
+    });
+
+    const_block(field_tokens.into_iter().chain(Some(has_tag)).chain(has_fields).map(Some))
+}
+
+pub(crate) fn derive_enum(
+    ctx: &Ctx,
+    data: &DataEnum,
+    client: Client,
+) -> Result<TokenStream, Error> {
+    // With no fields, there are no `HasField` or `ProjectField` impls to emit,
+    // and therefore no representation requirement to enforce.
+    if data.fields().is_empty() {
+        return Ok(TokenStream::new());
+    }
+
+    let repr = EnumRepr::from_attrs(&ctx.ast.attrs)?;
+    let (outer_tag_type, inner_tag_type) = if repr.is_c() {
+        (quote! { ___ZerocopyTag }, quote! { () })
+    } else if repr.is_primitive() {
+        (quote! { () }, quote! { ___ZerocopyTag })
+    } else {
+        return Err(Error::new(
+            ctx.ast.span(),
+            "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout",
+        ));
+    };
+
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let core = &ctx.core_path();
+    let client_path = &client.crate_path(ctx);
+    let has_tag_trait = Trait::HasTag { client };
+    let has_tag_path = &has_tag_trait.crate_path(ctx);
+    let infallible =
+        quote! { #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible };
+    let tag_enum = generate_tag_enum(ctx, &repr, data);
+    let tag_consts = generate_tag_consts(data);
+
+    let generics = &ctx.ast.generics;
+    let (impl_generics, ref ty_generics, where_clause) = generics.split_for_impl();
+
+    // Synthesize a `repr(C)` struct for each fieldful variant. We must do this
+    // because Rust does not provide an `addr_of!` that works on enums.
+    let variant_structs = data.variants.iter().filter_map(move |variant| {
+        if matches!(variant.fields, Fields::Unit) {
+            return None;
+        }
+
+        let ident = variant_struct_ident(&variant.ident);
+        let field_types = variant.fields.iter().map(|field| &field.ty);
+        let enum_name = &ctx.ast.ident;
+        let variant_struct: DeriveInput = parse_quote! {
+            #[repr(C)]
+            struct #ident #impl_generics (
+                #core::mem::MaybeUninit<___ZerocopyInnerTag>,
+                #(#field_types,)*
+                #core::marker::PhantomData<#enum_name #ty_generics>,
+            ) #where_clause;
+        };
+
+        let projections = derive_projection_struct_union(
+            &ctx.with_input(&variant_struct),
+            &variant_struct.data,
+            client,
+        );
+
+        Some(quote! {
+            #variant_struct
+            #projections
+        })
+    });
+
+    // Synthesize a `repr(C)` union encompassing all synthesized variants.
+    let variants_union = {
+        let fields = data.variants.iter().filter_map(|variant| {
+            if matches!(variant.fields, Fields::Unit) {
+                return None;
+            }
+            let field_name = variants_union_field_ident(&variant.ident);
+            let variant_struct = variant_struct_ident(&variant.ident);
+            Some(quote! {
+                #field_name: #core::mem::ManuallyDrop<#variant_struct #ty_generics>,
+            })
+        });
+
+        let variants_union: DeriveInput = parse_quote! {
+            #[repr(C)]
+            union ___ZerocopyVariants #generics {
+                #(#fields)*
+                // A fieldless enum produces no variant structs, but a union must
+                // have at least one field. This unit does not affect `repr(C)`
+                // layout.
+                __nonempty: (),
+            }
+        };
+        let projections = derive_projection_struct_union(
+            &ctx.with_input(&variants_union),
+            &variants_union.data,
+            client,
+        );
+
+        quote! {
+            #variants_union
+            #projections
+        }
+    };
+
+    // Synthesize a `repr(C)` struct that pairs the the tag with the synthesized
+    // variants union. In practice, the actual tag storage may be here, or
+    // inside the synthesized variant structs, depending on the `repr` of the
+    // enum.
+    let raw_enum: DeriveInput = parse_quote! {
+        #[repr(C)]
+        struct ___ZerocopyRawEnum #generics {
+            tag: ___ZerocopyOuterTag,
+            variants: ___ZerocopyVariants #ty_generics,
+        }
+    };
+
+    let raw_projections =
+        derive_projection_struct_union(&ctx.with_input(&raw_enum), &raw_enum.data, client);
+
+    let has_tag = ImplBlockBuilder::new(ctx, data, has_tag_trait, FieldBounds::None)
+        .inner_extras(quote! {
+            type Tag = ___ZerocopyTag;
+            type ProjectToTag = #zerocopy_crate::pointer::cast::CastSized;
+        })
+        .build();
+
+    let aliasing_param: &syn::GenericParam =
+        &parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Aliasing);
+    let reference_param: &syn::GenericParam =
+        &parse_quote!(___ZcAliasing: #zerocopy_crate::invariant::Reference);
+    let alignment_param: &syn::GenericParam =
+        &parse_quote!(___ZcAlignment: #zerocopy_crate::invariant::Alignment);
+
+    let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
+        let variant_ident = &variant.unwrap().ident;
+        let variants_union_field = variants_union_field_ident(variant_ident);
+        let infallible = &infallible;
+
+        fields.into_iter().enumerate().map(move |(idx, (vis, ident, ty))| {
+            // Rust does not presently support explicit visibility modifiers on
+            // enum fields. Keep this assertion so that a future language
+            // change cannot silently invalidate the visibility invariant.
+            assert!(matches!(vis, syn::Visibility::Inherited));
+            let projection = FieldProjection {
+                variant_id: parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) }),
+                field: parse_quote!(()),
+                field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
+            };
+            // The generated variant struct's first field is its inner tag.
+            let variant_struct_field_index = Index::from(idx + 1);
+            let has_field_trait = Trait::HasField {
+                client,
+                projection: projection.clone(),
+            };
+            let has_field_path = has_field_trait.crate_path(ctx);
+            let has_field = ImplBlockBuilder::new(ctx, data, has_field_trait, FieldBounds::None)
+                .inner_extras(quote! {
+                    type Type = #ty;
+
+                    #[inline(always)]
+                    fn project(
+                        slf: #zerocopy_crate::pointer::PtrInner<'_, Self>,
+                    ) -> *mut <Self as #has_field_path>::Type {
+                        use #zerocopy_crate::pointer::cast::{CastSized, Projection};
+
+                        slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
+                            .project::<_, Projection<#client_path, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
+                            .as_ptr()
+                    }
+                })
+                .build();
+
+            // SAFETY: `projection` is constructed from the current field and
+            // `variant_ident`, and that same `variant_ident` selects the
+            // variants union field through which `has_field` projects. Thus the
+            // `HasField` impl, `ProjectField` impls, and valid projection's tag
+            // check all identify the same enum field. `idx` is the current
+            // field's zero-based position, and the generated variant struct
+            // prepends its inner tag before reproducing the enum fields in
+            // source order, so `idx + 1` selects that same field. The assertion
+            // above enforces that `repr` is `repr(C)` or a primitive
+            // representation;
+            // `___ZerocopyRawEnum` and its nested types model exactly the
+            // representations specified by [1] and [2]. Those representations
+            // use `repr(C)` structs for variant fields, so field projection
+            // preserves alignment. Each `ProjectField` impl preserves the input
+            // validity. The `Uninit` and `Initialized` projections are
+            // infallible because those validity invariants do not depend on the
+            // enum's tag. The `Valid` projection first checks that the tag
+            // selects `variant_ident`; its `Reference` aliasing bound prevents
+            // mutation of the tag between that check and field projection. The
+            // corresponding `HasTag` impl projects to the raw representation's
+            // tag using `CastSized`.
+            //
+            // [1] Per https://doc.rust-lang.org/1.56.0/reference/type-layout.html#reprc-enums-with-fields:
+            //
+            //   The representation of a `repr(C)` enum with fields is a
+            //   `repr(C)` struct with two fields [...]: a `repr(C)` version of
+            //   the enum with all fields removed ("the tag") [and] a `repr(C)`
+            //   union of `repr(C)` structs for the fields of each variant [...].
+            //
+            // [2] Per https://doc.rust-lang.org/1.56.0/reference/type-layout.html#primitive-representation-of-enums-with-fields:
+            //
+            //   The representation of a primitive representation enum is a
+            //   `repr(C)` union of `repr(C)` structs for each variant with a
+            //   field. The first field of each struct in the union is [...] the
+            //   tag and the remaining fields are the fields of that variant.
+            let derive_enum_project_field = |validity| {
+                let (error, is_projectable, aliasing_bound) = if validity == Validity::Valid {
+                    assert!(!matches!(validity, Validity::Uninit | Validity::Initialized));
+                    (
+                        quote! { () },
+                        quote! {
+                            #[inline(always)]
+                            fn is_projectable(
+                                tag: #zerocopy_crate::pointer::Ptr<
+                                    '_,
+                                    <Self as #has_tag_path>::Tag,
+                                    (
+                                        #zerocopy_crate::invariant::Shared,
+                                        ___ZcAlignment,
+                                        #zerocopy_crate::invariant::Valid,
+                                    ),
+                                >,
+                            ) -> #core::result::Result<(), ()> {
+                                let tag = tag.read::<#zerocopy_crate::BecauseImmutable>();
+                                if tag == ___ZerocopyTag::#variant_ident {
+                                    #core::result::Result::Ok(())
+                                } else {
+                                    #core::result::Result::Err(())
+                                }
+                            }
+                        },
+                        reference_param.clone(),
+                    )
+                } else {
+                    (infallible.clone(), quote! {}, aliasing_param.clone())
+                };
+
+                let validity = validity.as_type(ctx);
+                let invariants: Box<Type> =
+                    parse_quote!((___ZcAliasing, ___ZcAlignment, #validity));
+                let project_field_trait = Trait::ProjectField {
+                    client,
+                    projection: projection.clone(),
+                    invariants: invariants.clone(),
+                };
+
+                ImplBlockBuilder::new(ctx, data, project_field_trait, FieldBounds::None)
+                    .param_extras(vec![aliasing_bound.clone(), alignment_param.clone()])
+                    .inner_extras(quote! {
+                        type Error = #error;
+                        type Invariants = #invariants;
+                        #is_projectable
+                    })
+                    .build()
+            };
+
+            let project_uninit = derive_enum_project_field(Validity::Uninit);
+            let project_initialized = derive_enum_project_field(Validity::Initialized);
+            let project_valid = derive_enum_project_field(Validity::Valid);
+
+            quote! {
+                #has_field
+                #project_uninit
+                #project_initialized
+                #project_valid
+            }
+        })
+    });
+
+    Ok(quote! {
+        #tag_enum
+
+        type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
+            { #core::mem::size_of::<___ZerocopyTag>() },
+        >;
+
+        #tag_consts
+
+        type ___ZerocopyOuterTag = #outer_tag_type;
+        type ___ZerocopyInnerTag = #inner_tag_type;
+
+        #(#variant_structs)*
+        #variants_union
+
+        #raw_enum
+        #raw_projections
+
+        #has_tag
+        #(#has_fields)*
+    })
+}
+
+pub(crate) fn derive(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error> {
+    match &ctx.ast.data {
+        Data::Struct(strct) => {
+            Ok(derive_projection_struct_union(ctx, strct, Client::ProjectDerive))
+        }
+        Data::Union(unn) => Ok(derive_projection_struct_union(ctx, unn, Client::ProjectDerive)),
+        Data::Enum(enm) => {
+            let projections = derive_enum(ctx, enm, Client::ProjectDerive)?;
+            if projections.is_empty() {
+                Ok(projections)
+            } else {
+                Ok(const_block([Some(projections)]))
+            }
+        }
+    }
+}

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -4,65 +4,20 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
     parse_quote, spanned::Spanned as _, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Error,
-    Expr, Fields, Ident, Index, Type,
+    Fields,
 };
 
 use crate::{
-    repr::{EnumRepr, StructUnionRepr},
+    derive::project::{
+        derive_has_field_enum, derive_has_field_struct_union, generate_tag_consts, tag_ident,
+        variant_struct_ident, variants_union_field_ident,
+    },
+    repr::EnumRepr,
     util::{
-        const_block, enum_size_from_repr, generate_tag_enum, Client, Ctx, DataExt, FieldBounds,
+        enum_size_from_repr, generate_tag_enum, Client, Ctx, DataExt, FieldBounds,
         ImplBlockBuilder, Trait, TraitBound,
     },
 };
-fn tag_ident(variant_ident: &Ident) -> Ident {
-    ident!(("___ZEROCOPY_TAG_{}", variant_ident), variant_ident.span())
-}
-
-/// Generates a constant for the tag associated with each variant of the enum.
-/// When we match on the enum's tag, each arm matches one of these constants. We
-/// have to use constants here because:
-///
-/// - The type that we're matching on is not the type of the tag, it's an
-///   integer of the same size as the tag type and with the same bit patterns.
-/// - We can't read the enum tag as an enum because the bytes may not represent
-///   a valid variant.
-/// - Patterns do not currently support const expressions, so we have to assign
-///   these constants to names rather than use them inline in the `match`
-///   statement.
-fn generate_tag_consts(data: &DataEnum) -> TokenStream {
-    let tags = data.variants.iter().map(|v| {
-        let variant_ident = &v.ident;
-        let tag_ident = tag_ident(variant_ident);
-
-        quote! {
-            // This casts the enum variant to its discriminant, and then
-            // converts the discriminant to the target integral type via a
-            // numeric cast [1].
-            //
-            // Because these are the same size, this is defined to be a no-op
-            // and therefore is a lossless conversion [2].
-            //
-            // [1] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#enum-cast:
-            //
-            //   Casts an enum to its discriminant.
-            //
-            // [2] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#numeric-cast:
-            //
-            //   Casting between two integers of the same size (e.g. i32 -> u32)
-            //   is a no-op.
-            const #tag_ident: ___ZerocopyTagPrimitive =
-                ___ZerocopyTag::#variant_ident as ___ZerocopyTagPrimitive;
-        }
-    });
-
-    quote! {
-        #(#tags)*
-    }
-}
-
-fn variant_struct_ident(variant_ident: &Ident) -> Ident {
-    ident!(("___ZerocopyVariantStruct_{}", variant_ident), variant_ident.span())
-}
 
 /// Generates variant structs for the given enum variant.
 ///
@@ -124,12 +79,6 @@ fn generate_variant_structs(ctx: &Ctx, data: &DataEnum) -> TokenStream {
     }
 }
 
-fn variants_union_field_ident(ident: &Ident) -> Ident {
-    // Field names are prefixed with `__field_` to prevent name collision
-    // with the `__nonempty` field.
-    ident!(("__field_{}", ident), ident.span())
-}
-
 fn generate_variants_union(ctx: &Ctx, data: &DataEnum) -> TokenStream {
     let generics = &ctx.ast.generics;
     let (_, ty_generics, _) = generics.split_for_impl();
@@ -163,8 +112,12 @@ fn generate_variants_union(ctx: &Ctx, data: &DataEnum) -> TokenStream {
         }
     };
 
-    let has_field =
-        derive_has_field_struct_union(&ctx.with_input(&variants_union), &variants_union.data);
+    let has_field = derive_has_field_struct_union(
+        &ctx.with_input(&variants_union),
+        &variants_union.data,
+        Client::TryFromBytesDerive,
+        true,
+    );
 
     quote! {
         #variants_union
@@ -231,81 +184,7 @@ pub(crate) fn derive_is_bit_valid(
         type ProjectToTag = #zerocopy_crate::pointer::cast::CastSized;
     })
     .build();
-    let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
-        let variant_ident = &variant.unwrap().ident;
-        let variants_union_field_ident = variants_union_field_ident(variant_ident);
-        let field: Box<syn::Type> = parse_quote!(());
-        fields.into_iter().enumerate().map(move |(idx, (vis, ident, ty))| {
-            // Rust does not presently support explicit visibility modifiers on
-            // enum fields, but we guard against the possibility to ensure this
-            // derive remains sound.
-            assert!(matches!(vis, syn::Visibility::Inherited));
-            let variant_struct_field_index = Index::from(idx + 1);
-            let (_, ty_generics, _) = ctx.ast.generics.split_for_impl();
-            let has_field_trait = Trait::HasField {
-                client: Client::TryFromBytesDerive,
-                variant_id: parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) }),
-                // Since Rust does not presently support explicit visibility
-                // modifiers on enum fields, any public type is suitable here;
-                // we use `()`.
-                field: field.clone(),
-                field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
-            };
-            let has_field_path = has_field_trait.crate_path(ctx);
-            let has_field = ImplBlockBuilder::new(
-                ctx,
-                data,
-                has_field_trait,
-                FieldBounds::None,
-            )
-            .inner_extras(quote! {
-                type Type = #ty;
-
-                #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut <Self as #has_field_path>::Type {
-                    use #zerocopy_crate::pointer::cast::{CastSized, Projection};
-
-                    slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
-                        .project::<_, Projection<#zerocopy_crate::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
-                        .project::<_, Projection<#zerocopy_crate::TryFromBytesDerive, _, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>>()
-                        .project::<_, Projection<#zerocopy_crate::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
-                        .project::<_, Projection<#zerocopy_crate::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
-                        .as_ptr()
-                }
-            })
-            .build();
-
-            let project = ImplBlockBuilder::new(
-                ctx,
-                data,
-                Trait::ProjectField {
-                    client: Client::TryFromBytesDerive,
-                    variant_id: parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) }),
-                    // Since Rust does not presently support explicit visibility
-                    // modifiers on enum fields, any public type is suitable
-                    // here; we use `()`.
-                    field: field.clone(),
-                    field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
-                    invariants: parse_quote!((Aliasing, Alignment, #zerocopy_crate::invariant::Initialized)),
-                },
-                FieldBounds::None,
-            )
-            .param_extras(vec![
-                parse_quote!(Aliasing: #zerocopy_crate::invariant::Aliasing),
-                parse_quote!(Alignment: #zerocopy_crate::invariant::Alignment),
-            ])
-            .inner_extras(quote! {
-                type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
-                type Invariants = (Aliasing, Alignment, #zerocopy_crate::invariant::Initialized);
-            })
-            .build();
-
-            quote! {
-                #has_field
-                #project
-            }
-        })
-    });
+    let has_fields = derive_has_field_enum(ctx, data, Client::TryFromBytesDerive);
 
     let core = ctx.core_path();
     let match_arms = data.variants.iter().map(|variant| {
@@ -365,8 +244,12 @@ pub(crate) fn derive_is_bit_valid(
         unsafe impl #impl_generics #zerocopy_crate::pointer::InvariantsEq<___ZerocopyRawEnum #ty_generics> for #self_ident #ty_generics #where_clause {}
     };
 
-    let raw_enum_projections =
-        derive_has_field_struct_union(&ctx.with_input(&raw_enum), &raw_enum.data);
+    let raw_enum_projections = derive_has_field_struct_union(
+        &ctx.with_input(&raw_enum),
+        &raw_enum.data,
+        Client::TryFromBytesDerive,
+        false,
+    );
 
     let raw_enum = quote! {
         #raw_enum
@@ -405,7 +288,7 @@ pub(crate) fn derive_is_bit_valid(
 
             #has_tag
 
-            #(#has_fields)*
+            #has_fields
 
             let tag = {
                 // SAFETY:
@@ -459,122 +342,6 @@ pub(crate) fn derive_try_from_bytes(ctx: &Ctx, top_level: Trait) -> Result<Token
         Data::Union(unn) => Ok(derive_try_from_bytes_union(ctx, unn, top_level)),
     }
 }
-fn derive_has_field_struct_union(ctx: &Ctx, data: &dyn DataExt) -> TokenStream {
-    let fields = ctx.ast.data.fields();
-    if fields.is_empty() {
-        return quote! {};
-    }
-
-    let field_tokens = fields.iter().map(|(vis, ident, _)| {
-        let ident = ident!(("ẕ{}", ident), ident.span());
-        quote!(
-            #vis enum #ident {}
-        )
-    });
-
-    let zerocopy_crate = &ctx.zerocopy_crate;
-    let variant_id: Box<Expr> = match &ctx.ast.data {
-        Data::Struct(_) => parse_quote!({ #zerocopy_crate::STRUCT_VARIANT_ID }),
-        Data::Union(_) => {
-            let is_repr_c = StructUnionRepr::from_attrs(&ctx.ast.attrs)
-                .map(|repr| repr.is_c())
-                .unwrap_or(false);
-            if is_repr_c {
-                parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
-            } else {
-                parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID })
-            }
-        }
-        _ => unreachable!(),
-    };
-
-    let core = ctx.core_path();
-    let has_tag = ImplBlockBuilder::new(
-        ctx,
-        data,
-        Trait::HasTag { client: Client::TryFromBytesDerive },
-        FieldBounds::None,
-    )
-    .inner_extras(quote! {
-        type Tag = ();
-        type ProjectToTag = #zerocopy_crate::pointer::cast::CastToUnit;
-    })
-    .build();
-    let has_fields = fields.iter().map(move |(_, ident, ty)| {
-        let field_token = ident!(("ẕ{}", ident), ident.span());
-        let field: Box<Type> = parse_quote!(#field_token);
-        let field_id: Box<Expr> = parse_quote!({ #zerocopy_crate::ident_id!(#ident) });
-        let has_field_trait = Trait::HasField {
-                client: Client::TryFromBytesDerive,
-                variant_id: variant_id.clone(),
-                field: field.clone(),
-                field_id: field_id.clone(),
-            };
-            let has_field_path = has_field_trait.crate_path(ctx);
-            ImplBlockBuilder::new(
-                ctx,
-                data,
-                has_field_trait,
-                FieldBounds::None,
-            )
-            .inner_extras(quote! {
-                type Type = #ty;
-
-                #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut <Self as #has_field_path>::Type {
-                    let slf = slf.as_ptr();
-                    // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
-                    // pointer whose referent is zero-sized or lives in a valid
-                    // allocation. Since `#ident` is a struct or union field of
-                    // `Self`, this projection preserves or shrinks the referent
-                    // size, and so the resulting referent also fits in the same
-                    // allocation.
-                    unsafe { #core::ptr::addr_of_mut!((*slf).#ident) }
-                }
-            }).outer_extras(if matches!(&ctx.ast.data, Data::Struct(..)) {
-            let fields_preserve_alignment = StructUnionRepr::from_attrs(&ctx.ast.attrs)
-                .map(|repr| repr.get_packed().is_none())
-                .unwrap();
-            let alignment = if fields_preserve_alignment {
-                quote! { Alignment }
-            } else {
-                quote! { #zerocopy_crate::invariant::Unaligned }
-            };
-            // SAFETY: See comments on items.
-            ImplBlockBuilder::new(
-                ctx,
-                data,
-                Trait::ProjectField {
-                    client: Client::TryFromBytesDerive,
-                    variant_id: variant_id.clone(),
-                    field,
-                    field_id,
-                    invariants: parse_quote!((Aliasing, Alignment, #zerocopy_crate::invariant::Initialized)),
-                },
-                FieldBounds::None,
-            )
-            .param_extras(vec![
-                parse_quote!(Aliasing: #zerocopy_crate::invariant::Aliasing),
-                parse_quote!(Alignment: #zerocopy_crate::invariant::Alignment),
-            ])
-            .inner_extras(quote! {
-                // SAFETY: Projection into structs is always infallible.
-                type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
-                // SAFETY: The alignment of the projected `Ptr` is `Unaligned`
-                // if the structure is packed; otherwise inherited from the
-                // outer `Ptr`. If the validity of the outer pointer is
-                // `Initialized`, so too is the validity of its fields.
-                type Invariants = (Aliasing, #alignment, #zerocopy_crate::invariant::Initialized);
-            })
-            .build()
-        } else {
-            quote! {}
-        })
-        .build()
-    });
-
-    const_block(field_tokens.into_iter().chain(Some(has_tag)).chain(has_fields).map(Some))
-}
 fn derive_try_from_bytes_struct(
     ctx: &Ctx,
     strct: &DataStruct,
@@ -600,7 +367,7 @@ fn derive_try_from_bytes_struct(
                 ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
             {
                 true #(&& {
-                    let field_candidate =   #zerocopy_crate::into_inner!(candidate.reborrow().project::<
+                    let field_candidate = #zerocopy_crate::into_inner!(candidate.reborrow().project::<
                         #zerocopy_crate::TryFromBytesDerive,
                         _,
                         { #zerocopy_crate::STRUCT_VARIANT_ID },
@@ -613,23 +380,13 @@ fn derive_try_from_bytes_struct(
     });
     Ok(ImplBlockBuilder::new(ctx, strct, Trait::TryFromBytes, FieldBounds::ALL_SELF)
         .inner_extras(extras)
-        .outer_extras(derive_has_field_struct_union(ctx, strct))
+        .outer_extras(derive_has_field_struct_union(ctx, strct, Client::TryFromBytesDerive, false))
         .build())
 }
 fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> TokenStream {
     let field_type_trait_bounds = FieldBounds::All(&[TraitBound::Slf]);
 
     let zerocopy_crate = &ctx.zerocopy_crate;
-    let variant_id: Box<Expr> = {
-        let is_repr_c =
-            StructUnionRepr::from_attrs(&ctx.ast.attrs).map(|repr| repr.is_c()).unwrap_or(false);
-        if is_repr_c {
-            parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
-        } else {
-            parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID })
-        }
-    };
-
     let extras = try_gen_trivial_is_bit_valid(ctx, top_level).unwrap_or_else(|| {
         let fields = unn.fields();
         let field_names = fields.iter().map(|(_vis, name, _ty)| name);
@@ -649,25 +406,14 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
                 ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
             {
                 false #(|| {
-                    // SAFETY:
-                    // - Since `ReadOnly<Self>: Immutable` unconditionally,
-                    //   neither `*slf` nor the returned pointer's referent
-                    //   permit interior mutation.
-                    // - Both source and destination validity are
-                    //   `Initialized`, which is always a sound
-                    //   transmutation.
-                    let field_candidate = unsafe {
-                        candidate.reborrow().project_transmute_unchecked::<
+                    let field_candidate = #zerocopy_crate::into_inner!(
+                        candidate.reborrow().project::<
+                            #zerocopy_crate::TryFromBytesDerive,
                             _,
-                            _,
-                            #zerocopy_crate::pointer::cast::Projection<
-                                #zerocopy_crate::TryFromBytesDerive,
-                                _,
-                                #variant_id,
-                                { #zerocopy_crate::ident_id!(#field_names) }
-                            >
+                            { #zerocopy_crate::UNION_VARIANT_ID },
+                            { #zerocopy_crate::ident_id!(#field_names) },
                         >()
-                    };
+                    );
 
                     <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
                 })*
@@ -676,7 +422,7 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
     });
     ImplBlockBuilder::new(ctx, unn, Trait::TryFromBytes, field_type_trait_bounds)
         .inner_extras(extras)
-        .outer_extras(derive_has_field_struct_union(ctx, unn))
+        .outer_extras(derive_has_field_struct_union(ctx, unn, Client::TryFromBytesDerive, false))
         .build()
 }
 fn derive_try_from_bytes_enum(

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -2,377 +2,77 @@
 //
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{
-    parse_quote, spanned::Spanned as _, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Error,
-    Expr, Fields, Ident, Index, Type,
-};
+use syn::{spanned::Spanned as _, Data, DataEnum, DataStruct, DataUnion, Error};
 
 use crate::{
-    repr::{EnumRepr, StructUnionRepr},
+    derive::project::{
+        derive_enum, derive_projection_struct_union, generate_tag_consts, struct_union_variant_id,
+        tag_ident,
+    },
+    repr::EnumRepr,
     util::{
-        const_block, enum_size_from_repr, generate_tag_enum, Client, Ctx, DataExt, FieldBounds,
+        enum_size_from_repr, generate_tag_enum, Client, Ctx, DataExt, FieldBounds,
         ImplBlockBuilder, Trait, TraitBound,
     },
 };
-fn tag_ident(variant_ident: &Ident) -> Ident {
-    ident!(("___ZEROCOPY_TAG_{}", variant_ident), variant_ident.span())
-}
-
-/// Generates a constant for the tag associated with each variant of the enum.
-/// When we match on the enum's tag, each arm matches one of these constants. We
-/// have to use constants here because:
-///
-/// - The type that we're matching on is not the type of the tag, it's an
-///   integer of the same size as the tag type and with the same bit patterns.
-/// - We can't read the enum tag as an enum because the bytes may not represent
-///   a valid variant.
-/// - Patterns do not currently support const expressions, so we have to assign
-///   these constants to names rather than use them inline in the `match`
-///   statement.
-fn generate_tag_consts(data: &DataEnum) -> TokenStream {
-    let tags = data.variants.iter().map(|v| {
-        let variant_ident = &v.ident;
-        let tag_ident = tag_ident(variant_ident);
-
-        quote! {
-            // This casts the enum variant to its discriminant, and then
-            // converts the discriminant to the target integral type via a
-            // numeric cast [1].
-            //
-            // Because these are the same size, this is defined to be a no-op
-            // and therefore is a lossless conversion [2].
-            //
-            // [1] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#enum-cast:
-            //
-            //   Casts an enum to its discriminant.
-            //
-            // [2] Per https://doc.rust-lang.org/1.81.0/reference/expressions/operator-expr.html#numeric-cast:
-            //
-            //   Casting between two integers of the same size (e.g. i32 -> u32)
-            //   is a no-op.
-            const #tag_ident: ___ZerocopyTagPrimitive =
-                ___ZerocopyTag::#variant_ident as ___ZerocopyTagPrimitive;
-        }
-    });
-
-    quote! {
-        #(#tags)*
-    }
-}
-
-fn variant_struct_ident(variant_ident: &Ident) -> Ident {
-    ident!(("___ZerocopyVariantStruct_{}", variant_ident), variant_ident.span())
-}
-
-/// Generates variant structs for the given enum variant.
-///
-/// These are structs associated with each variant of an enum. They are
-/// `repr(C)` tuple structs with the same fields as the variant after a
-/// `MaybeUninit<___ZerocopyInnerTag>`.
-///
-/// In order to unify the generated types for `repr(C)` and `repr(int)` enums,
-/// we use a "fused" representation with fields for both an inner tag and an
-/// outer tag. Depending on the repr, we will set one of these tags to the tag
-/// type and the other to `()`. This lets us generate the same code but put the
-/// tags in different locations.
-fn generate_variant_structs(ctx: &Ctx, data: &DataEnum) -> TokenStream {
-    let (impl_generics, ty_generics, where_clause) = ctx.ast.generics.split_for_impl();
-
-    let enum_name = &ctx.ast.ident;
-
-    // All variant structs have a `PhantomData<MyEnum<...>>` field because we
-    // don't know which generic parameters each variant will use, and unused
-    // generic parameters are a compile error.
-    let core = ctx.core_path();
-    let phantom_ty = quote! {
-        #core::marker::PhantomData<#enum_name #ty_generics>
-    };
-
-    let variant_structs = data.variants.iter().filter_map(|variant| {
-        // We don't generate variant structs for unit variants because we only
-        // need to check the tag. This helps cut down our generated code a bit.
-        if matches!(variant.fields, Fields::Unit) {
-            return None;
-        }
-
-        let variant_struct_ident = variant_struct_ident(&variant.ident);
-        let field_types = variant.fields.iter().map(|f| &f.ty);
-
-        let variant_struct = parse_quote! {
-            #[repr(C)]
-            struct #variant_struct_ident #impl_generics (
-                #core::mem::MaybeUninit<___ZerocopyInnerTag>,
-                #(#field_types,)*
-                #phantom_ty,
-            ) #where_clause;
-        };
-
-        // We do this rather than emitting `#[derive(::zerocopy::TryFromBytes)]`
-        // because that is not hygienic, and this is also more performant.
-        let try_from_bytes_impl =
-            derive_try_from_bytes(&ctx.with_input(&variant_struct), Trait::TryFromBytes)
-                .expect("derive_try_from_bytes should not fail on synthesized type");
-
-        Some(quote! {
-            #variant_struct
-            #try_from_bytes_impl
-        })
-    });
-
-    quote! {
-        #(#variant_structs)*
-    }
-}
-
-fn variants_union_field_ident(ident: &Ident) -> Ident {
-    // Field names are prefixed with `__field_` to prevent name collision
-    // with the `__nonempty` field.
-    ident!(("__field_{}", ident), ident.span())
-}
-
-fn generate_variants_union(ctx: &Ctx, data: &DataEnum) -> TokenStream {
-    let generics = &ctx.ast.generics;
-    let (_, ty_generics, _) = generics.split_for_impl();
-
-    let fields = data.variants.iter().filter_map(|variant| {
-        // We don't generate variant structs for unit variants because we only
-        // need to check the tag. This helps cut down our generated code a bit.
-        if matches!(variant.fields, Fields::Unit) {
-            return None;
-        }
-
-        let field_name = variants_union_field_ident(&variant.ident);
-        let variant_struct_ident = variant_struct_ident(&variant.ident);
-
-        let core = ctx.core_path();
-        Some(quote! {
-            #field_name: #core::mem::ManuallyDrop<#variant_struct_ident #ty_generics>,
-        })
-    });
-
-    let variants_union = parse_quote! {
-        #[repr(C)]
-        union ___ZerocopyVariants #generics {
-            #(#fields)*
-            // Enums can have variants with no fields, but unions must
-            // have at least one field. So we just add a trailing unit
-            // to ensure that this union always has at least one field.
-            // Because this union is `repr(C)`, this unit type does not
-            // affect the layout.
-            __nonempty: (),
-        }
-    };
-
-    let has_field =
-        derive_has_field_struct_union(&ctx.with_input(&variants_union), &variants_union.data);
-
-    quote! {
-        #variants_union
-        #has_field
-    }
-}
 
 /// Generates an implementation of `is_bit_valid` for an arbitrary enum.
 ///
-/// The general process is:
-///
-/// 1. Generate a tag enum. This is an enum with the same repr, variants, and
-///    corresponding discriminants as the original enum, but without any fields
-///    on the variants. This gives us access to an enum where the variants have
-///    the same discriminants as the one we're writing `is_bit_valid` for.
-/// 2. Make constants from the variants of the tag enum. We need these because
-///    we can't put const exprs in match arms.
-/// 3. Generate variant structs. These are structs which have the same fields as
-///    each variant of the enum, and are `#[repr(C)]` with an optional "inner
-///    tag".
-/// 4. Generate a variants union, with one field for each variant struct type.
-/// 5. And finally, our raw enum is a `#[repr(C)]` struct of an "outer tag" and
-///    the variants union.
-///
-/// See these reference links for fully-worked example decompositions.
-///
-/// - `repr(C)`: <https://doc.rust-lang.org/reference/type-layout.html#reprc-enums-with-fields>
-/// - `repr(int)`: <https://doc.rust-lang.org/reference/type-layout.html#primitive-representation-of-enums-with-fields>
-/// - `repr(C, int)`: <https://doc.rust-lang.org/reference/type-layout.html#combining-primitive-representations-of-enums-with-fields-and-reprc>
+/// For an enum with fields, [`derive_enum`] generates the representation model
+/// and projection impls. This function reads the tag, matches it against the
+/// enum's discriminants, and validates each field of the selected variant
+/// through those projections. A fieldless enum needs only the generated tag
+/// enum and discriminant constants.
 pub(crate) fn derive_is_bit_valid(
     ctx: &Ctx,
     data: &DataEnum,
     repr: &EnumRepr,
 ) -> Result<TokenStream, Error> {
-    let trait_path = Trait::TryFromBytes.crate_path(ctx);
-    let tag_enum = generate_tag_enum(ctx, repr, data);
-    let tag_consts = generate_tag_consts(data);
-
-    let (outer_tag_type, inner_tag_type) = if repr.is_c() {
-        (quote! { ___ZerocopyTag }, quote! { () })
-    } else if repr.is_primitive() {
-        (quote! { () }, quote! { ___ZerocopyTag })
-    } else {
+    if !(repr.is_c() || repr.is_primitive()) {
         return Err(Error::new(
             ctx.ast.span(),
             "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout",
         ));
-    };
+    }
 
-    let variant_structs = generate_variant_structs(ctx, data);
-    let variants_union = generate_variants_union(ctx, data);
-
-    let (impl_generics, ty_generics, where_clause) = ctx.ast.generics.split_for_impl();
-
+    let trait_path = Trait::TryFromBytes.crate_path(ctx);
     let zerocopy_crate = &ctx.zerocopy_crate;
-    let has_tag = ImplBlockBuilder::new(
-        ctx,
-        data,
-        Trait::HasTag { client: Client::TryFromBytesDerive },
-        FieldBounds::None,
-    )
-    .inner_extras(quote! {
-        type Tag = ___ZerocopyTag;
-        type ProjectToTag = #zerocopy_crate::pointer::cast::CastSized;
-    })
-    .build();
-    let has_fields = data.variants().into_iter().flat_map(|(variant, fields)| {
-        let variant_ident = &variant.unwrap().ident;
-        let variants_union_field_ident = variants_union_field_ident(variant_ident);
-        let field: Box<syn::Type> = parse_quote!(());
-        fields.into_iter().enumerate().map(move |(idx, (vis, ident, ty))| {
-            // Rust does not presently support explicit visibility modifiers on
-            // enum fields, but we guard against the possibility to ensure this
-            // derive remains sound.
-            assert!(matches!(vis, syn::Visibility::Inherited));
-            let variant_struct_field_index = Index::from(idx + 1);
-            let (_, ty_generics, _) = ctx.ast.generics.split_for_impl();
-            let has_field_trait = Trait::HasField {
-                client: Client::TryFromBytesDerive,
-                variant_id: parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) }),
-                // Since Rust does not presently support explicit visibility
-                // modifiers on enum fields, any public type is suitable here;
-                // we use `()`.
-                field: field.clone(),
-                field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
-            };
-            let has_field_path = has_field_trait.crate_path(ctx);
-            let has_field = ImplBlockBuilder::new(
-                ctx,
-                data,
-                has_field_trait,
-                FieldBounds::None,
-            )
-            .inner_extras(quote! {
-                type Type = #ty;
-
-                #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut <Self as #has_field_path>::Type {
-                    use #zerocopy_crate::pointer::cast::{CastSized, Projection};
-
-                    slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
-                        .project::<_, Projection<#zerocopy_crate::project_clients::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
-                        .project::<_, Projection<#zerocopy_crate::project_clients::TryFromBytesDerive, _, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>>()
-                        .project::<_, Projection<#zerocopy_crate::project_clients::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
-                        .project::<_, Projection<#zerocopy_crate::project_clients::TryFromBytesDerive, _, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
-                        .as_ptr()
-                }
-            })
-            .build();
-
-            let project = ImplBlockBuilder::new(
-                ctx,
-                data,
-                Trait::ProjectField {
-                    client: Client::TryFromBytesDerive,
-                    variant_id: parse_quote!({ #zerocopy_crate::ident_id!(#variant_ident) }),
-                    // Since Rust does not presently support explicit visibility
-                    // modifiers on enum fields, any public type is suitable
-                    // here; we use `()`.
-                    field: field.clone(),
-                    field_id: parse_quote!({ #zerocopy_crate::ident_id!(#ident) }),
-                    invariants: parse_quote!((Aliasing, Alignment, #zerocopy_crate::invariant::Initialized)),
-                },
-                FieldBounds::None,
-            )
-            .param_extras(vec![
-                parse_quote!(Aliasing: #zerocopy_crate::invariant::Aliasing),
-                parse_quote!(Alignment: #zerocopy_crate::invariant::Alignment),
-            ])
-            .inner_extras(quote! {
-                type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
-                type Invariants = (Aliasing, Alignment, #zerocopy_crate::invariant::Initialized);
-            })
-            .build();
-
-            quote! {
-                #has_field
-                #project
-            }
-        })
-    });
-
     let core = ctx.core_path();
-    let match_arms = data.variants.iter().map(|variant| {
-        let tag_ident = tag_ident(&variant.ident);
-        let variant_struct_ident = variant_struct_ident(&variant.ident);
-        let variants_union_field_ident = variants_union_field_ident(&variant.ident);
+    let projections = if data.fields().is_empty() {
+        let tag_enum = generate_tag_enum(ctx, repr, data);
+        let tag_consts = generate_tag_consts(data);
+        quote! {
+            #tag_enum
 
-        if matches!(variant.fields, Fields::Unit) {
-            // Unit variants don't need any further validation beyond checking
-            // the tag.
-            quote! {
-                #tag_ident => true
-            }
-        } else {
-            quote! {
-                #tag_ident => {
-                    // SAFETY: Since we know that the tag is `#tag_ident`, we
-                    // know that no other `&`s exist which refer to this enum
-                    // as any other variant.
-                    let variant_md = variants.cast::<
+            type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
+                { #core::mem::size_of::<___ZerocopyTag>() },
+            >;
+
+            #tag_consts
+        }
+    } else {
+        derive_enum(ctx, data, Client::TryFromBytesDerive)?
+    };
+
+    let match_arms = data.variants().into_iter().map(|(variant, fields)| {
+        let variant = &variant.unwrap().ident;
+        let tag = tag_ident(variant);
+        let field_names = fields.iter().map(|(_, name, _)| name);
+        let field_tys = fields.iter().map(|(_, _, ty)| ty);
+        quote! {
+            #tag => true #(&& {
+                let field_candidate = #zerocopy_crate::into_inner!(
+                    candidate.reborrow().project::<
+                        #zerocopy_crate::project_clients::TryFromBytesDerive,
                         _,
-                        #zerocopy_crate::pointer::cast::Projection<
-                            #zerocopy_crate::project_clients::TryFromBytesDerive,
-                            // #zerocopy_crate::ReadOnly<_>,
-                            _,
-                            { #zerocopy_crate::REPR_C_UNION_VARIANT_ID },
-                            { #zerocopy_crate::ident_id!(#variants_union_field_ident) }
-                        >,
-                        _
-                    >();
-                    let variant = variant_md.cast::<
-                        #zerocopy_crate::ReadOnly<#variant_struct_ident #ty_generics>,
-                        #zerocopy_crate::pointer::cast::CastSized,
-                        (#zerocopy_crate::pointer::BecauseRead, _)
-                    >();
-                    <
-                        #variant_struct_ident #ty_generics as #trait_path
-                    >::is_bit_valid(variant)
-                }
-            }
+                        { #zerocopy_crate::ident_id!(#variant) },
+                        { #zerocopy_crate::ident_id!(#field_names) },
+                    >()
+                );
+                <#field_tys as #trait_path>::is_bit_valid(field_candidate)
+            })*
         }
     });
-
-    let generics = &ctx.ast.generics;
-    let raw_enum: DeriveInput = parse_quote! {
-        #[repr(C)]
-        struct ___ZerocopyRawEnum #generics {
-            tag: ___ZerocopyOuterTag,
-            variants: ___ZerocopyVariants #ty_generics,
-        }
-    };
-
-    let self_ident = &ctx.ast.ident;
-    let invariants_eq_impl = quote! {
-        // SAFETY: `___ZerocopyRawEnum` is designed to have the same layout,
-        // validity, and invariants as `Self`.
-        unsafe impl #impl_generics #zerocopy_crate::pointer::InvariantsEq<___ZerocopyRawEnum #ty_generics> for #self_ident #ty_generics #where_clause {}
-    };
-
-    let raw_enum_projections =
-        derive_has_field_struct_union(&ctx.with_input(&raw_enum), &raw_enum.data);
-
-    let raw_enum = quote! {
-        #raw_enum
-        #invariants_eq_impl
-        #raw_enum_projections
-    };
 
     Ok(quote! {
         // SAFETY: We use `is_bit_valid` to validate that the bit pattern of the
@@ -386,64 +86,17 @@ pub(crate) fn derive_is_bit_valid(
         where
             ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
         {
-            #tag_enum
+            #projections
 
-            type ___ZerocopyTagPrimitive = #zerocopy_crate::util::macro_util::SizeToTag<
-                { #core::mem::size_of::<___ZerocopyTag>() },
-            >;
-
-            #tag_consts
-
-            type ___ZerocopyOuterTag = #outer_tag_type;
-            type ___ZerocopyInnerTag = #inner_tag_type;
-
-            #variant_structs
-
-            #variants_union
-
-            #raw_enum
-
-            #has_tag
-
-            #(#has_fields)*
-
-            let tag = {
-                // SAFETY:
-                // - The provided cast addresses a subset of the bytes addressed
-                //   by `candidate` because it addresses the starting tag of the
-                //   enum.
-                // - Because the pointer is cast from `candidate`, it has the
-                //   same provenance as it.
-                // - There are no `UnsafeCell`s in the tag because it is a
-                //   primitive integer.
-                // - `tag_ptr` is casted from `candidate`, whose referent is
-                //   `Initialized`. Since we have not written uninitialized
-                //   bytes into the referent, `tag_ptr` is also `Initialized`.
-                //
-                // FIXME(#2874): Revise this to a `cast` once `candidate`
-                // references a `ReadOnly<Self>`.
-                let tag_ptr = unsafe {
-                    candidate.reborrow().project_transmute_unchecked::<
-                        _,
-                        #zerocopy_crate::invariant::Initialized,
-                        #zerocopy_crate::pointer::cast::CastSized
-                    >()
-                };
-                tag_ptr.recall_validity::<_, (_, (_, _))>().read::<#zerocopy_crate::BecauseImmutable>()
-            };
-
-            let mut raw_enum = candidate.cast::<
-                #zerocopy_crate::ReadOnly<___ZerocopyRawEnum #ty_generics>,
-                #zerocopy_crate::pointer::cast::CastSized,
-                (#zerocopy_crate::pointer::BecauseRead, _)
-            >();
-
-            let variants = #zerocopy_crate::into_inner!(raw_enum.project::<
-                #zerocopy_crate::project_clients::TryFromBytesDerive,
-                _,
-                { #zerocopy_crate::STRUCT_VARIANT_ID },
-                { #zerocopy_crate::ident_id!(variants) }
-            >());
+            let tag = candidate
+                .reborrow()
+                .cast::<
+                    ___ZerocopyTagPrimitive,
+                    #zerocopy_crate::pointer::cast::CastSized,
+                    (#zerocopy_crate::pointer::BecauseRead, _),
+                >()
+                .recall_validity::<_, (_, (_, _))>()
+                .read::<#zerocopy_crate::BecauseImmutable>();
 
             match tag {
                 #(#match_arms,)*
@@ -458,122 +111,6 @@ pub(crate) fn derive_try_from_bytes(ctx: &Ctx, top_level: Trait) -> Result<Token
         Data::Enum(enm) => derive_try_from_bytes_enum(ctx, enm, top_level),
         Data::Union(unn) => Ok(derive_try_from_bytes_union(ctx, unn, top_level)),
     }
-}
-fn derive_has_field_struct_union(ctx: &Ctx, data: &dyn DataExt) -> TokenStream {
-    let fields = ctx.ast.data.fields();
-    if fields.is_empty() {
-        return quote! {};
-    }
-
-    let field_tokens = fields.iter().map(|(vis, ident, _)| {
-        let ident = ident!(("ẕ{}", ident), ident.span());
-        quote!(
-            #vis enum #ident {}
-        )
-    });
-
-    let zerocopy_crate = &ctx.zerocopy_crate;
-    let variant_id: Box<Expr> = match &ctx.ast.data {
-        Data::Struct(_) => parse_quote!({ #zerocopy_crate::STRUCT_VARIANT_ID }),
-        Data::Union(_) => {
-            let is_repr_c = StructUnionRepr::from_attrs(&ctx.ast.attrs)
-                .map(|repr| repr.is_c())
-                .unwrap_or(false);
-            if is_repr_c {
-                parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
-            } else {
-                parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID })
-            }
-        }
-        _ => unreachable!(),
-    };
-
-    let core = ctx.core_path();
-    let has_tag = ImplBlockBuilder::new(
-        ctx,
-        data,
-        Trait::HasTag { client: Client::TryFromBytesDerive },
-        FieldBounds::None,
-    )
-    .inner_extras(quote! {
-        type Tag = ();
-        type ProjectToTag = #zerocopy_crate::pointer::cast::CastToUnit;
-    })
-    .build();
-    let has_fields = fields.iter().map(move |(_, ident, ty)| {
-        let field_token = ident!(("ẕ{}", ident), ident.span());
-        let field: Box<Type> = parse_quote!(#field_token);
-        let field_id: Box<Expr> = parse_quote!({ #zerocopy_crate::ident_id!(#ident) });
-        let has_field_trait = Trait::HasField {
-                client: Client::TryFromBytesDerive,
-                variant_id: variant_id.clone(),
-                field: field.clone(),
-                field_id: field_id.clone(),
-            };
-            let has_field_path = has_field_trait.crate_path(ctx);
-            ImplBlockBuilder::new(
-                ctx,
-                data,
-                has_field_trait,
-                FieldBounds::None,
-            )
-            .inner_extras(quote! {
-                type Type = #ty;
-
-                #[inline(always)]
-                fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut <Self as #has_field_path>::Type {
-                    let slf = slf.as_ptr();
-                    // SAFETY: By invariant on `PtrInner`, `slf` is a non-null
-                    // pointer whose referent is zero-sized or lives in a valid
-                    // allocation. Since `#ident` is a struct or union field of
-                    // `Self`, this projection preserves or shrinks the referent
-                    // size, and so the resulting referent also fits in the same
-                    // allocation.
-                    unsafe { #core::ptr::addr_of_mut!((*slf).#ident) }
-                }
-            }).outer_extras(if matches!(&ctx.ast.data, Data::Struct(..)) {
-            let fields_preserve_alignment = StructUnionRepr::from_attrs(&ctx.ast.attrs)
-                .map(|repr| repr.get_packed().is_none())
-                .unwrap();
-            let alignment = if fields_preserve_alignment {
-                quote! { Alignment }
-            } else {
-                quote! { #zerocopy_crate::invariant::Unaligned }
-            };
-            // SAFETY: See comments on items.
-            ImplBlockBuilder::new(
-                ctx,
-                data,
-                Trait::ProjectField {
-                    client: Client::TryFromBytesDerive,
-                    variant_id: variant_id.clone(),
-                    field,
-                    field_id,
-                    invariants: parse_quote!((Aliasing, Alignment, #zerocopy_crate::invariant::Initialized)),
-                },
-                FieldBounds::None,
-            )
-            .param_extras(vec![
-                parse_quote!(Aliasing: #zerocopy_crate::invariant::Aliasing),
-                parse_quote!(Alignment: #zerocopy_crate::invariant::Alignment),
-            ])
-            .inner_extras(quote! {
-                // SAFETY: Projection into structs is always infallible.
-                type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
-                // SAFETY: The alignment of the projected `Ptr` is `Unaligned`
-                // if the structure is packed; otherwise inherited from the
-                // outer `Ptr`. If the validity of the outer pointer is
-                // `Initialized`, so too is the validity of its fields.
-                type Invariants = (Aliasing, #alignment, #zerocopy_crate::invariant::Initialized);
-            })
-            .build()
-        } else {
-            quote! {}
-        })
-        .build()
-    });
-
-    const_block(field_tokens.into_iter().chain(Some(has_tag)).chain(has_fields).map(Some))
 }
 fn derive_try_from_bytes_struct(
     ctx: &Ctx,
@@ -600,7 +137,7 @@ fn derive_try_from_bytes_struct(
                 ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
             {
                 true #(&& {
-                    let field_candidate =   #zerocopy_crate::into_inner!(candidate.reborrow().project::<
+                    let field_candidate = #zerocopy_crate::into_inner!(candidate.reborrow().project::<
                         #zerocopy_crate::project_clients::TryFromBytesDerive,
                         _,
                         { #zerocopy_crate::STRUCT_VARIANT_ID },
@@ -613,23 +150,14 @@ fn derive_try_from_bytes_struct(
     });
     Ok(ImplBlockBuilder::new(ctx, strct, Trait::TryFromBytes, FieldBounds::ALL_SELF)
         .inner_extras(extras)
-        .outer_extras(derive_has_field_struct_union(ctx, strct))
+        .outer_extras(derive_projection_struct_union(ctx, strct, Client::TryFromBytesDerive))
         .build())
 }
 fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> TokenStream {
     let field_type_trait_bounds = FieldBounds::All(&[TraitBound::Slf]);
 
     let zerocopy_crate = &ctx.zerocopy_crate;
-    let variant_id: Box<Expr> = {
-        let is_repr_c =
-            StructUnionRepr::from_attrs(&ctx.ast.attrs).map(|repr| repr.is_c()).unwrap_or(false);
-        if is_repr_c {
-            parse_quote!({ #zerocopy_crate::REPR_C_UNION_VARIANT_ID })
-        } else {
-            parse_quote!({ #zerocopy_crate::UNION_VARIANT_ID })
-        }
-    };
-
+    let union_variant_id = struct_union_variant_id(ctx);
     let extras = try_gen_trivial_is_bit_valid(ctx, top_level).unwrap_or_else(|| {
         let fields = unn.fields();
         let field_names = fields.iter().map(|(_vis, name, _ty)| name);
@@ -649,25 +177,14 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
                 ___ZcAlignment: #zerocopy_crate::invariant::Alignment,
             {
                 false #(|| {
-                    // SAFETY:
-                    // - Since `ReadOnly<Self>: Immutable` unconditionally,
-                    //   neither `*slf` nor the returned pointer's referent
-                    //   permit interior mutation.
-                    // - Both source and destination validity are
-                    //   `Initialized`, which is always a sound
-                    //   transmutation.
-                    let field_candidate = unsafe {
-                        candidate.reborrow().project_transmute_unchecked::<
+                    let field_candidate = #zerocopy_crate::into_inner!(
+                        candidate.reborrow().project::<
+                            #zerocopy_crate::project_clients::TryFromBytesDerive,
                             _,
-                            _,
-                            #zerocopy_crate::pointer::cast::Projection<
-                                #zerocopy_crate::project_clients::TryFromBytesDerive,
-                                _,
-                                #variant_id,
-                                { #zerocopy_crate::ident_id!(#field_names) }
-                            >
+                            { #union_variant_id },
+                            { #zerocopy_crate::ident_id!(#field_names) },
                         >()
-                    };
+                    );
 
                     <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
                 })*
@@ -676,7 +193,7 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
     });
     ImplBlockBuilder::new(ctx, unn, Trait::TryFromBytes, field_type_trait_bounds)
         .inner_extras(extras)
-        .outer_extras(derive_has_field_struct_union(ctx, unn))
+        .outer_extras(derive_projection_struct_union(ctx, unn, Client::TryFromBytesDerive))
         .build()
 }
 fn derive_try_from_bytes_enum(
@@ -784,6 +301,8 @@ unsafe fn gen_trivial_is_bit_valid_unchecked(ctx: &Ctx) -> proc_macro2::TokenStr
 
 #[cfg(test)]
 mod tests {
+    use syn::{parse_quote, DeriveInput};
+
     use super::*;
 
     fn derive_error(input: DeriveInput) -> String {

--- a/zerocopy/zerocopy-derive/src/lib.rs
+++ b/zerocopy/zerocopy-derive/src/lib.rs
@@ -79,7 +79,8 @@ use crate::util::*;
 /// are currently required to live at the crate root, and so the caller must
 /// specify the name in order to avoid name collisions.
 macro_rules! derive {
-    ($trait:ident => $outer:ident => $inner:path) => {
+    ($(#[$attr:meta])* $trait:ident => $outer:ident => $inner:path) => {
+        $(#[$attr])*
         #[proc_macro_derive($trait, attributes(zerocopy))]
         pub fn $outer(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let ast = syn::parse_macro_input!(ts as DeriveInput);
@@ -120,6 +121,7 @@ impl IntoTokenStream for Result<proc_macro2::TokenStream, Error> {
 
 derive!(KnownLayout => derive_known_layout => crate::derive::known_layout::derive);
 derive!(Immutable => derive_immutable => crate::derive::derive_immutable);
+derive!(#[doc(hidden)] Project => derive_project => crate::derive::project::derive);
 derive!(TryFromBytes => derive_try_from_bytes => crate::derive::try_from_bytes::derive_try_from_bytes);
 derive!(FromZeros => derive_from_zeros => crate::derive::from_bytes::derive_from_zeros);
 derive!(FromBytes => derive_from_bytes => crate::derive::from_bytes::derive_from_bytes);

--- a/zerocopy/zerocopy-derive/src/lib.rs
+++ b/zerocopy/zerocopy-derive/src/lib.rs
@@ -83,7 +83,8 @@ use crate::util::*;
 /// are currently required to live at the crate root, and so the caller must
 /// specify the name in order to avoid name collisions.
 macro_rules! derive {
-    ($trait:ident => $outer:ident => $inner:path) => {
+    ($(#[$attr:meta])* $trait:ident => $outer:ident => $inner:path) => {
+        $(#[$attr])*
         #[proc_macro_derive($trait, attributes(zerocopy))]
         pub fn $outer(ts: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let ast = syn::parse_macro_input!(ts as DeriveInput);
@@ -124,6 +125,7 @@ impl IntoTokenStream for Result<proc_macro2::TokenStream, Error> {
 
 derive!(KnownLayout => derive_known_layout => crate::derive::known_layout::derive);
 derive!(Immutable => derive_immutable => crate::derive::derive_immutable);
+derive!(#[doc(hidden)] Project => derive_project => crate::derive::project::derive);
 derive!(TryFromBytes => derive_try_from_bytes => crate::derive::try_from_bytes::derive_try_from_bytes);
 derive!(FromZeros => derive_from_zeros => crate::derive::from_bytes::derive_from_zeros);
 derive!(FromBytes => derive_from_bytes => crate::derive::from_bytes::derive_from_bytes);

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
@@ -106,6 +106,102 @@ const _: () = {
                 }
             }
         };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::TryFromBytesDerive,
+                ẕa,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(a) },
+            > for Foo {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::TryFromBytesDerive,
+                ẕa,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(a) },
+            > for Foo {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::TryFromBytesDerive,
+                ẕa,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(a) },
+            > for Foo {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
     };
 };
 #[allow(

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
@@ -108,6 +108,70 @@ const _: () = {
                 }
             }
         };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::TryFromBytesDerive,
+                ẕa,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(a) },
+            > for Foo {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::TryFromBytesDerive,
+                ẕa,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(a) },
+            > for Foo {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
     };
 };
 #[allow(

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(C)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(C)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i128)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i128)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i16)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i16)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i32)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i32)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i64)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i64)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i8)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(i8)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(isize)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(isize)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u128)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u128)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u16)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u16)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u32)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u32)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u64)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u64)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u8)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(u8)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(usize)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
@@ -18,6 +18,7 @@ const _: () = {
             {
                 #[repr(usize)]
                 #[allow(dead_code)]
+                #[derive(Copy, Clone, PartialEq)]
                 pub enum ___ZerocopyTag {
                     Bar,
                 }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_1.expected.rs
@@ -1,0 +1,4664 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    #[repr(u8)]
+    #[allow(dead_code)]
+    #[derive(Copy, Clone, PartialEq)]
+    pub enum ___ZerocopyTag {
+        UnitLike,
+        StructLike,
+        TupleLike,
+    }
+    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+        { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
+    >;
+    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+        as ___ZerocopyTagPrimitive;
+    type ___ZerocopyOuterTag = ();
+    type ___ZerocopyInnerTag = ___ZerocopyTag;
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_StructLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        u8,
+        X,
+        X::Target,
+        Y::Target,
+        [(X, Y); N],
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        enum ẕ5 {}
+        enum ẕ6 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ5,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(5) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).5
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ6,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(6) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).6
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_TupleLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        bool,
+        Y,
+        PhantomData<&'a [(X, Y); N]>,
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+        __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+        >,
+        __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+        >,
+        __nonempty: (),
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ__field_StructLike {}
+        enum ẕ__field_TupleLike {}
+        enum ẕ__nonempty {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_StructLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_StructLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_TupleLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ();
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__nonempty,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__nonempty
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+        tag: ___ZerocopyOuterTag,
+        variants: ___ZerocopyVariants<'a, N, X, Y>,
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕtag {}
+        enum ẕvariants {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyOuterTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).tag
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).variants
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ___ZerocopyTag;
+            type ProjectToTag = ::zerocopy::pointer::cast::CastSized;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = [(X, Y); N];
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = bool;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = PhantomData<&'a [(X, Y); N]>;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_2.expected.rs
@@ -1,0 +1,4664 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    #[repr(u32)]
+    #[allow(dead_code)]
+    #[derive(Copy, Clone, PartialEq)]
+    pub enum ___ZerocopyTag {
+        UnitLike,
+        StructLike,
+        TupleLike,
+    }
+    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+        { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
+    >;
+    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+        as ___ZerocopyTagPrimitive;
+    type ___ZerocopyOuterTag = ();
+    type ___ZerocopyInnerTag = ___ZerocopyTag;
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_StructLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        u8,
+        X,
+        X::Target,
+        Y::Target,
+        [(X, Y); N],
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        enum ẕ5 {}
+        enum ẕ6 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ5,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(5) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).5
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ6,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(6) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).6
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_TupleLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        bool,
+        Y,
+        PhantomData<&'a [(X, Y); N]>,
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+        __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+        >,
+        __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+        >,
+        __nonempty: (),
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ__field_StructLike {}
+        enum ẕ__field_TupleLike {}
+        enum ẕ__nonempty {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_StructLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_StructLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_TupleLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ();
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__nonempty,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__nonempty
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+        tag: ___ZerocopyOuterTag,
+        variants: ___ZerocopyVariants<'a, N, X, Y>,
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕtag {}
+        enum ẕvariants {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyOuterTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).tag
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).variants
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ___ZerocopyTag;
+            type ProjectToTag = ::zerocopy::pointer::cast::CastSized;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = [(X, Y); N];
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = bool;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = PhantomData<&'a [(X, Y); N]>;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_3.expected.rs
@@ -1,0 +1,4664 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    #[repr(C)]
+    #[allow(dead_code)]
+    #[derive(Copy, Clone, PartialEq)]
+    pub enum ___ZerocopyTag {
+        UnitLike,
+        StructLike,
+        TupleLike,
+    }
+    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
+        fn only_derive_is_allowed_to_implement_this_trait() {}
+    }
+    type ___ZerocopyTagPrimitive = ::zerocopy::util::macro_util::SizeToTag<
+        { ::zerocopy::util::macro_util::core_reexport::mem::size_of::<___ZerocopyTag>() },
+    >;
+    const ___ZEROCOPY_TAG_UnitLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::UnitLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_StructLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::StructLike
+        as ___ZerocopyTagPrimitive;
+    const ___ZEROCOPY_TAG_TupleLike: ___ZerocopyTagPrimitive = ___ZerocopyTag::TupleLike
+        as ___ZerocopyTagPrimitive;
+    type ___ZerocopyOuterTag = ___ZerocopyTag;
+    type ___ZerocopyInnerTag = ();
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_StructLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        u8,
+        X,
+        X::Target,
+        Y::Target,
+        [(X, Y); N],
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        enum ẕ5 {}
+        enum ẕ6 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = u8;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = X::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y::Target;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = [(X, Y); N];
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ5,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(5) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).5
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ5,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(5) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ6,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(6) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).6
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ6,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(6) },
+            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyVariantStruct_TupleLike<'a: 'static, const N: usize, X, Y: Deref>(
+        ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+            ___ZerocopyInnerTag,
+        >,
+        bool,
+        Y,
+        PhantomData<&'a [(X, Y); N]>,
+        ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+            ComplexWithGenerics<'a, N, X, Y>,
+        >,
+    )
+    where
+        X: Deref<Target = &'a [(X, Y); N]>;
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ0 {}
+        enum ẕ1 {}
+        enum ẕ2 {}
+        enum ẕ3 {}
+        enum ẕ4 {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                    ___ZerocopyInnerTag,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ0,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(0) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).0
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ0,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(0) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = bool;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ1,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(1) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).1
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ1,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(1) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = Y;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ2,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(2) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).2
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ2,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(2) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = PhantomData<&'a [(X, Y); N]>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ3,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(3) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).3
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ3,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(3) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                    ComplexWithGenerics<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ4,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(4) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).4
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ4,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(4) },
+            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    union ___ZerocopyVariants<'a: 'static, const N: usize, X, Y: Deref> {
+        __field_StructLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+        >,
+        __field_TupleLike: ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+            ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+        >,
+        __nonempty: (),
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕ__field_StructLike {}
+        enum ẕ__field_TupleLike {}
+        enum ẕ__nonempty {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_StructLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_StructLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_StructLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_StructLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_StructLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ::zerocopy::util::macro_util::core_reexport::mem::ManuallyDrop<
+                    ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
+                >;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__field_TupleLike,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__field_TupleLike) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__field_TupleLike
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__field_TupleLike,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__field_TupleLike) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ();
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕ__nonempty,
+                    { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                    { ::zerocopy::ident_id!(__nonempty) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).__nonempty
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕ__nonempty,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(__nonempty) },
+            > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+    };
+    #[repr(C)]
+    struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
+        tag: ___ZerocopyOuterTag,
+        variants: ___ZerocopyVariants<'a, N, X, Y>,
+    }
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        enum ẕtag {}
+        enum ẕvariants {}
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+            for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Tag = ();
+                type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyOuterTag;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕtag,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(tag) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).tag
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕtag,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(tag) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                const N: usize,
+            > ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Type = ___ZerocopyVariants<'a, N, X, Y>;
+                #[inline(always)]
+                fn project(
+                    slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                ) -> *mut <Self as ::zerocopy::HasField<
+                    ::zerocopy::project_clients::ProjectDerive,
+                    ẕvariants,
+                    { ::zerocopy::STRUCT_VARIANT_ID },
+                    { ::zerocopy::ident_id!(variants) },
+                >>::Type {
+                    let slf = slf.as_ptr();
+                    unsafe {
+                        ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                            (* slf).variants
+                        )
+                    }
+                }
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Uninit,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Initialized,
+                );
+            }
+        };
+        #[allow(
+            deprecated,
+            private_bounds,
+            non_local_definitions,
+            non_camel_case_types,
+            non_upper_case_globals,
+            non_snake_case,
+            non_ascii_idents,
+            clippy::missing_inline_in_public_items,
+        )]
+        #[deny(ambiguous_associated_items)]
+        #[automatically_derived]
+        const _: () = {
+            unsafe impl<
+                'a: 'static,
+                X,
+                Y: Deref,
+                ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                const N: usize,
+            > ::zerocopy::ProjectField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕvariants,
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(variants) },
+            > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                type Invariants = (
+                    ___ZcAliasing,
+                    ___ZcAlignment,
+                    ::zerocopy::invariant::Valid,
+                );
+            }
+        };
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ___ZerocopyTag;
+            type ProjectToTag = ::zerocopy::pointer::cast::CastSized;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(a) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(a) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(b) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(b) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = X::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(c) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(c) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y::Target;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(d) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(d) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = [(X, Y); N];
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(StructLike) },
+                { ::zerocopy::ident_id!(e) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_StructLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(StructLike) },
+            { ::zerocopy::ident_id!(e) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::StructLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = bool;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(0) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(0) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = Y;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(1) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(1) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            const N: usize,
+        > ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = PhantomData<&'a [(X, Y); N]>;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                (),
+                { ::zerocopy::ident_id!(TupleLike) },
+                { ::zerocopy::ident_id!(2) },
+            >>::Type {
+                use ::zerocopy::pointer::cast::{CastSized, Projection};
+                slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(variants) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                            { ::zerocopy::ident_id!(__field_TupleLike) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(value) },
+                        >,
+                    >()
+                    .project::<
+                        _,
+                        Projection<
+                            ::zerocopy::project_clients::ProjectDerive,
+                            _,
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        >,
+                    >()
+                    .as_ptr()
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            'a: 'static,
+            X,
+            Y: Deref,
+            ___ZcAliasing: ::zerocopy::invariant::Reference,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+            const N: usize,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            (),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::ident_id!(TupleLike) },
+            { ::zerocopy::ident_id!(2) },
+        > for ComplexWithGenerics<'a, { N }, X, Y>
+        where
+            X: Deref<Target = &'a [(X, Y); N]>,
+        {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ();
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+            #[inline(always)]
+            fn is_projectable(
+                tag: ::zerocopy::pointer::Ptr<
+                    '_,
+                    <Self as ::zerocopy::HasTag<
+                        ::zerocopy::project_clients::ProjectDerive,
+                    >>::Tag,
+                    (
+                        ::zerocopy::invariant::Shared,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    ),
+                >,
+            ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
+                let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                if tag == ___ZerocopyTag::TupleLike {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                } else {
+                    ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                }
+            }
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
@@ -1,0 +1,170 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    enum ẕfield {}
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ();
+            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕfield,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(field) },
+            >>::Type {
+                let slf = slf.as_ptr();
+                unsafe {
+                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                        (* slf).field
+                    )
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
@@ -1,0 +1,169 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    enum ẕfield {}
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasTag<::zerocopy::ProjectDerive> for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ();
+            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasField<
+            ::zerocopy::ProjectDerive,
+            ẕfield,
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::ProjectDerive,
+                ẕfield,
+                { ::zerocopy::STRUCT_VARIANT_ID },
+                { ::zerocopy::ident_id!(field) },
+            >>::Type {
+                let slf = slf.as_ptr();
+                unsafe {
+                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                        (* slf).field
+                    )
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            { ::zerocopy::STRUCT_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Valid,
+            );
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_union_default_repr.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_union_default_repr.expected.rs
@@ -1,0 +1,138 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    enum ẕfield {}
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ();
+            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            { ::zerocopy::UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕfield,
+                { ::zerocopy::UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(field) },
+            >>::Type {
+                let slf = slf.as_ptr();
+                unsafe {
+                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                        (* slf).field
+                    )
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_union_repr_c.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_union_repr_c.expected.rs
@@ -1,0 +1,138 @@
+#[allow(
+    deprecated,
+    private_bounds,
+    non_local_definitions,
+    non_camel_case_types,
+    non_upper_case_globals,
+    non_snake_case,
+    non_ascii_idents,
+    clippy::missing_inline_in_public_items,
+)]
+#[deny(ambiguous_associated_items)]
+#[automatically_derived]
+const _: () = {
+    enum ẕfield {}
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasTag<::zerocopy::project_clients::ProjectDerive>
+        for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Tag = ();
+            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl ::zerocopy::HasField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Type = u8;
+            #[inline(always)]
+            fn project(
+                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+            ) -> *mut <Self as ::zerocopy::HasField<
+                ::zerocopy::project_clients::ProjectDerive,
+                ẕfield,
+                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                { ::zerocopy::ident_id!(field) },
+            >>::Type {
+                let slf = slf.as_ptr();
+                unsafe {
+                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                        (* slf).field
+                    )
+                }
+            }
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Uninit,
+            );
+        }
+    };
+    #[allow(
+        deprecated,
+        private_bounds,
+        non_local_definitions,
+        non_camel_case_types,
+        non_upper_case_globals,
+        non_snake_case,
+        non_ascii_idents,
+        clippy::missing_inline_in_public_items,
+    )]
+    #[deny(ambiguous_associated_items)]
+    #[automatically_derived]
+    const _: () = {
+        unsafe impl<
+            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+        > ::zerocopy::ProjectField<
+            ::zerocopy::project_clients::ProjectDerive,
+            ẕfield,
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+            { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+            { ::zerocopy::ident_id!(field) },
+        > for Foo {
+            fn only_derive_is_allowed_to_implement_this_trait() {}
+            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+            type Invariants = (
+                ___ZcAliasing,
+                ___ZcAlignment,
+                ::zerocopy::invariant::Initialized,
+            );
+        }
+    };
+};

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(u8)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -303,45 +304,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -389,45 +480,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -475,45 +656,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -561,45 +832,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -647,45 +1008,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -733,45 +1184,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -821,45 +1362,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1080,45 +1711,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1166,45 +1887,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1252,45 +2063,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1338,45 +2239,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1426,45 +2417,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1582,6 +2663,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1628,6 +2821,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1653,6 +2958,118 @@ const _: () = {
                                 )
                             }
                         }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
                     }
                 };
             };
@@ -1754,42 +3171,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1834,42 +3327,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1997,13 +3566,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2013,10 +3582,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2116,13 +3784,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2132,10 +3800,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2235,13 +4002,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2251,10 +4018,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2354,13 +4220,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2370,10 +4236,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2473,13 +4438,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2489,10 +4454,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2592,13 +4656,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2608,10 +4672,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2711,13 +4874,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2727,10 +4890,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2830,13 +5092,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2846,10 +5108,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             let tag = {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(u8)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone, PartialEq)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -91,122 +92,13 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    u8: ::zerocopy::TryFromBytes,
-                    X: ::zerocopy::TryFromBytes,
-                    X::Target: ::zerocopy::TryFromBytes,
-                    Y::Target: ::zerocopy::TryFromBytes,
-                    [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5)
-                                    } > ()
-                                );
-                                <[(
-                                    X,
-                                    Y,
-                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(6)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
+                enum ẕ5 {}
+                enum ẕ6 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -220,648 +112,1200 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    enum ẕ5 {}
-                    enum ẕ6 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = u8;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ5,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(5) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = [(X, Y); N];
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).5
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ6,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(6) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).6
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -896,97 +1340,11 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <PhantomData<
-                                    &'a [(X, Y); N],
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -1000,474 +1358,864 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = bool;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = PhantomData<&'a [(X, Y); N]>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -1584,6 +2332,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1630,6 +2454,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1657,22 +2557,88 @@ const _: () = {
                         }
                     }
                 };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
             };
             #[repr(C)]
             struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                 tag: ___ZerocopyOuterTag,
                 variants: ___ZerocopyVariants<'a, N, X, Y>,
             }
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-            for ComplexWithGenerics<'a, N, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {}
             #[allow(
                 deprecated,
                 private_bounds,
@@ -1756,42 +2722,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1836,42 +2878,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1999,13 +3117,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2015,10 +3133,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2118,13 +3338,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2134,10 +3354,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2237,13 +3559,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2253,10 +3575,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2356,13 +3780,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2372,10 +3796,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2475,13 +4001,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2491,10 +4017,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2594,13 +4222,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2610,10 +4238,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2713,13 +4443,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2729,10 +4459,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2832,13 +4664,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2848,92 +4680,221 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
                 }
             };
-            let tag = {
-                let tag_ptr = unsafe {
-                    candidate
-                        .reborrow()
-                        .project_transmute_unchecked::<
-                            _,
-                            ::zerocopy::invariant::Initialized,
-                            ::zerocopy::pointer::cast::CastSized,
-                        >()
-                };
-                tag_ptr
-                    .recall_validity::<_, (_, (_, _))>()
-                    .read::<::zerocopy::BecauseImmutable>()
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
+                }
             };
-            let mut raw_enum = candidate
+            let tag = candidate
+                .reborrow()
                 .cast::<
-                    ::zerocopy::ReadOnly<___ZerocopyRawEnum<'a, N, X, Y>>,
+                    ___ZerocopyTagPrimitive,
                     ::zerocopy::pointer::cast::CastSized,
                     (::zerocopy::pointer::BecauseRead, _),
-                >();
-            let variants = ::zerocopy::into_inner!(
-                raw_enum.project:: < ::zerocopy::project_clients::TryFromBytesDerive, _,
-                { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) } >
-                ()
-            );
+                >()
+                .recall_validity::<_, (_, (_, _))>()
+                .read::<::zerocopy::BecauseImmutable>();
             match tag {
                 ___ZEROCOPY_TAG_UnitLike => true,
                 ___ZEROCOPY_TAG_StructLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_StructLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(a) }, > ()
+                            );
+                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(b) }, > ()
+                            );
+                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(c) }, > ()
+                            );
+                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(d) }, > ()
+                            );
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(e) }, > ()
+                            );
+                            <[(
+                                X,
+                                Y,
+                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_TupleLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(0) }, > ()
+                            );
+                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(1) }, > ()
+                            );
+                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(2) }, > ()
+                            );
+                            <PhantomData<
+                                &'a [(X, Y); N],
+                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                        }
                 }
                 _ => false,
             }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(u32)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -303,45 +304,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -389,45 +480,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -475,45 +656,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -561,45 +832,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -647,45 +1008,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -733,45 +1184,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -821,45 +1362,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1080,45 +1711,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1166,45 +1887,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1252,45 +2063,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1338,45 +2239,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1426,45 +2417,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1582,6 +2663,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1628,6 +2821,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1653,6 +2958,118 @@ const _: () = {
                                 )
                             }
                         }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
                     }
                 };
             };
@@ -1754,42 +3171,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1834,42 +3327,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1997,13 +3566,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2013,10 +3582,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2116,13 +3784,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2132,10 +3800,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2235,13 +4002,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2251,10 +4018,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2354,13 +4220,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2370,10 +4236,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2473,13 +4438,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2489,10 +4454,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2592,13 +4656,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2608,10 +4672,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2711,13 +4874,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2727,10 +4890,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2830,13 +5092,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2846,10 +5108,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             let tag = {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(u32)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone, PartialEq)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -91,122 +92,13 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    u8: ::zerocopy::TryFromBytes,
-                    X: ::zerocopy::TryFromBytes,
-                    X::Target: ::zerocopy::TryFromBytes,
-                    Y::Target: ::zerocopy::TryFromBytes,
-                    [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5)
-                                    } > ()
-                                );
-                                <[(
-                                    X,
-                                    Y,
-                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(6)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
+                enum ẕ5 {}
+                enum ẕ6 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -220,648 +112,1200 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    enum ẕ5 {}
-                    enum ẕ6 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = u8;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ5,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(5) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = [(X, Y); N];
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).5
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ6,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(6) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).6
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -896,97 +1340,11 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <PhantomData<
-                                    &'a [(X, Y); N],
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -1000,474 +1358,864 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = bool;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = PhantomData<&'a [(X, Y); N]>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -1584,6 +2332,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1630,6 +2454,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1657,22 +2557,88 @@ const _: () = {
                         }
                     }
                 };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
             };
             #[repr(C)]
             struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                 tag: ___ZerocopyOuterTag,
                 variants: ___ZerocopyVariants<'a, N, X, Y>,
             }
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-            for ComplexWithGenerics<'a, N, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {}
             #[allow(
                 deprecated,
                 private_bounds,
@@ -1756,42 +2722,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1836,42 +2878,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1999,13 +3117,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2015,10 +3133,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2118,13 +3338,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2134,10 +3354,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2237,13 +3559,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2253,10 +3575,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2356,13 +3780,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2372,10 +3796,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2475,13 +4001,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2491,10 +4017,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2594,13 +4222,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2610,10 +4238,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2713,13 +4443,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2729,10 +4459,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2832,13 +4664,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2848,92 +4680,221 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
                 }
             };
-            let tag = {
-                let tag_ptr = unsafe {
-                    candidate
-                        .reborrow()
-                        .project_transmute_unchecked::<
-                            _,
-                            ::zerocopy::invariant::Initialized,
-                            ::zerocopy::pointer::cast::CastSized,
-                        >()
-                };
-                tag_ptr
-                    .recall_validity::<_, (_, (_, _))>()
-                    .read::<::zerocopy::BecauseImmutable>()
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
+                }
             };
-            let mut raw_enum = candidate
+            let tag = candidate
+                .reborrow()
                 .cast::<
-                    ::zerocopy::ReadOnly<___ZerocopyRawEnum<'a, N, X, Y>>,
+                    ___ZerocopyTagPrimitive,
                     ::zerocopy::pointer::cast::CastSized,
                     (::zerocopy::pointer::BecauseRead, _),
-                >();
-            let variants = ::zerocopy::into_inner!(
-                raw_enum.project:: < ::zerocopy::project_clients::TryFromBytesDerive, _,
-                { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) } >
-                ()
-            );
+                >()
+                .recall_validity::<_, (_, (_, _))>()
+                .read::<::zerocopy::BecauseImmutable>();
             match tag {
                 ___ZEROCOPY_TAG_UnitLike => true,
                 ___ZEROCOPY_TAG_StructLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_StructLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(a) }, > ()
+                            );
+                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(b) }, > ()
+                            );
+                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(c) }, > ()
+                            );
+                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(d) }, > ()
+                            );
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(e) }, > ()
+                            );
+                            <[(
+                                X,
+                                Y,
+                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_TupleLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(0) }, > ()
+                            );
+                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(1) }, > ()
+                            );
+                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(2) }, > ()
+                            );
+                            <PhantomData<
+                                &'a [(X, Y); N],
+                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                        }
                 }
                 _ => false,
             }

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(C)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -303,45 +304,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -389,45 +480,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -475,45 +656,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -561,45 +832,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -647,45 +1008,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -733,45 +1184,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ5,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(5) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -821,45 +1362,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ6,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(6) },
+                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1080,45 +1711,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ0,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(0) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1166,45 +1887,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ1,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(1) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1252,45 +2063,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ2,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(2) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1338,45 +2239,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ3,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(3) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                     #[allow(
                         deprecated,
@@ -1426,45 +2417,135 @@ const _: () = {
                                 }
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Uninit,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Initialized,
+                            );
+                        }
+                    };
+                    #[allow(
+                        deprecated,
+                        private_bounds,
+                        non_local_definitions,
+                        non_camel_case_types,
+                        non_upper_case_globals,
+                        non_snake_case,
+                        non_ascii_idents,
+                        clippy::missing_inline_in_public_items,
+                    )]
+                    #[deny(ambiguous_associated_items)]
+                    #[automatically_derived]
+                    const _: () = {
+                        unsafe impl<
+                            'a: 'static,
+                            X,
+                            Y: Deref,
+                            ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                            ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                            const N: usize,
+                        > ::zerocopy::ProjectField<
+                            ::zerocopy::TryFromBytesDerive,
+                            ẕ4,
+                            (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                            { ::zerocopy::STRUCT_VARIANT_ID },
+                            { ::zerocopy::ident_id!(4) },
+                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                        where
+                            X: Deref<Target = &'a [(X, Y); N]>,
+                        {
+                            fn only_derive_is_allowed_to_implement_this_trait() {}
+                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                            type Invariants = (
+                                ___ZcAliasing,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            );
+                        }
                     };
                 };
             };
@@ -1582,6 +2663,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1628,6 +2821,118 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::TryFromBytesDerive,
@@ -1653,6 +2958,118 @@ const _: () = {
                                 )
                             }
                         }
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
                     }
                 };
             };
@@ -1754,42 +3171,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1834,42 +3327,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1997,13 +3566,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2013,10 +3582,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2116,13 +3784,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2132,10 +3800,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2235,13 +4002,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2251,10 +4018,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2354,13 +4220,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2370,10 +4236,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2473,13 +4438,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2489,10 +4454,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2592,13 +4656,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2608,10 +4672,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2711,13 +4874,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2727,10 +4890,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2830,13 +5092,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2846,10 +5108,109 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::TryFromBytesDerive,
+                            >>::Tag,
+                            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>()
+                            as ___ZerocopyTagPrimitive;
+                        if tag == ___ZEROCOPY_TAG_TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             let tag = {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -34,6 +34,7 @@ const _: () = {
         {
             #[repr(C)]
             #[allow(dead_code)]
+            #[derive(Copy, Clone, PartialEq)]
             pub enum ___ZerocopyTag {
                 UnitLike,
                 StructLike,
@@ -91,122 +92,13 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    u8: ::zerocopy::TryFromBytes,
-                    X: ::zerocopy::TryFromBytes,
-                    X::Target: ::zerocopy::TryFromBytes,
-                    Y::Target: ::zerocopy::TryFromBytes,
-                    [(X, Y); N]: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(5)
-                                    } > ()
-                                );
-                                <[(
-                                    X,
-                                    Y,
-                                ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(6)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
+                enum ẕ5 {}
+                enum ẕ6 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -220,648 +112,1200 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    enum ẕ5 {}
-                    enum ẕ6 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = u8;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = u8;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = X::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = X::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y::Target;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y::Target;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = [(X, Y); N];
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ5,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(5) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = [(X, Y); N];
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).5
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).5
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ5,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(5) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ5,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(5) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ6,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(6) },
-                        > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).6
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).6
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ6,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(6) },
-                            > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ6,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(6) },
+                    > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -896,97 +1340,11 @@ const _: () = {
             #[deny(ambiguous_associated_items)]
             #[automatically_derived]
             const _: () = {
-                unsafe impl<
-                    'a: 'static,
-                    X,
-                    Y: Deref,
-                    const N: usize,
-                > ::zerocopy::TryFromBytes
-                for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                where
-                    X: Deref<Target = &'a [(X, Y); N]>,
-                    ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                        ___ZerocopyInnerTag,
-                    >: ::zerocopy::TryFromBytes,
-                    bool: ::zerocopy::TryFromBytes,
-                    Y: ::zerocopy::TryFromBytes,
-                    PhantomData<&'a [(X, Y); N]>: ::zerocopy::TryFromBytes,
-                    ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                        ComplexWithGenerics<'a, N, X, Y>,
-                    >: ::zerocopy::TryFromBytes,
-                {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                    #[inline]
-                    fn is_bit_valid<___ZcAlignment>(
-                        mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
-                    ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
-                    where
-                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
-                    {
-                        true
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(0)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                    ___ZerocopyInnerTag,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(1)
-                                    } > ()
-                                );
-                                <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(2)
-                                    } > ()
-                                );
-                                <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(3)
-                                    } > ()
-                                );
-                                <PhantomData<
-                                    &'a [(X, Y); N],
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                            && {
-                                let field_candidate = ::zerocopy::into_inner!(
-                                    candidate.reborrow().project:: <
-                                    ::zerocopy::project_clients::TryFromBytesDerive, _, {
-                                    ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(4)
-                                    } > ()
-                                );
-                                <::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                    ComplexWithGenerics<'a, N, X, Y>,
-                                > as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                    field_candidate,
-                                )
-                            }
-                    }
-                }
+                enum ẕ0 {}
+                enum ẕ1 {}
+                enum ẕ2 {}
+                enum ẕ3 {}
+                enum ẕ4 {}
                 #[allow(
                     deprecated,
                     private_bounds,
@@ -1000,474 +1358,864 @@ const _: () = {
                 #[deny(ambiguous_associated_items)]
                 #[automatically_derived]
                 const _: () = {
-                    enum ẕ0 {}
-                    enum ẕ1 {}
-                    enum ẕ2 {}
-                    enum ẕ3 {}
-                    enum ẕ4 {}
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasTag<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Tag = ();
-                            type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
-                        }
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasTag<::zerocopy::project_clients::TryFromBytesDerive>
+                    for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Tag = ();
+                        type ProjectToTag = ::zerocopy::pointer::cast::CastToUnit;
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
+                            ___ZerocopyInnerTag,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ0,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(0) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
-                                ___ZerocopyInnerTag,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).0
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).0
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ0,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(0) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ0,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(0) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = bool;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ1,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(1) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = bool;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).1
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).1
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ1,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(1) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ1,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(1) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = Y;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ2,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(2) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = Y;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).2
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).2
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ2,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(2) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ2,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(2) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = PhantomData<&'a [(X, Y); N]>;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ3,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(3) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = PhantomData<&'a [(X, Y); N]>;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).3
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).3
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ3,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(3) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            const N: usize,
-                        > ::zerocopy::HasField<
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ3,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(3) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        const N: usize,
+                    > ::zerocopy::HasField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
+                            ComplexWithGenerics<'a, N, X, Y>,
+                        >;
+                        #[inline(always)]
+                        fn project(
+                            slf: ::zerocopy::pointer::PtrInner<'_, Self>,
+                        ) -> *mut <Self as ::zerocopy::HasField<
                             ::zerocopy::project_clients::TryFromBytesDerive,
                             ẕ4,
                             { ::zerocopy::STRUCT_VARIANT_ID },
                             { ::zerocopy::ident_id!(4) },
-                        > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                        where
-                            X: Deref<Target = &'a [(X, Y); N]>,
-                        {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Type = ::zerocopy::util::macro_util::core_reexport::marker::PhantomData<
-                                ComplexWithGenerics<'a, N, X, Y>,
-                            >;
-                            #[inline(always)]
-                            fn project(
-                                slf: ::zerocopy::pointer::PtrInner<'_, Self>,
-                            ) -> *mut <Self as ::zerocopy::HasField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            >>::Type {
-                                let slf = slf.as_ptr();
-                                unsafe {
-                                    ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
-                                        (* slf).4
-                                    )
-                                }
+                        >>::Type {
+                            let slf = slf.as_ptr();
+                            unsafe {
+                                ::zerocopy::util::macro_util::core_reexport::ptr::addr_of_mut!(
+                                    (* slf).4
+                                )
                             }
                         }
-                        #[allow(
-                            deprecated,
-                            private_bounds,
-                            non_local_definitions,
-                            non_camel_case_types,
-                            non_upper_case_globals,
-                            non_snake_case,
-                            non_ascii_idents,
-                            clippy::missing_inline_in_public_items,
-                        )]
-                        #[deny(ambiguous_associated_items)]
-                        #[automatically_derived]
-                        const _: () = {
-                            unsafe impl<
-                                'a: 'static,
-                                X,
-                                Y: Deref,
-                                Aliasing: ::zerocopy::invariant::Aliasing,
-                                Alignment: ::zerocopy::invariant::Alignment,
-                                const N: usize,
-                            > ::zerocopy::ProjectField<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                ẕ4,
-                                (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                                { ::zerocopy::STRUCT_VARIANT_ID },
-                                { ::zerocopy::ident_id!(4) },
-                            > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
-                            where
-                                X: Deref<Target = &'a [(X, Y); N]>,
-                            {
-                                fn only_derive_is_allowed_to_implement_this_trait() {}
-                                type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                                type Invariants = (
-                                    Aliasing,
-                                    Alignment,
-                                    ::zerocopy::invariant::Initialized,
-                                );
-                            }
-                        };
-                    };
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ4,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(4) },
+                    > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
+                    where
+                        X: Deref<Target = &'a [(X, Y); N]>,
+                    {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[repr(C)]
@@ -1584,6 +2332,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_StructLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_StructLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1630,6 +2454,82 @@ const _: () = {
                         'a: 'static,
                         X,
                         Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__field_TupleLike,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__field_TupleLike) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
                         const N: usize,
                     > ::zerocopy::HasField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
@@ -1657,22 +2557,88 @@ const _: () = {
                         }
                     }
                 };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕ__nonempty,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::REPR_C_UNION_VARIANT_ID },
+                        { ::zerocopy::ident_id!(__nonempty) },
+                    > for ___ZerocopyVariants<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
             };
             #[repr(C)]
             struct ___ZerocopyRawEnum<'a: 'static, const N: usize, X, Y: Deref> {
                 tag: ___ZerocopyOuterTag,
                 variants: ___ZerocopyVariants<'a, N, X, Y>,
             }
-            unsafe impl<
-                'a: 'static,
-                const N: usize,
-                X,
-                Y: Deref,
-            > ::zerocopy::pointer::InvariantsEq<___ZerocopyRawEnum<'a, N, X, Y>>
-            for ComplexWithGenerics<'a, N, X, Y>
-            where
-                X: Deref<Target = &'a [(X, Y); N]>,
-            {}
             #[allow(
                 deprecated,
                 private_bounds,
@@ -1756,42 +2722,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕtag,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(tag) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕtag,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(tag) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
                 #[allow(
                     deprecated,
@@ -1836,42 +2878,118 @@ const _: () = {
                             }
                         }
                     }
-                    #[allow(
-                        deprecated,
-                        private_bounds,
-                        non_local_definitions,
-                        non_camel_case_types,
-                        non_upper_case_globals,
-                        non_snake_case,
-                        non_ascii_idents,
-                        clippy::missing_inline_in_public_items,
-                    )]
-                    #[deny(ambiguous_associated_items)]
-                    #[automatically_derived]
-                    const _: () = {
-                        unsafe impl<
-                            'a: 'static,
-                            X,
-                            Y: Deref,
-                            Aliasing: ::zerocopy::invariant::Aliasing,
-                            Alignment: ::zerocopy::invariant::Alignment,
-                            const N: usize,
-                        > ::zerocopy::ProjectField<
-                            ::zerocopy::project_clients::TryFromBytesDerive,
-                            ẕvariants,
-                            (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
-                            { ::zerocopy::STRUCT_VARIANT_ID },
-                            { ::zerocopy::ident_id!(variants) },
-                        > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
-                            fn only_derive_is_allowed_to_implement_this_trait() {}
-                            type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
-                            type Invariants = (
-                                Aliasing,
-                                Alignment,
-                                ::zerocopy::invariant::Initialized,
-                            );
-                        }
-                    };
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Uninit,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        ),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Initialized,
+                        );
+                    }
+                };
+                #[allow(
+                    deprecated,
+                    private_bounds,
+                    non_local_definitions,
+                    non_camel_case_types,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    non_ascii_idents,
+                    clippy::missing_inline_in_public_items,
+                )]
+                #[deny(ambiguous_associated_items)]
+                #[automatically_derived]
+                const _: () = {
+                    unsafe impl<
+                        'a: 'static,
+                        X,
+                        Y: Deref,
+                        ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                        ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                        const N: usize,
+                    > ::zerocopy::ProjectField<
+                        ::zerocopy::project_clients::TryFromBytesDerive,
+                        ẕvariants,
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        { ::zerocopy::STRUCT_VARIANT_ID },
+                        { ::zerocopy::ident_id!(variants) },
+                    > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
+                        fn only_derive_is_allowed_to_implement_this_trait() {}
+                        type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                        type Invariants = (
+                            ___ZcAliasing,
+                            ___ZcAlignment,
+                            ::zerocopy::invariant::Valid,
+                        );
+                    }
                 };
             };
             #[allow(
@@ -1999,13 +3117,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2015,10 +3133,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(a) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2118,13 +3338,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2134,10 +3354,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(b) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2237,13 +3559,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2253,10 +3575,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(c) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2356,13 +3780,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2372,10 +3796,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(d) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2475,13 +4001,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2491,10 +4017,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(StructLike) },
+                    { ::zerocopy::ident_id!(e) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::StructLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2594,13 +4222,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2610,10 +4238,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(0) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2713,13 +4443,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2729,10 +4459,112 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(1) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
                 }
             };
             #[allow(
@@ -2832,13 +4664,13 @@ const _: () = {
                     'a: 'static,
                     X,
                     Y: Deref,
-                    Aliasing: ::zerocopy::invariant::Aliasing,
-                    Alignment: ::zerocopy::invariant::Alignment,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
                     const N: usize,
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (Aliasing, Alignment, ::zerocopy::invariant::Initialized),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Uninit),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -2848,92 +4680,221 @@ const _: () = {
                     fn only_derive_is_allowed_to_implement_this_trait() {}
                     type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
                     type Invariants = (
-                        Aliasing,
-                        Alignment,
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Uninit,
+                    );
+                }
+            };
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Aliasing,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Initialized),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ::zerocopy::util::macro_util::core_reexport::convert::Infallible;
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
                         ::zerocopy::invariant::Initialized,
                     );
                 }
             };
-            let tag = {
-                let tag_ptr = unsafe {
-                    candidate
-                        .reborrow()
-                        .project_transmute_unchecked::<
-                            _,
-                            ::zerocopy::invariant::Initialized,
-                            ::zerocopy::pointer::cast::CastSized,
-                        >()
-                };
-                tag_ptr
-                    .recall_validity::<_, (_, (_, _))>()
-                    .read::<::zerocopy::BecauseImmutable>()
+            #[allow(
+                deprecated,
+                private_bounds,
+                non_local_definitions,
+                non_camel_case_types,
+                non_upper_case_globals,
+                non_snake_case,
+                non_ascii_idents,
+                clippy::missing_inline_in_public_items,
+            )]
+            #[deny(ambiguous_associated_items)]
+            #[automatically_derived]
+            const _: () = {
+                unsafe impl<
+                    'a: 'static,
+                    X,
+                    Y: Deref,
+                    ___ZcAliasing: ::zerocopy::invariant::Reference,
+                    ___ZcAlignment: ::zerocopy::invariant::Alignment,
+                    const N: usize,
+                > ::zerocopy::ProjectField<
+                    ::zerocopy::project_clients::TryFromBytesDerive,
+                    (),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    { ::zerocopy::ident_id!(TupleLike) },
+                    { ::zerocopy::ident_id!(2) },
+                > for ComplexWithGenerics<'a, { N }, X, Y>
+                where
+                    X: Deref<Target = &'a [(X, Y); N]>,
+                {
+                    fn only_derive_is_allowed_to_implement_this_trait() {}
+                    type Error = ();
+                    type Invariants = (
+                        ___ZcAliasing,
+                        ___ZcAlignment,
+                        ::zerocopy::invariant::Valid,
+                    );
+                    #[inline(always)]
+                    fn is_projectable(
+                        tag: ::zerocopy::pointer::Ptr<
+                            '_,
+                            <Self as ::zerocopy::HasTag<
+                                ::zerocopy::project_clients::TryFromBytesDerive,
+                            >>::Tag,
+                            (
+                                ::zerocopy::invariant::Shared,
+                                ___ZcAlignment,
+                                ::zerocopy::invariant::Valid,
+                            ),
+                        >,
+                    ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
+                        (),
+                        (),
+                    > {
+                        let tag = tag.read::<::zerocopy::BecauseImmutable>();
+                        if tag == ___ZerocopyTag::TupleLike {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Ok(())
+                        } else {
+                            ::zerocopy::util::macro_util::core_reexport::result::Result::Err(())
+                        }
+                    }
+                }
             };
-            let mut raw_enum = candidate
+            let tag = candidate
+                .reborrow()
                 .cast::<
-                    ::zerocopy::ReadOnly<___ZerocopyRawEnum<'a, N, X, Y>>,
+                    ___ZerocopyTagPrimitive,
                     ::zerocopy::pointer::cast::CastSized,
                     (::zerocopy::pointer::BecauseRead, _),
-                >();
-            let variants = ::zerocopy::into_inner!(
-                raw_enum.project:: < ::zerocopy::project_clients::TryFromBytesDerive, _,
-                { ::zerocopy::STRUCT_VARIANT_ID }, { ::zerocopy::ident_id!(variants) } >
-                ()
-            );
+                >()
+                .recall_validity::<_, (_, (_, _))>()
+                .read::<::zerocopy::BecauseImmutable>();
             match tag {
                 ___ZEROCOPY_TAG_UnitLike => true,
                 ___ZEROCOPY_TAG_StructLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_StructLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_StructLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_StructLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(a) }, > ()
+                            );
+                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(b) }, > ()
+                            );
+                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(c) }, > ()
+                            );
+                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(d) }, > ()
+                            );
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(StructLike) }, {
+                                ::zerocopy::ident_id!(e) }, > ()
+                            );
+                            <[(
+                                X,
+                                Y,
+                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
-                    let variant_md = variants
-                        .cast::<
-                            _,
-                            ::zerocopy::pointer::cast::Projection<
-                                ::zerocopy::project_clients::TryFromBytesDerive,
-                                _,
-                                { ::zerocopy::REPR_C_UNION_VARIANT_ID },
-                                { ::zerocopy::ident_id!(__field_TupleLike) },
-                            >,
-                            _,
-                        >();
-                    let variant = variant_md
-                        .cast::<
-                            ::zerocopy::ReadOnly<
-                                ___ZerocopyVariantStruct_TupleLike<'a, N, X, Y>,
-                            >,
-                            ::zerocopy::pointer::cast::CastSized,
-                            (::zerocopy::pointer::BecauseRead, _),
-                        >();
-                    <___ZerocopyVariantStruct_TupleLike<
-                        'a,
-                        N,
-                        X,
-                        Y,
-                    > as ::zerocopy::TryFromBytes>::is_bit_valid(variant)
+                    true
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(0) }, > ()
+                            );
+                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(1) }, > ()
+                            );
+                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
+                                field_candidate,
+                            )
+                        }
+                        && {
+                            let field_candidate = ::zerocopy::into_inner!(
+                                candidate.reborrow().project:: <
+                                ::zerocopy::project_clients::TryFromBytesDerive, _, {
+                                ::zerocopy::ident_id!(TupleLike) }, {
+                                ::zerocopy::ident_id!(2) }, > ()
+                            );
+                            <PhantomData<
+                                &'a [(X, Y); N],
+                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                        }
                 }
                 _ => false,
             }

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -24,6 +24,7 @@ macro_rules! use_as_trait_name {
 use_as_trait_name!(
     KnownLayout => super::derive::known_layout::derive,
     Immutable => super::derive::derive_immutable,
+    Project => super::derive::project::derive,
     TryFromBytes => super::derive::try_from_bytes::derive_try_from_bytes,
     FromZeros => super::derive::from_bytes::derive_from_zeros,
     FromBytes => super::derive::from_bytes::derive_from_bytes,
@@ -155,6 +156,26 @@ fn test_immutable() {
         Immutable {
             struct Foo;
         } expands to "expected/immutable.expected.rs"
+    }
+}
+
+#[test]
+fn test_project_empty_struct() {
+    test! {
+        Project {
+            struct Foo;
+        } expands to {}
+    }
+}
+
+#[test]
+fn test_project_struct() {
+    test! {
+        Project {
+            struct Foo {
+                field: u8,
+            }
+        } expands to "expected/project_struct.expected.rs"
     }
 }
 

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -24,6 +24,7 @@ macro_rules! use_as_trait_name {
 use_as_trait_name!(
     KnownLayout => super::derive::known_layout::derive,
     Immutable => super::derive::derive_immutable,
+    Project => super::derive::project::derive,
     TryFromBytes => super::derive::try_from_bytes::derive_try_from_bytes,
     FromZeros => super::derive::from_bytes::derive_from_zeros,
     FromBytes => super::derive::from_bytes::derive_from_bytes,
@@ -157,6 +158,91 @@ fn test_immutable() {
         Immutable {
             struct Foo;
         } expands to "expected/immutable.expected.rs"
+    }
+}
+
+#[test]
+fn test_project_empty_struct() {
+    test! {
+        Project {
+            struct Foo;
+        } expands to {}
+    }
+}
+
+#[test]
+fn test_project_struct() {
+    test! {
+        Project {
+            struct Foo {
+                field: u8,
+            }
+        } expands to "expected/project_struct.expected.rs"
+    }
+}
+
+#[test]
+fn test_project_enum() {
+    test! {
+        Project {
+            #[repr(u8)]
+            enum ComplexWithGenerics<'a: 'static, const N: usize, X, Y: Deref>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                UnitLike,
+                StructLike { a: u8, b: X, c: X::Target, d: Y::Target, e: [(X, Y); N] },
+                TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
+            }
+        } expands to "expected/project_enum_1.expected.rs"
+    }
+
+    test! {
+        Project {
+            #[repr(u32)]
+            enum ComplexWithGenerics<'a: 'static, const N: usize, X, Y: Deref>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                UnitLike,
+                StructLike { a: u8, b: X, c: X::Target, d: Y::Target, e: [(X, Y); N] },
+                TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
+            }
+        } expands to "expected/project_enum_2.expected.rs"
+    }
+
+    test! {
+        Project {
+            #[repr(C)]
+            enum ComplexWithGenerics<'a: 'static, const N: usize, X, Y: Deref>
+            where
+                X: Deref<Target = &'a [(X, Y); N]>,
+            {
+                UnitLike,
+                StructLike { a: u8, b: X, c: X::Target, d: Y::Target, e: [(X, Y); N] },
+                TupleLike(bool, Y, PhantomData<&'a [(X, Y); N]>),
+            }
+        } expands to "expected/project_enum_3.expected.rs"
+    }
+}
+
+#[test]
+fn test_project_union() {
+    test! {
+        Project {
+            #[repr(C)]
+            union Foo {
+                field: u8,
+            }
+        } expands to "expected/project_union_repr_c.expected.rs"
+    }
+
+    test! {
+        Project {
+            union Foo {
+                field: u8,
+            }
+        } expands to "expected/project_union_default_repr.expected.rs"
     }
 }
 

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -298,14 +298,16 @@ impl PaddingCheck {
     }
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub(crate) enum Client {
+    ProjectDerive,
     TryFromBytesDerive,
 }
 
 impl ToTokens for Client {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let s = match self {
+            Client::ProjectDerive => "ProjectDerive",
             Client::TryFromBytesDerive => "TryFromBytesDerive",
         };
         let ident = Ident::new(s, Span::call_site());
@@ -340,6 +342,7 @@ pub(crate) enum Trait {
         invariants: Box<Type>,
     },
     Immutable,
+    Project,
     TryFromBytes,
     FromZeros,
     FromBytes,
@@ -368,6 +371,7 @@ impl ToTokens for Trait {
             Trait::KnownLayout => "KnownLayout",
             Trait::HasTag { .. } => "HasTag",
             Trait::Immutable => "Immutable",
+            Trait::Project => "Project",
             Trait::TryFromBytes => "TryFromBytes",
             Trait::FromZeros => "FromZeros",
             Trait::FromBytes => "FromBytes",
@@ -389,6 +393,7 @@ impl ToTokens for Trait {
             }
             Trait::KnownLayout
             | Trait::Immutable
+            | Trait::Project
             | Trait::TryFromBytes
             | Trait::FromZeros
             | Trait::FromBytes
@@ -825,6 +830,7 @@ pub(crate) fn generate_tag_enum(ctx: &Ctx, repr: &EnumRepr, data: &DataEnum) -> 
     quote! {
         #repr
         #[allow(dead_code)]
+        #[derive(Copy, Clone)]
         pub enum ___ZerocopyTag {
             #(#variants,)*
         }

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -376,14 +376,16 @@ impl PaddingCheck {
     }
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub(crate) enum Client {
+    ProjectDerive,
     TryFromBytesDerive,
 }
 
 impl ToTokens for Client {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let s = match self {
+            Client::ProjectDerive => "ProjectDerive",
             Client::TryFromBytesDerive => "TryFromBytesDerive",
         };
         let ident = Ident::new(s, Span::call_site());
@@ -398,26 +400,22 @@ impl Client {
     }
 }
 
+/// Bundles the trait parameters for `HasField` and `ProjectField`.
+#[derive(Clone)]
+pub(crate) struct FieldProjection {
+    pub(crate) variant_id: Box<Expr>,
+    pub(crate) field: Box<Type>,
+    pub(crate) field_id: Box<Expr>,
+}
+
 #[derive(Clone)]
 pub(crate) enum Trait {
     KnownLayout,
-    HasTag {
-        client: Client,
-    },
-    HasField {
-        client: Client,
-        variant_id: Box<Expr>,
-        field: Box<Type>,
-        field_id: Box<Expr>,
-    },
-    ProjectField {
-        client: Client,
-        variant_id: Box<Expr>,
-        field: Box<Type>,
-        field_id: Box<Expr>,
-        invariants: Box<Type>,
-    },
+    HasTag { client: Client },
+    HasField { client: Client, projection: FieldProjection },
+    ProjectField { client: Client, projection: FieldProjection, invariants: Box<Type> },
     Immutable,
+    Project,
     TryFromBytes,
     FromZeros,
     FromBytes,
@@ -446,6 +444,7 @@ impl ToTokens for Trait {
             Trait::KnownLayout => "KnownLayout",
             Trait::HasTag { .. } => "HasTag",
             Trait::Immutable => "Immutable",
+            Trait::Project => "Project",
             Trait::TryFromBytes => "TryFromBytes",
             Trait::FromZeros => "FromZeros",
             Trait::FromBytes => "FromBytes",
@@ -459,14 +458,17 @@ impl ToTokens for Trait {
         let ident = Ident::new(s, Span::call_site());
         let arguments: Option<syn::AngleBracketedGenericArguments> = match self {
             Trait::HasTag { client } => Some(parse_quote!(<#client>)),
-            Trait::HasField { client, variant_id, field, field_id } => {
+            Trait::HasField { client, projection } => {
+                let FieldProjection { variant_id, field, field_id } = projection;
                 Some(parse_quote!(<#client, #field, #variant_id, #field_id>))
             }
-            Trait::ProjectField { client, variant_id, field, field_id, invariants } => {
+            Trait::ProjectField { client, projection, invariants } => {
+                let FieldProjection { variant_id, field, field_id } = projection;
                 Some(parse_quote!(<#client, #field, #invariants, #variant_id, #field_id>))
             }
             Trait::KnownLayout
             | Trait::Immutable
+            | Trait::Project
             | Trait::TryFromBytes
             | Trait::FromZeros
             | Trait::FromBytes
@@ -491,11 +493,13 @@ impl Trait {
                 let client = client.crate_path(ctx);
                 parse_quote!(#zerocopy_crate::HasTag<#client>)
             }
-            Self::HasField { client, variant_id, field, field_id } => {
+            Self::HasField { client, projection } => {
+                let FieldProjection { variant_id, field, field_id } = projection;
                 let client = client.crate_path(ctx);
                 parse_quote!(#zerocopy_crate::HasField<#client, #field, #variant_id, #field_id>)
             }
-            Self::ProjectField { client, variant_id, field, field_id, invariants } => {
+            Self::ProjectField { client, projection, invariants } => {
+                let FieldProjection { variant_id, field, field_id } = projection;
                 let client = client.crate_path(ctx);
                 parse_quote!(
                     #zerocopy_crate::ProjectField<
@@ -903,6 +907,7 @@ pub(crate) fn generate_tag_enum(ctx: &Ctx, repr: &EnumRepr, data: &DataEnum) -> 
     quote! {
         #repr
         #[allow(dead_code)]
+        #[derive(Copy, Clone, PartialEq)]
         pub enum ___ZerocopyTag {
             #(#variants,)*
         }

--- a/zerocopy/zerocopy-derive/tests/project.rs
+++ b/zerocopy/zerocopy-derive/tests/project.rs
@@ -1,0 +1,359 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://opensource.org/licenses/MIT>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+type SharedAligned<V> = (imp::invariant::Shared, imp::invariant::Aligned, V);
+type SharedUnaligned<V> = (imp::invariant::Shared, imp::invariant::Unaligned, V);
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Named {
+    byte: u8,
+    word: u16,
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Tuple(u8, u16);
+
+#[test]
+fn struct_fields() {
+    let named = Named { byte: 1, word: 0x0203 };
+    let word: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&named)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
+    imp::assert_eq!(*word.unwrap().as_ref(), 0x0203);
+
+    let tuple = Tuple(4, 0x0506);
+    let field: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&tuple)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(1) }>();
+    imp::assert_eq!(*field.unwrap().as_ref(), 0x0506);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct NoPadding {
+    first: u8,
+    second: u8,
+}
+
+#[test]
+fn struct_validity_is_preserved() {
+    let value = NoPadding { first: 7, second: 8 };
+
+    // SAFETY: `Uninit` permits every bit pattern.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert!(projected.is_ok());
+
+    // SAFETY: `NoPadding` consists of two `u8` fields and has no padding, so
+    // all of its bytes are initialized.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert!(projected.is_ok());
+
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 8);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, packed)]
+struct Packed {
+    byte: u8,
+    word: u32,
+}
+
+#[test]
+fn packed_struct_loses_alignment() {
+    let value = Packed { byte: 1, word: 0x0203_0405 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u32, SharedUnaligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
+    imp::assert_eq!(projected.unwrap().read::<imp::BecauseImmutable>(), 0x0203_0405);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct Unsized<T: ?imp::Sized> {
+    head: u8,
+    tail: T,
+}
+
+fn project_unsized_tail(
+    value: imp::Ptr<'_, Unsized<[u8]>, SharedAligned<imp::invariant::Valid>>,
+) -> imp::core::result::Result<
+    imp::Ptr<'_, [u8], SharedAligned<imp::invariant::Valid>>,
+    imp::core::convert::Infallible,
+> {
+    value.project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(tail) }>()
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+union Union {
+    unsigned: u32,
+    signed: i32,
+}
+
+#[test]
+fn union_uninit_and_initialized() {
+    let value = Union { unsigned: 0x0102_0304 };
+
+    // SAFETY: `Uninit` permits every bit pattern.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, i32, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit
+        .project::<imp::ProjectDerive, _, { imp::UNION_VARIANT_ID }, { imp::ident_id!(signed) }>();
+    imp::assert!(projected.is_ok());
+
+    // SAFETY: `value` was initialized through its `u32` field, which occupies
+    // every byte of this union.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, i32, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::ProjectDerive, _, { imp::UNION_VARIANT_ID }, { imp::ident_id!(signed) }>();
+    imp::assert!(projected.is_ok());
+
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, i32, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::UNION_VARIANT_ID }, { imp::ident_id!(signed) }>();
+    imp::assert!(projected.is_ok());
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+enum Fieldless {
+    A,
+    B,
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+enum CEnum {
+    Number(u32),
+    Flag { value: u16 },
+}
+
+#[test]
+fn repr_c_enum_checks_its_tag() {
+    let value = CEnum::Flag { value: 0x1234 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(Flag) }, { imp::ident_id!(value) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 0x1234);
+
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u32, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(Number) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_err());
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum U8Enum {
+    A(u8),
+    B(u8),
+}
+
+#[test]
+fn repr_u8_enum_validity_and_tag_checks() {
+    let value = U8Enum::A(11);
+
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(A) }, { imp::ident_id!(0) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 11);
+
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_err());
+
+    // SAFETY: `Uninit` permits every bit pattern. Unlike a `Valid`
+    // projection, this projection must not inspect the tag.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit.project::<imp::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_ok());
+
+    imp::assert_eq!(imp::core::mem::size_of::<U8Enum>(), 2);
+    // SAFETY: The primitive tag and the `A` variant's `u8` field occupy both
+    // bytes of `value`, with no padding.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_ok());
+}
+
+// Projection must not add zerocopy trait bounds to field types.
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Generic<T, U> {
+    first: T,
+    second: U,
+}
+
+#[test]
+fn generic_fields_need_no_zerocopy_bounds() {
+    let value = Generic { first: util::NotZerocopy(1u8), second: util::NotZerocopy(0x0203u16) };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert_eq!(projected.unwrap().as_ref().0, 0x0203);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum GenericEnum<'a, T, const N: usize> {
+    Borrowed(&'a T),
+    Array([T; N]),
+}
+
+#[test]
+fn generic_enum_fields_need_no_zerocopy_bounds() {
+    let inner = util::NotZerocopy(0x1234u16);
+    let value: GenericEnum<'_, util::NotZerocopy<u16>, 2> = GenericEnum::Borrowed(&inner);
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, &util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(Borrowed) }, { imp::ident_id!(0) }>();
+    imp::assert_eq!((**projected.unwrap().as_ref()).0, 0x1234);
+}
+
+mod visibility {
+    #[derive(super::imp::Project)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    pub struct Public {
+        pub field: u16,
+        private: u8,
+    }
+
+    pub fn new() -> Public {
+        Public { field: 0x1234, private: 0 }
+    }
+}
+
+#[test]
+fn public_marker_is_inferred_across_module_boundary() {
+    let value = visibility::new();
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 0x1234);
+}
+
+#[derive(imp::Project, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct ProjectThenTryFromBytes {
+    field: u8,
+}
+
+#[derive(imp::TryFromBytes, imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+union TryFromBytesThenProject {
+    field: u8,
+}
+
+#[derive(imp::Project, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ProjectAndTryFromBytes {
+    A(u8),
+    B { field: bool },
+}
+
+fn assert_try_from_bytes<T: imp::TryFromBytes>() {}
+
+#[test]
+fn project_and_try_from_bytes_impls_coexist() {
+    assert_try_from_bytes::<ProjectThenTryFromBytes>();
+    assert_try_from_bytes::<TryFromBytesThenProject>();
+    assert_try_from_bytes::<ProjectAndTryFromBytes>();
+
+    let value = ProjectThenTryFromBytes { field: 42 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 42);
+
+    let value = TryFromBytesThenProject { field: 43 };
+    // SAFETY: `Uninit` permits every bit pattern.
+    let value = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = value
+        .project::<imp::ProjectDerive, _, { imp::UNION_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert!(projected.is_ok());
+
+    let value = ProjectAndTryFromBytes::B { field: true };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, bool, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(field) }>();
+    imp::assert!(*projected.unwrap().as_ref());
+}

--- a/zerocopy/zerocopy-derive/tests/project.rs
+++ b/zerocopy/zerocopy-derive/tests/project.rs
@@ -1,0 +1,352 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://opensource.org/licenses/MIT>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+type SharedAligned<V> = (imp::invariant::Shared, imp::invariant::Aligned, V);
+type SharedUnaligned<V> = (imp::invariant::Shared, imp::invariant::Unaligned, V);
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Named {
+    byte: u8,
+    word: u16,
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Tuple(u8, u16);
+
+#[test]
+fn struct_fields() {
+    let named = Named { byte: 1, word: 0x0203 };
+    let word: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&named)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
+    imp::assert_eq!(*word.unwrap().as_ref(), 0x0203);
+
+    let tuple = Tuple(4, 0x0506);
+    let field: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&tuple)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(1) }>();
+    imp::assert_eq!(*field.unwrap().as_ref(), 0x0506);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct NoPadding {
+    first: u8,
+    second: u8,
+}
+
+#[test]
+fn struct_validity_is_preserved() {
+    let value = NoPadding { first: 7, second: 8 };
+
+    // SAFETY: `Uninit` permits every bit pattern.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert!(projected.is_ok());
+
+    // SAFETY: `NoPadding` consists of two `u8` fields and has no padding, so
+    // all of its bytes are initialized.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert!(projected.is_ok());
+
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 8);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, packed)]
+struct Packed {
+    byte: u8,
+    word: u32,
+}
+
+#[test]
+fn packed_struct_loses_alignment() {
+    let value = Packed { byte: 1, word: 0x0203_0405 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u32, SharedUnaligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
+    imp::assert_eq!(projected.unwrap().read::<imp::BecauseImmutable>(), 0x0203_0405);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct Unsized<T: ?imp::Sized> {
+    head: u8,
+    tail: T,
+}
+
+fn project_unsized_tail(
+    value: imp::Ptr<'_, Unsized<[u8]>, SharedAligned<imp::invariant::Valid>>,
+) -> imp::core::result::Result<
+    imp::Ptr<'_, [u8], SharedAligned<imp::invariant::Valid>>,
+    imp::core::convert::Infallible,
+> {
+    value.project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(tail) }>()
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+union Union {
+    unsigned: u32,
+    signed: i32,
+}
+
+#[test]
+fn union_uninit_and_initialized() {
+    let value = Union { unsigned: 0x0102_0304 };
+
+    // SAFETY: `Uninit` permits every bit pattern.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, i32, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit
+        .project::<imp::project_clients::ProjectDerive, _, { imp::REPR_C_UNION_VARIANT_ID }, { imp::ident_id!(signed) }>();
+    imp::assert!(projected.is_ok());
+
+    // SAFETY: `value` was initialized through its `u32` field, which occupies
+    // every byte of this union.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, i32, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::project_clients::ProjectDerive, _, { imp::REPR_C_UNION_VARIANT_ID }, { imp::ident_id!(signed) }>();
+    imp::assert!(projected.is_ok());
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+enum Fieldless {
+    A,
+    B,
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+enum CEnum {
+    Number(u32),
+    Flag { value: u16 },
+}
+
+#[test]
+fn repr_c_enum_checks_its_tag() {
+    let value = CEnum::Flag { value: 0x1234 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Flag) }, { imp::ident_id!(value) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 0x1234);
+
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u32, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Number) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_err());
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum U8Enum {
+    A(u8),
+    B(u8),
+}
+
+#[test]
+fn repr_u8_enum_validity_and_tag_checks() {
+    let value = U8Enum::A(11);
+
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(A) }, { imp::ident_id!(0) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 11);
+
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_err());
+
+    // SAFETY: `Uninit` permits every bit pattern. Unlike a `Valid`
+    // projection, this projection must not inspect the tag.
+    let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = uninit.project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_ok());
+
+    imp::assert_eq!(imp::core::mem::size_of::<U8Enum>(), 2);
+    // SAFETY: The primitive tag and the `A` variant's `u8` field occupy both
+    // bytes of `value`, with no padding.
+    let initialized = unsafe { imp::Ptr::from_ref(&value).assume_initialized() };
+    let wrong_variant: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Initialized>>,
+        imp::core::convert::Infallible,
+    > = initialized
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
+    imp::assert!(wrong_variant.is_ok());
+}
+
+// Projection must not add zerocopy trait bounds to field types.
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct Generic<T, U> {
+    first: T,
+    second: U,
+}
+
+#[test]
+fn generic_fields_need_no_zerocopy_bounds() {
+    let value = Generic { first: util::NotZerocopy(1u8), second: util::NotZerocopy(0x0203u16) };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
+    imp::assert_eq!(projected.unwrap().as_ref().0, 0x0203);
+}
+
+#[derive(imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum GenericEnum<'a, T, const N: usize> {
+    Borrowed(&'a T),
+    Array([T; N]),
+}
+
+#[test]
+fn generic_enum_fields_need_no_zerocopy_bounds() {
+    let inner = util::NotZerocopy(0x1234u16);
+    let value: GenericEnum<'_, util::NotZerocopy<u16>, 2> = GenericEnum::Borrowed(&inner);
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, &util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Borrowed) }, { imp::ident_id!(0) }>();
+    imp::assert_eq!((**projected.unwrap().as_ref()).0, 0x1234);
+}
+
+mod visibility {
+    #[derive(super::imp::Project)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    pub struct Public {
+        pub field: u16,
+        private: u8,
+    }
+
+    pub fn new() -> Public {
+        Public { field: 0x1234, private: 0 }
+    }
+}
+
+#[test]
+fn public_marker_is_inferred_across_module_boundary() {
+    let value = visibility::new();
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 0x1234);
+}
+
+#[derive(imp::Project, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct ProjectThenTryFromBytes {
+    field: u8,
+}
+
+#[derive(imp::TryFromBytes, imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+union TryFromBytesThenProject {
+    field: u8,
+}
+
+#[derive(imp::Project, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ProjectAndTryFromBytes {
+    A(u8),
+    B { field: bool },
+}
+
+fn assert_try_from_bytes<T: imp::TryFromBytes>() {}
+
+#[test]
+fn project_and_try_from_bytes_impls_coexist() {
+    assert_try_from_bytes::<ProjectThenTryFromBytes>();
+    assert_try_from_bytes::<TryFromBytesThenProject>();
+    assert_try_from_bytes::<ProjectAndTryFromBytes>();
+
+    let value = ProjectThenTryFromBytes { field: 42 };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::core::convert::Infallible,
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert_eq!(*projected.unwrap().as_ref(), 42);
+
+    let value = TryFromBytesThenProject { field: 43 };
+    // SAFETY: `Uninit` permits every bit pattern.
+    let value = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
+        imp::core::convert::Infallible,
+    > = value
+        .project::<imp::project_clients::ProjectDerive, _, { imp::REPR_C_UNION_VARIANT_ID }, { imp::ident_id!(field) }>();
+    imp::assert!(projected.is_ok());
+
+    let value = ProjectAndTryFromBytes::B { field: true };
+    let projected: imp::core::result::Result<
+        imp::Ptr<'_, bool, SharedAligned<imp::invariant::Valid>>,
+        (),
+    > = imp::Ptr::from_ref(&value)
+        .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(field) }>();
+    imp::assert!(*projected.unwrap().as_ref());
+}

--- a/zerocopy/zerocopy-derive/tests/project_enum.rs
+++ b/zerocopy/zerocopy-derive/tests/project_enum.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in compliance with those licenses.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+// In the `repr(C)` layout, the tag precedes a union of variant payloads. In the
+// primitive layout, the tag is instead the first field of each variant payload.
+// The differently-aligned fields below ensure that confusing those layouts
+// would project to the wrong offsets.
+#[derive(Clone, Copy, imp::KnownLayout, imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+enum ReprC {
+    UnitLike,
+    TupleLike(u8, u16),
+    StructLike { a: u8, b: u16 },
+}
+
+#[derive(Clone, Copy, imp::KnownLayout, imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ReprU8 {
+    UnitLike,
+    TupleLike(u8, u16),
+    StructLike { a: u8, b: u16 },
+}
+
+// Rustfmt repeatedly indents multiline generic method calls inside this macro.
+// The false `cfg` hides its tool attribute from rustc while rustfmt honors it.
+#[cfg_attr(any(), rustfmt::skip)]
+macro_rules! test_enum {
+    ($module:ident, $ty:ident) => {
+        mod $module {
+            use super::imp;
+
+            type Enum = super::$ty;
+
+            const TUPLE_BYTE: u8 = 0x12;
+            const TUPLE_WORD: u16 = 0x3456;
+            const STRUCT_BYTE: u8 = 0x78;
+            const STRUCT_WORD: u16 = 0x9ABC;
+
+            #[test]
+            fn tag() {
+                let read_tag = |value: &Enum| {
+                    imp::Ptr::from_ref(value)
+                        .project_tag::<imp::project_clients::ProjectDerive>()
+                        .read::<imp::BecauseImmutable>()
+                        as isize
+                };
+
+                let unit_tag = read_tag(&Enum::UnitLike);
+                let tuple_tag = read_tag(&Enum::TupleLike(0, 0));
+                let struct_tag = read_tag(&Enum::StructLike { a: 0, b: 0 });
+
+                imp::assert_eq!(unit_tag, 0);
+                imp::assert_eq!(tuple_tag, 1);
+                imp::assert_eq!(struct_tag, 2);
+            }
+
+            #[test]
+            fn uninit() {
+                let mut storage = imp::MaybeUninit::<Enum>::uninit();
+                let mut ptr = imp::Ptr::from_mut(&mut storage)
+                    .transmute::<Enum, imp::invariant::Uninit, _>()
+                    .try_into_aligned()
+                    .unwrap();
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(0) },
+                    >()
+                    .unwrap()
+                    .transmute::<
+                        imp::MaybeUninit<u8>,
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .bikeshed_recall_aligned()
+                    .as_mut()
+                    .write(TUPLE_BYTE);
+                imp::assert_eq!(*field, TUPLE_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(1) },
+                    >()
+                    .unwrap()
+                    .transmute::<
+                        imp::MaybeUninit<u16>,
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .try_into_aligned()
+                    .unwrap()
+                    .as_mut()
+                    .write(TUPLE_WORD);
+                imp::assert_eq!(*field, TUPLE_WORD);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(a) },
+                    >()
+                    .unwrap()
+                    .transmute::<
+                        imp::MaybeUninit<u8>,
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .bikeshed_recall_aligned()
+                    .as_mut()
+                    .write(STRUCT_BYTE);
+                imp::assert_eq!(*field, STRUCT_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(b) },
+                    >()
+                    .unwrap()
+                    .transmute::<
+                        imp::MaybeUninit<u16>,
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .try_into_aligned()
+                    .unwrap()
+                    .as_mut()
+                    .write(STRUCT_WORD);
+                imp::assert_eq!(*field, STRUCT_WORD);
+
+                // A `MaybeUninit<Enum>` is the strictest type through which all
+                // bytes of an `Uninit` `Ptr<Enum>` may be read.
+                let _: imp::MaybeUninit<Enum> = *ptr
+                    .transmute::<
+                        imp::MaybeUninit<Enum>,
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .try_into_aligned()
+                    .unwrap()
+                    .as_ref();
+            }
+
+            #[test]
+            fn initialized() {
+                const SIZE: usize = imp::core::mem::size_of::<Enum>();
+
+                // The zero-length array gives the byte array `Enum`'s
+                // alignment without contributing to the storage size.
+                #[repr(C)]
+                struct AlignedBytes([Enum; 0], [u8; SIZE]);
+
+                let mut storage = AlignedBytes([], [0; SIZE]);
+                let bytes = imp::Ptr::from_mut(&mut storage.1).as_slice();
+                let mut ptr = bytes.try_cast_into_no_leftover::<Enum, _>(imp::None).unwrap();
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(0) },
+                    >()
+                    .unwrap()
+                    .recall_validity::<
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .as_mut();
+                *field = TUPLE_BYTE;
+                imp::assert_eq!(*field, TUPLE_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(1) },
+                    >()
+                    .unwrap()
+                    .recall_validity::<
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .as_mut();
+                *field = TUPLE_WORD;
+                imp::assert_eq!(*field, TUPLE_WORD);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(a) },
+                    >()
+                    .unwrap()
+                    .recall_validity::<
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .as_mut();
+                *field = STRUCT_BYTE;
+                imp::assert_eq!(*field, STRUCT_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(b) },
+                    >()
+                    .unwrap()
+                    .recall_validity::<
+                        imp::invariant::Valid,
+                        (_, (_, imp::BecauseExclusive)),
+                    >()
+                    .as_mut();
+                *field = STRUCT_WORD;
+                imp::assert_eq!(*field, STRUCT_WORD);
+
+                // Initialized bytes are valid `u8`s, so a byte slice is the
+                // strictest form through which the entire pointer may be read.
+                let bytes = ptr.as_bytes().as_ref();
+                imp::assert_eq!(bytes.len(), SIZE);
+                imp::assert_ne!(bytes, &[0; SIZE]);
+            }
+
+            #[test]
+            fn valid() {
+                let mut value = Enum::UnitLike;
+                let mut ptr = imp::Ptr::from_mut(&mut value);
+                let wrong_variant = ptr.reborrow().project::<
+                    imp::project_clients::ProjectDerive,
+                    _,
+                    { imp::ident_id!(TupleLike) },
+                    { imp::ident_id!(0) },
+                >();
+                imp::assert!(wrong_variant.is_err());
+                imp::assert_eq!(
+                    imp::core::mem::discriminant(ptr.as_ref()),
+                    imp::core::mem::discriminant(&Enum::UnitLike),
+                );
+
+                let mut value = Enum::TupleLike(0, 0);
+                let mut ptr = imp::Ptr::from_mut(&mut value);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(0) },
+                    >()
+                    .unwrap()
+                    .as_mut();
+                *field = TUPLE_BYTE;
+                imp::assert_eq!(*field, TUPLE_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(TupleLike) },
+                        { imp::ident_id!(1) },
+                    >()
+                    .unwrap()
+                    .as_mut();
+                *field = TUPLE_WORD;
+                imp::assert_eq!(*field, TUPLE_WORD);
+
+                let wrong_variant = ptr.reborrow().project::<
+                    imp::project_clients::ProjectDerive,
+                    _,
+                    { imp::ident_id!(StructLike) },
+                    { imp::ident_id!(a) },
+                >();
+                imp::assert!(wrong_variant.is_err());
+
+                match ptr.as_ref() {
+                    Enum::TupleLike(a, b) => {
+                        imp::assert_eq!(*a, TUPLE_BYTE);
+                        imp::assert_eq!(*b, TUPLE_WORD);
+                    }
+                    _ => imp::assert!(false),
+                }
+
+                let mut value = Enum::StructLike { a: 0, b: 0 };
+                let mut ptr = imp::Ptr::from_mut(&mut value);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(a) },
+                    >()
+                    .unwrap()
+                    .as_mut();
+                *field = STRUCT_BYTE;
+                imp::assert_eq!(*field, STRUCT_BYTE);
+
+                let field = ptr
+                    .reborrow()
+                    .project::<
+                        imp::project_clients::ProjectDerive,
+                        _,
+                        { imp::ident_id!(StructLike) },
+                        { imp::ident_id!(b) },
+                    >()
+                    .unwrap()
+                    .as_mut();
+                *field = STRUCT_WORD;
+                imp::assert_eq!(*field, STRUCT_WORD);
+
+                let wrong_variant = ptr.reborrow().project::<
+                    imp::project_clients::ProjectDerive,
+                    _,
+                    { imp::ident_id!(TupleLike) },
+                    { imp::ident_id!(0) },
+                >();
+                imp::assert!(wrong_variant.is_err());
+
+                match ptr.as_ref() {
+                    Enum::StructLike { a, b } => {
+                        imp::assert_eq!(*a, STRUCT_BYTE);
+                        imp::assert_eq!(*b, STRUCT_WORD);
+                    }
+                    _ => imp::assert!(false),
+                }
+            }
+        }
+    };
+}
+
+test_enum!(repr_c, ReprC);
+test_enum!(repr_u8, ReprU8);

--- a/zerocopy/zerocopy-derive/tests/project_struct.rs
+++ b/zerocopy/zerocopy-derive/tests/project_struct.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in compliance with those licenses.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+#[derive(Clone, Copy, imp::FromBytes, imp::IntoBytes, imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(2))]
+struct Align2([u8; 2]);
+
+// `first` is followed by one byte of padding needed to align `second`, and
+// `second` is followed by four bytes of trailing padding needed to align the
+// struct.
+#[derive(Clone, Copy, imp::KnownLayout, imp::Project)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, align(8))]
+struct Padded {
+    first: u8,
+    second: Align2,
+}
+
+const FIRST: u8 = 0x12;
+const SECOND: Align2 = Align2([0x34, 0x56]);
+
+#[test]
+fn uninit() {
+    let mut storage = imp::MaybeUninit::<Padded>::uninit();
+    let mut ptr = imp::Ptr::from_mut(&mut storage)
+        .transmute::<Padded, imp::invariant::Uninit, _>()
+        .try_into_aligned()
+        .unwrap();
+
+    let first = ptr
+        .reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(first) },
+        >()
+        .unwrap()
+        .transmute::<
+            imp::MaybeUninit<u8>,
+            imp::invariant::Valid,
+            (_, (_, imp::BecauseExclusive)),
+        >()
+        .bikeshed_recall_aligned()
+        .as_mut()
+        .write(FIRST);
+    imp::assert_eq!(*first, FIRST);
+
+    let second = ptr
+        .reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(second) },
+        >()
+        .unwrap()
+        .transmute::<
+            imp::MaybeUninit<Align2>,
+            imp::invariant::Valid,
+            (_, (_, imp::BecauseExclusive)),
+        >()
+        .try_into_aligned()
+        .unwrap()
+        .as_mut()
+        .write(SECOND);
+    imp::assert_eq!(second.0, SECOND.0);
+
+    // A `MaybeUninit<Padded>` is the strictest type through which all bytes of
+    // an `Uninit` `Ptr<Padded>` may be read.
+    let _: imp::MaybeUninit<Padded> = *ptr
+        .transmute::<
+            imp::MaybeUninit<Padded>,
+            imp::invariant::Valid,
+            (_, (_, imp::BecauseExclusive)),
+        >()
+        .try_into_aligned()
+        .unwrap()
+        .as_ref();
+}
+
+#[test]
+fn initialized() {
+    #[repr(C, align(8))]
+    struct AlignedBytes([u8; 8]);
+
+    let mut storage = AlignedBytes([0; 8]);
+    let bytes = imp::Ptr::from_mut(&mut storage.0).as_slice();
+    let mut ptr = bytes.try_cast_into_no_leftover::<Padded, _>(imp::None).unwrap();
+
+    let first = ptr
+        .reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(first) },
+        >()
+        .unwrap()
+        .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>();
+    *first.as_mut() = FIRST;
+    imp::assert_eq!(
+        *ptr.reborrow()
+            .project::<
+                imp::project_clients::ProjectDerive,
+                _,
+                { imp::STRUCT_VARIANT_ID },
+                { imp::ident_id!(first) },
+            >()
+            .unwrap()
+            .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>()
+            .as_ref(),
+        FIRST,
+    );
+
+    let second = ptr
+        .reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(second) },
+        >()
+        .unwrap()
+        .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>();
+    *second.as_mut() = SECOND;
+    imp::assert_eq!(
+        ptr.reborrow()
+            .project::<
+                imp::project_clients::ProjectDerive,
+                _,
+                { imp::STRUCT_VARIANT_ID },
+                { imp::ident_id!(second) },
+            >()
+            .unwrap()
+            .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>()
+            .as_ref()
+            .0,
+        SECOND.0,
+    );
+
+    // Initialized bytes are valid `u8`s, so a byte slice is the strictest
+    // form through which the entire `Ptr<Padded>` may be read.
+    let bytes = ptr.as_bytes().as_ref();
+    imp::assert_eq!(bytes, &[FIRST, 0, 0x34, 0x56, 0, 0, 0, 0]);
+}
+
+#[test]
+fn valid() {
+    let mut value = Padded { first: 0, second: Align2([0; 2]) };
+    let mut ptr = imp::Ptr::from_mut(&mut value);
+
+    *ptr.reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(first) },
+        >()
+        .unwrap()
+        .as_mut() = FIRST;
+    imp::assert_eq!(
+        *ptr.reborrow()
+            .project::<
+                imp::project_clients::ProjectDerive,
+                _,
+                { imp::STRUCT_VARIANT_ID },
+                { imp::ident_id!(first) },
+            >()
+            .unwrap()
+            .as_ref(),
+        FIRST,
+    );
+
+    *ptr.reborrow()
+        .project::<
+            imp::project_clients::ProjectDerive,
+            _,
+            { imp::STRUCT_VARIANT_ID },
+            { imp::ident_id!(second) },
+        >()
+        .unwrap()
+        .as_mut() = SECOND;
+    imp::assert_eq!(
+        ptr.reborrow()
+            .project::<
+                imp::project_clients::ProjectDerive,
+                _,
+                { imp::STRUCT_VARIANT_ID },
+                { imp::ident_id!(second) },
+            >()
+            .unwrap()
+            .as_ref()
+            .0,
+        SECOND.0,
+    );
+
+    // A valid `Padded` is the strictest form through which a `Valid`
+    // `Ptr<Padded>` may be read.
+    let value = ptr.as_ref();
+    imp::assert_eq!(value.first, FIRST);
+    imp::assert_eq!(value.second.0, SECOND.0);
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

This factors out the `derive(TryFromBytes)` into `project.rs`, and
exposes this machinery as a doc-hidden `derive(Project)`. The
implementation of `is_bit_valid` on enums is now fully safe, and a
soundness issue of mutable enum tag projection is resolved by
permitting only immutable tag projection.




---

- 　  #3665
- 👉 #3492


**Latest Update:** v16 — [Compare vs v15](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v15 | v14 | v13 | v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v16|[v15](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v14](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v13](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v12](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v11](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v16)|
|v15||[v14](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v13](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v12](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v11](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v15)|
|v14|||[v13](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v12](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v11](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v14)|
|v13||||[v12](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v11](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v13)|
|v12|||||[v11](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v12)|
|v11||||||[v10](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v11)|
|v10|||||||[v9](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v10)|
|v9||||||||[v8](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v9)|
|v8|||||||||[v7](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v8)|
|v7||||||||||[v6](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v7)|
|v6|||||||||||[v5](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v6)|
|v5||||||||||||[v4](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5)|[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v5)|
|v4|||||||||||||[v3](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4)|[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v4)|
|v3||||||||||||||[v2](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3)|[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v3)|
|v2|||||||||||||||[v1](/google/zerocopy/compare/gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2)|[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v2)|
|v1||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gcc56a15ce65387a017464947e8c2f25dc9e8c737/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gcc56a15ce65387a017464947e8c2f25dc9e8c737 && git checkout -b pr-Gcc56a15ce65387a017464947e8c2f25dc9e8c737 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gcc56a15ce65387a017464947e8c2f25dc9e8c737 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gcc56a15ce65387a017464947e8c2f25dc9e8c737 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gcc56a15ce65387a017464947e8c2f25dc9e8c737
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gcc56a15ce65387a017464947e8c2f25dc9e8c737", "parent": null, "child": "G5fa632801df03c070c991b72a15721a1f2d66490"}" -->