### PR TITLE
Fix unused 'extern crate alloc' error under cfg(kani)

### DIFF
--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -401,7 +401,7 @@ pub use crate::{
     wrappers::*,
 };
 
-#[cfg(any(feature = "alloc", test, kani))]
+#[cfg(any(feature = "alloc", test))]
 extern crate alloc;
 #[cfg(any(feature = "alloc", test))]
 use alloc::{boxed::Box, vec::Vec};


### PR DESCRIPTION
Building zerocopy under Kani without the `alloc` feature (e.g. a plain `cargo kani autoharness` / `cargo kani --only-codegen -Zfunction-contracts` on the crate) fails with:

```
error: unused extern crate
   --> src/lib.rs:405:1
    |
405 | extern crate alloc;
    | ^^^^^^^^^^^^^^^^^^^ unused
```

because the crate denies `unused_extern_crates`.

Under `cfg(kani)` the crate is not `no_std` (`lib.rs` gates `no_std` on `not(any(test, kani, feature = "std"))`), so the Kani proofs resolve `Vec`/`vec!` through the std prelude, and nothing references the `alloc` crate *by name*: the `use alloc::...` imports are gated on `any(feature = "alloc", test)` only. Hence the `kani` predicate in the `extern crate alloc` gate declares a crate that is never used unless the `alloc` feature is (also) enabled — and CI always enables it via `--features __internal_use_only_features_that_work_on_stable`, which is why this never shows up there.

This PR drops `kani` from the gate. Verified that all of the following compile:
- `cargo kani --only-codegen -Z function-contracts` with no features (previously broken) and with `--features __internal_use_only_features_that_work_on_stable` (the CI configuration);
- `cargo check` with no features (`no_std`), with `--features alloc`, and with `--tests`.

Context: found while evaluating Kani's `autoharness` feature across the top-100 crates.io crates. With `--features alloc`, zerocopy works very nicely under autoharness (1539 functions verified automatically, and the crate's own Kani proofs pass).
