### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/anneal/Cargo.toml
+++ b/anneal/Cargo.toml
@@ -14,7 +14,6 @@ categories = [
   "security",
 ]
 keywords = ["verification", "cargo", "plugin", "unsafe", "lean"]
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy/tree/main/anneal"
 publish = true

--- a/anneal/v2/Cargo.toml
+++ b/anneal/v2/Cargo.toml
@@ -18,7 +18,6 @@ categories = [
   "security",
 ]
 keywords = ["verification", "cargo", "plugin", "unsafe", "lean"]
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy/tree/main/anneal"
 publish = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,6 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 version = "0.0.0"
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>"]
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 publish = false
 

--- a/tools/cargo-zerocopy/Cargo.toml
+++ b/tools/cargo-zerocopy/Cargo.toml
@@ -10,7 +10,6 @@
 edition.workspace = true
 name = "cargo-zerocopy"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 publish.workspace = true
 

--- a/tools/generate-readme/Cargo.toml
+++ b/tools/generate-readme/Cargo.toml
@@ -10,7 +10,6 @@
 edition.workspace = true
 name = "generate-readme"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 publish.workspace = true
 

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -16,10 +16,6 @@
 edition = "2021"
 name = "zerocopy"
 version = "0.8.55"
-authors = [
-    "Joshua Liebow-Feeser <joshlf@google.com>",
-    "Jack Wrenn <jswrenn@amazon.com>",
-]
 description = "Zerocopy makes zero-cost memory manipulation effortless. We write \"unsafe\" so you don't have to."
 categories = [
     "embedded",

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -10,7 +10,6 @@
 edition = "2021"
 name = "zerocopy-derive"
 version = "0.8.55"
-authors = ["Joshua Liebow-Feeser <joshlf@google.com>", "Jack Wrenn <jswrenn@amazon.com>"]
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068