### PR TITLE
[ci] Distribute immutable workflow artifacts

### DIFF
--- a/.github/actions/download-artifact-with-retry/action.yml
+++ b/.github/actions/download-artifact-with-retry/action.yml
@@ -2,8 +2,8 @@ name: Download artifact with retry
 description: Download one artifact, retrying transient service and transfer failures
 
 inputs:
-  name:
-    description: Name of the artifact to download
+  artifact-id:
+    description: Immutable artifact ID received from the producer job
     required: true
   path:
     description: Directory into which the artifact is extracted
@@ -15,6 +15,33 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate artifact contract
+      shell: bash
+      env:
+        ARTIFACT_ID: ${{ inputs.artifact-id }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+        EXPECTED_FILE: ${{ inputs.expected-file }}
+      run: |
+        set -eu
+
+        # With neither `name` nor `artifact-ids`, download-artifact downloads
+        # *every* artifact in the run. Validate the producer-provided ID before
+        # invoking it so an accidentally empty job output fails closed. IDs also
+        # avoid binding to a stale or similarly named artifact: v4+ artifacts
+        # are immutable, and each successful upload receives a unique ID.
+        if [[ ! "$ARTIFACT_ID" =~ ^[0-9]+$ ]]; then
+          echo "Artifact ID must be a nonempty integer: $ARTIFACT_ID" >&2
+          exit 1
+        fi
+        if [[ -z "$ARTIFACT_PATH" ]]; then
+          echo "Artifact destination path must not be empty" >&2
+          exit 1
+        fi
+        if [[ -z "$EXPECTED_FILE" || "$EXPECTED_FILE" == */* || "$EXPECTED_FILE" == "." || "$EXPECTED_FILE" == ".." ]]; then
+          echo "Expected artifact file must be a filename, not a path: $EXPECTED_FILE" >&2
+          exit 1
+        fi
+
     # download-artifact retries some blob transfers internally, but failures
     # while looking up an artifact or obtaining a signed URL happen outside
     # that retry loop. Retrying the complete action reacquires both. A failed
@@ -25,7 +52,7 @@ runs:
       continue-on-error: true
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: ${{ inputs.name }}
+        artifact-ids: ${{ inputs.artifact-id }}
         path: ${{ inputs.path }}
 
     - name: Clean up and wait to retry artifact download
@@ -47,7 +74,7 @@ runs:
       continue-on-error: true
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: ${{ inputs.name }}
+        artifact-ids: ${{ inputs.artifact-id }}
         path: ${{ inputs.path }}
 
     - name: Clean up and wait to retry artifact download again
@@ -67,7 +94,7 @@ runs:
       if: ${{ !cancelled() && steps.download_2.outcome == 'failure' }}
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: ${{ inputs.name }}
+        artifact-ids: ${{ inputs.artifact-id }}
         path: ${{ inputs.path }}
 
     - name: Verify downloaded artifact
@@ -76,4 +103,4 @@ runs:
       env:
         ARTIFACT_PATH: ${{ inputs.path }}
         EXPECTED_FILE: ${{ inputs.expected-file }}
-      run: test -f "$ARTIFACT_PATH/$EXPECTED_FILE"
+      run: test -s "$ARTIFACT_PATH/$EXPECTED_FILE"

--- a/.github/actions/upload-file-artifact/action.yml
+++ b/.github/actions/upload-file-artifact/action.yml
@@ -1,0 +1,85 @@
+name: Upload file artifact
+description: Publish one already-compressed file for jobs in this workflow run
+
+inputs:
+  name:
+    description: Artifact name; must exactly match the basename of path
+    required: true
+  path:
+    description: Exact path of the nonempty file to publish
+    required: true
+
+outputs:
+  artifact-id:
+    description: Immutable ID assigned to the published artifact
+    value: ${{ steps.upload.outputs.artifact-id }}
+  artifact-digest:
+    description: SHA-256 digest assigned to the published artifact
+    value: ${{ steps.upload.outputs.artifact-digest }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate artifact contract
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.name }}
+        ARTIFACT_PATH: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+
+        # upload-artifact v7's direct-file mode derives the published name from
+        # the file basename, even though its overwrite path still looks up the
+        # explicit `name` input. Requiring them to match makes overwrite reliable
+        # on a full workflow rerun and prevents that subtle action contract from
+        # becoming an implicit coupling in each caller.
+        if [[ -z "$ARTIFACT_NAME" || "$ARTIFACT_NAME" == */* || "$ARTIFACT_NAME" == "." || "$ARTIFACT_NAME" == ".." ]]; then
+          echo "Artifact name must be a nonempty filename, not a path: $ARTIFACT_NAME" >&2
+          exit 1
+        fi
+        if [[ "${ARTIFACT_PATH##*/}" != "$ARTIFACT_NAME" ]]; then
+          echo "Artifact name '$ARTIFACT_NAME' does not match path basename '${ARTIFACT_PATH##*/}'" >&2
+          exit 1
+        fi
+        if [[ ! -s "$ARTIFACT_PATH" ]]; then
+          echo "Artifact is missing or empty: $ARTIFACT_PATH" >&2
+          exit 1
+        fi
+
+        artifact_size=$(stat --format=%s "$ARTIFACT_PATH")
+        echo "Uploading $ARTIFACT_NAME ($artifact_size bytes)" | tee -a "$GITHUB_STEP_SUMMARY"
+
+    # Both current callers produce tar archives whose contents are already
+    # compressed (Docker's image layers use gzip; Anneal uses zstd). Version 7's
+    # direct-file mode avoids a redundant ZIP on upload and extraction on every
+    # consumer. Keep this coordinated with download-artifact v8 in
+    # `../download-artifact-with-retry/action.yml`, which understands direct
+    # artifacts and verifies their service-provided digest.
+    - name: Upload artifact
+      id: upload
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: error
+        retention-days: 1
+        archive: false
+        # Artifacts are immutable. Delete an artifact with the same validated
+        # name first so "Re-run all jobs" can republish it under a new ID.
+        overwrite: true
+
+    - name: Verify published artifact metadata
+      shell: bash
+      env:
+        ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+      run: |
+        set -eu
+        if [[ ! "$ARTIFACT_ID" =~ ^[0-9]+$ ]]; then
+          echo "Upload did not return a numeric artifact ID: $ARTIFACT_ID" >&2
+          exit 1
+        fi
+        if [[ -z "$ARTIFACT_DIGEST" ]]; then
+          echo "Upload did not return an artifact digest" >&2
+          exit 1
+        fi

--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -24,6 +24,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # `v2_nix_cache` produces this file and every downstream Anneal job validates
+  # the same filename after downloading by immutable artifact ID. Keep the
+  # filename centralized here; the ID, not this name, selects the artifact.
+  ANNEAL_TOOLCHAIN_ARCHIVE: anneal-exocrate.tar.zst
   # Keep these bounded, download-only retry counts coordinated with ci.yml and
   # its Dockerfile. Neither setting reruns a build or test command.
   CARGO_NET_RETRY: "10"
@@ -102,9 +106,9 @@ jobs:
       - name: Download Anneal toolchain archive
         uses: ./.github/actions/download-artifact-with-retry
         with:
-          name: anneal-exocrate.tar.zst
+          artifact-id: ${{ needs.v2_nix_cache.outputs.toolchain_artifact_id }}
           path: anneal/target
-          expected-file: anneal-exocrate.tar.zst
+          expected-file: ${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
 
       # Ensure `llms-full.txt` file is up-to-date.
       - name: Check doc generation
@@ -112,7 +116,7 @@ jobs:
         working-directory: anneal/v1
 
       - name: Install Anneal toolchain archive
-        run: cargo run setup --local-archive ../target/anneal-exocrate.tar.zst
+        run: cargo run setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
         working-directory: anneal/v1
 
       # Run unit tests separately, as they're much less likely to have bugs
@@ -219,12 +223,12 @@ jobs:
       - name: Download Anneal toolchain archive
         uses: ./.github/actions/download-artifact-with-retry
         with:
-          name: anneal-exocrate.tar.zst
+          artifact-id: ${{ needs.v2_nix_cache.outputs.toolchain_artifact_id }}
           path: anneal/target
-          expected-file: anneal-exocrate.tar.zst
+          expected-file: ${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
 
       - name: Install Anneal toolchain archive
-        run: cargo run setup --local-archive ../target/anneal-exocrate.tar.zst
+        run: cargo run setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
         working-directory: anneal/v1
 
       - name: Verify example
@@ -268,6 +272,11 @@ jobs:
   v2_nix_cache:
     name: Build Anneal Toolchain Archive
     runs-on: ubuntu-latest
+    # All consumers depend on this job and select exactly the immutable artifact
+    # instance it published. This replaces the formerly duplicated artifact-name
+    # contract across the producer and three fan-out sites.
+    outputs:
+      toolchain_artifact_id: ${{ steps.upload_toolchain.outputs.artifact-id }}
     permissions:
       contents: read
     steps:
@@ -330,15 +339,15 @@ jobs:
             fi
           done
 
-          nix build "${nix_args[@]}" .#omnibus-archive-ci --out-link target/anneal-exocrate.tar.zst
-          archive="$(readlink -f target/anneal-exocrate.tar.zst)"
-          rm target/anneal-exocrate.tar.zst
-          cp "$archive" target/anneal-exocrate.tar.zst
-          archive_size="$(python3 -c 'import os, sys; print(os.path.getsize(sys.argv[1]))' target/anneal-exocrate.tar.zst)"
+          nix build "${nix_args[@]}" .#omnibus-archive-ci --out-link "target/$ANNEAL_TOOLCHAIN_ARCHIVE"
+          archive="$(readlink -f "target/$ANNEAL_TOOLCHAIN_ARCHIVE")"
+          rm "target/$ANNEAL_TOOLCHAIN_ARCHIVE"
+          cp "$archive" "target/$ANNEAL_TOOLCHAIN_ARCHIVE"
+          archive_size="$(python3 -c 'import os, sys; print(os.path.getsize(sys.argv[1]))' "target/$ANNEAL_TOOLCHAIN_ARCHIVE")"
           max_github_release_asset_size=2147483647
-          printf 'Built anneal-exocrate.tar.zst (%s bytes)\n' "$archive_size"
+          printf 'Built %s (%s bytes)\n' "$ANNEAL_TOOLCHAIN_ARCHIVE" "$archive_size"
           if [ "$archive_size" -gt "$max_github_release_asset_size" ]; then
-            echo "::error::anneal-exocrate.tar.zst is ${archive_size} bytes, which exceeds GitHub's ${max_github_release_asset_size}-byte release asset limit."
+            echo "::error::$ANNEAL_TOOLCHAIN_ARCHIVE is ${archive_size} bytes, which exceeds GitHub's ${max_github_release_asset_size}-byte release asset limit."
             exit 1
           fi
           nix build "${nix_args[@]}" .#omnibus-archive-layout-check --no-link
@@ -392,13 +401,14 @@ jobs:
           key: ${{ steps.restore_anneal_pr_nix_cache.outputs.cache-primary-key }}
 
       - name: Upload Anneal toolchain archive
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        id: upload_toolchain
+        # This archive is already zstd-compressed. The shared action publishes
+        # it directly instead of wrapping it in a ZIP that every matrix runner
+        # would otherwise have to extract.
+        uses: ./.github/actions/upload-file-artifact
         with:
-          name: anneal-exocrate.tar.zst
-          path: anneal/target/anneal-exocrate.tar.zst
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
+          name: ${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
+          path: anneal/target/${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
 
   v2:
     name: Run V2 tests
@@ -417,9 +427,9 @@ jobs:
       - name: Download Anneal toolchain archive
         uses: ./.github/actions/download-artifact-with-retry
         with:
-          name: anneal-exocrate.tar.zst
+          artifact-id: ${{ needs.v2_nix_cache.outputs.toolchain_artifact_id }}
           path: anneal/target
-          expected-file: anneal-exocrate.tar.zst
+          expected-file: ${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
 
       # FIXME: Pin this nightly to the same Rust date encoded in
       # anneal/flake.nix, or derive it from the archive metadata, so v2 CI is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ env:
   # with `.github/workflows/anneal.yml` and the CI Dockerfile.
   CARGO_NET_RETRY: "10"
   RUSTUP_MAX_RETRIES: "10"
+  # These two values are the producer/consumer protocol for the matrix's CI
+  # image. `build_docker_env` must export this tag into this archive, each
+  # consumer must load that archive, and the Docker shell wrapper must run this
+  # tag. Keep the protocol centralized here rather than duplicating literals in
+  # the upload/download actions.
+  ZC_CI_IMAGE: zerocopy-ci:local
+  ZC_CI_IMAGE_ARCHIVE: zerocopy-ci.tar
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings --cfg=zerocopy_unstable_ptr
   # `ZC_NIGHTLY_XXX` are flags that we add to `XXX` only on the nightly
@@ -54,7 +61,6 @@ jobs:
     needs: build_docker_env
     permissions:
       contents: read
-      packages: read # required to pull docker caches from ghcr.io
     defaults:
       run:
         shell: /tmp/docker-shell.sh {0} # zizmor: ignore[misfeature] (CI intentionally routes build matrix commands through the prebuilt Docker image)
@@ -307,34 +313,38 @@ jobs:
         fetch-depth: 2
         persist-credentials: false
 
-    - name: Set up Docker
-      uses: ./.github/actions/setup-docker-with-retry
+    # The producer exposes the ID assigned by upload-artifact, rather than an
+    # artifact name. The ID identifies one immutable artifact from this exact
+    # run, so a renamed, stale, or Buildx-generated artifact cannot be selected
+    # accidentally. Checkout must remain first because this is a local action.
+    - name: Download prebuilt Docker image
+      uses: ./.github/actions/download-artifact-with-retry
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        artifact-id: ${{ needs.build_docker_env.outputs.image_artifact_id }}
+        path: ${{ runner.temp }}
+        expected-file: ${{ env.ZC_CI_IMAGE_ARCHIVE }}
 
-    - name: Generate sanitized Docker tag
-      id: docker_tag
-      env:
-        REF_NAME: ${{ github.ref_name }}
+    # This step runs before /tmp/docker-shell.sh exists, so its explicit Bash
+    # shell is load-bearing. The Docker exporter is single-platform; the
+    # producer and every consumer intentionally use the same ubuntu-latest
+    # runner architecture. If CI gains another architecture, build and select a
+    # distinct artifact ID for it rather than silently sharing this archive.
+    - name: Load prebuilt Docker image
       shell: bash
+      env:
+        IMAGE_ARCHIVE: ${{ runner.temp }}/${{ env.ZC_CI_IMAGE_ARCHIVE }}
+        IMAGE_NAME: ${{ env.ZC_CI_IMAGE }}
       run: |
-        echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
-
-    - name: Load image from cache
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-      with:
-        context: .
-        file: .github/workflows/Dockerfile
-        load: true # This loads the resulting image into the local 'docker' daemon
-        tags: zerocopy-ci:local
-        provenance: false
-        cache-from: |
-          type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:${{ steps.docker_tag.outputs.tag }}
-          type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main
-        # Notice we omit `cache-to` here. We don't want many parallel jobs
-        # fighting to write the exact same layers back to the cache API.
+        set -euo pipefail
+        # Keep the large archive only as long as `docker load` needs it. The
+        # trap also reclaims it if loading or validation fails, avoiding archive
+        # plus expanded-image disk pressure for later diagnostic steps.
+        trap 'rm -f -- "$IMAGE_ARCHIVE"' EXIT
+        docker load --input "$IMAGE_ARCHIVE"
+        docker image inspect "$IMAGE_NAME" >/dev/null
+        # `inspect` proves the tag exists; running a trivial command also proves
+        # that the archive matches this runner's architecture.
+        docker run --rm "$IMAGE_NAME" true
 
     - name: Create Docker Shell Wrapper
       shell: bash
@@ -363,7 +373,7 @@ jobs:
           -e CARGO_NET_RETRY -e RUSTUP_MAX_RETRIES \
           -e ZC_NIGHTLY_RUSTFLAGS -e ZC_NIGHTLY_MIRIFLAGS \
           -e ZC_SKIP_CARGO_SEMVER_CHECKS \
-          zerocopy-ci:local bash -c "git config --global --add safe.directory '*' && exec bash \"\$1\"" -- "$1"
+          "$ZC_CI_IMAGE" bash -c "git config --global --add safe.directory '*' && exec bash \"\$1\"" -- "$1"
         EOF
         chmod +x /tmp/docker-shell.sh
 
@@ -988,6 +998,11 @@ jobs:
   build_docker_env:
     name: Build Docker image
     runs-on: ubuntu-latest
+    # Consumers select the upload by this immutable, producer-generated ID.
+    # Do not replace it with a duplicated artifact-name string: an empty ID is
+    # deliberately rejected by download-artifact-with-retry before fan-out.
+    outputs:
+      image_artifact_id: ${{ steps.upload_image.outputs.artifact-id }}
     permissions:
       contents: read
       packages: write # required to push docker caches to ghcr.io
@@ -1011,19 +1026,34 @@ jobs:
         run: |
           echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and cache layers
+      - name: Build, cache, and export image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: .github/workflows/Dockerfile
-          push: false
+          tags: ${{ env.ZC_CI_IMAGE }}
           provenance: false
+          # The Docker exporter creates a single archive accepted directly by
+          # `docker load`. Its gzip-compressed layers make the tar suitable for
+          # upload-file-artifact's direct (non-ZIP) transfer. This path and tag
+          # are coupled to the workflow-level producer/consumer values above.
+          outputs: type=docker,dest=${{ runner.temp }}/${{ env.ZC_CI_IMAGE_ARCHIVE }},compression=gzip
           cache-from: |
             type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:${{ steps.docker_tag.outputs.tag }}
             type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main
           # External pull requests have read-only package permissions, so they
           # can consume GHCR caches but cannot export updated cache layers.
           cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:{0},mode=max', steps.docker_tag.outputs.tag) || '' }}
+
+      # Uploading is the producer's final gate. Matrix jobs cannot start until
+      # this succeeds and the job exposes its artifact ID, so no runner is spent
+      # on an image that was only partially published.
+      - name: Upload image for matrix jobs
+        id: upload_image
+        uses: ./.github/actions/upload-file-artifact
+        with:
+          name: ${{ env.ZC_CI_IMAGE_ARCHIVE }}
+          path: ${{ runner.temp }}/${{ env.ZC_CI_IMAGE_ARCHIVE }}
 
   # Used to signal to branch protections that all other jobs have succeeded.
   all-jobs-succeed:


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Build and export the CI Docker image once, upload its gzip-layer archive
directly, and have every matrix cell select that exact artifact by
the producer-generated ID. Load and validate the image locally, then
remove the archive immediately. This eliminates per-cell Buildx setup,
registry login, and cache reconstruction while preserving fork behavior.

Apply the same immutable-ID contract to the Anneal toolchain
fan-out. Upload both already-compressed files without a redundant ZIP,
centralize their filenames, and validate upload metadata, download
selectors, file shape, digest, and rerun overwrite behavior in shared
local actions.

The current Docker cache contains 1,275,967,148 compressed bytes. A
representative 60-cell hosted PR spent 3,265 aggregate seconds
in per-cell Buildx and cache loading, averaging 54.4 seconds per
cell. This change should remove repeated BuildKit bootstrap and
cache-solve overhead; artifact transfer and docker load remain and
require hosted follow-up measurement.




---

- 　  #3506
- 　  #3505
- 　  #3509
- 👉 #3508


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v1..gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v1..gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2 && git checkout -b pr-Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gr7m2v9k4x6c3p8s5d1f0h2j4l6n8q0w2", "parent": null, "child": "G8b5ff74785cf1dfeef62eb4ce695116cac0e9290"}" -->