### PR TITLE
[exocrate] Lift `parse_remote_archive` dependency on `toml_const`

### DIFF
--- a/anneal/Cargo.lock
+++ b/anneal/Cargo.lock
@@ -288,7 +288,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
- "toml_const",
  "walkdir",
 ]
 
@@ -377,7 +376,7 @@ dependencies = [
  "strip-ansi-escapes",
  "take_mut",
  "tempfile",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1445,49 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "serde",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,15 +1802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_stacker"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,12 +1868,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2157,48 +2098,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_const"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389864cf501669b741746e9bc35e66c67f2b80266482ad04c452e2410433f205"
-dependencies = [
- "phf",
- "toml 0.9.12+spec-1.1.0",
- "toml_const_macros",
-]
-
-[[package]]
-name = "toml_const_macros"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0f202adfb96027640ad9786a0657775414482cfd840c19e9957ada8cfbbfd"
-dependencies = [
- "indexmap",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2211,15 +2113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,19 +2120,10 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -2247,12 +2131,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -2745,12 +2623,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winsafe"

--- a/anneal/Cargo.toml
+++ b/anneal/Cargo.toml
@@ -45,7 +45,6 @@ url = "https://example.com/macos-aarch64.tar.zst"
 
 [dependencies]
 exocrate = { path = "../exocrate" }
-toml_const = "1.3.0"
 clap = { version = "4.5", features = ["derive"] }
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 env_logger = "0.11"

--- a/anneal/src/main.rs
+++ b/anneal/src/main.rs
@@ -47,12 +47,7 @@ exocrate::config! {
 }
 
 exocrate::parse_remote_archive! {
-    const REMOTE: RemoteArchive = "Cargo.toml" [
-        (linux, x86_64),
-        (macos, x86_64),
-        (linux, aarch64),
-        (macos, aarch64),
-    ];
+    const REMOTE: RemoteArchive;
 }
 
 fn setup_installation_dir(args: SetupArgs) -> std::path::PathBuf {

--- a/anneal/src/setup.rs
+++ b/anneal/src/setup.rs
@@ -21,12 +21,7 @@ exocrate::config! {
 }
 
 exocrate::parse_remote_archive! {
-    pub const REMOTE: RemoteArchive = "Cargo.toml" [
-        (linux, x86_64),
-        (macos, x86_64),
-        (linux, aarch64),
-        (macos, aarch64),
-    ];
+    pub const REMOTE: RemoteArchive;
 }
 
 pub enum Tool {

--- a/exocrate/src/lib.rs
+++ b/exocrate/src/lib.rs
@@ -349,65 +349,55 @@ fn install(mut reader: impl Read, dst: &Path, expected_sha256: Option<[u8; 32]>)
 /// [package.metadata.exocrate.macos.aarch64]
 /// sha256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
 /// url = "https://example.com/macos-aarch64.tar.zst"
-/// ```
 ///
-/// The `parse_remote_archive!` invocation must specify the set of OS/Arch
-/// pairs, e.g.:
-///
-/// ```rust,ignore
+/// Example Usage:
 /// parse_remote_archive! {
-///     const REMOTE: RemoteArchive = "Cargo.toml" [
-///         (linux, x86_64),
-///         (linux, aarch64),
-///         (macos, aarch64),
-///         (macos, x86_64),
-///     ];
+///     const REMOTE: RemoteArchive;
 /// }
 /// ```
 ///
-/// **NOTE**: The calling crate must have its own dependency on the `toml_const`
-/// crate.
-// - FIXME(#3409): Lift this limitation.
-// - FIXME(#3410): Don't require the user to specify os/arch pairs in the macro invocation.
 #[macro_export]
 macro_rules! parse_remote_archive {
-    ($vis:vis const $name:ident: RemoteArchive = $cargo_toml_path:literal [
-        $(($os:ident, $arch:ident)),* $(,)?
-    ];) => {
+    ($vis:vis const $name:ident: RemoteArchive;) => {
         $vis const $name: $crate::RemoteArchive = {
-            ::toml_const::toml_const!{
-                const MANIFEST: $cargo_toml_path;
+            // Read the calling crate's `Cargo.toml`. `CARGO_MANIFEST_DIR` is expanded
+            // at the invocation site, so this always refers to the manifest of the crate
+            // using `parse_remote_archive!`, not the crate defining the macro.
+            const MANIFEST: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+            const PREFIX: &str = "[package.metadata.exocrate.";
+
+            let Some(header) = $crate::macro_util::find_line(
+                MANIFEST,
+                ::std::env::consts::OS,
+                ::std::env::consts::ARCH,
+                PREFIX,
+            ) else {
+                panic!("unsupported platform")
+            };
+            let bytes = MANIFEST.as_bytes();
+            let mut body_start = header;
+            while body_start < bytes.len() && bytes[body_start] != b'\n' {
+                body_start += 1;
+            }
+            if body_start < bytes.len() {
+                body_start += 1;
             }
 
-            let config = {
-                use std::env::consts::*;
-                use $crate::macro_util::pack;
-
-                // NOTE: Rust doesn't support checking `&str`s for equality in a
-                // `const` context. We work around that limitation by packing
-                // their bytes into `u128`s, which can be compared.
-                //
-                // FIXME(#3410): How can we detect if os/arch pairs have been added to
-                // `Cargo.toml` without being added to the macro invocation?
-                match (pack(OS), pack(ARCH)) {
-                    $(
-                        (os, arch) if os == pack(stringify!($os)) && arch == pack(stringify!($arch)) => {
-                            MANIFEST.package.metadata.exocrate.$os.$arch
-                        }
-                    )*
-                    _ => panic!("unsupported platform"),
-                }
+            let Some(url) = $crate::macro_util::find_field(MANIFEST, body_start, "url") else {
+                panic!("missing `url` field")
             };
-
-            let Some(sha256) = $crate::macro_util::decode_hex(config.sha256) else {
+            let Some(sha256_str) =
+                $crate::macro_util::find_field(MANIFEST, body_start, "sha256")
+            else {
+                panic!("missing `sha256` field")
+            };
+            let Some(sha256) = $crate::macro_util::decode_hex(sha256_str) else {
                 panic!("invalid sha256")
             };
-            $crate::RemoteArchive {
-                sha256,
-                url: config.url,
-            }
+
+            $crate::RemoteArchive { sha256, url }
         };
-    }
+    };
 }
 
 /// Defines a versioned exocrate configuration (a [`Config`])
@@ -547,6 +537,157 @@ pub mod macro_util {
             i += 1;
         }
         res
+    }
+
+    #[doc(hidden)]
+    pub struct ParsedRemoteArchive<'a> {
+        pub url: &'a str,
+        pub sha256: &'a str,
+    }
+
+    /// Returns `true` if the bytes in `data` starting at `offset` exactly match
+    /// `to_search`.
+    ///
+    /// If `offset + to_search.len()` would exceed the bounds of `data`, this
+    /// function returns `false`.
+    pub const fn bytes_eq_at(data: &[u8], offset: usize, to_search: &[u8]) -> bool {
+        if offset + to_search.len() > data.len() {
+            return false;
+        }
+
+        let mut i = 0;
+        while i < to_search.len() {
+            if data[offset + i] != to_search[i] {
+                return false;
+            }
+            i += 1;
+        }
+
+        true
+    }
+
+    /// Searches `manifest` for a metadata section whose header matches
+    /// `prefix`, `os`, and `arch`.
+    /// The expected format is `[metadata.exocrate.manifest.{os}.{arch}]`
+    pub const fn find_line(manifest: &str, os: &str, arch: &str, prefix: &str) -> Option<usize> {
+        let bytes = manifest.as_bytes();
+        let os = os.as_bytes();
+        let arch = arch.as_bytes();
+        let prefix = prefix.as_bytes();
+
+        let mut i = 0;
+
+        while i < bytes.len() {
+            // Only consider the beginning of lines.
+            if i != 0 && bytes[i - 1] != b'\n' {
+                i += 1;
+                continue;
+            }
+
+            if !bytes_eq_at(bytes, i, prefix) {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+
+            let mut pos = i + prefix.len();
+
+            if !bytes_eq_at(bytes, pos, os) {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+            pos += os.len();
+
+            if pos >= bytes.len() || bytes[pos] != b'.' {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+            pos += 1;
+
+            if !bytes_eq_at(bytes, pos, arch) {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+                continue;
+            }
+            pos += arch.len();
+
+            if pos < bytes.len() && bytes[pos] == b']' {
+                return Some(i);
+            }
+
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+        }
+
+        None
+    }
+
+    /// This function finds the `value` for a passed `key` in the passed
+    /// `manifest` after starting at `start` offset. It  returns a `None`
+    /// variant if it hits a `[` or an `EOF` before finding the key.
+    ///
+    /// Note: Expected format for key/value pair is:
+    /// `Key = "Value"` do mind the spaces otherwise it will return `None`.
+    pub const fn find_field<'a>(manifest: &'a str, start: usize, key: &str) -> Option<&'a str> {
+        let bytes = manifest.as_bytes();
+        let key = key.as_bytes();
+        let mut i = start;
+        while i < bytes.len() {
+            if bytes[i] == b'[' {
+                return None;
+            }
+            if bytes_eq_at(bytes, i, key) {
+                let mut pos = i + key.len();
+                // expect exactly " = \"" (space, equals, space, quote)
+                if pos + 4 <= bytes.len()
+                    && bytes[pos] == b' '
+                    && bytes[pos + 1] == b'='
+                    && bytes[pos + 2] == b' '
+                    && bytes[pos + 3] == b'"'
+                {
+                    pos += 4;
+                    let value_start = pos;
+                    let mut value_end = value_start;
+                    while value_end < bytes.len() && bytes[value_end] != b'"' {
+                        value_end += 1;
+                    }
+                    if value_end < bytes.len() {
+                        let (_, rest) = manifest.split_at(value_start);
+                        let (value, _) = rest.split_at(value_end - value_start);
+                        return Some(value);
+                    }
+                }
+            }
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1;
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
Changelog:
- `exocrate/lib.rs` : Write helper const fn's `bytes_eq_at`, `find_line` and `find_field` to replace `toml_const` from `parse_remote_archive` macro. This also resolves #3410 since the section header is now located by scanning rather than matching against a pre-declared list.

- `anneal/main.rs` , `anneal/setup.rs` : Fix the macro declaration.
- `anneal/cargo.toml` : Remove `toml_const` as a dependency.

Fixes: #3409 , #3410

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
