### PR TITLE
[ci] Avoid redundant Anneal PR caches

### DIFF
--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -303,11 +303,19 @@ jobs:
 
       # Pull request caches are scoped by GitHub to the PR merge ref, so they
       # can speed up repeated pushes to the same PR without becoming visible to
-      # `main` or to sibling PRs. Keep this separate from the trusted main cache
-      # so untrusted PR output cannot publish a shared substituter.
+      # `main` or to sibling PRs. This cache is a fallback for an exact miss in
+      # the trusted main cache above, not a second copy to restore after a main
+      # hit: both exact keys identify the same archive inputs, and the trusted
+      # main result is already usable by the PR.
+      #
+      # Keep this condition coordinated with both PR cache population steps
+      # below. An archive-changing PR must still be able to restore and publish
+      # its branch-local result after the trusted main key misses.
       - name: Restore Anneal PR Nix binary cache
         id: restore_anneal_pr_nix_cache
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore_anneal_main_nix_cache.outputs.cache-hit != 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: anneal/target/nix-cache-pr
@@ -383,7 +391,10 @@ jobs:
           key: ${{ steps.restore_anneal_main_nix_cache.outputs.cache-primary-key }}
 
       - name: Populate Anneal PR Nix binary cache
-        if: github.event_name == 'pull_request' && steps.restore_anneal_pr_nix_cache.outputs.cache-hit != 'true'
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore_anneal_main_nix_cache.outputs.cache-hit != 'true' &&
+          steps.restore_anneal_pr_nix_cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/nix-cache-pr
@@ -394,7 +405,10 @@ jobs:
         working-directory: anneal
 
       - name: Save Anneal PR Nix binary cache
-        if: github.event_name == 'pull_request' && steps.restore_anneal_pr_nix_cache.outputs.cache-hit != 'true'
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.restore_anneal_main_nix_cache.outputs.cache-hit != 'true' &&
+          steps.restore_anneal_pr_nix_cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: anneal/target/nix-cache-pr


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Treat the PR-local Anneal Nix cache as a fallback for an exact miss in
the trusted main cache. Skip its restore, population, and save when
`main` already supplies the same archive inputs.

This removes a redundant 1.465 GB cache transfer or publication from
ordinary pull requests while preserving branch-local reuse for
archive-changing PRs.




---

- 　  #3506
- 　  #3505
- 👉 #3509


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v1..gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v1..gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290 && git checkout -b pr-G8b5ff74785cf1dfeef62eb4ce695116cac0e9290 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G8b5ff74785cf1dfeef62eb4ce695116cac0e9290
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G8b5ff74785cf1dfeef62eb4ce695116cac0e9290", "parent": null, "child": "Ghjiwdkxk7bi3ag2zcvbf3jc2c5yyyafc"}" -->