### PR TITLE
[ci] Serialize pre-push toolchain setup

### DIFF
--- a/ci/check_actions.sh
+++ b/ci/check_actions.sh
@@ -117,6 +117,7 @@ if ! output=$("$actionlint_bin" -shellcheck= -pyflakes= 2>&1); then
 fi
 
 python3 .github/actions/require-successful-jobs/test_check.py
+python3 githooks/test_pre_push.py
 
 # The hosted workflows delegate every apt operation to this bounded retry
 # helper. Its fake-command tests verify timeouts, retries, failure propagation,

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -10,33 +10,68 @@
 
 set -eo pipefail
 echo "Running pre-push git hook: $0"
+
+# The checks below use cargo-zerocopy's pinned stable and nightly toolchains.
+# On a fresh machine, check_fmt.sh and both toolchain-policy checks can all
+# reach rustup installation concurrently. Rustup shares download and rollback
+# paths across toolchains, so those installations can remove one another's
+# partial files. Bootstrap the two toolchains serially before retaining useful
+# parallelism between the actual checks.
+#
+# Keep this list coordinated with the backgrounded scripts below: if another
+# check starts using a different cargo-zerocopy descriptor, initialize it here
+# before that check may run in parallel.
+CHECKS_FAILED=0
+TOOLCHAINS_READY=1
+bootstrap_toolchain() {
+    local descriptor="$1"
+    local status
+    # Git sends the ref-update protocol to pre-push hooks on stdin. Bootstrap
+    # is deliberately noninteractive, and neither cargo-zerocopy nor a rustup
+    # child may consume input needed by a chained git-lfs or GHerrit hook.
+    if CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN=1 \
+        ./zerocopy/cargo.sh "+$descriptor" --version </dev/null >/dev/null; then
+        return
+    else
+        status=$?
+    fi
+    echo "zerocopy/cargo.sh +$descriptor --version failed with status $status" >&2
+    CHECKS_FAILED=1
+    TOOLCHAINS_READY=0
+}
+
+bootstrap_toolchain stable
+bootstrap_toolchain nightly
+
 # Forego redirecting stdout to /dev/null on check_fmt.sh because the output from
 # `cargo fmt` is useful (and the good stuff is not delivered by stderr).
 #
-# Background all jobs and wait for them so they can run in parallel.
-./ci/check_actions.sh                                  & ACTIONS_PID=$!
-./ci/check_fmt.sh                                      & FMT_PID=$!
-./ci/check_job_dependencies.sh      >/dev/null         & JOB_DEPS_PID=$!
-./zerocopy/ci/check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_PID=$!
-./zerocopy/ci/check_readme.sh                >/dev/null & README_PID=$!
-./zerocopy/ci/check_stale_stderr.sh          >/dev/null & STALE_STDERR_PID=$!
-./zerocopy/ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
-./zerocopy/ci/check_msrv_is_minimal.sh       >/dev/null & MSRV_PID=$!
+# Background all jobs and wait for them so they can run in parallel. Do not
+# launch them after a bootstrap failure: they could otherwise race to repair
+# the same incomplete toolchain state. Static script-inventory checks below
+# still run, including when bootstrap fails.
+if [[ "$TOOLCHAINS_READY" -eq 1 ]]; then
+    ./ci/check_actions.sh                                  & ACTIONS_PID=$!
+    ./ci/check_fmt.sh                                      & FMT_PID=$!
+    ./ci/check_job_dependencies.sh      >/dev/null         & JOB_DEPS_PID=$!
+    ./zerocopy/ci/check_all_toolchains_tested.sh >/dev/null & TOOLCHAINS_PID=$!
+    ./zerocopy/ci/check_readme.sh                >/dev/null & README_PID=$!
+    ./zerocopy/ci/check_stale_stderr.sh          >/dev/null & STALE_STDERR_PID=$!
+    ./zerocopy/ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
+    ./zerocopy/ci/check_msrv_is_minimal.sh       >/dev/null & MSRV_PID=$!
 
-# `wait <pid>` exits with the same status code as the job it's waiting for.
-# Since we `set -e` above, this will have the effect of causing the entire
-# script to exit with a non-zero status code if any of these jobs does the same.
-# Note that, while `wait` (with no PID argument) waits for all backgrounded
-# jobs, it exits with code 0 even if one of the backgrounded jobs does not, so
-# we can't use it here.
-wait $ACTIONS_PID
-wait $FMT_PID
-wait $TOOLCHAINS_PID
-wait $JOB_DEPS_PID
-wait $README_PID
-wait $STALE_STDERR_PID
-wait $VERSIONS_PID
-wait $MSRV_PID
+    # `wait <pid>` exits with the same status code as the job it's waiting for.
+    # Since we `set -e` above, this causes the hook to fail if a child does.
+    # A bare `wait` loses child statuses, so wait for each named process.
+    wait "$ACTIONS_PID"
+    wait "$FMT_PID"
+    wait "$TOOLCHAINS_PID"
+    wait "$JOB_DEPS_PID"
+    wait "$README_PID"
+    wait "$STALE_STDERR_PID"
+    wait "$VERSIONS_PID"
+    wait "$MSRV_PID"
+fi
 
 # Ensure that this script calls all scripts in `ci/*` and `zerocopy/ci/*`. This
 # isn't a foolproof check since it just checks for the string in this script
@@ -60,3 +95,5 @@ for f in ./zerocopy/ci/*; do
 done
 unset GLOBIGNORE
 shopt -u extglob
+
+exit "$CHECKS_FAILED"

--- a/githooks/test_pre_push.py
+++ b/githooks/test_pre_push.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Regression tests for serialized pre-push toolchain bootstrap."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_HOOK = _ROOT / "githooks" / "pre-push"
+_CHECKS = (
+    "ci/check_actions.sh",
+    "ci/check_fmt.sh",
+    "ci/check_job_dependencies.sh",
+    "zerocopy/ci/check_all_toolchains_tested.sh",
+    "zerocopy/ci/check_readme.sh",
+    "zerocopy/ci/check_stale_stderr.sh",
+    "zerocopy/ci/check_versions.sh",
+    "zerocopy/ci/check_msrv_is_minimal.sh",
+)
+
+_CHECK_STUB = """\
+#!/usr/bin/env bash
+set -eu
+check=${0#./}
+if [[ -n "${CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN:-}" ]]; then
+    echo "bootstrap auto-install setting leaked into $check" >&2
+    exit 24
+fi
+touch "$MARKER_DIR/${check//\\//_}"
+"""
+
+_CARGO_STUB = """\
+#!/usr/bin/env bash
+set -eu
+invocation="$*"
+if [[ "${CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN:-}" != 1 ]]; then
+    echo "bootstrap did not enable noninteractive auto-install" >&2
+    exit 24
+fi
+if [[ "${PROBE_BOOTSTRAP_STDIN:-}" == 1 ]] && IFS= read -r line; then
+    printf '%s\\n' "$line" > "$MARKER_DIR/bootstrap_stdin"
+    echo "bootstrap consumed pre-push protocol input" >&2
+    exit 25
+fi
+if ! mkdir "$MARKER_DIR/cargo_bootstrap_lock"; then
+    echo "concurrent cargo bootstrap" >&2
+    exit 42
+fi
+trap 'rmdir "$MARKER_DIR/cargo_bootstrap_lock"' EXIT
+printf '%s\n' "$invocation" >> "$MARKER_DIR/cargo_invocations"
+sleep 0.05
+if [[ "$invocation" == "${FAIL_CARGO_INVOCATION:-}" ]]; then
+    exit 23
+fi
+"""
+
+
+class FakeRepository:
+    def __init__(self):
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self.path = Path(self._temporary_directory.name)
+        self.markers = self.path / "markers"
+
+        (self.path / "githooks").mkdir()
+        self.markers.mkdir()
+        shutil.copy2(_HOOK, self.path / "githooks" / "pre-push")
+
+        for check in _CHECKS:
+            path = self.path / check
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(_CHECK_STUB, encoding="utf-8")
+            path.chmod(0o755)
+
+        cargo = self.path / "zerocopy/cargo.sh"
+        cargo.write_text(_CARGO_STUB, encoding="utf-8")
+        cargo.chmod(0o755)
+
+    def close(self):
+        self._temporary_directory.cleanup()
+
+    def run_hook(self, **environment):
+        child_environment = os.environ.copy()
+        child_environment.pop(
+            "CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN", None
+        )
+        child_environment.update(environment)
+        child_environment["MARKER_DIR"] = str(self.markers)
+        return subprocess.run(
+            ["bash", str(self.path / "githooks" / "pre-push")],
+            cwd=self.path,
+            env=child_environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def run_hook_then_capture_stdin(self, hook_input, **environment):
+        child_environment = os.environ.copy()
+        child_environment.pop(
+            "CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN", None
+        )
+        child_environment.update(environment)
+        child_environment["MARKER_DIR"] = str(self.markers)
+        downstream_input = self.markers / "downstream_stdin"
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                'bash "$1"; status=$?; cat > "$2"; exit "$status"',
+                "pre-push-test-wrapper",
+                str(self.path / "githooks" / "pre-push"),
+                str(downstream_input),
+            ],
+            cwd=self.path,
+            env=child_environment,
+            input=hook_input,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+
+class PrePushTest(unittest.TestCase):
+    def setUp(self):
+        self.repository = FakeRepository()
+
+    def tearDown(self):
+        self.repository.close()
+
+    def cargo_invocations(self):
+        return (self.repository.markers / "cargo_invocations").read_text(
+            encoding="utf-8"
+        ).splitlines()
+
+    def test_bootstraps_toolchains_serially_before_checks(self):
+        result = self.repository.run_hook()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            self.cargo_invocations(),
+            ["+stable --version", "+nightly --version"],
+        )
+        for check in _CHECKS:
+            self.assertTrue(
+                (self.repository.markers / check.replace("/", "_")).is_file()
+            )
+
+    def test_bootstrap_preserves_protocol_input_for_downstream_hooks(self):
+        protocol = (
+            "refs/heads/main 1111111111111111111111111111111111111111 "
+            "refs/heads/main 2222222222222222222222222222222222222222\n"
+            "refs/heads/topic 3333333333333333333333333333333333333333 "
+            "refs/heads/topic 4444444444444444444444444444444444444444\n"
+        )
+        result = self.repository.run_hook_then_capture_stdin(
+            protocol, PROBE_BOOTSTRAP_STDIN="1"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(
+            (self.repository.markers / "bootstrap_stdin").exists()
+        )
+        self.assertEqual(
+            (self.repository.markers / "downstream_stdin").read_text(
+                encoding="utf-8"
+            ),
+            protocol,
+        )
+
+    def test_bootstrap_failure_does_not_launch_parallel_checks(self):
+        result = self.repository.run_hook(
+            FAIL_CARGO_INVOCATION="+stable --version"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "zerocopy/cargo.sh +stable --version failed with status 23",
+            result.stderr,
+        )
+        self.assertEqual(
+            self.cargo_invocations(),
+            ["+stable --version", "+nightly --version"],
+        )
+        for check in _CHECKS:
+            self.assertFalse(
+                (self.repository.markers / check.replace("/", "_")).exists()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Bootstrap the pinned stable and nightly toolchains before launching the
pre-push checks in parallel. This prevents concurrent first-use rustup
installations from corrupting one another's shared download state.

Run bootstrap noninteractively with stdin isolated so cargo-zerocopy
cannot consume Git's pre-push ref-update protocol or hang prompting
after EOF. Scope auto-install behavior to the bootstrap commands.

Skip the parallel checks after a bootstrap failure while retaining the
static script inventory. Add a fake-repository regression harness which
proves bootstrap ordering, serialization, failure handling, and stdin
preservation for downstream hooks.

This standalone foundation lets later CI changes extend pre-push
accounting without depending on the build-matrix consolidation that will
remain at the bottom of the review stack.




---

- 　  #3561
- 　  #3560
- 　  #3559
- 　  #3558
- 　  #3557
- 👉 #3556
- 　  #3551
- 　  #3555


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v3..gherrit/G5beb3b8009067383ec63f493b4115323/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v3..gherrit/G5beb3b8009067383ec63f493b4115323/v4)|[vs v2](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v2..gherrit/G5beb3b8009067383ec63f493b4115323/v4)|[vs v1](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v1..gherrit/G5beb3b8009067383ec63f493b4115323/v4)|[vs Base](/google/zerocopy/compare/Gmc3muzd2a4fiqkbgoi52b3unvwslj53t..gherrit/G5beb3b8009067383ec63f493b4115323/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v2..gherrit/G5beb3b8009067383ec63f493b4115323/v3)|[vs v1](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v1..gherrit/G5beb3b8009067383ec63f493b4115323/v3)|[vs Base](/google/zerocopy/compare/Gmc3muzd2a4fiqkbgoi52b3unvwslj53t..gherrit/G5beb3b8009067383ec63f493b4115323/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/G5beb3b8009067383ec63f493b4115323/v1..gherrit/G5beb3b8009067383ec63f493b4115323/v2)|[vs Base](/google/zerocopy/compare/Gmc3muzd2a4fiqkbgoi52b3unvwslj53t..gherrit/G5beb3b8009067383ec63f493b4115323/v2)|
|v1||||[vs Base](/google/zerocopy/compare/Gmc3muzd2a4fiqkbgoi52b3unvwslj53t..gherrit/G5beb3b8009067383ec63f493b4115323/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5beb3b8009067383ec63f493b4115323 && git checkout -b pr-G5beb3b8009067383ec63f493b4115323 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5beb3b8009067383ec63f493b4115323 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5beb3b8009067383ec63f493b4115323 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5beb3b8009067383ec63f493b4115323
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"G5beb3b8009067383ec63f493b4115323","parent":"Gmc3muzd2a4fiqkbgoi52b3unvwslj53t","child":"Gb02b26ae5d20d53b66325769f509c0b1"} -->