### PR TITLE
Use 'Josh Liebow-Feeser' in repository metadata and Anneal docs

### DIFF
--- a/anneal/Cargo.toml
+++ b/anneal/Cargo.toml
@@ -14,7 +14,7 @@ categories = [
   "security",
 ]
 keywords = ["verification", "cargo", "plugin", "unsafe", "lean"]
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
+authors = ["Josh Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy/tree/main/anneal"
 publish = true

--- a/anneal/docs/design/design.md
+++ b/anneal/docs/design/design.md
@@ -1,6 +1,6 @@
 # Anneal: A Literate Verification Toolchain for (`unsafe`) Rust
 
-Joshua Liebow-Feeser ([joshlf@google.com](mailto:joshlf@google.com))
+Josh Liebow-Feeser ([joshlf@google.com](mailto:joshlf@google.com))
 
 ## 1\. Summary
 

--- a/anneal/v2/Cargo.toml
+++ b/anneal/v2/Cargo.toml
@@ -18,7 +18,7 @@ categories = [
   "security",
 ]
 keywords = ["verification", "cargo", "plugin", "unsafe", "lean"]
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
+authors = ["Josh Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy/tree/main/anneal"
 publish = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "0.0.0"
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
+authors = ["Josh Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 publish = false
 

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 name = "zerocopy"
 version = "0.8.55"
 authors = [
-    "Joshua Liebow-Feeser <joshlf@google.com>",
+    "Josh Liebow-Feeser <joshlf@google.com>",
     "Jack Wrenn <jswrenn@amazon.com>",
 ]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -10,7 +10,7 @@
 edition = "2021"
 name = "zerocopy-derive"
 version = "0.8.55"
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
+authors = ["Josh Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"


### PR DESCRIPTION
### Motivation
- Standardize the author's public name across repository metadata and documentation by replacing the longer form with the preferred short form.

### Description
- Replaced `Joshua Liebow-Feeser` with `Josh Liebow-Feeser` (and `Joshua` with `Josh` where applicable) in Cargo manifests and the Anneal design document.
- Files modified: `anneal/Cargo.toml`, `anneal/v2/Cargo.toml`, `tools/Cargo.toml`, `zerocopy/Cargo.toml`, `zerocopy/zerocopy-derive/Cargo.toml`, and `anneal/docs/design/design.md`.
- Changes are limited to metadata and author attribution only and include minor whitespace normalization in `tools/Cargo.toml` to satisfy diff checks.

### Testing
- Parsed each modified Cargo manifest with Python's `tomllib` to ensure the TOML remains valid and the files parse successfully.
- Verified no remaining tracked occurrences with `git grep -n -e 'Joshua Liebow-Feeser' -e 'Joshua'`.
- Ran `git -c core.whitespace=cr-at-eol diff --check` to ensure there are no diff/whitespace issues and inspected `git status --short` to confirm the working tree state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64cbb4fae48333aeef7b66beec3c77)