### PR TITLE
[ci] Retry transient setup failures

### DIFF
--- a/.github/actions/download-artifact-with-retry/action.yml
+++ b/.github/actions/download-artifact-with-retry/action.yml
@@ -1,0 +1,79 @@
+name: Download artifact with retry
+description: Download one artifact, retrying transient service and transfer failures
+
+inputs:
+  name:
+    description: Name of the artifact to download
+    required: true
+  path:
+    description: Directory into which the artifact is extracted
+    required: true
+  expected-file:
+    description: File expected directly under path after extraction
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # download-artifact retries some blob transfers internally, but failures
+    # while looking up an artifact or obtaining a signed URL happen outside
+    # that retry loop. Retrying the complete action reacquires both. A failed
+    # extraction can leave a partial file behind, so remove exactly the one
+    # expected file before retrying; never clear the caller's whole directory.
+    - name: Download artifact (attempt 1)
+      id: download_1
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Clean up and wait to retry artifact download
+      if: ${{ !cancelled() && steps.download_1.outcome == 'failure' }}
+      shell: bash
+      env:
+        ARTIFACT_PATH: ${{ inputs.path }}
+        EXPECTED_FILE: ${{ inputs.expected-file }}
+      run: |
+        set -eu
+        rm -f -- "$ARTIFACT_PATH/$EXPECTED_FILE"
+        delay=$((5 + RANDOM % 11))
+        echo "Artifact download failed; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Download artifact (attempt 2)
+      id: download_2
+      if: ${{ !cancelled() && steps.download_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Clean up and wait to retry artifact download again
+      if: ${{ !cancelled() && steps.download_2.outcome == 'failure' }}
+      shell: bash
+      env:
+        ARTIFACT_PATH: ${{ inputs.path }}
+        EXPECTED_FILE: ${{ inputs.expected-file }}
+      run: |
+        set -eu
+        rm -f -- "$ARTIFACT_PATH/$EXPECTED_FILE"
+        delay=$((15 + RANDOM % 16))
+        echo "Artifact download failed again; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Download artifact (attempt 3)
+      if: ${{ !cancelled() && steps.download_2.outcome == 'failure' }}
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Verify downloaded artifact
+      if: ${{ !cancelled() }}
+      shell: bash
+      env:
+        ARTIFACT_PATH: ${{ inputs.path }}
+        EXPECTED_FILE: ${{ inputs.expected-file }}
+      run: test -f "$ARTIFACT_PATH/$EXPECTED_FILE"

--- a/.github/actions/setup-docker-with-retry/action.yml
+++ b/.github/actions/setup-docker-with-retry/action.yml
@@ -1,0 +1,102 @@
+name: Set up Docker with retry
+description: Set up Buildx and authenticate to a registry, retrying transient failures
+
+inputs:
+  registry:
+    description: Container registry hostname
+    required: false
+    default: ghcr.io
+  username:
+    description: Container registry username
+    required: true
+  password:
+    description: Container registry password or token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # Retry the actions themselves rather than reproducing their behavior in
+    # shell. This preserves Buildx's builder cleanup and login-action's use of
+    # password-stdin and its end-of-job logout. The first two attempts use
+    # `continue-on-error` only so this composite can inspect `outcome`; the last
+    # attempt fails the caller normally.
+    - name: Set up Docker Buildx (attempt 1)
+      id: buildx_1
+      continue-on-error: true
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Wait to retry Docker Buildx
+      if: ${{ !cancelled() && steps.buildx_1.outcome == 'failure' }}
+      shell: bash
+      run: |
+        set -eu
+        delay=$((5 + RANDOM % 11))
+        echo "Docker Buildx setup failed; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Set up Docker Buildx (attempt 2)
+      id: buildx_2
+      if: ${{ !cancelled() && steps.buildx_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    - name: Wait to retry Docker Buildx again
+      if: ${{ !cancelled() && steps.buildx_2.outcome == 'failure' }}
+      shell: bash
+      run: |
+        set -eu
+        delay=$((15 + RANDOM % 16))
+        echo "Docker Buildx setup failed again; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Set up Docker Buildx (attempt 3)
+      if: ${{ !cancelled() && steps.buildx_2.outcome == 'failure' }}
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    # Keep the token inside action inputs. In particular, do not pass it to a
+    # shell or expose it in a `docker login` command line.
+    - name: Log in to the container registry (attempt 1)
+      id: login_1
+      continue-on-error: true
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Wait to retry container registry login
+      if: ${{ !cancelled() && steps.login_1.outcome == 'failure' }}
+      shell: bash
+      run: |
+        set -eu
+        delay=$((5 + RANDOM % 11))
+        echo "Container registry login failed; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Log in to the container registry (attempt 2)
+      id: login_2
+      if: ${{ !cancelled() && steps.login_1.outcome == 'failure' }}
+      continue-on-error: true
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Wait to retry container registry login again
+      if: ${{ !cancelled() && steps.login_2.outcome == 'failure' }}
+      shell: bash
+      run: |
+        set -eu
+        delay=$((15 + RANDOM % 16))
+        echo "Container registry login failed again; retrying in ${delay}s"
+        sleep "$delay"
+
+    - name: Log in to the container registry (attempt 3)
+      if: ${{ !cancelled() && steps.login_2.outcome == 'failure' }}
+      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -8,6 +8,13 @@
 
 FROM ubuntu:24.04
 
+# These are the same bounded, download-only retry counts configured in
+# `ci.yml`. Defining them before the first networked build step covers rustup
+# and Cargo operations while the image is built; the workflow-level values
+# cover host operations and are forwarded into containers at runtime.
+ENV CARGO_NET_RETRY=10 \
+    RUSTUP_MAX_RETRIES=10
+
 # Use `DEBIAN_FRONTEND=noninteractive` to prevent timezone prompts.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     gcc-multilib    \

--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -24,6 +24,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Keep these bounded, download-only retry counts coordinated with ci.yml and
+  # its Dockerfile. Neither setting reruns a build or test command.
+  CARGO_NET_RETRY: "10"
+  RUSTUP_MAX_RETRIES: "10"
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN: 1
@@ -96,10 +100,11 @@ jobs:
           toolchain: stable
 
       - name: Download Anneal toolchain archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: ./.github/actions/download-artifact-with-retry
         with:
           name: anneal-exocrate.tar.zst
           path: anneal/target
+          expected-file: anneal-exocrate.tar.zst
 
       # Ensure `llms-full.txt` file is up-to-date.
       - name: Check doc generation
@@ -212,10 +217,11 @@ jobs:
           toolchain: stable
 
       - name: Download Anneal toolchain archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: ./.github/actions/download-artifact-with-retry
         with:
           name: anneal-exocrate.tar.zst
           path: anneal/target
+          expected-file: anneal-exocrate.tar.zst
 
       - name: Install Anneal toolchain archive
         run: cargo run setup --local-archive ../target/anneal-exocrate.tar.zst
@@ -409,10 +415,11 @@ jobs:
           persist-credentials: false
 
       - name: Download Anneal toolchain archive
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: ./.github/actions/download-artifact-with-retry
         with:
           name: anneal-exocrate.tar.zst
           path: anneal/target
+          expected-file: anneal-exocrate.tar.zst
 
       # FIXME: Pin this nightly to the same Rust date encoded in
       # anneal/flake.nix, or derive it from the archive metadata, so v2 CI is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # These are bounded, client-native retries for recognized transient download
+  # failures. They never rerun a Cargo or rustup command, so deterministic build
+  # and test failures still fail immediately. Keep these values coordinated
+  # with `.github/workflows/anneal.yml` and the CI Dockerfile.
+  CARGO_NET_RETRY: "10"
+  RUSTUP_MAX_RETRIES: "10"
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings --cfg=zerocopy_unstable_ptr
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly
@@ -301,11 +307,8 @@ jobs:
         fetch-depth: 2
         persist-credentials: false
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+    - name: Set up Docker
+      uses: ./.github/actions/setup-docker-with-retry
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -357,6 +360,7 @@ jobs:
           -e CI -e GITHUB_ACTIONS -e GITHUB_ACTOR -e GITHUB_REPOSITORY -e GITHUB_SHA -e GITHUB_REF -e GITHUB_EVENT_NAME \
           -e TOOLCHAIN -e CRATE -e TARGET -e FEATURES -e ZC_TOOLCHAIN \
           -e RUSTFLAGS -e RUSTDOCFLAGS -e MIRIFLAGS \
+          -e CARGO_NET_RETRY -e RUSTUP_MAX_RETRIES \
           -e ZC_NIGHTLY_RUSTFLAGS -e ZC_NIGHTLY_MIRIFLAGS \
           -e ZC_SKIP_CARGO_SEMVER_CHECKS \
           zerocopy-ci:local bash -c "git config --global --add safe.directory '*' && exec bash \"\$1\"" -- "$1"
@@ -992,11 +996,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+      - name: Set up Docker
+        uses: ./.github/actions/setup-docker-with-retry
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Retry Buildx setup, registry authentication, and Anneal artifact
downloads up to three times, with increasing jitter between
attempts. Clean up only the expected partial artifact before a
download retry.

Enable bounded Cargo and rustup client-native retries for recognized
transient downloads, and propagate them through the CI image build
and runtime container boundary.

Keep every retry below the build and test command boundary so
deterministic compilation, test, Miri, and Anneal failures are never
retried.




---

- 　  #3506
- 　  #3505
- 　  #3508
- 👉 #3507

<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq && git checkout -b pr-G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G5v4j2xq7m3n6c9kptwfhzr8dsaeybluq", "parent": null, "child": "Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2"}" -->