### PR TITLE
[ci] Consolidate build and test passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,92 +419,17 @@ jobs:
           echo "Using non-nightly toolchain; not modifying RUSTFLAGS='$RUSTFLAGS' or MIRIFLAGS='$MIRIFLAGS'" | tee -a $GITHUB_STEP_SUMMARY
         fi
 
-    # On the `thumbv6m-none-eabi` target, we can't run `cargo check --tests` due
-    # to the `memchr` crate, so we just do `cargo check` instead.
-    - name: Check
+    # Keep this step unconditional. The helper classifies every target and
+    # fails if the workflow adds one without an explicit build/test mode.
+    # check_all_toolchains_tested.sh compares the helper's machine-readable
+    # policy with this matrix, preventing either side from drifting.
+    - name: Build and test
       env:
         TOOLCHAIN: ${{ matrix.toolchain }}
         CRATE: ${{ matrix.crate }}
         TARGET: ${{ matrix.target }}
-      run: ./cargo.sh +$TOOLCHAIN check --package $CRATE --target $TARGET $FEATURES --verbose
-      if: matrix.target == 'thumbv6m-none-eabi'
-
-    - name: Check tests
-      env:
-        TOOLCHAIN: ${{ matrix.toolchain }}
-        CRATE: ${{ matrix.crate }}
-        TARGET: ${{ matrix.target }}
-      run: ./cargo.sh +$TOOLCHAIN check --tests --package $CRATE --target $TARGET $FEATURES --verbose
-      if: matrix.target != 'thumbv6m-none-eabi'
-
-    - name: Build
-      env:
-        TOOLCHAIN: ${{ matrix.toolchain }}
-        CRATE: ${{ matrix.crate }}
-        TARGET: ${{ matrix.target }}
-      run: ./cargo.sh +$TOOLCHAIN build --package $CRATE --target $TARGET $FEATURES --verbose
-      if: matrix.target != 'thumbv6m-none-eabi'
-
-    - name: Run tests
-      env:
-        TOOLCHAIN: ${{ matrix.toolchain }}
-        CRATE: ${{ matrix.crate }}
-        TARGET: ${{ matrix.target }}
-      run: |
-        ./cargo.sh +$TOOLCHAIN test \
-          --package $CRATE \
-          --target $TARGET \
-          $FEATURES \
-          --verbose \
-          -- \
-          --skip ui \
-          --skip codegen
-
-      # Only run tests when targetting Linux x86 (32- or 64-bit) - we're
-      # executing on Linux x86_64, so we can't run tests for any non-x86 target.
-      #
-      # TODO(https://github.com/dtolnay/trybuild/issues/184#issuecomment-1269097742):
-      # Run compile tests when building for other targets.
-      if: contains(matrix.target, 'linux') && (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686'))
-
-    - name: Run UI tests
-      env:
-        TOOLCHAIN: ${{ matrix.toolchain }}
-        CRATE: ${{ matrix.crate }}
-        TARGET: ${{ matrix.target }}
-      run: |
-        # Run UI tests separately, treating warnings as warnings (rather than
-        # as errors, as we do everywhere else in our CI tests). This allows
-        # our UI tests to more accurately reflect what users will see, and
-        # also ensures that we're not spuriously relying on warnings being
-        # errors to ensure compilation failure (if we were, then our code
-        # would be unsound whenever -Dwarnings is not enabled).
-        #
-        # TODO(#560), TODO(#187): Once we migrate to the ui-test crate, we
-        # likely won't have to special-case the UI tests like this.
-        RUSTFLAGS="$RUSTFLAGS -Wwarnings" ./cargo.sh +$TOOLCHAIN test \
-          --package $CRATE \
-          --target $TARGET \
-          $FEATURES \
-          --verbose \
-          ui
-
-      # Only run tests when targetting Linux x86 (32- or 64-bit) - we're
-      # executing on Linux x86_64, so we can't run tests for any non-x86 target.
-      #
-      # TODO(https://github.com/dtolnay/trybuild/issues/184#issuecomment-1269097742):
-      # Run compile tests when building for other targets.
-      #
-      # Only run UI tests for the 'msrv', 'stable', and 'nightly' toolchains.
-      # Other toolchains are tested only because zerocopy has behavior which
-      # differs on those toolchains, but at present, none of that behavior
-      # affects UI tests. If we were to run UI tests on these toolchains, we
-      # would need a new set of UI test files per toolchain, which would be a
-      # maintenance burden not worth the (at present, zero) benefit.
-      if: |
-        (!contains(matrix.target, 'windows')) &&
-        (contains(matrix.target, 'x86_64') || contains(matrix.target, 'i686')) &&
-        (matrix.toolchain == 'msrv' || matrix.toolchain == 'stable' || matrix.toolchain == 'nightly')
+        FEATURE_PROFILE: ${{ matrix.feature_profile }}
+      run: ./ci/run_build_test_cell.sh "$TOOLCHAIN" "$CRATE" "$TARGET" "$FEATURE_PROFILE"
 
     # On the `thumbv6m-none-eabi` target, we can't run `cargo clippy --tests`
     # due to the `memchr` crate, so we just do `cargo clippy` instead.
@@ -710,6 +635,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Cargo.toml excludes codegen from default test selection. This job owns
+      # both linting and executing that target so it cannot lose coverage when
+      # the ordinary build matrix uses an unfiltered default `cargo test`.
+      - name: Clippy
+        run: |
+          ./cargo.sh +nightly clippy --locked \
+            --package zerocopy \
+            --target x86_64-unknown-linux-gnu \
+            --all-features \
+            --test codegen \
+            --verbose
       - name: Run tests
         run: |
           set -eo pipefail
@@ -745,10 +681,7 @@ jobs:
             --doctests \
             --lcov \
             --output-path lcov.info \
-            --verbose \
-            -- \
-            --skip ui \
-            --skip codegen
+            --verbose
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -964,6 +897,16 @@ jobs:
           persist-credentials: false
       - name: Run check
         run: cd zerocopy && ./ci/check_all_toolchains_tested.sh
+      # These tests cover the feature protocol across the zerocopy and tools
+      # workspaces, plus the checker's fail-closed mutation coverage.
+      - name: Test CI support code
+        run: |
+          (cd zerocopy && ./cargo.sh +stable test --package testutil)
+          # cargo.sh delegates from zerocopy/, whose vendor excludes the tools
+          # workspace.
+          TOOLS_STABLE="$(zerocopy/cargo.sh --version stable)"
+          cargo +"$TOOLS_STABLE" test --locked --manifest-path tools/cargo-zerocopy/Cargo.toml
+          (cd zerocopy && ./ci/test_check_all_toolchains_tested.sh)
 
   check-job-dependencies:
     runs-on: ubuntu-latest

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -103,6 +103,7 @@ if [[ "$TOOLCHAINS_READY" -eq 1 ]]; then
     ./ci/check_fmt.sh                                      & FMT_PID=$!
     ./ci/check_job_dependencies.sh      >/dev/null         & JOB_DEPS_PID=$!
     ./zerocopy/ci/check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_PID=$!
+    ./zerocopy/ci/test_check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_TEST_PID=$!
     ./zerocopy/ci/check_readme.sh                >/dev/null & README_PID=$!
     ./zerocopy/ci/check_stale_stderr.sh          >/dev/null & STALE_STDERR_PID=$!
     ./zerocopy/ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
@@ -116,6 +117,7 @@ if [[ "$TOOLCHAINS_READY" -eq 1 ]]; then
     wait_for_check "ci/check_fmt.sh" "$FMT_PID"
     wait_for_check "ci/check_job_dependencies.sh" "$JOB_DEPS_PID"
     wait_for_check "zerocopy/ci/check_all_toolchains_tested.sh" "$TOOLCHAINS_PID"
+    wait_for_check "zerocopy/ci/test_check_all_toolchains_tested.sh" "$TOOLCHAINS_TEST_PID"
     wait_for_check "zerocopy/ci/check_readme.sh" "$README_PID"
     wait_for_check "zerocopy/ci/check_stale_stderr.sh" "$STALE_STDERR_PID"
     wait_for_check "zerocopy/ci/check_versions.sh" "$VERSIONS_PID"
@@ -145,11 +147,12 @@ for f in ./ci/*; do
 done
 # The release helpers are exercised by the release-workflow tests rather than
 # run during every push. check_fmt.sh is called through the repository-wide
-# ci/check_fmt.sh rather than directly; feature_profile.sh, feature_policy.jq,
-# and test_feature_policy.sh are exercised by check_all_toolchains_tested.sh.
+# ci/check_fmt.sh rather than directly. feature_profile.sh,
+# test_feature_policy.sh, feature_policy.jq, and run_build_test_cell.sh are
+# exercised by check_all_toolchains_tested.sh and its focused regression tests.
 # Keep these exemptions synchronized with their owning tests so a new CI helper
 # cannot silently go unused.
-GLOBIGNORE="./zerocopy/ci/@(release_crate_version|package_release_crates|check_fmt|feature_profile|test_feature_policy).sh:./zerocopy/ci/feature_policy.jq"
+GLOBIGNORE="./zerocopy/ci/@(release_crate_version|package_release_crates|check_fmt|feature_profile|test_feature_policy|run_build_test_cell).sh:./zerocopy/ci/feature_policy.jq"
 for f in ./zerocopy/ci/*; do
     grep "$f" githooks/pre-push >/dev/null || {
         echo "$f not called from githooks/pre-push" >&2

--- a/githooks/test_pre_push.py
+++ b/githooks/test_pre_push.py
@@ -8,7 +8,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-"""Regression tests for pre-push child and lockfile accounting."""
+"""Regression tests for pre-push bootstrap, children, and lockfile accounting."""
 
 import os
 from pathlib import Path
@@ -32,14 +32,23 @@ _CHECKS = (
     "ci/check_fmt.sh",
     "ci/check_job_dependencies.sh",
     "zerocopy/ci/check_all_toolchains_tested.sh",
+    "zerocopy/ci/test_check_all_toolchains_tested.sh",
     "zerocopy/ci/check_readme.sh",
     "zerocopy/ci/check_stale_stderr.sh",
     "zerocopy/ci/check_versions.sh",
     "zerocopy/ci/check_msrv_is_minimal.sh",
 )
-_EXEMPT_RELEASE_HELPERS = (
+_EXEMPT_HELPERS = (
+    "ci/check_todo.sh",
+    "ci/release_anneal_version.sh",
     "ci/run_cargo_for_release.sh",
+    "zerocopy/ci/check_fmt.sh",
+    "zerocopy/ci/feature_policy.jq",
+    "zerocopy/ci/feature_profile.sh",
     "zerocopy/ci/package_release_crates.sh",
+    "zerocopy/ci/release_crate_version.sh",
+    "zerocopy/ci/run_build_test_cell.sh",
+    "zerocopy/ci/test_feature_policy.sh",
 )
 
 _CHECK_STUB = """\
@@ -114,8 +123,8 @@ class FakeRepository:
 
         # These helpers are deliberately inventoried but not executed by the
         # read-only hook. Their presence catches drift in its GLOBIGNORE
-        # contract without invoking publication-oriented behavior in a test.
-        for helper in _EXEMPT_RELEASE_HELPERS:
+        # contract without invoking publication or nested build behavior.
+        for helper in _EXEMPT_HELPERS:
             path = self.path / helper
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
@@ -128,9 +137,7 @@ class FakeRepository:
         subprocess.run(
             ["git", "init", "--quiet"], cwd=self.path, check=True
         )
-        subprocess.run(
-            ["git", "add", "."], cwd=self.path, check=True
-        )
+        subprocess.run(["git", "add", "."], cwd=self.path, check=True)
 
     def close(self):
         self._temporary_directory.cleanup()
@@ -209,12 +216,16 @@ class PrePushTest(unittest.TestCase):
                     environment = (
                         {
                             "MUTATING_CHECK": "ci/check_actions.sh",
-                            "MUTATE_LOCKFILE": str(self.repository.path / lockfile),
+                            "MUTATE_LOCKFILE": str(
+                                self.repository.path / lockfile
+                            ),
                         }
                         if operation == "mutate"
                         else {
                             "DELETING_CHECK": "ci/check_actions.sh",
-                            "DELETE_LOCKFILE": str(self.repository.path / lockfile),
+                            "DELETE_LOCKFILE": str(
+                                self.repository.path / lockfile
+                            ),
                         }
                     )
                     result = self.repository.run_hook(**environment)
@@ -248,7 +259,8 @@ class PrePushTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("ci/check_actions.sh failed with status 23", result.stderr)
         self.assertIn(f"{lockfile} was modified", result.stderr)
-        self.assertTrue((self.repository.markers / slow_check.replace("/", "_")).is_file())
+        marker = self.repository.markers / slow_check.replace("/", "_")
+        self.assertTrue(marker.is_file())
 
     def test_reports_a_non_first_child_failure(self):
         failed_check = "zerocopy/ci/check_stale_stderr.sh"

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -28,6 +28,22 @@ use std::{
 
 use toml::{map::Map, Value};
 
+// This list has two consumers outside this workspace:
+//
+// - The UI test entry points use the cfg named by `UI_TEST_TOOLCHAIN_CFG` to
+//   decide whether their diagnostic snapshots support the selected toolchain.
+// - `testutil::UiTestRunner` maps these same names to snapshot suffixes.
+//
+// Keep all three in sync. CI checks the coupling so adding another supported
+// UI toolchain fails until its snapshots and runner support are also added.
+const UI_TEST_TOOLCHAINS: [&str; 3] = ["msrv", "stable", "nightly"];
+const UI_TEST_TOOLCHAIN_CFG: &str = "__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN";
+
+// Cargo test executables inherit this variable from the delegated Cargo
+// process. `testutil::UiTestRunner` decodes it and reuses the outer command's
+// feature selection when it builds artifacts for the UI fixtures.
+const UI_TEST_FEATURE_ARGS_ENV: &str = "ZEROCOPY_UI_TEST_FEATURE_ARGS";
+
 #[derive(Debug)]
 enum Error {
     NoArguments,
@@ -264,12 +280,72 @@ fn install_targets_or_exit(version: &str, targets: &[String]) -> Result<(), Erro
     )
 }
 
+fn is_ui_test_toolchain(name: &str) -> bool {
+    UI_TEST_TOOLCHAINS.contains(&name)
+}
+
+// Extract Cargo's feature-selection options from the arguments before `--`.
+// UI tests invoke Cargo recursively to locate the exact artifacts supplied to
+// rustc. Reusing these options ensures that recursive build has the same
+// default, disabled-default, explicit, or all-feature policy as its parent.
+//
+// Preserve each option's spelling and ordering. Cargo makes repeated feature
+// options additive, and forwarding the original arguments delegates all of
+// those semantics back to Cargo instead of duplicating them here.
+fn capture_feature_selection_args(args: &[String]) -> Vec<String> {
+    let mut captured = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            break;
+        }
+
+        if arg == "--features" || arg == "-F" {
+            captured.push(arg.clone());
+            if let Some(value) = args.get(index + 1) {
+                captured.push(value.clone());
+                index += 1;
+            }
+        } else if arg == "--all-features"
+            || arg == "--no-default-features"
+            || arg.starts_with("--features=")
+            || (arg.starts_with("-F") && arg.len() > 2)
+        {
+            captured.push(arg.clone());
+        }
+
+        index += 1;
+    }
+
+    captured
+}
+
+// Environment variables cannot contain NUL bytes, so encode each argument as
+// its decimal UTF-8 byte length, a colon, and its unmodified contents. Unlike
+// choosing a separator, this remains lossless for every Unicode OS argument
+// Cargo accepts. `testutil::UiTestRunner` implements the matching decoder.
+fn encode_feature_selection_args(args: &[String]) -> String {
+    let mut encoded = String::new();
+    for arg in args {
+        encoded.push_str(&arg.len().to_string());
+        encoded.push(':');
+        encoded.push_str(arg);
+    }
+    encoded
+}
+
 fn get_rustflags(name: &str) -> String {
     // See #1792 for context on zerocopy_derive_union_into_bytes.
     let mut flags =
         "--cfg zerocopy_unstable_linux --cfg zerocopy_derive_union_into_bytes --cfg __ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE"
             .to_string();
     flags += &format!(" --cfg __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN=\"{name}\"");
+
+    if is_ui_test_toolchain(name) {
+        flags += &format!(" --cfg {UI_TEST_TOOLCHAIN_CFG}");
+    }
 
     if name == "nightly" {
         flags += " --cfg __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS";
@@ -399,6 +475,7 @@ fn delegate_cargo() -> Result<(), Error> {
                 }
 
                 let mut args_vec = args.collect::<Vec<_>>();
+                let feature_selection_args = capture_feature_selection_args(&args_vec);
                 let mut i = 0;
                 while i < args_vec.len() {
                     let arg = &args_vec[i];
@@ -446,6 +523,12 @@ fn delegate_cargo() -> Result<(), Error> {
                 let mut cmd = rustup(["run", version, "cargo"], Some(("RUSTFLAGS", &rustflags)));
                 cmd.env("RUSTDOCFLAGS", &rustdocflags);
                 add_default_lock_mode(&mut cmd, &mut args_vec);
+                // Test executables inherit this value. UiTestRunner uses it
+                // when recursively building zerocopy's fixture artifacts.
+                cmd.env(
+                    UI_TEST_FEATURE_ARGS_ENV,
+                    encode_feature_selection_args(&feature_selection_args),
+                );
                 let mut args = args_vec.into_iter();
 
                 if env::var("CARGO_TARGET_DIR").is_ok() {
@@ -599,5 +682,76 @@ fn main() {
         eprintln!("Error: {e}");
         print_usage();
         process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    #[test]
+    fn captures_all_feature_selection_spellings_before_separator() {
+        let args = strings(&[
+            "test",
+            "--all-features",
+            "--features",
+            "alloc,derive",
+            "-Fsimd",
+            "-F",
+            "std",
+            "--no-default-features",
+            "--features=float-nightly",
+            "--",
+            "--features",
+            "ignored-test-argument",
+        ]);
+
+        assert_eq!(
+            capture_feature_selection_args(&args),
+            strings(&[
+                "--all-features",
+                "--features",
+                "alloc,derive",
+                "-Fsimd",
+                "-F",
+                "std",
+                "--no-default-features",
+                "--features=float-nightly",
+            ])
+        );
+    }
+
+    #[test]
+    fn feature_selection_encoding_is_length_prefixed_utf8() {
+        assert_eq!(
+            encode_feature_selection_args(&strings(&[
+                "--all-features",
+                "--features",
+                "derive,simd-nightly",
+            ])),
+            "14:--all-features10:--features19:derive,simd-nightly"
+        );
+        assert_eq!(encode_feature_selection_args(&strings(&["", ":", "μ"])), "0:1::2:μ");
+    }
+
+    #[test]
+    fn ui_test_cfg_is_limited_to_snapshot_toolchains() {
+        for name in UI_TEST_TOOLCHAINS {
+            assert!(is_ui_test_toolchain(name));
+            assert!(get_rustflags(name)
+                .split_whitespace()
+                .any(|flag| flag == UI_TEST_TOOLCHAIN_CFG));
+        }
+
+        for name in ["no-zerocopy-core-error-1-81-0", "1.93.1", "beta", ""] {
+            assert!(!is_ui_test_toolchain(name));
+            assert!(!get_rustflags(name)
+                .split_whitespace()
+                .any(|flag| flag == UI_TEST_TOOLCHAIN_CFG));
+        }
     }
 }

--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -112,6 +112,14 @@ fn main() {
 
     config.stderr_filter(r"[^']*\.long-type-\d+\.txt", b"$OUT_DIR/long-type-HASH.txt");
 
+    // rustc summarizes long implementation-candidate lists as "and N
+    // others". The exact count changes when a CI feature profile enables more
+    // implementations, even when the diagnostic under test is unchanged.
+    // Normalize only that summary so one toolchain snapshot can exercise every
+    // feature profile without hiding differences in the candidates rustc does
+    // print.
+    config.stderr_filter(r"and \d+ others", b"and $$OTHER_TYPES others");
+
     // NOTE: We intentionally don't respect `RUSTFLAGS` here, as it is too
     // unreliable. Recall that we are only compiling the crate under test,
     // not zerocopy itself. Zerocopy has already been compiled by the time

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -31,6 +31,26 @@ rust-version = "1.56.0"
 
 exclude = [".*"]
 
+# The default build-matrix `cargo test` invocation is intentionally
+# unfiltered. Declare exceptional integration-test ownership here, where Cargo
+# can apply it consistently to local runs and every CI caller. The feature
+# requirement mirrors tests/ui.rs and avoids compiling an empty UI test target
+# when derive support is disabled. cargo-zerocopy identifies the three pinned
+# UI-test toolchains; the UI harness reports this target as ignored elsewhere.
+[[test]]
+name = "ui"
+path = "tests/ui.rs"
+required-features = ["derive"]
+
+# Codegen requires external tools and a carefully controlled environment, so
+# it is not part of Cargo's default test selection. The standalone codegen CI
+# job explicitly selects this target for both Clippy and execution. Keep that
+# job and ci/check_all_toolchains_tested.sh in sync with this declaration.
+[[test]]
+name = "codegen"
+path = "tests/codegen.rs"
+test = false
+
 [package.metadata.build-rs]
 # These key/value pairs are parsed by `build.rs`. Each entry names a `--cfg`
 # which will be emitted if zerocopy is built with a toolchain version *lower*

--- a/zerocopy/build.rs
+++ b/zerocopy/build.rs
@@ -91,6 +91,10 @@ fn main() {
         println!(
             "cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)"
         );
+        // cargo-zerocopy emits this only for toolchains with UI snapshots.
+        // `tests/ui.rs` uses it to make unfiltered Cargo tests safe on every
+        // other toolchain in the build matrix.
+        println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN)");
         println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)");
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
         println!("cargo:rustc-check-cfg=cfg(zerocopy_inline_always)");

--- a/zerocopy/ci/check_all_toolchains_tested.sh
+++ b/zerocopy/ci/check_all_toolchains_tested.sh
@@ -14,6 +14,8 @@ cd "$(dirname "$0")/.."
 readonly SCRIPT_NAME="ci/check_all_toolchains_tested.sh"
 readonly WORKFLOW="../.github/workflows/ci.yml"
 readonly STABLE_FEATURE="__internal_use_only_features_that_work_on_stable"
+readonly BUILD_TEST_EXECUTOR="./ci/run_build_test_cell.sh"
+readonly UI_TEST_CFG="__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN"
 
 failed=0
 
@@ -58,6 +60,26 @@ check_value() {
   local expected="$3"
   if [[ "$actual" != "$expected" ]]; then
     fail "$label: expected '$expected', found '$actual'"
+  fi
+}
+
+# Rustfmt and TOML formatting may move declarations across lines. For a small
+# number of cross-file contracts below, compare whitespace-insensitive source
+# fragments while still requiring the complete expression which carries the
+# policy (not just an easy-to-preserve identifier or comment).
+check_compact_source_fragment() {
+  local label="$1"
+  local file="$2"
+  local fragment="$3"
+  local compact_source
+
+  if [[ ! -f "$file" ]]; then
+    fail "$label: source file '$file' does not exist"
+    return
+  fi
+  compact_source="$(tr -d '[:space:]' < "$file")"
+  if ! grep -Fq -- "$fragment" <<< "$compact_source"; then
+    fail "$label is missing from $file"
   fi
 }
 
@@ -111,7 +133,7 @@ check_configure_step() {
   done
 }
 
-for command in cargo comm grep jq sed sort tr uniq wc yq; do
+for command in cargo comm find grep jq sed sort tr uniq wc yq; do
   command -v "$command" >/dev/null || fail "required command '$command' was not found"
 done
 if [[ "$failed" -ne 0 ]]; then
@@ -130,20 +152,38 @@ fi
 # each only as a YAML-to-JSON adapter, then apply all policy queries with jq so
 # this guard behaves identically in developer environments and CI.
 if yq --version 2>&1 | grep -qi mikefarah; then
+  YQ_IMPLEMENTATION=go
   if ! workflow_json="$(yq -o=json -I=0 '.' "$WORKFLOW")"; then
     fail "could not parse $WORKFLOW with Go yq"
     exit 1
   fi
 else
+  YQ_IMPLEMENTATION=python
   if ! workflow_json="$(yq -c '.' "$WORKFLOW")"; then
     fail "could not parse $WORKFLOW with Python yq"
     exit 1
   fi
+  if ! command -v tomlq >/dev/null; then
+    fail "Python yq is installed without its tomlq companion"
+    exit 1
+  fi
 fi
+readonly YQ_IMPLEMENTATION
 if ! jq -e . >/dev/null <<< "$workflow_json"; then
   fail "$WORKFLOW did not convert to valid JSON"
   exit 1
 fi
+
+# Use the matching yq distribution as a TOML-to-JSON adapter too. Parsing is
+# important here: TOML permits quoted keys, dotted keys, inline tables, and
+# whitespace variants which a source grep cannot soundly recognize.
+toml_to_json() {
+  if [[ "$YQ_IMPLEMENTATION" == "go" ]]; then
+    yq -p=toml -o=json -I=0 '.' "$1"
+  else
+    tomlq -c '.' "$1"
+  fi
+}
 
 # Use the same stable Cargo wrapper as the rest of CI. In particular, do not
 # inspect `resolve.nodes[].features`: workspace feature unification can make
@@ -233,9 +273,13 @@ if [[ -n "$default_outside_stable" ]]; then
   sed 's/^/  /' <<< "$default_outside_stable" >&2
 fi
 
+# The cross-workspace UI runner currently forwards the outer CLI feature
+# selection directly to its nested zerocopy artifact build. That is exact while
+# zerocopy-derive has no feature axis. A future derive feature needs an explicit
+# mapping policy here and in that protocol, not merely another matrix exclusion.
 derive_features="$(jq -r 'keys[]' <<< "$derive_feature_graph")"
 if [[ -n "$derive_features" ]]; then
-  fail "zerocopy-derive now defines features; update the CI profile policy before adding them:"
+  fail "zerocopy-derive now defines features; update the matrix and cross-workspace UI feature-forwarding policies:"
   sed 's/^/  /' <<< "$derive_features" >&2
 fi
 
@@ -243,6 +287,175 @@ expected_profiles=$'default\nstable\nall'
 if [[ "$(jq -r '.default_feature_exists' <<< "$feature_policy")" == "true" ]]; then
   expected_profiles+=$'\nno-default'
 fi
+# Target policy needs to know which semantic profiles transitively enable std,
+# not merely today's profile names. Keep that answer derived from the same
+# Cargo feature closure which defines the profiles above, so a future default
+# or stable feature change automatically updates both the exclusion audit and
+# the exact matrix-cell specification below.
+std_profiles_json="$(jq -cn --argjson policy "$feature_policy" '[
+  if $policy.default_enables_std then "default" else empty end,
+  if $policy.stable_enables_std then "stable" else empty end,
+  if $policy.std_feature_exists then "all" else empty end
+]')"
+
+# A runnable matrix cell relies on Cargo's *default* `cargo test` selection to
+# replace three formerly-separate passes. Keep the Cargo-side half of that
+# contract fail-closed. In particular:
+#
+# - library unit tests and doctests must remain enabled;
+# - each matrix-owned package must retain a default-selected integration test,
+#   which links the ordinary non-cfg(test) library in every native profile;
+# - every integration-test source which Cargo would conventionally discover
+#   must actually appear in metadata (this catches `autotests = false` and
+#   accidental target-path changes); and
+# - opting a target out with `test = false` is an ownership transfer, not a way
+#   to silently lose it. The dedicated codegen job is currently the sole such
+#   owner and is checked against the workflow below.
+for package_name in zerocopy zerocopy-derive; do
+  package="$(jq -c --arg package "$package_name" \
+    '.packages[] | select(.name == $package)' <<< "$metadata")"
+  library_count="$(jq '[
+    .targets[]
+    | select(
+        (.kind | index("lib")) != null
+        or (.kind | index("proc-macro")) != null
+      )
+  ] | length' <<< "$package")"
+  check_value "$package_name library-target count" "$library_count" "1"
+
+  disabled_library_tests="$(jq -r '
+    .targets[]
+    | select(
+        (.kind | index("lib")) != null
+        or (.kind | index("proc-macro")) != null
+      )
+    | select(.test != true)
+    | .name
+  ' <<< "$package")"
+  if [[ -n "$disabled_library_tests" ]]; then
+    fail "$package_name disables its library test harness:"
+    sed 's/^/  /' <<< "$disabled_library_tests" >&2
+  fi
+
+  disabled_doctests="$(jq -r '
+    .targets[]
+    | select(
+        (.kind | index("lib")) != null
+        or (.kind | index("proc-macro")) != null
+      )
+    | select(.doctest != true)
+    | .name
+  ' <<< "$package")"
+  if [[ -n "$disabled_doctests" ]]; then
+    fail "$package_name disables library doctests:"
+    sed 's/^/  /' <<< "$disabled_doctests" >&2
+  fi
+
+  always_selected_integration_test_count="$(jq '[
+    .targets[]
+    | select(
+        (.kind | index("test")) != null
+        and .test == true
+        and ((.["required-features"] // []) | length) == 0
+      )
+  ] | length' <<< "$package")"
+  if [[ "$always_selected_integration_test_count" -eq 0 ]]; then
+    fail "$package_name has no default-selected integration test to link its ordinary library"
+  fi
+done
+
+disabled_integration_tests="$(jq -r '
+  .packages[]
+  | select(.name == "zerocopy" or .name == "zerocopy-derive")
+  | .name as $package
+  | .targets[]
+  | select((.kind | index("test")) != null and .test != true)
+  | "\($package)/\(.name)"
+' <<< "$metadata")"
+check_set "dedicated integration-test targets" \
+  "$disabled_integration_tests" "zerocopy/codegen"
+
+# Cargo auto-discovers `tests/foo.rs` and `tests/foo/main.rs`. Comparing those
+# paths with metadata is stronger than merely checking today's target names: a
+# new conventional test is covered automatically, while disabling discovery
+# or redirecting an explicit target fails here until CI ownership is revisited.
+filesystem_test_sources="$({
+  find tests -mindepth 1 -maxdepth 1 -type f -name '*.rs' -print
+  find tests -mindepth 2 -maxdepth 2 -type f -name main.rs -print
+  find zerocopy-derive/tests -mindepth 1 -maxdepth 1 -type f -name '*.rs' -print
+  find zerocopy-derive/tests -mindepth 2 -maxdepth 2 -type f -name main.rs -print
+} | sed 's#^\./##')"
+metadata_test_sources="$(jq -r '
+  .packages[]
+  | select(.name == "zerocopy" or .name == "zerocopy-derive")
+  | .targets[]
+  | select((.kind | index("test")) != null)
+  | .src_path
+' <<< "$metadata" | sed "s#^$PWD/##")"
+check_set "Cargo integration-test source discovery" \
+  "$metadata_test_sources" "$filesystem_test_sources"
+
+# `cargo test` uses the test profile while the eliminated `cargo build` used
+# the dev profile. Cargo's test profile inherits dev in the absence of an
+# override, which is the equivalence this optimization relies on. Cargo reads
+# both config filenames from the invocation directory and every ancestor. The
+# matrix invokes Cargo from this workspace root, so inspect every
+# repository-controlled location on that search path, including currently
+# absent files. Keep this list coordinated with the `working-directory` in
+# ci.yml; moving the invocation changes which Cargo config files are effective.
+cargo_profile_sources=(
+  Cargo.toml
+  .cargo/config
+  .cargo/config.toml
+  ../.cargo/config
+  ../.cargo/config.toml
+)
+for profile_override_source in "${cargo_profile_sources[@]}"; do
+  [[ -f "$profile_override_source" ]] || continue
+  if ! profile_source_json="$(toml_to_json "$profile_override_source")"; then
+    fail "could not parse $profile_override_source while checking Cargo profiles"
+    continue
+  fi
+  if jq -e '.profile | type == "object" and has("test")' \
+      >/dev/null <<< "$profile_source_json"; then
+    fail "$profile_override_source overrides profile.test; re-audit the single-pass native test contract"
+  fi
+done
+
+# Environment variables override both manifests and Cargo config. Check every
+# repository-controlled source which can set the matrix process environment:
+# the workflow (including its generated Docker wrapper), the image definition,
+# and the two wrappers on the path to pinned Cargo. If that launch chain gains
+# another layer, add it here in the same change.
+for profile_override_source in \
+  "$WORKFLOW" \
+  ../.github/workflows/Dockerfile \
+  cargo.sh \
+  "$BUILD_TEST_EXECUTOR" \
+  ../tools/cargo-zerocopy/src/main.rs; do
+  if [[ -f "$profile_override_source" ]] && \
+      grep -Eq 'CARGO_PROFILE_TEST_[A-Z0-9_]+' "$profile_override_source"; then
+    fail "$profile_override_source sets a test-profile override; re-audit the single-pass native test contract"
+  fi
+done
+
+# The Docker image can also acquire a global Cargo config indirectly (for
+# example, from its base image or a RUN command). The executor performs the
+# final runtime check inside that image. Pin the meaningful source fragments so
+# refactoring the helper cannot silently discard either the config-file or
+# environment half of this cross-file profile contract.
+check_compact_source_fragment \
+  "CI Cargo-home config guard" \
+  "$BUILD_TEST_EXECUTOR" \
+  'forconfigin"$cargo_home/config""$cargo_home/config.toml";do'
+check_compact_source_fragment \
+  "CI test-profile environment guard" \
+  "$BUILD_TEST_EXECUTOR" \
+  'case"$environment_name"inCARGO_PROFILE_TEST_*)fail'
+check_compact_source_fragment \
+  "CI test-profile guard invocation" \
+  "$BUILD_TEST_EXECUTOR" \
+  'if[["$PLAN_ONLY"-eq0]];thencheck_ci_test_profile_contractfi'
 
 # The semantic profile helper is the single translation point from matrix
 # policy to Cargo arguments. Exercise every supported mapping, including the
@@ -289,13 +502,605 @@ build_profiles="$(jq -r '.jobs.build_test.strategy.matrix.feature_profile[]' <<<
 build_crates="$(jq -r '.jobs.build_test.strategy.matrix.crate[]' <<< "$workflow_json")"
 build_targets="$(jq -r '.jobs.build_test.strategy.matrix.target[]' <<< "$workflow_json")"
 build_event_names="$(jq -r '.jobs.build_test.strategy.matrix.event_name[]' <<< "$workflow_json")"
+workflow_events="$(jq -r '.on | keys[]' <<< "$workflow_json")"
 check_set "build feature profiles" "$build_profiles" "$expected_profiles"
 check_set "build crates" "$build_crates" $'zerocopy\nzerocopy-derive'
+# The exact-cell audit below expands every workflow trigger. Assert that set
+# independently first: deriving both actual and expected cells from `.on`
+# without this boundary would let deletion of merge_group silently delete all
+# merge-queue coverage from both sides of the comparison.
+check_set "workflow triggers" "$workflow_events" \
+  $'merge_group\npull_request\npush\nworkflow_dispatch'
+if jq -e '.jobs.build_test | has("if") or has("continue-on-error")' \
+    >/dev/null <<< "$workflow_json"; then
+  fail "the build_test job must run and propagate failures for every workflow event"
+fi
+
+# An exclusion with an unknown key or value is accepted by GitHub but matches
+# no cells, which makes a typo look like policy. Validate each exclusion against
+# the real matrix axes and workflow trigger names before evaluating it. The
+# sorted JSON self-comparison separately rejects duplicate exclusions.
+invalid_build_exclusions="$(jq -c --argjson workflow "$workflow_json" '
+  def value_is_on_axis($matrix; $events):
+    .key as $key
+    | .value as $value
+    | if $key == "event_name"
+      then ($events | index($value)) != null
+      else ($matrix[$key] | index($value)) != null
+      end;
+  $workflow.jobs.build_test.strategy.matrix as $matrix
+  | ($workflow.on | keys) as $events
+  | $matrix.exclude[]
+  | select(
+      (type != "object")
+      or length == 0
+      or ((keys - [
+        "crate", "event_name", "feature_profile", "target", "toolchain"
+      ]) | length) != 0
+      or any(to_entries[];
+        (.value | type) != "string"
+        or (value_is_on_axis($matrix; $events) | not)
+      )
+    )
+' <<< '{}')"
+if [[ -n "$invalid_build_exclusions" ]]; then
+  fail "build matrix has exclusions with unknown keys or values:"
+  sed 's/^/  /' <<< "$invalid_build_exclusions" >&2
+fi
+build_exclusions="$(jq -cS \
+  '.jobs.build_test.strategy.matrix.exclude[]' <<< "$workflow_json")"
+check_set "build matrix exclusions" "$build_exclusions" "$build_exclusions"
+
+# Every workspace package needs an explicit CI owner. The build matrix owns the
+# two publishable packages. `testutil` is a dev-only harness exercised through
+# those packages and directly by the support-code step checked below, so its
+# exemption from the cross-target matrix is intentional. A new workspace
+# member fails until its owner is recorded.
+workspace_packages="$(jq -r '
+  .workspace_members[] as $id
+  | .packages[]
+  | select(.id == $id)
+  | .name
+' <<< "$metadata")"
+expected_workspace_packages="$build_crates"$'\n'"testutil"
+check_set "workspace package CI ownership" \
+  "$workspace_packages" "$expected_workspace_packages"
+
+# The feature-forwarding protocol crosses Cargo workspaces, so compiling the
+# publishable packages does not execute either side's unit tests. Keep the two
+# cheap suites immediately after this invariant checker in the same job: the
+# checker proves the ownership exists, then CI exercises the implementation.
+support_test_step_count="$(jq '[
+  .jobs["check-all-toolchains-tested"].steps[]
+  | select(.name == "Test CI support code")
+] | length' <<< "$workflow_json")"
+check_value "CI support-code test-step count" "$support_test_step_count" "1"
+if [[ "$support_test_step_count" == "1" ]]; then
+  support_test_step="$(jq -c '
+    .jobs["check-all-toolchains-tested"].steps[]
+    | select(.name == "Test CI support code")
+  ' <<< "$workflow_json")"
+  check_set "CI support-code test-step keys" \
+    "$(jq -r 'keys[]' <<< "$support_test_step")" $'name\nrun'
+  check_value "CI support-code test commands" \
+    "$(jq -r '.run' <<< "$support_test_step")" \
+    $'(cd zerocopy && ./cargo.sh +stable test --package testutil)\n# cargo.sh delegates from zerocopy/, whose vendor excludes the tools\n# workspace.\nTOOLS_STABLE="$(zerocopy/cargo.sh --version stable)"\ncargo +"$TOOLS_STABLE" test --locked --manifest-path tools/cargo-zerocopy/Cargo.toml\n(cd zerocopy && ./ci/test_check_all_toolchains_tested.sh)'
+
+  support_test_previous_step="$(jq -r '
+    .jobs["check-all-toolchains-tested"].steps
+    | (map(.name) | index("Test CI support code")) as $index
+    | if $index == null or $index == 0
+      then ""
+      else .[$index - 1].name
+      end
+  ' <<< "$workflow_json")"
+  check_value "step before CI support-code tests" \
+    "$support_test_previous_step" "Run check"
+fi
+
+# Cargo silently omits a target whose `required-features` are not enabled.
+# Prove from manifest metadata that every integration test can be selected by
+# at least one semantically-owned feature profile. The post-exclusion expansion
+# below independently proves that every such profile has native execution
+# cells. Together, those checks prevent either required-feature drift or matrix
+# exclusions from making a test unreachable. Derive's only owned profile is
+# `default`; zerocopy's sets use the feature graph audited above.
+zerocopy_profile_features="$(jq -cn \
+  --argjson graph "$feature_graph" \
+  --argjson policy "$feature_policy" '
+    {
+      "default": (
+        (if ($graph | has("default")) then ["default"] else [] end)
+        + $policy.default_closure
+        | unique
+      ),
+      "no-default": [],
+      "stable": $policy.stable_actual,
+      "all": ($graph | keys)
+    }
+  ')"
+derive_profile_features='{"default":[]}'
+
+while IFS=$'\t' read -r package_name target_name required_features_json; do
+  [[ -n "$package_name" ]] || continue
+  case "$package_name" in
+    zerocopy)
+      package_feature_graph="$feature_graph"
+      package_profile_features="$zerocopy_profile_features"
+      package_profiles="$build_profiles"
+      ;;
+    zerocopy-derive)
+      package_feature_graph="$derive_feature_graph"
+      package_profile_features="$derive_profile_features"
+      package_profiles="default"
+      ;;
+  esac
+
+  unknown_required_features="$(jq -r \
+    --argjson required "$required_features_json" \
+    --argjson graph "$package_feature_graph" '
+      ($required - ($graph | keys) | unique)[]
+    ' <<< '{}')"
+  if [[ -n "$unknown_required_features" ]]; then
+    fail "$package_name/$target_name requires unknown Cargo features:"
+    sed 's/^/  /' <<< "$unknown_required_features" >&2
+  fi
+
+  reachable_profile=""
+  while IFS= read -r profile; do
+    [[ -n "$profile" ]] || continue
+    enabled_features="$(jq -c --arg profile "$profile" \
+      '.[$profile] // []' <<< "$package_profile_features")"
+    if jq -en \
+        --argjson required "$required_features_json" \
+        --argjson enabled "$enabled_features" \
+        '($required - $enabled | length) == 0' >/dev/null; then
+      reachable_profile="$profile"
+      break
+    fi
+  done <<< "$package_profiles"
+  if [[ -z "$reachable_profile" ]]; then
+    fail "$package_name/$target_name is unreachable from every runnable feature profile (requires $required_features_json)"
+  fi
+done < <(jq -r '
+  .packages[]
+  | select(.name == "zerocopy" or .name == "zerocopy-derive")
+  | .name as $package
+  | .targets[]
+  | select((.kind | index("test")) != null)
+  | [$package, .name, ((.["required-features"] // []) | tojson)]
+  | @tsv
+' <<< "$metadata")
+
+# The zerocopy UI entry point is itself feature-gated. Keep Cargo's selection
+# rule coupled to that source-level contract so a no-derive cell cannot compile
+# an empty test binary and appear to provide UI coverage.
+zerocopy_ui_required_features="$(jq -r '
+  .packages[]
+  | select(.name == "zerocopy")
+  | .targets[]
+  | select((.kind | index("test")) != null and .name == "ui")
+  | (.["required-features"] // [])[]
+' <<< "$metadata")"
+check_set "zerocopy UI-test required features" \
+  "$zerocopy_ui_required_features" "derive"
+
 # Self-comparison intentionally checks for duplicate targets while allowing the
 # build matrix itself to remain the source of truth for the supported set.
 check_set "build targets" "$build_targets" "$build_targets"
 check_set "build event-name axis" "$build_event_names" '${{ github.event_name }}'
 check_configure_step "build_test" "build"
+
+# The workflow deliberately delegates every build-matrix cell to one executor.
+# Its machine-readable description is the source used by the executor itself,
+# while this checker supplies an independent audit boundary: every workflow
+# target must be classified exactly once, and changing the strength assigned to
+# any existing target requires updating this explicit policy review point.
+executor_ready=1
+if [[ ! -x "$BUILD_TEST_EXECUTOR" ]]; then
+  fail "$BUILD_TEST_EXECUTOR is not executable"
+  executor_ready=0
+elif ! executor_description="$($BUILD_TEST_EXECUTOR --describe)"; then
+  fail "$BUILD_TEST_EXECUTOR --describe failed"
+  executor_ready=0
+elif ! jq -e '
+  (keys | sort) == ["schema_version", "targets"]
+  and .schema_version == 1
+  and (.targets | type) == "array"
+  and all(.targets[];
+    (keys | sort) == ["mode", "target"]
+    and (.target | type) == "string"
+    and (.target | length) > 0
+    and (.mode | type) == "string"
+  )
+' >/dev/null <<< "$executor_description"; then
+  fail "$BUILD_TEST_EXECUTOR --describe returned an invalid schema"
+  executor_ready=0
+fi
+
+if [[ "$executor_ready" -eq 1 ]]; then
+  described_targets="$(jq -r '.targets[].target' <<< "$executor_description")"
+  described_modes="$(jq -r '.targets[].mode' <<< "$executor_description")"
+  check_set "build/test executor targets" "$described_targets" "$build_targets"
+  check_set "build/test executor modes" \
+    "$(sort -u <<< "$described_modes")" \
+    $'run\ncompile-tests\nlibrary-only'
+
+  run_targets="$(jq -r '.targets[] | select(.mode == "run") | .target' \
+    <<< "$executor_description")"
+  compile_test_targets="$(jq -r '
+    .targets[] | select(.mode == "compile-tests") | .target
+  ' <<< "$executor_description")"
+  library_only_targets="$(jq -r '
+    .targets[] | select(.mode == "library-only") | .target
+  ' <<< "$executor_description")"
+  check_set "natively runnable targets" "$run_targets" \
+    $'i686-unknown-linux-gnu\nx86_64-unknown-linux-gnu'
+  check_set "cross-compiled test targets" "$compile_test_targets" \
+    $'arm-unknown-linux-gnueabi\naarch64-unknown-linux-gnu\npowerpc-unknown-linux-gnu\npowerpc64-unknown-linux-gnu\nriscv64gc-unknown-linux-gnu\ns390x-unknown-linux-gnu\nx86_64-pc-windows-msvc\nwasm32-unknown-unknown'
+  check_set "library-only targets" "$library_only_targets" \
+    "thumbv6m-none-eabi"
+
+  # Expand the matrix exactly as GitHub does, once for every event which can
+  # trigger this workflow, and apply *every* exclusion key. Axis membership is
+  # not enough: two target-only exclusions could otherwise leave all profiles
+  # visible in YAML while silently removing every executable test cell.
+  #
+  # The executor description supplies the target mode. This is a deliberate
+  # three-file contract among ci.yml, run_build_test_cell.sh, and this checker:
+  # changing an axis, exclusion, or target classification changes this final
+  # cell set and must continue to satisfy the coverage assertions below.
+  final_build_cells="$(jq -cn \
+    --argjson workflow "$workflow_json" \
+    --argjson executor "$executor_description" '
+      def excluded($cell; $exclusion):
+        all($exclusion | to_entries[];
+          . as $entry | $cell[$entry.key] == $entry.value);
+
+      $workflow.jobs.build_test.strategy.matrix as $matrix
+      | ($workflow.on | keys) as $events
+      | [
+          $events[] as $event_name
+          | $matrix.toolchain[] as $toolchain
+          | $matrix.target[] as $target
+          | $matrix.feature_profile[] as $feature_profile
+          | $matrix.crate[] as $crate
+          | {
+              event_name: $event_name,
+              toolchain: $toolchain,
+              target: $target,
+              feature_profile: $feature_profile,
+              crate: $crate
+            } as $cell
+          | select(any($matrix.exclude[]; excluded($cell; .)) | not)
+          | $cell + {
+              mode: (
+                $executor.targets[]
+                | select(.target == $target)
+                | .mode
+              )
+            }
+        ]
+    ')"
+
+  # Most threshold toolchains describe language/library behavior which can be
+  # exercised on a native runner. These two specifically describe AArch64 SIMD
+  # behavior, so they are the only reviewed cross-only exceptions. Three other
+  # thresholds are deliberately native-only because their behavior is target
+  # independent. Every other current or future threshold is full-target by
+  # default. Changing either exception list is therefore an explicit review of
+  # less-than-full target coverage, rather than an exclusion which can silently
+  # weaken CI.
+  cross_only_toolchains=$'no-zerocopy-aarch64-simd-1-59-0\nno-zerocopy-aarch64-simd-be-1-87-0'
+  native_only_toolchains=$'no-zerocopy-core-error-1-81-0\nno-zerocopy-diagnostic-on-unimplemented-1-78-0\nno-zerocopy-generic-bounds-in-const-fn-1-61-0'
+  target_exception_toolchains="$cross_only_toolchains"$'\n'"$native_only_toolchains"
+  # These lists must be duplicate-free, mutually disjoint, and drawn from the
+  # live Cargo-derived build toolchains. Otherwise a renamed/removed threshold
+  # could leave behind a stale exception which appears to document policy but
+  # no longer constrains any matrix cell.
+  check_set "target-coverage exception toolchains" \
+    "$target_exception_toolchains" "$target_exception_toolchains"
+  unknown_target_exception_toolchains="$(comm -13 \
+    <(printf '%s\n' "$build_toolchains" | sed '/^$/d' | sort -u) \
+    <(printf '%s\n' "$target_exception_toolchains" | sed '/^$/d' | sort -u))"
+  if [[ -n "$unknown_target_exception_toolchains" ]]; then
+    fail "target-coverage exceptions name unknown build toolchains:"
+    sed 's/^/  /' <<< "$unknown_target_exception_toolchains" >&2
+  fi
+  for cross_only_toolchain in $cross_only_toolchains; do
+    # These descriptors bracket AArch64-specific compiler behavior. Merely
+    # retaining some cross target is insufficient: an exclusion typo could
+    # leave ARM32 or x86 coverage while dropping the AArch64 configuration the
+    # descriptor exists to test. PRs deliberately omit this expensive target;
+    # every full event must retain exactly AArch64.
+    while IFS= read -r workflow_event; do
+      [[ "$workflow_event" == "pull_request" ]] && continue
+      cross_only_targets="$(jq -r \
+        --arg event "$workflow_event" \
+        --arg toolchain "$cross_only_toolchain" '[
+          .[]
+          | select(
+              .event_name == $event
+              and .toolchain == $toolchain
+            )
+          | .target
+        ] | unique[]' <<< "$final_build_cells")"
+      check_set \
+        "$workflow_event targets for cross-only toolchain '$cross_only_toolchain'" \
+        "$cross_only_targets" \
+        "aarch64-unknown-linux-gnu"
+    done < <(jq -r '.on | keys[]' <<< "$workflow_json")
+  done
+
+  # Require the complete reviewed event x crate x toolchain x profile x target
+  # product after exclusions. Derive owns only its default profile on the three
+  # general toolchains. Zerocopy owns every semantic profile, except that a
+  # non-empty nightly feature set restricts `all` to nightly. Full events cover
+  # every target by default; PRs retain the two native targets plus the cheap
+  # Windows cross-check. The explicit exceptions below mirror reasons which
+  # cannot be inferred mechanically: unavailable stable wasm, thumb's lack of
+  # std, and the reviewed native-only/cross-only threshold classes above.
+  #
+  # This is intentionally independent of ci.yml's exclusion list. That file is
+  # the mechanism which realizes the policy, while this block is the fail-closed
+  # specification which reviews it. A future exclusion, toolchain, target,
+  # feature profile, or default-feature change must either preserve this full
+  # product or update the relevant exception here with an explanation.
+  workflow_events_json="$(jq -c '.on | keys' <<< "$workflow_json")"
+  cross_only_toolchains_json="$(printf '%s\n' "$cross_only_toolchains" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  native_only_toolchains_json="$(printf '%s\n' "$native_only_toolchains" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  run_targets_json="$(printf '%s\n' "$run_targets" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  build_profiles_json="$(printf '%s\n' "$expected_profiles" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  build_toolchains_json="$(printf '%s\n' "$build_toolchains" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  build_targets_json="$(printf '%s\n' "$build_targets" | \
+    jq -Rsc 'split("\n") | map(select(length != 0))')"
+  expected_build_cells="$(jq -rn \
+    --argjson events "$workflow_events_json" \
+    --argjson toolchains "$build_toolchains_json" \
+    --argjson run_targets "$run_targets_json" \
+    --argjson all_targets "$build_targets_json" \
+    --argjson profiles "$build_profiles_json" \
+    --argjson cross_only "$cross_only_toolchains_json" \
+    --argjson native_only "$native_only_toolchains_json" \
+    --argjson std_profiles "$std_profiles_json" \
+    --argjson nightly_features "$nightly_features_json" '
+      [
+        $events[] as $event
+        | $toolchains[] as $toolchain
+        | $all_targets[] as $target
+        | $profiles[] as $profile
+        | ["zerocopy", "zerocopy-derive"][] as $crate
+        | select(
+            if ($cross_only | index($toolchain)) != null then
+              $target == "aarch64-unknown-linux-gnu"
+            elif ($native_only | index($toolchain)) != null then
+              ($run_targets | index($target)) != null
+            else
+              true
+            end
+          )
+        | select(
+            $event != "pull_request"
+            or (($run_targets + ["x86_64-pc-windows-msvc"]) | index($target)) != null
+          )
+        | select(
+            $toolchain != "stable"
+            or $target != "wasm32-unknown-unknown"
+          )
+        | select(
+            if $crate == "zerocopy-derive" then
+              $profile == "default"
+              and (["msrv", "stable", "nightly"] | index($toolchain)) != null
+            else
+              $profile != "all"
+              or ($nightly_features | length) == 0
+              or $toolchain == "nightly"
+            end
+          )
+        | select(
+            $target != "thumbv6m-none-eabi"
+            or $crate != "zerocopy"
+            or ($std_profiles | index($profile)) == null
+          )
+        | [$event, $crate, $toolchain, $profile, $target]
+        | @tsv
+      ]
+      | unique[]
+    ')"
+  actual_build_cells="$(jq -r '[
+    .[]
+    | [
+        .event_name,
+        .crate,
+        .toolchain,
+        .feature_profile,
+        .target
+      ]
+    | @tsv
+  ] | unique[]' <<< "$final_build_cells")"
+  check_set "post-exclusion build-matrix cells" \
+    "$actual_build_cells" "$expected_build_cells"
+
+  # `--plan` records the exact argv arrays assembled by the real execution
+  # path. Compare the whole JSON object, not substrings: this proves that native
+  # cells use Cargo's unfiltered default target selection, cross cells retain
+  # `check --tests` plus code generation, and thumb retains its narrower check.
+  # It also forbids a future positional test-name filter, `--skip`, `--lib`, or
+  # another target selector from hiding newly-added tests.
+  while IFS= read -r target; do
+    mode="$(jq -r --arg target "$target" '
+      .targets[] | select(.target == $target) | .mode
+    ' <<< "$executor_description")"
+    for crate in zerocopy zerocopy-derive; do
+      if [[ "$crate" == "zerocopy-derive" ]]; then
+        plan_profiles="default"
+      else
+        plan_profiles="$expected_profiles"
+      fi
+      while IFS= read -r profile; do
+        [[ -n "$profile" ]] || continue
+        if [[ "$profile" == "all" ]]; then
+          plan_toolchain="nightly"
+        else
+          plan_toolchain="msrv"
+        fi
+
+        feature_output="$(./ci/feature_profile.sh "$profile")"
+        feature_args_json='[]'
+        if [[ -n "$feature_output" ]]; then
+          read -r -a feature_args <<< "$feature_output"
+          feature_args_json="$(jq -cn --args '$ARGS.positional' -- \
+            "${feature_args[@]}")"
+        fi
+
+        case "$mode" in
+          run)
+            expected_commands="$(jq -cn \
+              --arg toolchain "+$plan_toolchain" \
+              --arg crate "$crate" \
+              --arg target "$target" \
+              --argjson features "$feature_args_json" '
+                [["./cargo.sh", $toolchain, "test",
+                  "--package", $crate, "--target", $target]
+                  + $features + ["--verbose"]]
+              ')"
+            ;;
+          compile-tests)
+            expected_commands="$(jq -cn \
+              --arg toolchain "+$plan_toolchain" \
+              --arg crate "$crate" \
+              --arg target "$target" \
+              --argjson features "$feature_args_json" '
+                [
+                  (["./cargo.sh", $toolchain, "check", "--tests",
+                    "--package", $crate, "--target", $target]
+                    + $features + ["--verbose"]),
+                  (["./cargo.sh", $toolchain, "build",
+                    "--package", $crate, "--target", $target]
+                    + $features + ["--verbose"])
+                ]
+              ')"
+            ;;
+          library-only)
+            expected_commands="$(jq -cn \
+              --arg toolchain "+$plan_toolchain" \
+              --arg crate "$crate" \
+              --arg target "$target" \
+              --argjson features "$feature_args_json" '
+                [["./cargo.sh", $toolchain, "check",
+                  "--package", $crate, "--target", $target]
+                  + $features + ["--verbose"]]
+              ')"
+            ;;
+        esac
+
+        expected_plan="$(jq -cn \
+          --arg toolchain "$plan_toolchain" \
+          --arg crate "$crate" \
+          --arg target "$target" \
+          --arg profile "$profile" \
+          --arg mode "$mode" \
+          --argjson features "$feature_args_json" \
+          --argjson commands "$expected_commands" '
+            {
+              schema_version: 1,
+              toolchain: $toolchain,
+              crate: $crate,
+              target: $target,
+              feature_profile: $profile,
+              mode: $mode,
+              feature_args: $features,
+              commands: $commands
+            }
+          ')"
+        if ! actual_plan="$($BUILD_TEST_EXECUTOR --plan \
+            "$plan_toolchain" "$crate" "$target" "$profile")"; then
+          fail "$BUILD_TEST_EXECUTOR --plan failed for $crate/$plan_toolchain/$profile/$target"
+        elif ! jq -e . >/dev/null <<< "$actual_plan"; then
+          fail "$BUILD_TEST_EXECUTOR --plan returned invalid JSON for $crate/$plan_toolchain/$profile/$target"
+        else
+          check_value \
+            "build/test plan for $crate/$plan_toolchain/$profile/$target" \
+            "$(jq -cS . <<< "$actual_plan")" \
+            "$(jq -cS . <<< "$expected_plan")"
+        fi
+      done <<< "$plan_profiles"
+    done
+  done <<< "$described_targets"
+
+  if $BUILD_TEST_EXECUTOR --plan msrv zerocopy \
+      __unclassified_ci_target__ default >/dev/null 2>&1; then
+    fail "$BUILD_TEST_EXECUTOR accepts an unclassified target"
+  fi
+fi
+
+# There is exactly one unconditional workflow bridge into the executor. Target
+# selection belongs in its exhaustively-checked policy, not in duplicated YAML
+# `if` expressions. These structural checks also prevent the old Check / Build /
+# Run tests / Run UI tests steps from being reintroduced alongside the helper.
+executor_step_count="$(jq '[
+  .jobs.build_test.steps[]
+  | select((.run // "") | contains("run_build_test_cell.sh"))
+] | length' <<< "$workflow_json")"
+check_value "build/test executor-step count" "$executor_step_count" "1"
+all_executor_invocations="$(jq '[
+  .jobs[].steps[]?
+  | select((.run // "") | contains("run_build_test_cell.sh"))
+] | length' <<< "$workflow_json")"
+check_value "workflow build/test executor invocation count" \
+  "$all_executor_invocations" "1"
+if [[ "$executor_step_count" == "1" ]]; then
+  executor_step="$(jq -c '
+    .jobs.build_test.steps[]
+    | select((.run // "") | contains("run_build_test_cell.sh"))
+  ' <<< "$workflow_json")"
+  check_value "build/test executor-step name" \
+    "$(jq -r '.name' <<< "$executor_step")" "Build and test"
+  check_value "build/test executor-step command" \
+    "$(jq -r '.run' <<< "$executor_step")" \
+    './ci/run_build_test_cell.sh "$TOOLCHAIN" "$CRATE" "$TARGET" "$FEATURE_PROFILE"'
+  check_set "build/test executor-step environment" \
+    "$(jq -r '.env | keys[]' <<< "$executor_step")" \
+    $'CRATE\nFEATURE_PROFILE\nTARGET\nTOOLCHAIN'
+  check_value "build/test executor TOOLCHAIN" \
+    "$(jq -r '.env.TOOLCHAIN' <<< "$executor_step")" \
+    '${{ matrix.toolchain }}'
+  check_value "build/test executor CRATE" \
+    "$(jq -r '.env.CRATE' <<< "$executor_step")" \
+    '${{ matrix.crate }}'
+  check_value "build/test executor TARGET" \
+    "$(jq -r '.env.TARGET' <<< "$executor_step")" \
+    '${{ matrix.target }}'
+  check_value "build/test executor FEATURE_PROFILE" \
+    "$(jq -r '.env.FEATURE_PROFILE' <<< "$executor_step")" \
+    '${{ matrix.feature_profile }}'
+  if jq -e 'has("if")' >/dev/null <<< "$executor_step"; then
+    fail "the build/test executor step must be unconditional"
+  fi
+fi
+
+legacy_build_step_count="$(jq '[
+  .jobs.build_test.steps[]
+  | select(.name == "Check"
+      or .name == "Check tests"
+      or .name == "Build"
+      or .name == "Run tests"
+      or .name == "Run UI tests")
+] | length' <<< "$workflow_json")"
+check_value "legacy build/test step count" "$legacy_build_step_count" "0"
+
+relevant_test_scripts="$(jq -r '
+  [.jobs[].steps[]?.run // empty] | join("\n")
+' <<< "$workflow_json")"$'\n'"$(< "$BUILD_TEST_EXECUTOR")"
+if tr '\n' ' ' <<< "$relevant_test_scripts" | \
+    grep -Eq -- '--skip([=[:space:]]+)(ui|codegen)([^[:alnum:]_-]|$)'; then
+  fail "CI must classify UI/codegen structurally rather than using a libtest --skip filter"
+fi
 
 build_profile_exclusions="$(jq -r '
   .jobs.build_test.strategy.matrix.exclude[]
@@ -321,13 +1126,8 @@ while IFS= read -r profile; do
   if [[ "$profile" != "default" ]]; then
     expected_build_profile_exclusions+="crate"$'\t'"zerocopy-derive"$'\t'"$profile"$'\n'
   fi
-  case "$profile" in
-    default) profile_enables_std="$(jq -r '.default_enables_std' <<< "$feature_policy")" ;;
-    no-default) profile_enables_std="false" ;;
-    stable) profile_enables_std="$(jq -r '.stable_enables_std' <<< "$feature_policy")" ;;
-    all) profile_enables_std="$(jq -r '.std_feature_exists' <<< "$feature_policy")" ;;
-  esac
-  if [[ "$profile_enables_std" == "true" ]]; then
+  if jq -e --arg profile "$profile" \
+      'index($profile) != null' >/dev/null <<< "$std_profiles_json"; then
     expected_build_profile_exclusions+="target"$'\t'"thumbv6m-none-eabi"$'\t'"zerocopy"$'\t'"$profile"$'\n'
   fi
 done <<< "$expected_profiles"
@@ -432,19 +1232,167 @@ else
   fi
 fi
 
-# Semver checks intentionally select the stable semantic profile rather than
-# coupling their condition to Cargo argument spelling. UI tests have no
-# crate/profile filter so that a future default feature cannot silently miss UI
-# coverage.
-ui_step_count="$(jq '[.jobs.build_test.steps[] | select(.name == "Run UI tests")] | length' <<< "$workflow_json")"
-semver_step_count="$(jq '[.jobs.build_test.steps[] | select(.name == "Check semver compatibility")] | length' <<< "$workflow_json")"
-check_value "UI-test step count" "$ui_step_count" "1"
-check_value "semver step count" "$semver_step_count" "1"
-ui_condition="$(jq -r '.jobs.build_test.steps[] | select(.name == "Run UI tests") | .if' <<< "$workflow_json")"
-semver_condition="$(jq -r '.jobs.build_test.steps[] | select(.name == "Check semver compatibility") | .if' <<< "$workflow_json")"
-if grep -Eq 'matrix\.(crate|feature_profile)' <<< "$ui_condition"; then
-  fail "the UI-test condition must not filter by crate or feature profile"
+# A `test = false` integration target is invisible to unfiltered `cargo test`.
+# The manifest audit above permits only codegen, and this job must explicitly
+# lint and execute that exact target. Keeping both commands target-specific
+# makes the ownership transfer visible and prevents an apparently successful
+# generic Cargo invocation from masking its omission.
+if ! jq -e '.jobs | has("codegen")' >/dev/null <<< "$workflow_json"; then
+  fail "workflow does not define the dedicated codegen job"
+else
+  codegen_clippy_step_count="$(jq '[
+    .jobs.codegen.steps[] | select(.name == "Clippy")
+  ] | length' <<< "$workflow_json")"
+  codegen_test_step_count="$(jq '[
+    .jobs.codegen.steps[] | select(.name == "Run tests")
+  ] | length' <<< "$workflow_json")"
+  check_value "codegen Clippy-step count" "$codegen_clippy_step_count" "1"
+  check_value "codegen test-step count" "$codegen_test_step_count" "1"
+
+  if [[ "$codegen_clippy_step_count" == "1" ]]; then
+    codegen_clippy_run="$(jq -r '
+      .jobs.codegen.steps[] | select(.name == "Clippy") | .run
+    ' <<< "$workflow_json")"
+    codegen_clippy_run="$(tr '\n' ' ' <<< "$codegen_clippy_run" \
+      | sed -E 's/\\[[:space:]]+/ /g; s/[[:space:]]+/ /g')"
+    for fragment in \
+      './cargo.sh +nightly clippy' \
+      '--locked' \
+      '--package zerocopy' \
+      '--target x86_64-unknown-linux-gnu' \
+      '--all-features' \
+      '--test codegen' \
+      '--verbose'; do
+      if ! grep -Fq -- "$fragment" <<< "$codegen_clippy_run"; then
+        fail "codegen Clippy step is missing '$fragment'"
+      fi
+    done
+    codegen_clippy_selector_count="$(grep -Fo -- '--test codegen' \
+      <<< "$codegen_clippy_run" | wc -l)"
+    check_value "codegen Clippy target-selector count" \
+      "$codegen_clippy_selector_count" "1"
+  fi
+
+  if [[ "$codegen_test_step_count" == "1" ]]; then
+    codegen_test_run="$(jq -r '
+      .jobs.codegen.steps[] | select(.name == "Run tests") | .run
+    ' <<< "$workflow_json")"
+    codegen_test_run="$(tr '\n' ' ' <<< "$codegen_test_run" \
+      | sed -E 's/\\[[:space:]]+/ /g; s/[[:space:]]+/ /g')"
+    for fragment in \
+      './cargo.sh +nightly test' \
+      '--package zerocopy' \
+      '--target x86_64-unknown-linux-gnu' \
+      '--all-features' \
+      '--test codegen' \
+      '--verbose'; do
+      if ! grep -Fq -- "$fragment" <<< "$codegen_test_run"; then
+        fail "codegen test step is missing '$fragment'"
+      fi
+    done
+    codegen_test_selector_count="$(grep -Fo -- '--test codegen' \
+      <<< "$codegen_test_run" | wc -l)"
+    check_value "codegen test target-selector count" \
+      "$codegen_test_selector_count" "1"
+  fi
 fi
+
+# UI tests now belong to Cargo's unfiltered native test selection. There must
+# be no legacy workflow step which reruns them. Instead, cargo-zerocopy emits a
+# capability cfg for exactly the semantic toolchains with checked-in snapshots,
+# and both UI entry points ignore themselves on all other toolchains, under
+# Miri, and under source coverage. The declarations below are deliberately
+# coordinated by this fail-closed guard because they live in separate Cargo
+# workspaces and cannot share a Rust constant directly.
+ui_step_count="$(jq '[
+  .jobs[].steps[]? | select(.name == "Run UI tests")
+] | length' <<< "$workflow_json")"
+check_value "legacy UI-test step count" "$ui_step_count" "0"
+
+cargo_zerocopy_source="../tools/cargo-zerocopy/src/main.rs"
+testutil_source="testutil/src/lib.rs"
+root_ui_source="tests/ui.rs"
+derive_ui_source="zerocopy-derive/tests/ui.rs"
+
+check_compact_source_fragment \
+  "UI-test toolchain capability list" "$cargo_zerocopy_source" \
+  'constUI_TEST_TOOLCHAINS:[&str;3]=["msrv","stable","nightly"];'
+check_compact_source_fragment \
+  "UI-test capability cfg declaration" "$cargo_zerocopy_source" \
+  'constUI_TEST_TOOLCHAIN_CFG:&str="__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN";'
+check_compact_source_fragment \
+  "UI-test toolchain classifier" "$cargo_zerocopy_source" \
+  'fnis_ui_test_toolchain(name:&str)->bool{UI_TEST_TOOLCHAINS.contains(&name)}'
+check_compact_source_fragment \
+  "conditional UI-test cfg emission" "$cargo_zerocopy_source" \
+  'ifis_ui_test_toolchain(name){flags+=&format!("--cfg{UI_TEST_TOOLCHAIN_CFG}");}'
+
+# The test harness must decode the same three semantic descriptors and map
+# each one to the matching snapshot suffix. `check_set` makes either additions
+# or omissions fail; the variant/name pairs prevent a silent transposition.
+testutil_cfg_toolchains="$(grep -oE \
+  '__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN[[:space:]]*=[[:space:]]*"[^"]+"' \
+  "$testutil_source" | sed -E 's/.*"([^"]+)"/\1/')"
+check_set "testutil UI-test cfg toolchains" "$testutil_cfg_toolchains" \
+  $'msrv\nstable\nnightly'
+testutil_toolchain_names="$(sed -nE \
+  's/.*ToolchainVersion::([^[:space:]]+)[[:space:]]*=>[[:space:]]*"([^"]+)".*/\1\t\2/p' \
+  "$testutil_source")"
+check_set "testutil UI-test snapshot-name mappings" \
+  "$testutil_toolchain_names" \
+  $'PinnedMsrv\tmsrv\nPinnedStable\tstable\nPinnedNightly\tnightly'
+
+expected_ui_attr="#[cfg_attr(any(miri,coverage_nightly,not($UI_TEST_CFG)),ignore)]"
+check_compact_source_fragment "zerocopy UI-test capability predicate" \
+  "$root_ui_source" "${expected_ui_attr}fntest_ui()"
+check_compact_source_fragment "zerocopy-derive UI-test capability predicate" \
+  "$derive_ui_source" "${expected_ui_attr}fnui()"
+for ui_source in "$root_ui_source" "$derive_ui_source"; do
+  compact_ui_source="$(tr -d '[:space:]' < "$ui_source")"
+  ui_attr_count="$(grep -Fo -- "$expected_ui_attr" \
+    <<< "$compact_ui_source" | wc -l)"
+  check_value "$ui_source UI-test capability-predicate count" \
+    "$ui_attr_count" "1"
+  if grep -Fq -- '--cfg=feature=' "$ui_source"; then
+    fail "$ui_source hard-codes a feature cfg instead of using Cargo's resolved feature set"
+  fi
+done
+
+# Register the internal cfg with both packages' unexpected-cfg machinery.
+# Otherwise a supported UI cell can turn into a warning/failure independently
+# of the capability predicate itself.
+check_value "zerocopy UI-test check-cfg registration count" \
+  "$(grep -Fc "cargo:rustc-check-cfg=cfg($UI_TEST_CFG)" build.rs)" "1"
+check_value "zerocopy-derive UI-test check-cfg registration count" \
+  "$(grep -Fc "'cfg($UI_TEST_CFG)'" zerocopy-derive/Cargo.toml)" "1"
+
+# UI fixtures recursively ask Cargo for artifacts. Keep that build on the
+# outer matrix cell's feature selection, and pass Cargo's resolved feature
+# closure to rustc rather than maintaining another manually curated list.
+check_compact_source_fragment \
+  "cargo-zerocopy UI feature-protocol declaration" "$cargo_zerocopy_source" \
+  'constUI_TEST_FEATURE_ARGS_ENV:&str="ZEROCOPY_UI_TEST_FEATURE_ARGS";'
+check_compact_source_fragment \
+  "cargo-zerocopy UI feature capture" "$cargo_zerocopy_source" \
+  'letfeature_selection_args=capture_feature_selection_args(&args_vec);'
+check_compact_source_fragment \
+  "cargo-zerocopy UI feature forwarding" "$cargo_zerocopy_source" \
+  'cmd.env(UI_TEST_FEATURE_ARGS_ENV,encode_feature_selection_args(&feature_selection_args),);'
+check_compact_source_fragment \
+  "testutil UI feature-protocol declaration" "$testutil_source" \
+  'constUI_TEST_FEATURE_ARGS_ENV:&str="ZEROCOPY_UI_TEST_FEATURE_ARGS";'
+check_compact_source_fragment \
+  "testutil outer feature reuse" "$testutil_source" \
+  'letfeature_selection_args=outer_feature_selection_args();command.args(&feature_selection_args);'
+check_compact_source_fragment \
+  "testutil resolved feature forwarding" "$testutil_source" \
+  'forfeaturein&zerocopy_features{command.arg(format!("--rustc-arg=--cfg=feature={:?}",feature));}'
+
+# Semver checks intentionally select the stable semantic profile rather than
+# coupling their condition to Cargo argument spelling.
+semver_step_count="$(jq '[.jobs.build_test.steps[] | select(.name == "Check semver compatibility")] | length' <<< "$workflow_json")"
+check_value "semver step count" "$semver_step_count" "1"
+semver_condition="$(jq -r '.jobs.build_test.steps[] | select(.name == "Check semver compatibility") | .if' <<< "$workflow_json")"
 if ! grep -Fq "matrix.feature_profile == 'stable'" <<< "$semver_condition"; then
   fail "the semver condition does not select the stable semantic feature profile"
 fi

--- a/zerocopy/ci/feature_profile.sh
+++ b/zerocopy/ci/feature_profile.sh
@@ -10,6 +10,13 @@
 
 set -euo pipefail
 
+# This helper is the only translation from semantic CI profiles to Cargo
+# feature arguments. Both ci.yml's shared environment setup and
+# run_build_test_cell.sh consume it, while check_all_toolchains_tested.sh
+# validates every mapping and requires the matrix to add `no-default` as soon
+# as Cargo.toml defines a non-empty default feature set. Keep the output as
+# whitespace-separated arguments: run_build_test_cell.sh deliberately parses
+# it into an array without `eval`.
 if [[ $# -ne 1 ]]; then
   echo "usage: $0 <default|no-default|stable|all>" >&2
   exit 1

--- a/zerocopy/ci/run_build_test_cell.sh
+++ b/zerocopy/ci/run_build_test_cell.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+readonly SCRIPT_NAME="ci/run_build_test_cell.sh"
+
+# This is the single source of truth for how the build matrix can exercise a
+# target on an x86_64 Linux GitHub Actions runner. Keep this table exhaustive:
+# an unclassified target is an error rather than silently receiving weaker
+# coverage. `ci/check_all_toolchains_tested.sh` compares `--describe` with the
+# workflow matrix and exercises `--plan` for every supported feature profile.
+#
+# The three modes are:
+#
+# - run: compile and run every default-selected test target;
+# - compile-tests: type-check tests, then code-generate the library; and
+# - library-only: type-check the library without its incompatible dev-deps.
+readonly TARGET_SPECS=(
+  "i686-unknown-linux-gnu|run"
+  "x86_64-unknown-linux-gnu|run"
+  "arm-unknown-linux-gnueabi|compile-tests"
+  "aarch64-unknown-linux-gnu|compile-tests"
+  "powerpc-unknown-linux-gnu|compile-tests"
+  "powerpc64-unknown-linux-gnu|compile-tests"
+  "riscv64gc-unknown-linux-gnu|compile-tests"
+  "s390x-unknown-linux-gnu|compile-tests"
+  "x86_64-pc-windows-msvc|compile-tests"
+  "thumbv6m-none-eabi|library-only"
+  "wasm32-unknown-unknown|compile-tests"
+)
+
+usage() {
+  cat >&2 <<EOF
+usage: $SCRIPT_NAME <toolchain> <crate> <target> <feature-profile>
+       $SCRIPT_NAME --plan <toolchain> <crate> <target> <feature-profile>
+       $SCRIPT_NAME --describe
+EOF
+}
+
+fail() {
+  echo "$SCRIPT_NAME: $*" >&2
+  exit 1
+}
+
+target_mode() {
+  local requested="$1"
+  local spec target mode
+
+  for spec in "${TARGET_SPECS[@]}"; do
+    target="${spec%%|*}"
+    mode="${spec#*|}"
+    if [[ "$requested" == "$target" ]]; then
+      echo "$mode"
+      return
+    fi
+  done
+
+  fail "target '$requested' has no build/test mode"
+}
+
+describe() {
+  # JSON keeps the checker independent of shell parsing details. Generate it
+  # from TARGET_SPECS so execution and validation cannot drift apart.
+  local spec target mode separator=""
+
+  printf '{"schema_version":1,"targets":['
+  for spec in "${TARGET_SPECS[@]}"; do
+    target="${spec%%|*}"
+    mode="${spec#*|}"
+    printf '%s{"target":"%s","mode":"%s"}' \
+      "$separator" "$target" "$mode"
+    separator=,
+  done
+  printf ']}\n'
+}
+
+args_json() {
+  if [[ $# -eq 0 ]]; then
+    echo '[]'
+    return
+  fi
+
+  jq -cn --args '$ARGS.positional' -- "$@"
+}
+
+emit_plan() {
+  local toolchain="$1"
+  local crate="$2"
+  local target="$3"
+  local feature_profile="$4"
+  local mode="$5"
+  shift 5
+
+  local feature_json
+  feature_json="$(args_json "$@")"
+
+  jq -cn \
+    --arg toolchain "$toolchain" \
+    --arg crate "$crate" \
+    --arg target "$target" \
+    --arg feature_profile "$feature_profile" \
+    --arg mode "$mode" \
+    --argjson feature_args "$feature_json" \
+    --argjson commands "$COMMANDS_JSON" \
+    '{
+      schema_version: 1,
+      toolchain: $toolchain,
+      crate: $crate,
+      target: $target,
+      feature_profile: $feature_profile,
+      mode: $mode,
+      feature_args: $feature_args,
+      commands: $commands
+    }'
+}
+
+run_cargo() {
+  if [[ "$PLAN_ONLY" -eq 1 ]]; then
+    # Capture the exact argv assembled by the execution path. The invariant
+    # checker can therefore prove that runnable cells contain no selectors or
+    # libtest filters rather than trusting a second, abstract description.
+    local command_json
+    command_json="$(args_json "$@")"
+    COMMANDS_JSON="$(jq -cn \
+      --argjson commands "$COMMANDS_JSON" \
+      --argjson command "$command_json" \
+      '$commands + [$command]')"
+    return
+  fi
+
+  printf 'Running:'
+  printf ' %q' "$@"
+  printf '\n'
+  "$@"
+}
+
+check_ci_test_profile_contract() {
+  # The checker parses every repository Cargo config and scans the workflow and
+  # Dockerfile for profile environment variables. The running image can still
+  # acquire a global Cargo config from its base image or a Docker RUN command,
+  # so close that final boundary immediately before executing Cargo in CI.
+  #
+  # Reject the entire global config rather than trying to parse it here: yq is
+  # intentionally not part of the build image, and repository-owned settings
+  # belong in `.cargo/config.toml`, where the checker can audit them. Local
+  # developer configs remain supported because this guard is CI-only.
+  if [[ "${CI:-}" != "true" ]]; then
+    return
+  fi
+
+  local cargo_home="${CARGO_HOME:-}"
+  if [[ -z "$cargo_home" ]]; then
+    [[ -n "${HOME:-}" ]] || fail "CI defines neither CARGO_HOME nor HOME"
+    cargo_home="$HOME/.cargo"
+  fi
+
+  local config
+  for config in "$cargo_home/config" "$cargo_home/config.toml"; do
+    if [[ -e "$config" ]]; then
+      fail "CI Cargo home contains '$config'; re-audit the single-pass native test contract"
+    fi
+  done
+
+  # Environment variables have higher precedence than manifest/config values.
+  # Inspect names rather than a fixed option list so every current or future
+  # CARGO_PROFILE_TEST_* setting fails closed.
+  local environment_name
+  while IFS= read -r environment_name; do
+    case "$environment_name" in
+      CARGO_PROFILE_TEST_*)
+        fail "CI sets '$environment_name'; re-audit the single-pass native test contract"
+        ;;
+    esac
+  done < <(compgen -e)
+}
+
+if [[ $# -eq 1 && "$1" == "--describe" ]]; then
+  describe
+  exit
+fi
+
+PLAN_ONLY=0
+if [[ $# -gt 0 && "$1" == "--plan" ]]; then
+  PLAN_ONLY=1
+  shift
+fi
+COMMANDS_JSON='[]'
+
+if [[ $# -ne 4 ]]; then
+  usage
+  exit 1
+fi
+
+readonly TOOLCHAIN="$1"
+readonly CRATE="$2"
+readonly TARGET="$3"
+readonly FEATURE_PROFILE="$4"
+MODE="$(target_mode "$TARGET")"
+readonly MODE
+
+# feature_profile.sh emits a deliberately small, shell-like argument string.
+# Split it into an array without `eval`: Cargo feature names cannot contain
+# whitespace, and every option emitted by that helper is one word. Quoted array
+# expansion below prevents pathname expansion and preserves argument bounds.
+feature_output="$(./ci/feature_profile.sh "$FEATURE_PROFILE")"
+FEATURE_ARGS=()
+if [[ -n "$feature_output" ]]; then
+  if [[ "$feature_output" == *$'\n'* ]]; then
+    fail "feature profile output must be a single line"
+  fi
+  read -r -a FEATURE_ARGS <<< "$feature_output"
+fi
+readonly FEATURE_ARGS
+
+if [[ "$PLAN_ONLY" -eq 0 ]]; then
+  check_ci_test_profile_contract
+fi
+
+# Cargo.toml, rather than a libtest name filter here, owns exceptional test
+# targets. The UI target declares the feature it needs; the codegen target is
+# excluded from default test selection and is run and linted by its dedicated
+# CI job. cargo-zerocopy and the UI harness arrange for unsupported toolchains
+# to report the UI test as ignored. This lets every runnable cell use one
+# unfiltered default `cargo test`, so future default-selected tests run
+# automatically.
+case "$MODE" in
+  run)
+    run_cargo \
+      ./cargo.sh "+$TOOLCHAIN" test \
+      --package "$CRATE" \
+      --target "$TARGET" \
+      "${FEATURE_ARGS[@]}" \
+      --verbose
+    ;;
+  compile-tests)
+    # These targets cannot execute on the runner. `check --tests` covers their
+    # test-only code without linking, while `build` still exercises codegen for
+    # the library's ordinary artifact.
+    run_cargo \
+      ./cargo.sh "+$TOOLCHAIN" check \
+      --tests \
+      --package "$CRATE" \
+      --target "$TARGET" \
+      "${FEATURE_ARGS[@]}" \
+      --verbose
+    run_cargo \
+      ./cargo.sh "+$TOOLCHAIN" build \
+      --package "$CRATE" \
+      --target "$TARGET" \
+      "${FEATURE_ARGS[@]}" \
+      --verbose
+    ;;
+  library-only)
+    # thumbv6m cannot check tests because memchr, a dev-dependency, does not
+    # support the target. Keep this exception explicit and fail closed if the
+    # workflow adds another target with the same limitation.
+    run_cargo \
+      ./cargo.sh "+$TOOLCHAIN" check \
+      --package "$CRATE" \
+      --target "$TARGET" \
+      "${FEATURE_ARGS[@]}" \
+      --verbose
+    ;;
+  *)
+    fail "internal error: unknown build/test mode '$MODE'"
+    ;;
+esac
+
+if [[ "$PLAN_ONLY" -eq 1 ]]; then
+  emit_plan \
+    "$TOOLCHAIN" \
+    "$CRATE" \
+    "$TARGET" \
+    "$FEATURE_PROFILE" \
+    "$MODE" \
+    "${FEATURE_ARGS[@]}"
+fi

--- a/zerocopy/ci/test_check_all_toolchains_tested.sh
+++ b/zerocopy/ci/test_check_all_toolchains_tested.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -euo pipefail
+
+# The test process symlinks this script into PATH as `yq`. Delegate ordinary
+# parsing to the real implementation, then mutate only its JSON output. This
+# leaves the worktree untouched and reuses the real Cargo metadata and executor.
+if [[ -n "${ZEROCOPY_CI_CHECK_REAL_YQ:-}" ]]; then
+  invoked_name="${0##*/}"
+  if [[ "$invoked_name" == "tomlq" ]]; then
+    # Python yq ships TOML parsing as a separate executable. Inject the parsed
+    # table, rather than depending on one particular TOML spelling, to prove
+    # that every quoted/dotted/inline representation is caught structurally.
+    [[ -n "${ZEROCOPY_CI_CHECK_REAL_TOMLQ:-}" ]] || exit 1
+    "$ZEROCOPY_CI_CHECK_REAL_TOMLQ" "$@" | jq -c '.profile.test = {}'
+    exit
+  fi
+  if [[ "${1:-}" == "--version" ]]; then
+    exec "$ZEROCOPY_CI_CHECK_REAL_YQ" "$@"
+  fi
+  # Go yq parses TOML through the same executable. Detect that input mode and
+  # apply the same parsed-table mutation as the Python tomlq branch above.
+  for arg in "$@"; do
+    if [[ "$arg" == "-p=toml" || "$arg" == "--input-format=toml" ]]; then
+      "$ZEROCOPY_CI_CHECK_REAL_YQ" "$@" | jq -c '.profile.test = {}'
+      exit
+    fi
+  done
+  # Exercise ten independent ownership boundaries in one checker run:
+  #
+  # - a parsed Cargo test-profile override;
+  # - a target added without an executor classification;
+  # - deletion of a required workflow trigger;
+  # - exclusions which erase every natively-runnable target;
+  # - a narrow exclusion which erases one required cross-target feature set;
+  # - removal of an exclusion which admits an unsupported matrix cell;
+  # - removal of an exclusion from a reviewed native-only threshold;
+  # - AArch64-specific toolchains accidentally redirected to ARM32;
+  # - removal of the workflow's sole executor bridge; and
+  # - removal of dedicated codegen lint ownership.
+  #
+  # Requiring every diagnostic below is important: the checker accumulates
+  # failures, so one early mutation must not mask a later invariant.
+  "$ZEROCOPY_CI_CHECK_REAL_YQ" "$@" | jq -c '
+    del(.on.push)
+    | .jobs.build_test.strategy.matrix.target +=
+      ["__mutation_unclassified_target__"]
+    | .jobs.build_test.strategy.matrix.exclude += [
+        {"target": "i686-unknown-linux-gnu"},
+        {"target": "x86_64-unknown-linux-gnu"},
+        {
+          "toolchain": "nightly",
+          "target": "wasm32-unknown-unknown",
+          "crate": "zerocopy"
+        }
+      ]
+    | .jobs.build_test.strategy.matrix.exclude |= map(select((
+        (.toolchain == "stable"
+          and .target == "wasm32-unknown-unknown")
+        or (.toolchain == "no-zerocopy-core-error-1-81-0"
+          and .target == "arm-unknown-linux-gnueabi")
+      ) | not))
+    | (
+        .jobs.build_test.strategy.matrix.exclude[]
+        | select(
+            (.toolchain == "no-zerocopy-aarch64-simd-1-59-0"
+              or .toolchain == "no-zerocopy-aarch64-simd-be-1-87-0")
+            and .target == "arm-unknown-linux-gnueabi"
+          )
+        | .target
+      ) = "aarch64-unknown-linux-gnu"
+    | .jobs.build_test.steps |= map(select(.name != "Build and test"))
+    | (.jobs.codegen.steps[] | select(.name == "Clippy").run) |=
+        gsub("--test codegen"; "")
+  '
+  exit
+fi
+
+cd "$(dirname "$0")/.."
+
+readonly CHECKER="./ci/check_all_toolchains_tested.sh"
+REAL_YQ="$(command -v yq)"
+readonly REAL_YQ
+REAL_TOMLQ="$(command -v tomlq || true)"
+readonly REAL_TOMLQ
+TEMP_DIR="$(mktemp -d)"
+readonly TEMP_DIR
+trap 'rm -rf -- "$TEMP_DIR"' EXIT
+
+# Feature-graph semantics belong to test_feature_policy.sh, which was added
+# with the policy itself. This test mutates only the executor and matrix
+# contracts introduced alongside run_build_test_cell.sh.
+ln -s "$PWD/ci/test_check_all_toolchains_tested.sh" "$TEMP_DIR/yq"
+ln -s "$PWD/ci/test_check_all_toolchains_tested.sh" "$TEMP_DIR/tomlq"
+
+if output="$(
+  PATH="$TEMP_DIR:$PATH" \
+    ZEROCOPY_CI_CHECK_REAL_YQ="$REAL_YQ" \
+    ZEROCOPY_CI_CHECK_REAL_TOMLQ="$REAL_TOMLQ" \
+    "$CHECKER" 2>&1
+)"; then
+  echo "mutation unexpectedly passed $CHECKER" >&2
+  exit 1
+fi
+
+for expected_diagnostic in \
+  "Cargo.toml overrides profile.test" \
+  "build/test executor targets is missing required entries:" \
+  "workflow triggers is missing required entries:" \
+  "post-exclusion build-matrix cells is missing required entries:" \
+  "post-exclusion build-matrix cells contains unexpected entries:" \
+  $'merge_group\tzerocopy\tnightly\tdefault\tx86_64-unknown-linux-gnu' \
+  $'merge_group\tzerocopy\tnightly\tall\twasm32-unknown-unknown' \
+  $'merge_group\tzerocopy\tstable\tdefault\twasm32-unknown-unknown' \
+  $'merge_group\tzerocopy\tno-zerocopy-core-error-1-81-0\tdefault\tarm-unknown-linux-gnueabi' \
+  "merge_group targets for cross-only toolchain 'no-zerocopy-aarch64-simd-1-59-0' is missing required entries:" \
+  "build/test executor-step count: expected '1', found '0'" \
+  "codegen Clippy step is missing '--test codegen'"; do
+  if ! grep -Fq "$expected_diagnostic" <<< "$output"; then
+    echo "mutation did not produce: $expected_diagnostic" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+done

--- a/zerocopy/tests/ui.rs
+++ b/zerocopy/tests/ui.rs
@@ -23,12 +23,17 @@
 use testutil::UiTestRunner;
 
 #[test]
-#[cfg_attr(miri, ignore)]
+// UI fixtures spawn external compiler processes, so Miri and source coverage
+// must not execute them. Ignoring coverage here lets CI use an unfiltered
+// default `cargo test` without attributing the subprocess's code to the test
+// process. Diagnostic snapshots exist only for the three pinned toolchains;
+// cargo-zerocopy emits the final cfg only for those semantic descriptors.
+#[cfg_attr(
+    any(miri, coverage_nightly, not(__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN)),
+    ignore
+)]
 fn test_ui() {
-    // FIXME: Instead of manually passing `--features derive` when building, we
-    // should just pass whatever is passed to us.
     UiTestRunner::new()
-        .rustc_arg("--cfg=feature=\"derive\"") // For tests that check #cfg(feature = "derive")
         .rustc_arg("-Wwarnings") // To reflect typical user experience in stderr
         .run();
 }

--- a/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:77:24
    |
@@ -49,7 +49,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 141 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_zeros`
   --> $DIR/diagnostic-not-implemented.rs:78:24
    |
@@ -79,7 +79,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 128 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_immutable`
   --> $DIR/diagnostic-not-implemented.rs:79:23
    |
@@ -109,7 +109,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_into_bytes`
   --> $DIR/diagnostic-not-implemented.rs:80:24
    |
@@ -137,7 +137,7 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AU16
              AtomicBool
              AtomicI16
-           and 65 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_known_layout`
   --> $DIR/diagnostic-not-implemented.rs:81:26
    |
@@ -165,7 +165,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 153 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_try_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:82:28
    |
@@ -195,7 +195,7 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_unaligned`
   --> $DIR/diagnostic-not-implemented.rs:83:23
    |
@@ -245,7 +245,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `Foo::write_obj`
   --> $DIR/diagnostic-not-implemented.rs:73:37
    |

--- a/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:77:24
    |
@@ -49,7 +49,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 141 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_zeros`
   --> $DIR/diagnostic-not-implemented.rs:78:24
    |
@@ -79,7 +79,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 128 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_immutable`
   --> $DIR/diagnostic-not-implemented.rs:79:23
    |
@@ -109,7 +109,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_into_bytes`
   --> $DIR/diagnostic-not-implemented.rs:80:24
    |
@@ -137,7 +137,7 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AU16
              AtomicBool
              AtomicI16
-           and 65 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_known_layout`
   --> $DIR/diagnostic-not-implemented.rs:81:26
    |
@@ -165,7 +165,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 153 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_try_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:82:28
    |
@@ -195,7 +195,7 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_unaligned`
   --> $DIR/diagnostic-not-implemented.rs:83:23
    |
@@ -245,7 +245,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `Foo::write_obj`
   --> $DIR/diagnostic-not-implemented.rs:73:37
    |

--- a/zerocopy/tests/ui/include_value.nightly.stderr
+++ b/zerocopy/tests/ui/include_value.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> $DIR/include_value.rs:17:5
    |

--- a/zerocopy/tests/ui/include_value.stable.stderr
+++ b/zerocopy/tests/ui/include_value.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> $DIR/include_value.rs:17:5
    |

--- a/zerocopy/tests/ui/transmute.nightly.stderr
+++ b/zerocopy/tests/ui/transmute.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> $DIR/transmute.rs:17:41
    |
@@ -56,7 +56,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> $DIR/transmute.rs:21:32
    |

--- a/zerocopy/tests/ui/transmute.stable.stderr
+++ b/zerocopy/tests/ui/transmute.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> $DIR/transmute.rs:17:41
    |
@@ -56,7 +56,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> $DIR/transmute.rs:21:32
    |

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -39,7 +39,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:814:14
     |
@@ -73,7 +73,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:814:26
     |
@@ -149,7 +149,7 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:813:14
     |
@@ -183,7 +183,7 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:813:26
     |

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -39,7 +39,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:814:14
     |
@@ -73,7 +73,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:814:26
     |
@@ -149,7 +149,7 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:813:14
     |
@@ -183,7 +183,7 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:813:26
     |

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -102,7 +102,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
   --> $DIR/transmute_ref.rs:40:35
    |
@@ -136,7 +136,7 @@ help: the trait `Immutable` is not implemented for `DstB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
   --> $DIR/transmute_ref.rs:48:34
    |
@@ -242,7 +242,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -271,7 +271,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -303,7 +303,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |
@@ -334,7 +334,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -102,7 +102,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
   --> $DIR/transmute_ref.rs:40:35
    |
@@ -136,7 +136,7 @@ help: the trait `Immutable` is not implemented for `DstB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
   --> $DIR/transmute_ref.rs:48:34
    |
@@ -242,7 +242,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -271,7 +271,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -303,7 +303,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |
@@ -334,7 +334,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -49,7 +49,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
    --> src/util/macro_util.rs:528:10
     |
@@ -83,7 +83,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -114,7 +114,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
    --> src/util/macro_util.rs:527:10
     |

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -49,7 +49,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
    --> $WORKSPACE/src/util/macro_util.rs:528:10
     |
@@ -83,7 +83,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -114,7 +114,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
    --> $WORKSPACE/src/util/macro_util.rs:527:10
     |

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:14
     |
@@ -53,7 +53,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |
@@ -85,7 +85,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -115,7 +115,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -146,7 +146,7 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 80 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:836:14
     |
@@ -180,7 +180,7 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |
@@ -212,7 +212,7 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:836:26
     |
@@ -244,7 +244,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:14
     |
@@ -53,7 +53,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |
@@ -85,7 +85,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -115,7 +115,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -146,7 +146,7 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 80 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:836:14
     |
@@ -180,7 +180,7 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |
@@ -212,7 +212,7 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:836:26
     |
@@ -244,7 +244,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -36,7 +36,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:757:14
     |
@@ -70,7 +70,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:757:29
     |
@@ -104,7 +104,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -134,7 +134,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -165,7 +165,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:756:14
     |
@@ -197,7 +197,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:756:26
     |

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -36,7 +36,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:757:14
     |
@@ -70,7 +70,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:757:29
     |
@@ -104,7 +104,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -134,7 +134,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -165,7 +165,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:756:14
     |
@@ -197,7 +197,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:756:26
     |

--- a/zerocopy/testutil/src/lib.rs
+++ b/zerocopy/testutil/src/lib.rs
@@ -11,6 +11,52 @@
 
 use std::{env, path::PathBuf, process::Command};
 
+// `tools/cargo-zerocopy` sets this on every delegated Cargo process. Test
+// executables inherit it, allowing a UI test's recursive artifact build to use
+// the same feature-selection options as the outer Cargo invocation.
+const UI_TEST_FEATURE_ARGS_ENV: &str = "ZEROCOPY_UI_TEST_FEATURE_ARGS";
+
+// Decode the length-prefixed UTF-8 format produced by cargo-zerocopy. This
+// format avoids assigning special meaning to any character Cargo permits in
+// an argument. Keep the protocol and its fixed-vector tests in both workspaces
+// synchronized.
+fn decode_feature_selection_args(encoded: &str) -> Result<Vec<String>, String> {
+    let mut args = Vec::new();
+    let mut remaining = encoded;
+
+    while !remaining.is_empty() {
+        let colon = remaining.find(':').ok_or_else(|| "missing length delimiter".to_string())?;
+        let length = remaining[..colon]
+            .parse::<usize>()
+            .map_err(|_| "invalid argument length".to_string())?;
+        let contents = &remaining[colon + 1..];
+        if contents.len() < length {
+            return Err("argument is shorter than its encoded length".to_string());
+        }
+        if !contents.is_char_boundary(length) {
+            return Err("argument length splits a UTF-8 character".to_string());
+        }
+
+        let (arg, rest) = contents.split_at(length);
+        args.push(arg.to_string());
+        remaining = rest;
+    }
+
+    Ok(args)
+}
+
+fn outer_feature_selection_args() -> Vec<String> {
+    match env::var(UI_TEST_FEATURE_ARGS_ENV) {
+        Ok(encoded) => decode_feature_selection_args(&encoded).unwrap_or_else(|error| {
+            panic!("could not decode {}: {}", UI_TEST_FEATURE_ARGS_ENV, error)
+        }),
+        Err(env::VarError::NotPresent) => Vec::new(),
+        Err(env::VarError::NotUnicode(_)) => {
+            panic!("{} is not valid UTF-8", UI_TEST_FEATURE_ARGS_ENV)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ToolchainVersion {
     /// The version listed as our MSRV (ie, the `package.rust-version` key in
@@ -123,6 +169,7 @@ impl UiTestRunner {
         let mut rlib_path = None;
         let mut derive_lib_path = None;
         let mut static_assertions_path = None;
+        let mut zerocopy_features = None;
 
         let mut command = Command::new("cargo");
         command.current_dir(workspace_root.clone());
@@ -194,17 +241,23 @@ impl UiTestRunner {
             ]);
         }
 
-        let mut args = vec![
-            "build",
-            "--locked",
-            "--offline",
-            "-p",
-            "zerocopy",
-            "--features",
-            "derive",
-            "--tests",
-            "--message-format=json",
-        ];
+        command.args(["build", "--locked", "--offline", "-p", "zerocopy"]);
+
+        // cargo-zerocopy captured these options before starting the outer
+        // Cargo command. Applying them here makes default features,
+        // `--no-default-features`, explicit features, and `--all-features`
+        // behave identically in both builds.
+        //
+        // CI requires zerocopy-derive to define no features. If that changes,
+        // its package-local feature arguments will need an explicit mapping
+        // before they can be applied to this nested zerocopy build.
+        let feature_selection_args = outer_feature_selection_args();
+        command.args(&feature_selection_args);
+
+        // Both UI suites need the derive proc macro artifact. Cargo feature
+        // options are additive, so this retains the outer selection while
+        // structurally adding the one feature required by the harness.
+        command.args(["--features", "derive", "--tests", "--message-format=json"]);
 
         // `cargo-zerocopy` uses `ZEROCOPY_UI_TEST_TARGET` to pass the value of
         // any `--target` CLI argument. Here, we use this target when building
@@ -212,11 +265,8 @@ impl UiTestRunner {
         let target = env::var("ZEROCOPY_UI_TEST_TARGET").ok();
 
         if let Some(ref t) = target {
-            args.push("--target");
-            args.push(t);
+            command.args(["--target", t]);
         }
-
-        command.args(args);
 
         let output = command.output().expect("Failed to execute cargo build for artifacts");
         if !output.status.success() {
@@ -241,9 +291,17 @@ impl UiTestRunner {
                 if artifact.target.name == "zerocopy"
                     && artifact.target.kind.iter().any(|k| k == "lib")
                 {
+                    let features = artifact.features.clone();
                     for file in artifact.filenames {
                         if file.extension() == Some("rlib") {
+                            if let Some(ref previous) = zerocopy_features {
+                                assert_eq!(
+                                    previous, &features,
+                                    "zerocopy artifacts used different features"
+                                );
+                            }
                             rlib_path = Some(file);
+                            zerocopy_features = Some(features.clone());
                         }
                     }
                 } else if artifact.target.name == "zerocopy-derive"
@@ -271,6 +329,14 @@ impl UiTestRunner {
         let derive_lib_path = derive_lib_path.expect("failed to find zerocopy_derive proc-macro");
         let static_assertions_path =
             static_assertions_path.expect("failed to find static_assertions rlib");
+        let mut zerocopy_features =
+            zerocopy_features.expect("failed to find zerocopy artifact features");
+        zerocopy_features.sort();
+        zerocopy_features.dedup();
+        assert!(
+            zerocopy_features.iter().any(|feature| feature == "derive"),
+            "UI artifact build did not enable its required derive feature"
+        );
 
         let mut build_command = Command::new("rustup");
 
@@ -321,6 +387,13 @@ impl UiTestRunner {
             command.arg(format!("--rustc-arg={}", arg));
         }
 
+        // Cargo's artifact message is authoritative for the complete feature
+        // closure, including default, transitive, and implicit dependency
+        // features. Give each fixture exactly the cfgs Cargo gave zerocopy.
+        for feature in &zerocopy_features {
+            command.arg(format!("--rustc-arg=--cfg=feature={:?}", feature));
+        }
+
         command.env("ZEROCOPY_RLIB_PATH", rlib_path);
         command.env("ZEROCOPY_DERIVE_LIB_PATH", derive_lib_path);
         command.env("ZEROCOPY_STATIC_ASSERTIONS_PATH", static_assertions_path);
@@ -357,5 +430,34 @@ impl UiTestRunner {
 
         let mut proc = command.spawn().expect("Failed to spawn ui-runner");
         assert!(proc.wait().unwrap().success(), "ui-runner failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_feature_selection_args;
+
+    #[test]
+    fn decodes_cargo_zerocopy_feature_selection_protocol() {
+        assert_eq!(
+            decode_feature_selection_args("14:--all-features10:--features19:derive,simd-nightly")
+                .unwrap(),
+            vec![
+                "--all-features".to_string(),
+                "--features".to_string(),
+                "derive,simd-nightly".to_string(),
+            ]
+        );
+        assert_eq!(
+            decode_feature_selection_args("0:1::2:μ").unwrap(),
+            vec!["".to_string(), ":".to_string(), "μ".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_feature_selection_protocol() {
+        for encoded in &[":", "x:a", "2:a", "1:μ"] {
+            assert!(decode_feature_selection_args(encoded).is_err());
+        }
     }
 }

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -23,8 +23,13 @@ exclude = [".*", "tests/enum_from_bytes.rs", "tests/ui-nightly/enum_from_bytes_u
 
 [lints.rust]
 # See #1792 for more context.
+# cargo-zerocopy emits the UI-test cfg only for semantic toolchain descriptors
+# with diagnostic snapshots. The coverage cfg is emitted by cargo-llvm-cov.
+# `tests/ui.rs` uses both to make an unfiltered default Cargo test safe.
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)',
+  'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN)',
+  'cfg(coverage_nightly)',
   'cfg(zerocopy_derive_union_into_bytes)',
   'cfg(zerocopy_unstable_linux)',
 ] }

--- a/zerocopy/zerocopy-derive/tests/ui.rs
+++ b/zerocopy/zerocopy-derive/tests/ui.rs
@@ -9,7 +9,14 @@
 use testutil::UiTestRunner;
 
 #[test]
-#[cfg_attr(miri, ignore)]
+// Keep this predicate synchronized with `tests/ui.rs`. UI fixtures spawn
+// external compiler processes, which Miri and source coverage must not run.
+// Diagnostic snapshots exist only for the pinned toolchains; cargo-zerocopy
+// emits the final cfg only for those semantic descriptors.
+#[cfg_attr(
+    any(miri, coverage_nightly, not(__ZEROCOPY_INTERNAL_USE_ONLY_UI_TEST_TOOLCHAIN)),
+    ignore
+)]
 fn ui() {
     // This tests the behavior when `--cfg zerocopy_derive_union_into_bytes` is
     // present.

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 154 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::TryFromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -60,7 +60,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 142 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -101,7 +101,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -142,7 +142,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/derive_transparent.rs:24:10
    |
@@ -181,7 +181,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocop
              F32<O>
              F64<O>
              I128<O>
-           and 27 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::Unaligned`
   --> $DIR/derive_transparent.rs:24:32
    |

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 154 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::TryFromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -55,7 +55,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 142 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -91,7 +91,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -127,7 +127,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/derive_transparent.rs:24:10
    |
@@ -161,7 +161,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocop
              F32<O>
              F64<O>
              I128<O>
-           and 27 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::Unaligned`
   --> $DIR/derive_transparent.rs:24:32
    |

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -334,7 +334,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -360,7 +360,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -391,7 +391,7 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -422,7 +422,7 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -453,7 +453,7 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 142 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -479,7 +479,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -594,7 +594,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
 note: required for `FooU8` to implement `FromBytes`
    --> $DIR/enum.rs:247:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -310,7 +310,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -332,7 +332,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -359,7 +359,7 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -386,7 +386,7 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -413,7 +413,7 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 142 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -435,7 +435,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -542,7 +542,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
 note: required for `FooU8` to implement `FromBytes`
    --> $DIR/enum.rs:247:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -58,7 +58,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -89,7 +89,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -120,7 +120,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -151,7 +151,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -182,7 +182,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -213,7 +213,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -242,7 +242,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -271,7 +271,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -300,7 +300,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 29 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -329,7 +329,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/late_compile_pass.rs:54:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -54,7 +54,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -81,7 +81,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -108,7 +108,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -135,7 +135,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -162,7 +162,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -189,7 +189,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,7 +214,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -239,7 +239,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -264,7 +264,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 29 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -289,7 +289,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/late_compile_pass.rs:54:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/msrv_specific.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/msrv_specific.nightly.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required for `IntoBytes1<AU16>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/msrv_specific.rs:25:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/msrv_specific.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/msrv_specific.stable.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required for `IntoBytes1<AU16>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/msrv_specific.rs:25:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -200,7 +200,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -229,7 +229,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -253,7 +253,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -279,7 +279,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
@@ -359,7 +359,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -538,7 +538,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtN
               AU16
               AtomicBool
               AtomicI16
-            and 73 others
+            and $OTHER_TYPES others
 note: required by a bound in `SplitAt`
    --> src/split_at.rs:63:0
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -589,7 +589,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
    --> $DIR/struct.rs:232:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -187,7 +187,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -212,7 +212,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -232,7 +232,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -254,7 +254,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
@@ -330,7 +330,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -505,7 +505,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtN
               AU16
               AtomicBool
               AtomicI16
-            and 73 others
+            and $OTHER_TYPES others
 note: required by a bound in `SplitAt`
    --> $WORKSPACE/src/split_at.rs:63:27
     |
@@ -557,7 +557,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
    --> $DIR/struct.rs:232:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 129 others
+           and $OTHER_TYPES others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'

--- a/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 129 others
+           and $OTHER_TYPES others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Run one target-appropriate Cargo pass in each build-matrix job instead
of separate check, build, test, and UI passes. Jobs that run on their
target execute the full test suite; cross-target jobs keep explicit
build and code-generation coverage.

Forward selected features into recursive UI builds and derive fixture
configuration from Cargo output. Specify the complete post-exclusion
matrix independently, so trigger, target, toolchain, profile, or
exception drift fails closed.

When measured in the original stack order, this reduced non-Anneal PR
wall time from 5:32 to 4:04 against its then-parent. Across two
comparable baselines, the average reduction was 73 seconds (23%); total
runner time across the 60-job matrix fell by 30:03 (17.3%).




---

- 👉 #3553
- 　  #3552
- 　  #3516
- 　  #3515
- 　  #3554
- 　  #3556
- 　  #3551
- 　  #3555


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v3..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v3..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v2..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v1..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v4)|[vs Base](/google/zerocopy/compare/Gwjyfp42do4erbwki767mq4bhkekmhz7o..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v2..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v1..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v3)|[vs Base](/google/zerocopy/compare/Gwjyfp42do4erbwki767mq4bhkekmhz7o..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v1..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v2)|[vs Base](/google/zerocopy/compare/Gwjyfp42do4erbwki767mq4bhkekmhz7o..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v2)|
|v1||||[vs Base](/google/zerocopy/compare/Gwjyfp42do4erbwki767mq4bhkekmhz7o..gherrit/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb && git checkout -b pr-Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gpmi5azzuunwnv5a7j3vsc3c2n6gvaymb","parent":"Gwjyfp42do4erbwki767mq4bhkekmhz7o","child":null} -->