### PR TITLE
[ci] Forward env vars correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,9 @@ jobs:
           -v /home/runner/.docker-cargo/git:/root/.cargo/git \
           -e GITHUB_ENV -e GITHUB_PATH -e GITHUB_STEP_SUMMARY -e GITHUB_OUTPUT -e GITHUB_WORKSPACE \
           -e CI -e GITHUB_ACTIONS -e GITHUB_ACTOR -e GITHUB_REPOSITORY -e GITHUB_SHA -e GITHUB_REF -e GITHUB_EVENT_NAME \
-          -e TOOLCHAIN -e CRATE -e TARGET -e FEATURES -e RUSTFLAGS -e MIRIFLAGS -e ZC_TOOLCHAIN \
+          -e TOOLCHAIN -e CRATE -e TARGET -e FEATURES -e ZC_TOOLCHAIN \
+          -e RUSTFLAGS -e RUSTDOCFLAGS -e MIRIFLAGS \
+          -e ZC_NIGHTLY_RUSTFLAGS -e ZC_NIGHTLY_MIRIFLAGS \
           -e ZC_SKIP_CARGO_SEMVER_CHECKS \
           zerocopy-ci:local bash -c "git config --global --add safe.directory '*' && exec bash \"\$1\"" -- "$1"
         EOF
@@ -591,7 +593,7 @@ jobs:
         if [[ "$TOOLCHAIN" == "nightly" ]]; then
           export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS $RUSTDOCFLAGS"
         fi
-        ./cargo.sh +$TOOLCHAIN doc --document-private-items --package $CRATE $FEATURES
+        ./cargo.sh +$TOOLCHAIN doc --no-deps --document-private-items --package $CRATE $FEATURES
 
     # If the commit message contains the line `SKIP_CARGO_SEMVER_CHECKS=1`, then
     # skip the cargo-semver-checks step.

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -361,6 +361,10 @@ fn delegate_cargo() -> Result<(), Error> {
                     .filter_map(|(k, v)| if k == "RUSTFLAGS" { Some(v) } else { None })
                     .next()
                     .unwrap_or_default();
+                let env_rustdocflags = env::vars()
+                    .filter_map(|(k, v)| if k == "RUSTDOCFLAGS" { Some(v) } else { None })
+                    .next()
+                    .unwrap_or_default();
 
                 let rustflags = format!(
                     "{} {} {}",
@@ -368,11 +372,13 @@ fn delegate_cargo() -> Result<(), Error> {
                     get_toolchain_rustflags(name),
                     env_rustflags,
                 );
+                let rustdocflags = format!("{rustflags} {env_rustdocflags}");
 
-                // Pass RUSTFLAGS to both Rust (via `RUSTFLAGS`) and Rustdoc
-                // (via `RUSTDOCFLAGS`).
+                // Rustdoc needs the wrapper's cfgs and the caller's RUSTFLAGS
+                // in addition to any rustdoc-specific flags supplied through
+                // RUSTDOCFLAGS.
                 let mut cmd = rustup(["run", version, "cargo"], Some(("RUSTFLAGS", &rustflags)));
-                cmd.env("RUSTDOCFLAGS", &rustflags);
+                cmd.env("RUSTDOCFLAGS", &rustdocflags);
 
                 if env::var("CARGO_TARGET_DIR").is_ok() {
                     eprintln!("[cargo-zerocopy] WARNING: `CARGO_TARGET_DIR` is set - this may cause `cargo-zerocopy` to behave unexpectedly");


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 　  #3505
- 👉 #3503


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v3..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v2..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v1..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v3..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v2..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v1..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v2..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v1..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v1..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr && git checkout -b pr-Gpaak2r3mpajdigm5vcopjcopsv6gcuxr FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gpaak2r3mpajdigm5vcopjcopsv6gcuxr
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gpaak2r3mpajdigm5vcopjcopsv6gcuxr", "parent": null, "child": "Ghjiwdkxk7bi3ag2zcvbf3jc2c5yyyafc"}" -->