### PR TITLE
[exocrate] Re-export `toml_const` for `parse_remote_archive`

### DIFF
--- a/anneal/Cargo.lock
+++ b/anneal/Cargo.lock
@@ -288,7 +288,6 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
- "toml_const",
  "walkdir",
 ]
 
@@ -727,6 +726,7 @@ dependencies = [
  "sha2-const",
  "tar",
  "tempfile",
+ "toml_const",
  "ureq",
  "zstd",
 ]
@@ -2179,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "toml_const"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389864cf501669b741746e9bc35e66c67f2b80266482ad04c452e2410433f205"
+checksum = "683e27d47b82029b5ae915b5dd80c05b2065c1c06046199900e8b2acdf531135"
 dependencies = [
  "phf",
  "toml 0.9.12+spec-1.1.0",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "toml_const_macros"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0f202adfb96027640ad9786a0657775414482cfd840c19e9957ada8cfbbfd"
+checksum = "4a0d196bfbd74f5f2a9e37f35632c7217e4c46dedaed0327a20dd1230fad9504"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/anneal/Cargo.toml
+++ b/anneal/Cargo.toml
@@ -45,7 +45,6 @@ url = "https://example.com/macos-aarch64.tar.zst"
 
 [dependencies]
 exocrate = { path = "../exocrate" }
-toml_const = "1.3.0"
 clap = { version = "4.5", features = ["derive"] }
 clap-cargo = { version = "0.18.3", features = ["cargo_metadata"] }
 env_logger = "0.11"

--- a/exocrate/Cargo.lock
+++ b/exocrate/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "sha2-const",
  "tar",
  "tempfile",
+ "toml_const",
  "ureq",
  "windows-sys 0.52.0",
  "zstd",
@@ -384,6 +385,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +631,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "subtle"
@@ -639,6 +698,69 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_const"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683e27d47b82029b5ae915b5dd80c05b2065c1c06046199900e8b2acdf531135"
+dependencies = [
+ "phf",
+ "toml",
+ "toml_const_macros",
+]
+
+[[package]]
+name = "toml_const_macros"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0d196bfbd74f5f2a9e37f35632c7217e4c46dedaed0327a20dd1230fad9504"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "toml",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "typenum"
@@ -881,6 +1003,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/exocrate/Cargo.toml
+++ b/exocrate/Cargo.toml
@@ -11,6 +11,7 @@ sha2 = "0.10.9"
 sha2-const = "0.1.3"
 tar = "0.4.45"
 tempfile = "3.27.0"
+toml_const = "1.3.1"
 ureq = "3.3.0"
 zstd = "0.13.3"
 

--- a/exocrate/src/lib.rs
+++ b/exocrate/src/lib.rs
@@ -365,9 +365,6 @@ fn install(mut reader: impl Read, dst: &Path, expected_sha256: Option<[u8; 32]>)
 /// }
 /// ```
 ///
-/// **NOTE**: The calling crate must have its own dependency on the `toml_const`
-/// crate.
-// - FIXME(#3409): Lift this limitation.
 // - FIXME(#3410): Don't require the user to specify os/arch pairs in the macro invocation.
 #[macro_export]
 macro_rules! parse_remote_archive {
@@ -375,7 +372,7 @@ macro_rules! parse_remote_archive {
         $(($os:ident, $arch:ident)),* $(,)?
     ];) => {
         $vis const $name: $crate::RemoteArchive = {
-            ::toml_const::toml_const!{
+            $crate::macro_util::toml_const::toml_const!{
                 const MANIFEST: $cargo_toml_path;
             }
 
@@ -482,6 +479,7 @@ macro_rules! config {
 #[doc(hidden)]
 pub mod macro_util {
     pub use sha2_const::Sha256;
+    pub use toml_const;
 
     /// Packs the bytes of `s` into a `u128`.
     ///


### PR DESCRIPTION
Update `parse_remote_archive` to call `toml_const` via `$crate::toml_const` instead of `::toml_const`. As, `toml_const` version `1.3.1` removes the need for downstream crates to depend on it solely to use the macro.

Take advantage of this by dropping `toml_const` as a dependency from `anneal`.

Fixes: #3409

<!-- Thanks for your contribution to zerocopy, and welcome! Before you submit your PR, please make sure to read our Contributing Guide in its entirety: https://github.com/google/zerocopy/discussions/1318 -->
