### PR TITLE
[derive] Better error for `#[repr(C, Int)]` enums

### DIFF
--- a/zerocopy/zerocopy-derive/src/repr.rs
+++ b/zerocopy/zerocopy-derive/src/repr.rs
@@ -376,15 +376,39 @@ enum FromRawReprsError<E> {
     /// conservatively treat redundant reprs as conflicting (e.g.
     /// `#[repr(packed, packed)]`).
     Conflict,
+    /// `repr(C)` is combined with a primitive representation. This combination
+    /// is valid on data-carrying enums, but is not yet supported by our derive
+    /// macros.
+    UnsupportedCAndPrimitive,
+}
+
+/// Identifies the otherwise-valid representation combination that is not yet
+/// supported by our derive macros.
+trait IsCAndPrimitive {
+    fn is_c_and_primitive(&self, other: &Self) -> bool;
+}
+
+impl<Prim> IsCAndPrimitive for CompoundRepr<Prim> {
+    fn is_c_and_primitive(&self, other: &Self) -> bool {
+        use CompoundRepr::*;
+        matches!((self, other), (C, Primitive(_)) | (Primitive(_), C))
+    }
+}
+
+impl<Packed> IsCAndPrimitive for AlignRepr<Packed> {
+    fn is_c_and_primitive(&self, _other: &Self) -> bool {
+        false
+    }
 }
 
 /// Tries to extract a high-level repr from a list of `RawRepr`s.
-fn try_from_raw_reprs<'a, E, R: TryFrom<RawRepr, Error = FromRawReprError<E>>>(
+fn try_from_raw_reprs<'a, E, R: IsCAndPrimitive + TryFrom<RawRepr, Error = FromRawReprError<E>>>(
     r: impl IntoIterator<Item = &'a Spanned<RawRepr>>,
 ) -> Result<Option<Spanned<R>>, Spanned<FromRawReprsError<E>>> {
     // Walk the list of `RawRepr`s and attempt to convert each to an `R`. Bail
     // if we find any errors. If we find more than one which converts to an `R`,
-    // bail with a `Conflict` error.
+    // bail and distinguish the unsupported `repr(C, Int)` combination from
+    // genuinely conflicting hints.
     r.into_iter().try_fold(None, |found: Option<Spanned<R>>, raw| {
         let new = match Spanned::<R>::try_from(*raw) {
             Ok(r) => r,
@@ -400,13 +424,18 @@ fn try_from_raw_reprs<'a, E, R: TryFrom<RawRepr, Error = FromRawReprError<E>>>(
 
         if let Some(found) = found {
             // We already found an `R`, but this `RawRepr` also converts to an
-            // `R`, so that's a conflict.
+            // `R`, so this high-level representation cannot describe the pair.
             //
             // `Span::join` returns `None` if the two spans are from different
             // files or if we're not on the nightly compiler. In that case, just
             // use `new`'s span.
             let span = found.span.join(new.span).unwrap_or(new.span);
-            Err(Spanned::new(FromRawReprsError::Conflict, span))
+            let err = if found.t.is_c_and_primitive(&new.t) {
+                FromRawReprsError::UnsupportedCAndPrimitive
+            } else {
+                FromRawReprsError::Conflict
+            };
+            Err(Spanned::new(err, span))
         } else {
             Ok(Some(new))
         }
@@ -446,6 +475,12 @@ impl From<Spanned<FromAttrsError>> for Error {
                 // can't tell which repr came first, so we might report this on
                 // the first involved repr rather than the second, third, etc.
                 Error::new(span, "this conflicts with another representation hint")
+            }
+            FromAttrsError::FromRawReprs(FromRawReprsError::UnsupportedCAndPrimitive) => {
+                Error::new(
+                    span,
+                    "zerocopy derives do not support combining `repr(C)` with an integer representation",
+                )
             }
             FromAttrsError::Unrecognized => Error::new(span, "unrecognized representation hint"),
         }
@@ -825,8 +860,8 @@ mod tests {
         // that testing against u8 alone is fine.
         test!(@error #[repr(transparent, u8)] => EnumRepr => FromRawReprs(Conflict).into());
         test!(@error #[repr(u8, transparent)] => EnumRepr => FromRawReprs(Conflict).into());
-        test!(@error #[repr(C, u8)] => EnumRepr => FromRawReprs(Conflict).into());
-        test!(@error #[repr(u8, C)] => EnumRepr => FromRawReprs(Conflict).into());
+        test!(@error #[repr(C, u8)] => EnumRepr => FromRawReprs(UnsupportedCAndPrimitive).into());
+        test!(@error #[repr(u8, C)] => EnumRepr => FromRawReprs(UnsupportedCAndPrimitive).into());
         test!(@error #[repr(Rust, u8)] => EnumRepr => FromRawReprs(Conflict).into());
         test!(@error #[repr(u8, Rust)] => EnumRepr => FromRawReprs(Conflict).into());
         test!(@error #[repr(u8, u8)] => EnumRepr => FromRawReprs(Conflict).into());

--- a/zerocopy/zerocopy-derive/tests/ui/enum.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.msrv.stderr
@@ -261,6 +261,12 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: zerocopy derives do not support combining `repr(C)` with an integer representation
+   --> $DIR/enum.rs:692:11
+    |
+692 | #[repr(C, u8)]
+    |           ^^
+
 error: generic parameters may not be used in const operations
    --> $DIR/enum.rs:677:7
     |
@@ -413,7 +419,7 @@ error[E0277]: the trait bound `(): PaddingFree<IntoBytes7, 1_usize>` is not sati
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 52 previous errors
+error: aborting due to 53 previous errors
 
 Some errors have detailed explanations: E0277, E0552, E0565, E0566, E0658.
 For more information about an error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -284,6 +284,12 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: zerocopy derives do not support combining `repr(C)` with an integer representation
+   --> $DIR/enum.rs:692:8
+    |
+692 | #[repr(C, u8)]
+    |        ^^^^^
+
 error: generic parameters may not be used in const operations
    --> $DIR/enum.rs:677:7
     |
@@ -609,7 +615,7 @@ note: required by a bound in `assert_is_from_bytes`
     = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 52 previous errors
+error: aborting due to 53 previous errors
 
 Some errors have detailed explanations: E0277, E0552, E0565, E0566.
 For more information about an error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/enum.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.rs
@@ -686,3 +686,11 @@ enum IntoBytes6<T> {
 enum IntoBytes7 {
     A,
 }
+
+#[derive(FromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C, u8)]
+//~[msrv, stable, nightly]^ ERROR: zerocopy derives do not support combining `repr(C)` with an integer representation
+enum CAndPrimitiveIsUnsupported {
+    A(u8),
+}

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -261,6 +261,12 @@ error: must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this
     |
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: zerocopy derives do not support combining `repr(C)` with an integer representation
+   --> $DIR/enum.rs:692:11
+    |
+692 | #[repr(C, u8)]
+    |           ^^
+
 error: generic parameters may not be used in const operations
    --> $DIR/enum.rs:677:7
     |
@@ -557,7 +563,7 @@ note: required by a bound in `assert_is_from_bytes`
     = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 52 previous errors
+error: aborting due to 53 previous errors
 
 Some errors have detailed explanations: E0277, E0552, E0565, E0566.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Makes progress on #1779




---

- 👉 #3504

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5dhckkhnlcttmwz25brhjsm632quam2y && git checkout -b pr-G5dhckkhnlcttmwz25brhjsm632quam2y FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5dhckkhnlcttmwz25brhjsm632quam2y && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5dhckkhnlcttmwz25brhjsm632quam2y && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5dhckkhnlcttmwz25brhjsm632quam2y
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G5dhckkhnlcttmwz25brhjsm632quam2y", "parent": null, "child": null}" -->