### PR TITLE
#[zerocopy(crate = "...")] should parse paths, not idents

### DIFF
--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -13,9 +13,9 @@ use std::num::NonZeroU32;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    parse_quote, spanned::Spanned as _, Data, DataEnum, DataStruct, DataUnion, DeriveInput, Error,
-    Expr, ExprLit, Field, GenericParam, Ident, Index, Lit, LitStr, Meta, Path, Type, Variant,
-    Visibility, WherePredicate,
+    parse::ParseBuffer, parse_quote, spanned::Spanned as _, token::PathSep, Data, DataEnum,
+    DataStruct, DataUnion, DeriveInput, Error, Expr, ExprLit, Field, GenericParam, Ident, Index,
+    Lit, LitStr, Meta, Path, Type, Variant, Visibility, WherePredicate,
 };
 
 use crate::repr::{CompoundRepr, EnumRepr, PrimitiveRepr, Repr, Spanned};
@@ -32,6 +32,56 @@ pub(crate) struct Ctx {
     pub(crate) on_error_span: Option<proc_macro2::Span>,
 }
 
+#[derive(Eq, PartialEq)]
+enum CratePath {
+    External,
+    CrateRelative,
+    ModuleRelative,
+}
+
+fn validate_crate_path(path: &Path) -> Result<CratePath, ()> {
+    if path.segments.is_empty() {
+        return Err(());
+    }
+
+    enum ModuleRelative {
+        Yes,
+        No,
+    }
+    let first = path.segments[0].ident.to_string();
+    let (mut prev_segment, path_type) = match first.as_str() {
+        "Self" => return Err(()),
+        "crate" => {
+            if path.leading_colon.is_some() {
+                return Err(());
+            }
+            (ModuleRelative::No, CratePath::CrateRelative)
+        }
+        "self" | "super" => {
+            if path.leading_colon.is_some() {
+                return Err(());
+            }
+            (ModuleRelative::Yes, CratePath::ModuleRelative)
+        }
+        _ => (ModuleRelative::No, CratePath::External),
+    };
+
+    for seg in path.segments.iter().skip(1) {
+        let ident = seg.ident.to_string();
+        match ident.as_str() {
+            "Self" | "crate" | "self" => return Err(()),
+            "super" => match prev_segment {
+                ModuleRelative::Yes => {}
+                ModuleRelative::No => return Err(()),
+            },
+            _ => {
+                prev_segment = ModuleRelative::No;
+            }
+        }
+    }
+    Ok(path_type)
+}
+
 impl Ctx {
     /// Attempt to extract a crate path from the provided attributes. Defaults to
     /// `::zerocopy` if not found.
@@ -45,16 +95,32 @@ impl Ctx {
                 if meta_list.path.is_ident("zerocopy") {
                     attr.parse_nested_meta(|meta| {
                         if meta.path.is_ident("crate") {
-                            let expr = meta.value().and_then(|value| value.parse());
+                            let expr = meta.value().and_then(ParseBuffer::parse);
                             if let Ok(Expr::Lit(ExprLit { lit: Lit::Str(lit), .. })) = expr {
-                                if let Ok(path_lit) = lit.parse::<Ident>() {
-                                    path = parse_quote!(::#path_lit);
-                                    return Ok(());
+                                if let Ok(mut path_lit) = lit.parse_with(Path::parse_mod_style) {
+                                    if let Ok(crate_path) = validate_crate_path(&path_lit) {
+                                        // If not expressly relative, absolutize.
+                                        if path_lit.leading_colon.is_none() && crate_path == CratePath::External {
+                                            path_lit.leading_colon = Some(PathSep::default());
+                                        }
+                                        path = path_lit;
+                                        return Ok(());
+                                    }
+
+                                    return Err(Error::new(
+                                        lit.span(),
+                                        "`crate` attribute requires a valid module path",
+                                    ));
                                 }
+
+                                return Err(Error::new(
+                                    lit.span(),
+                                    "`crate` attribute requires a path as the value",
+                                ));
                             }
 
                             return Err(Error::new(
-                                Span::call_site(),
+                                meta.path.span(),
                                 "`crate` attribute requires a path as the value",
                             ));
                         }
@@ -859,5 +925,59 @@ pub(crate) mod testutil {
                 let _ = Self::Ambiguous;
             }
         });
+    }
+
+    #[test]
+    fn test_validate_crate_path() {
+        use syn::parse_str;
+
+        let valid = [
+            "zerocopy",
+            "crate",
+            "crate::foo::bar",
+            "self",
+            "self::foo",
+            "self::super::foo",
+            "super",
+            "super::foo",
+            "super::super::foo",
+            "super::super::super",
+            "foo::bar::baz",
+            "::foo::bar",
+        ];
+
+        for path_str in valid {
+            let path = parse_str::<syn::Path>(path_str).unwrap();
+            assert!(
+                super::validate_crate_path(&path).is_ok(),
+                "expected valid path for `{}`",
+                path_str
+            );
+        }
+
+        let invalid = [
+            "::crate::foo",
+            "::self::foo",
+            "::super::foo",
+            "Self",
+            "Self::foo",
+            "foo::Self::bar",
+            "foo::crate::bar",
+            "foo::super::bar",
+            "foo::self",
+            "super::foo::super",
+            "super::crate::foo",
+            "crate::super::foo",
+            "self::self::foo",
+        ];
+
+        for path_str in invalid {
+            let path = parse_str::<syn::Path>(path_str).unwrap();
+            assert!(
+                super::validate_crate_path(&path).is_err(),
+                "expected invalid path for `{}`",
+                path_str
+            );
+        }
     }
 }

--- a/zerocopy/zerocopy-derive/tests/hygiene.rs
+++ b/zerocopy/zerocopy-derive/tests/hygiene.rs
@@ -18,25 +18,79 @@ include!("include.rs");
 
 extern crate zerocopy_renamed as _zerocopy;
 
-#[derive(_zerocopy::KnownLayout, _zerocopy::FromBytes, _zerocopy::Unaligned)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(C)]
-struct TypeParams<'a, T, I: imp::Iterator> {
-    a: T,
-    c: I::Item,
-    d: u8,
-    e: imp::PhantomData<&'a [::core::primitive::u8]>,
-    f: imp::PhantomData<&'static ::core::primitive::str>,
-    g: imp::PhantomData<imp::String>,
+extern crate self as derive_path_test;
+
+pub mod nested {
+    pub extern crate zerocopy_renamed as reexported_zerocopy;
 }
 
-util_assert_impl_all!(
-    TypeParams<'static, (), imp::IntoIter<()>>:
-        _zerocopy::KnownLayout,
-        _zerocopy::FromZeros,
-        _zerocopy::FromBytes,
-        _zerocopy::Unaligned
-);
+macro_rules! test {
+    ($($path:tt)::*, $crate_str:tt) => {
+        #[derive(
+            $($path)::*::KnownLayout,
+            $($path)::*::FromBytes,
+            $($path)::*::Unaligned,
+        )]
+        #[zerocopy(crate = $crate_str)]
+        #[repr(C)]
+        struct TypeParams<'a, T, I: imp::Iterator> {
+            a: T,
+            c: I::Item,
+            d: u8,
+            e: imp::PhantomData<&'a [::core::primitive::u8]>,
+            f: imp::PhantomData<&'static ::core::primitive::str>,
+            g: imp::PhantomData<imp::String>,
+        }
+
+        util_assert_impl_all!(
+            TypeParams<'static, (), imp::IntoIter<()>>:
+                $($path)::*::KnownLayout,
+                $($path)::*::FromZeros,
+                $($path)::*::FromBytes,
+                $($path)::*::Unaligned
+        );
+    };
+}
+
+test!(_zerocopy, "zerocopy_renamed");
+
+mod nested_external {
+    use super::*;
+
+    test!(
+        derive_path_test::nested::reexported_zerocopy,
+        "derive_path_test::nested::reexported_zerocopy"
+    );
+}
+
+mod crate_relative {
+    use super::*;
+
+    test!(crate::nested::reexported_zerocopy, "crate::nested::reexported_zerocopy");
+}
+
+mod super_relative {
+    use super::*;
+
+    test!(super::nested::reexported_zerocopy, "super::nested::reexported_zerocopy");
+}
+
+mod self_super_relative {
+    use super::*;
+
+    test!(self::super::nested::reexported_zerocopy, "self::super::nested::reexported_zerocopy");
+}
+
+mod super_super_relative {
+    mod inner {
+        use super::super::*;
+
+        test!(
+            super::super::nested::reexported_zerocopy,
+            "super::super::nested::reexported_zerocopy"
+        );
+    }
+}
 
 // Regression test for #2177.
 //

--- a/zerocopy/zerocopy-derive/tests/paths_and_modules.rs
+++ b/zerocopy/zerocopy-derive/tests/paths_and_modules.rs
@@ -12,32 +12,78 @@
 
 include!("include.rs");
 
-// Ensure that types that are use'd and types that are referenced by path work.
+extern crate self as derive_path_test;
 
-mod foo {
-    use super::*;
-
-    #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
-    #[zerocopy(crate = "zerocopy_renamed")]
-    #[repr(C)]
-    pub struct Foo {
-        foo: u8,
-    }
-
-    #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
-    #[zerocopy(crate = "zerocopy_renamed")]
-    #[repr(C)]
-    pub struct Bar {
-        bar: u8,
-    }
+pub mod nested {
+    pub extern crate zerocopy_renamed as reexported_zerocopy;
 }
 
-use foo::Foo;
+// Ensure that types that are use'd and types that are referenced by path work.
 
-#[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(C)]
-struct Baz {
-    foo: Foo,
-    bar: foo::Bar,
+macro_rules! test {
+    ($crate_path:tt) => {
+        mod foo {
+            use super::*;
+
+            #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
+            #[zerocopy(crate = $crate_path)]
+            #[repr(C)]
+            pub struct Foo {
+                foo: u8,
+            }
+
+            #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
+            #[zerocopy(crate = $crate_path)]
+            #[repr(C)]
+            pub struct Bar {
+                bar: u8,
+            }
+        }
+
+        use self::foo::Foo;
+
+        #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
+        #[zerocopy(crate = $crate_path)]
+        #[repr(C)]
+        struct Baz {
+            foo: Foo,
+            bar: foo::Bar,
+        }
+    };
+}
+
+test!("zerocopy_renamed");
+
+mod root_relative {
+    use super::*;
+
+    test!("derive_path_test::nested::reexported_zerocopy");
+}
+
+mod crate_relative {
+    use super::*;
+
+    test!("crate::nested::reexported_zerocopy");
+}
+
+mod super_relative {
+    use super::*;
+
+    test!("super::nested::reexported_zerocopy");
+}
+
+mod self_super_relative {
+    use super::*;
+
+    test!("self::super::nested::reexported_zerocopy");
+}
+
+mod super_super_relative {
+    use super::*;
+
+    mod inner {
+        use super::*;
+
+        test!("super::super::nested::reexported_zerocopy");
+    }
 }

--- a/zerocopy/zerocopy-derive/tests/ui/struct.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.msrv.stderr
@@ -81,7 +81,7 @@ error[E0271]: type mismatch resolving `<u8 as zerocopy_renamed::KnownLayout>::Po
     = help: see issue #48214
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 32 previous errors
+error: aborting due to 39 previous errors
 
 Some errors have detailed explanations: E0271, E0277, E0692.
 For more information about an error, try `rustc --explain E0271`.

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -93,6 +93,48 @@ error: this conflicts with another representation hint
 353 | | #[repr(C, packed(2))]
     | |________^
 
+error: `crate` attribute requires a path as the value
+   --> $DIR/struct.rs:371:20
+    |
+371 | #[zerocopy(crate = "zerocopy_renamed"typo)]
+    |                    ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:377:20
+    |
+377 | #[zerocopy(crate = "Self::foo")]
+    |                    ^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:383:20
+    |
+383 | #[zerocopy(crate = "::crate::foo")]
+    |                    ^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:389:20
+    |
+389 | #[zerocopy(crate = "foo::crate::bar")]
+    |                    ^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:395:20
+    |
+395 | #[zerocopy(crate = "foo::super::bar")]
+    |                    ^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:401:20
+    |
+401 | #[zerocopy(crate = "foo::Self::bar")]
+    |                    ^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:407:20
+    |
+407 | #[zerocopy(crate = "foo::self")]
+    |                    ^^^^^^^^^^^
+
 error[E0692]: transparent struct cannot have other repr hints
    --> $DIR/struct.rs:308:8
     |
@@ -582,7 +624,7 @@ note: required by a bound in `assert_into_bytes`
     |                             ^^^^^^^^^ required by this bound in `assert_into_bytes`
     = note: this error originates in the derive macro `zerocopy_renamed::IntoBytes` which comes from the expansion of the macro `zerocopy_derive::__test_hygienically_mixed_into_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 38 previous errors
+error: aborting due to 45 previous errors
 
 Some errors have detailed explanations: E0271, E0277, E0587, E0588, E0692.
 For more information about an error, try `rustc --explain E0271`.

--- a/zerocopy/zerocopy-derive/tests/ui/struct.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.rs
@@ -366,3 +366,45 @@ struct SplitAtNotKnownLayout([u8]);
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(C)]
 struct SplitAtSized(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed"typo)]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a path as the value
+#[repr(C)]
+struct InvalidCrateSuffix(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "Self::foo")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateSelf(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "::crate::foo")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateLeadingColonRelative(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "foo::crate::bar")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateNonLeadingCrate(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "foo::super::bar")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateNonLeadingSuper(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "foo::Self::bar")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateMiddleSelf(u8);
+
+#[derive(KnownLayout)]
+#[zerocopy(crate = "foo::self")]
+//~[msrv, stable, nightly]^ ERROR: `crate` attribute requires a valid module path
+#[repr(C)]
+struct InvalidCrateTrailingSelf(u8);

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -88,6 +88,48 @@ error: this conflicts with another representation hint
 353 | #[repr(C, packed(2))]
     |        ^
 
+error: `crate` attribute requires a path as the value
+   --> $DIR/struct.rs:371:20
+    |
+371 | #[zerocopy(crate = "zerocopy_renamed"typo)]
+    |                    ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:377:20
+    |
+377 | #[zerocopy(crate = "Self::foo")]
+    |                    ^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:383:20
+    |
+383 | #[zerocopy(crate = "::crate::foo")]
+    |                    ^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:389:20
+    |
+389 | #[zerocopy(crate = "foo::crate::bar")]
+    |                    ^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:395:20
+    |
+395 | #[zerocopy(crate = "foo::super::bar")]
+    |                    ^^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:401:20
+    |
+401 | #[zerocopy(crate = "foo::Self::bar")]
+    |                    ^^^^^^^^^^^^^^^^
+
+error: `crate` attribute requires a valid module path
+   --> $DIR/struct.rs:407:20
+    |
+407 | #[zerocopy(crate = "foo::self")]
+    |                    ^^^^^^^^^^^
+
 error[E0692]: transparent struct cannot have other repr hints
    --> $DIR/struct.rs:308:8
     |
@@ -528,7 +570,7 @@ note: required by a bound in `is_into_bytes_11`
     |                        ^^^^^^^^^ required by this bound in `is_into_bytes_11`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 37 previous errors
+error: aborting due to 44 previous errors
 
 Some errors have detailed explanations: E0277, E0587, E0588, E0692.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Currently it parses the supplied literal as an identifier rather than a
path (contrary to its internal documentation).

This allows a crate to export an attribute macro of its own that deals
in re-exported zerocopy derive macros.
