### PR TITLE
[derive] Document MSRV as 1.56, update MSRV policy

### DIFF
--- a/.github/workflows/anneal-release.yml
+++ b/.github/workflows/anneal-release.yml
@@ -387,7 +387,7 @@ jobs:
       - name: Submit PR
         id: submit-pr-upstream
         if: github.repository == 'google/zerocopy'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "Release Anneal ${{ github.event.inputs.version }}"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
@@ -405,7 +405,7 @@ jobs:
       - name: Submit PR (fork test)
         id: submit-pr-fork
         if: github.repository != 'google/zerocopy'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "Release Anneal ${{ github.event.inputs.version }}"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -62,7 +62,7 @@ jobs:
           echo "AUTHOR=$AUTHOR" >> $GITHUB_ENV
 
       - name: Submit PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           author: "${{ env.AUTHOR }}"
           committer: "${{ env.AUTHOR }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -863,7 +863,7 @@ jobs:
 
   check_versions:
     runs-on: ubuntu-latest
-    name: Check crate versions match
+    name: Check crate versions and MSRVs match
     defaults:
       run:
         working-directory: zerocopy
@@ -871,10 +871,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # Make sure that both crates are at the same version, and that zerocopy
-      # depends exactly upon the current version of zerocopy-derive. See
-      # `INTERNAL.md` for an explanation of why we do this.
-      - name: Check crate versions match
+      # Make sure that both crates are at the same version and MSRV, and that
+      # zerocopy depends exactly upon the current version of zerocopy-derive.
+      # See `INTERNAL.md` for an explanation of the version requirement.
+      - name: Check crate versions and MSRVs match
         run: ./ci/check_versions.sh
 
   check_msrv_is_minimal:

--- a/.github/workflows/release-crate-version.yml
+++ b/.github/workflows/release-crate-version.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "Release ${{ github.event.inputs.version }}"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>

--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "[ci] Roll pinned ${{ matrix.toolchain }} toolchain"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
@@ -164,7 +164,7 @@ jobs:
           sed -i -E -e "s/^( *kani-version:)( [0-9]+\.[0-9]+\.[0-9]+)/\1 $KANI_LATEST/" .github/workflows/ci.yml
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "[ci] Roll pinned Kani version"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>

--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -10,6 +10,7 @@ use std::{
     env,
     fmt::Debug,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use ui_test::{
@@ -37,6 +38,7 @@ fn main() {
     );
     let toolchain = env::var("ZEROCOPY_UI_TEST_TOOLCHAIN")
         .expect("ZEROCOPY_UI_TEST_TOOLCHAIN must be set by tests/ui.rs");
+    let supports_diagnostic_width = rustc_supports_diagnostic_width(&toolchain);
 
     let root = env::current_dir().unwrap();
     let mut config = Config::rustc(tests_dir.clone());
@@ -125,9 +127,9 @@ fn main() {
     // terminal width of the environment in which the tests are run.
     //
     // However, this flag was only stabilized in Rust 1.70.0 (and was unstable
-    // starting in 1.62.0), so we only pass it if we're not on our MSRV
-    // toolchain (which is 1.56.0).
-    if toolchain_meta_name != "msrv" {
+    // starting in 1.62.0), so only pass it when the selected compiler supports
+    // it.
+    if supports_diagnostic_width {
         config.program.args.push("--diagnostic-width=100".into());
     }
 
@@ -215,6 +217,14 @@ fn main() {
         OverrideEmitter(ui_test::status_emitter::Text::verbose(), toolchain_meta_name),
     )
     .unwrap();
+}
+
+fn rustc_supports_diagnostic_width(toolchain: &str) -> bool {
+    Command::new("rustup")
+        .args(["run", toolchain, "rustc", "--diagnostic-width=100", "--version"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 // Used to add the `.msrv`, `.stable`, or `.nightly` suffix to test output files

--- a/zerocopy/POLICIES.md
+++ b/zerocopy/POLICIES.md
@@ -93,17 +93,22 @@ documented guarantees do not hold.
 circumstances. This implicitly relied on syn having the same MSRV policy, which
 it does not. See #1085 and #1088. -->
 
-Without the `derive` feature enabled, zerocopy's minimum supported Rust version
-(MSRV) is encoded the `package.rust-version` field in its `Cargo.toml` file. For
-zerocopy, we consider an increase in MSRV to be a semver-breaking change, and
-will only increase our MSRV during semver-breaking version changes (e.g., 0.1 ->
-0.2, 1.0 -> 2.0, etc).
+The `zerocopy` and `zerocopy-derive` crates declare the same minimum supported
+Rust version (MSRV) in the `package.rust-version` fields in their respective
+`Cargo.toml` files. These fields describe the package MSRV: each release admits
+at least one dependency resolution which builds on that Rust version. We
+consider an increase in this declared MSRV to be a semver-breaking change, and
+will only increase it during semver-breaking version changes (e.g., 0.1 -> 0.2,
+1.0 -> 2.0, etc).
 
-For zerocopy with the `derive` feature enabled, and for the zerocopy-derive
-crate, we inherit the maximum MSRV any of our dependencies. As of this writing
-(2024-10-03), at least one dependency (syn) does *not* consider MSRV increases
-to be semver-breaking changes. Thus, using the `derive` feature may result in
-the effective MSRV increasing within a semver version train.
+The package MSRV does not guarantee that every semver-compatible dependency
+resolution has the same MSRV. In particular, some dependencies of
+`zerocopy-derive` (including syn) do *not* consider MSRV increases to be
+semver-breaking changes. Cargo versions which do not account for MSRV when
+resolving dependencies may therefore select versions which require a newer
+compiler. Users building `zerocopy-derive`, or `zerocopy` with the `derive`
+feature enabled, on the declared MSRV may need to pin such dependencies to
+compatible versions.
 
 ## Yanking
 

--- a/zerocopy/agent_docs/development.md
+++ b/zerocopy/agent_docs/development.md
@@ -47,7 +47,11 @@ The `<toolchain>` argument is mandatory:
 
 ## MSRV (Minimum Supported Rust Version)
 
-The MSRV is **1.56.0**.
+The MSRV is **1.56.0**. It is encoded in the `package.rust-version` fields in
+both `Cargo.toml` and `zerocopy-derive/Cargo.toml`; these fields must remain
+identical. The root `Cargo.toml` is the canonical source used by `cargo.sh` to
+select the MSRV toolchain. `ci/check_versions.sh` verifies that both manifests
+declare the same MSRV.
 
 - **Do NOT** use features stabilized after 1.56.0 unless version-gated.
 - **Requirement:** Ask for user approval before introducing new version-gated

--- a/zerocopy/ci/check_versions.sh
+++ b/zerocopy/ci/check_versions.sh
@@ -19,6 +19,14 @@ function version {
 ver_zerocopy=$(version zerocopy)
 ver_zerocopy_derive=$(version zerocopy-derive)
 
+# Usage: rust-version <crate-name>
+function rust-version {
+  cargo metadata -q --format-version 1 | jq -r ".packages[] | select(.name == \"$1\").rust_version // empty"
+}
+
+rust_version_zerocopy=$(rust-version zerocopy)
+rust_version_zerocopy_derive=$(rust-version zerocopy-derive)
+
 # Usage: dependency-version <kind> <target>
 function dependency-version {
   KIND="$1"
@@ -52,9 +60,33 @@ function assert-match {
   fi
 }
 
+function assert-present {
+  VALUE="$1"
+  SUCCESS_MSG="$2"
+  FAILURE_MSG="$3"
+  if [[ -n "$VALUE" ]]; then
+    echo "$SUCCESS_MSG" | tee -a $GITHUB_STEP_SUMMARY
+  else
+    echo "$FAILURE_MSG" | tee -a $GITHUB_STEP_SUMMARY >&2
+    exit 1
+  fi
+}
+
 assert-match "$ver_zerocopy" "$ver_zerocopy_derive" \
   "Same crate version ($ver_zerocopy) found for zerocopy and zerocopy-derive." \
   "Different crate versions found for zerocopy ($ver_zerocopy) and zerocopy-derive ($ver_zerocopy_derive)."
+
+assert-present "$rust_version_zerocopy" \
+  "zerocopy declares package.rust-version ($rust_version_zerocopy)." \
+  "zerocopy does not declare package.rust-version."
+
+assert-present "$rust_version_zerocopy_derive" \
+  "zerocopy-derive declares package.rust-version ($rust_version_zerocopy_derive)." \
+  "zerocopy-derive does not declare package.rust-version."
+
+assert-match "$rust_version_zerocopy" "$rust_version_zerocopy_derive" \
+  "Same package.rust-version ($rust_version_zerocopy) found for zerocopy and zerocopy-derive." \
+  "Different package.rust-version values found for zerocopy ($rust_version_zerocopy) and zerocopy-derive ($rust_version_zerocopy_derive)."
 
 # Note the leading `=` sign - the dependency needs to be an exact one.
 assert-match "=$ver_zerocopy_derive" "$zerocopy_derive_dep_ver" \

--- a/zerocopy/testutil/src/lib.rs
+++ b/zerocopy/testutil/src/lib.rs
@@ -13,8 +13,8 @@ use std::{env, path::PathBuf, process::Command};
 
 #[derive(Debug)]
 pub enum ToolchainVersion {
-    /// The version listed as our MSRV (ie, the `package.rust-version` key in
-    /// `Cargo.toml`).
+    /// The shared package MSRV, sourced from `Cargo.toml` and required to match
+    /// `zerocopy-derive/Cargo.toml`.
     PinnedMsrv,
     /// The stable version pinned in CI.
     PinnedStable,

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.8.55"
 description = "Custom derive for traits from the zerocopy crate"
 license = "BSD-2-Clause OR Apache-2.0 OR MIT"
 repository = "https://github.com/google/zerocopy"
+rust-version = "1.56.0"
 
 # We prefer to include tests when publishing to crates.io so that Crater [1] can
 # detect regressions in our test suite. These two tests are excessively large,


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Update our MSRV policy to promise that `zerocopy-derive` will always
support its MSRV, but that getting this MSRV to work in practice may
require pinning dependencies (in particular, `syn`) which have more lax
MSRV policies.




---

- 👉 #3500


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v1..gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v1..gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Glcxdw676wu3lpncyoxezb43sqrukyhpa/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Glcxdw676wu3lpncyoxezb43sqrukyhpa && git checkout -b pr-Glcxdw676wu3lpncyoxezb43sqrukyhpa FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Glcxdw676wu3lpncyoxezb43sqrukyhpa && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Glcxdw676wu3lpncyoxezb43sqrukyhpa && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Glcxdw676wu3lpncyoxezb43sqrukyhpa
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Glcxdw676wu3lpncyoxezb43sqrukyhpa", "parent": null, "child": null}" -->