### PR TITLE
[ci] Repair weekly toolchain rollers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,7 +694,9 @@ jobs:
         run: |
           set -eo pipefail
           sudo apt install -qq llvm
-          ./cargo.sh +nightly install --quiet cargo-show-asm
+          # Snapshot generation calls this same helper, so generation and
+          # validation cannot silently select different tool releases.
+          bash ../tools/install-cargo-show-asm.sh
           RUSTFLAGS="$RUSTFLAGS -Awarnings" ./cargo.sh +nightly test \
             --package zerocopy \
             --target x86_64-unknown-linux-gnu \

--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -57,16 +57,20 @@ jobs:
         env:
           TOOLCHAIN: ${{ matrix.toolchain }}
         run: |
+          set -eo pipefail
+
           if [ "$TOOLCHAIN" == stable ]; then
-            # Install whatever the latest stable release is. This has the side
-            # effect of determining the latest stable release so that we can
-            # update `zerocopy/Cargo.toml`.
-            echo "ZC_TARGET_TOOLCHAIN=stable" >> $GITHUB_ENV
+            # Hosted runners may have an older `stable` toolchain installed.
+            # Update it explicitly so that this roller means "latest stable",
+            # independent of changes to the runner image.
+            rustup update stable --no-self-update
+            echo "ZC_TARGET_TOOLCHAIN=stable" >> "$GITHUB_ENV"
           else
             # Use yesterday's date (`-d '-1 day'`) so we're sure the nightly for
             # that date has actually been published yet. This allows us to not
             # worry about what time of day this job runs.
-            echo "ZC_TARGET_TOOLCHAIN=nightly-$(date -d '-1 day' +%Y-%m-%d)" >> $GITHUB_ENV
+            echo "ZC_TARGET_TOOLCHAIN=nightly-$(date -d '-1 day' +%Y-%m-%d)" \
+              >> "$GITHUB_ENV"
           fi
 
       - name: Update files
@@ -75,25 +79,30 @@ jobs:
         run: |
           set -eo pipefail
 
-          function validate-file {
-            REGEX="$1"
-            FILE="$2"
-            grep "$REGEX" "$FILE" >/dev/null || { echo "Failed to find line matching regex '$REGEX' in $FILE" >&2; exit 1; }
-          }
-
           function update-pinned-version {
             VERSION_NAME="$1"
             VERSION="$2"
             ZEROCOPY_FEATURES="$3"
 
-            # Confirm that `zerocopy/Cargo.toml` lists the pinned version in the expected
-            # format. This is a prerequisite for the subsequent `sed` command.
+            # Confirm that `zerocopy/Cargo.toml` lists exactly one pinned
+            # version in the expected format. This is a prerequisite for the
+            # subsequent `sed` command. Requiring exactly one match makes a
+            # future manifest reorganization fail visibly instead of silently
+            # editing only some of the version declarations.
             REGEX="^pinned-$VERSION_NAME = \"[a-z0-9\.-]*\"$"
-            validate-file "$REGEX" zerocopy/Cargo.toml
-            sed -i -e "s/$REGEX/pinned-$VERSION_NAME = \"$VERSION\"/" zerocopy/Cargo.toml
+            MATCH_COUNT="$(grep -Ec "$REGEX" zerocopy/Cargo.toml || true)"
+            if [ "$MATCH_COUNT" -ne 1 ]; then
+              echo "Expected exactly one line matching '$REGEX' in" \
+                "zerocopy/Cargo.toml; found $MATCH_COUNT" >&2
+              exit 1
+            fi
+            sed -i -e \
+              "s/$REGEX/pinned-$VERSION_NAME = \"$VERSION\"/" \
+              zerocopy/Cargo.toml
 
-            # Confirm that the update didn't bork `zerocopy/Cargo.toml`.
-            validate-file "$REGEX" zerocopy/Cargo.toml
+            # Confirm that the update produced precisely the requested value.
+            grep -Fx "pinned-$VERSION_NAME = \"$VERSION\"" \
+              zerocopy/Cargo.toml >/dev/null
 
             # Run `cargo fix` in case there are any warnings or errors
             # introduced on this new toolchain that we can fix automatically.
@@ -106,19 +115,29 @@ jobs:
           }
 
           if [ "$TOOLCHAIN" == stable ]; then
-            STABLE_VERSION="$(cargo +stable version | sed -e 's/^cargo \([0-9\.]*\) .*/\1/')"
-            update-pinned-version stable "$STABLE_VERSION" '--features __internal_use_only_features_that_work_on_stable'
+            STABLE_VERSION="$(
+              rustc +stable --version --verbose \
+                | sed -nE 's/^release: ([0-9]+\.[0-9]+\.[0-9]+)$/\1/p'
+            )"
+            if ! [[ "$STABLE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Could not determine the latest stable rustc version" >&2
+              exit 1
+            fi
+            update-pinned-version stable "$STABLE_VERSION" \
+              '--features __internal_use_only_features_that_work_on_stable'
 
             # Used as part of the branch name created by the "Submit PR" step.
-            echo "ZC_VERSION_FOR_BRANCH_NAME=$STABLE_VERSION" >> $GITHUB_ENV
+            echo "ZC_VERSION_FOR_BRANCH_NAME=$STABLE_VERSION" \
+              >> "$GITHUB_ENV"
           else
             update-pinned-version nightly "$ZC_TARGET_TOOLCHAIN" --all-features
-            echo "ZC_VERSION_FOR_BRANCH_NAME=$ZC_TARGET_TOOLCHAIN" >> $GITHUB_ENV
+            echo "ZC_VERSION_FOR_BRANCH_NAME=$ZC_TARGET_TOOLCHAIN" \
+              >> "$GITHUB_ENV"
           fi
 
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "[ci] Roll pinned ${{ matrix.toolchain }} toolchain"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>
@@ -142,9 +161,12 @@ jobs:
       contents: read
       pull-requests: write # Required to create pull requests
     strategy:
+      # A failure on one release branch must not cancel otherwise-independent
+      # rolls for the other branches.
+      fail-fast: false
       matrix:
         branch: ["main", "v0.7.x"]
-    name: Roll pinned Kani version
+    name: Roll pinned Kani version on ${{ matrix.branch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -154,17 +176,45 @@ jobs:
       - run: |
           set -eo pipefail
 
-          # NOTE: If this is failing, try adding the `cargo add` command on a
-          # separate line to see its output. As is, we pipe stdout and stderr to
-          # `grep`, which will eat any error messages.
-          KANI_LATEST=$(cargo add --dry-run kani-verifier 2>&1 | grep -oh '[0-9]\+\.[0-9]\+\.[0-9]\+')
-          echo "ZC_KANI_LATEST=$KANI_LATEST" >> $GITHUB_ENV
+          # `cargo add --dry-run` prints versions of transitive dependencies as
+          # well as the selected Kani version. Parsing every SemVer from that
+          # output once produced a multi-line GITHUB_ENV value and broke this
+          # roller. `cargo search --limit 1` has one anchored record for the
+          # named package; fail if its format ever changes.
+          KANI_SEARCH="$(
+            cargo search kani-verifier \
+              --registry crates-io \
+              --limit 1 \
+              --color never
+          )"
+          KANI_LATEST="$(
+            sed -nE \
+              's/^kani-verifier = "([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' \
+              <<< "$KANI_SEARCH"
+          )"
+          if ! [[ "$KANI_LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not parse a Kani version from: $KANI_SEARCH" >&2
+            exit 1
+          fi
+          echo "ZC_KANI_LATEST=$KANI_LATEST" >> "$GITHUB_ENV"
 
           # Update the `kani-version:` argument in-place.
-          sed -i -E -e "s/^( *kani-version:)( [0-9]+\.[0-9]+\.[0-9]+)/\1 $KANI_LATEST/" .github/workflows/ci.yml
+          MATCH_COUNT="$(
+            grep -Ec '^ *kani-version: [0-9]+\.[0-9]+\.[0-9]+$' \
+              .github/workflows/ci.yml || true
+          )"
+          if [ "$MATCH_COUNT" -ne 1 ]; then
+            echo "Expected exactly one Kani version in ci.yml; found $MATCH_COUNT" >&2
+            exit 1
+          fi
+          sed -i -E -e \
+            "s/^( *kani-version:)( [0-9]+\.[0-9]+\.[0-9]+)/\1 $KANI_LATEST/" \
+            .github/workflows/ci.yml
+          grep -E "^ *kani-version: $KANI_LATEST$" \
+            .github/workflows/ci.yml >/dev/null
       - name: Submit PR
         id: submit-pr
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.0 # zizmor: ignore[superfluous-actions]
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1 # zizmor: ignore[superfluous-actions]
         with:
           commit-message: "[ci] Roll pinned Kani version"
           author: Google PR Creation Bot <github-pull-request-creation-bot@google.com>

--- a/tools/install-cargo-show-asm.sh
+++ b/tools/install-cargo-show-asm.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# This helper is the single version contract for codegen snapshot generation
+# and validation. Keep the exact requirement here rather than duplicating it in
+# workflow YAML, where the two call sites could drift silently.
+"$ROOT/zerocopy/cargo.sh" +nightly install --quiet --locked \
+  --version '=0.2.62' cargo-show-asm

--- a/tools/update-expected-test-output.sh
+++ b/tools/update-expected-test-output.sh
@@ -11,6 +11,11 @@
 set -eo pipefail
 cd "$(dirname "$0")/../zerocopy"
 
+# Codegen tests invoke `cargo asm`. Installing through the same helper as the
+# validation workflow makes this script self-contained while keeping one exact
+# tool version for both snapshot generation and validation.
+bash ../tools/install-cargo-show-asm.sh
+
 # Update the `.stderr` reference files used to validate our UI tests and the
 # `.x86-64.mca` files used to validate our codegen tests.
 BLESS=1 ./cargo.sh +nightly test --test codegen -p zerocopy --all-features


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The Rust roller could not regenerate codegen snapshots because
cargo-show-asm was only installed by the validation workflow. Install
a pinned version in the regeneration helper and keep normal CI on that
same version.

Update stable explicitly before selecting its rustc version. Parse Kani
from the single anchored cargo-search record instead of collecting every
SemVer printed by cargo add.

Require each edited pin to have exactly one expected source line, and
let independent Kani branch rolls finish when one matrix cell fails.




---

- 　  #3506
- 　  #3505
- 　  #3516
- 　  #3515
- 　  #3514
- 　  #3513
- 　  #3512
- 👉 #3511


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v3..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v2..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v1..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v3..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v2..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v1..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v2..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v1..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v1..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/Gi7fqbztzwp7leeet4gpsldtxbcjupbml/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gi7fqbztzwp7leeet4gpsldtxbcjupbml && git checkout -b pr-Gi7fqbztzwp7leeet4gpsldtxbcjupbml FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gi7fqbztzwp7leeet4gpsldtxbcjupbml && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gi7fqbztzwp7leeet4gpsldtxbcjupbml && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gi7fqbztzwp7leeet4gpsldtxbcjupbml
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "Gi7fqbztzwp7leeet4gpsldtxbcjupbml", "parent": null, "child": "Gythmn2x4ak26nzocje3gxts44y7itqe6"}" -->