### PR TITLE
[ci] Separate testing from privileged publication

### DIFF
--- a/.github/actions/setup-docker-with-retry/action.yml
+++ b/.github/actions/setup-docker-with-retry/action.yml
@@ -7,15 +7,24 @@ inputs:
     required: false
     default: ghcr.io
   username:
-    description: Container registry username
-    required: true
+    description: Optional container registry username
+    required: false
+    default: ''
   password:
-    description: Container registry password or token
-    required: true
+    description: Optional container registry password or token
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
+    - name: Validate registry credentials
+      if: ${{ (inputs.username == '') != (inputs.password == '') }}
+      shell: bash
+      run: |
+        echo "Registry username and password must be provided together" >&2
+        exit 1
+
     # Retry the actions themselves rather than reproducing their behavior in
     # shell. This preserves Buildx's builder cleanup and login-action's use of
     # password-stdin and its end-of-job logout. The first two attempts use
@@ -58,6 +67,7 @@ runs:
     # shell or expose it in a `docker login` command line.
     - name: Log in to the container registry (attempt 1)
       id: login_1
+      if: ${{ inputs.username != '' && inputs.password != '' }}
       continue-on-error: true
       uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
       with:
@@ -66,7 +76,7 @@ runs:
         password: ${{ inputs.password }}
 
     - name: Wait to retry container registry login
-      if: ${{ !cancelled() && steps.login_1.outcome == 'failure' }}
+      if: ${{ inputs.username != '' && inputs.password != '' && !cancelled() && steps.login_1.outcome == 'failure' }}
       shell: bash
       run: |
         set -eu
@@ -76,7 +86,7 @@ runs:
 
     - name: Log in to the container registry (attempt 2)
       id: login_2
-      if: ${{ !cancelled() && steps.login_1.outcome == 'failure' }}
+      if: ${{ inputs.username != '' && inputs.password != '' && !cancelled() && steps.login_1.outcome == 'failure' }}
       continue-on-error: true
       uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
       with:
@@ -85,7 +95,7 @@ runs:
         password: ${{ inputs.password }}
 
     - name: Wait to retry container registry login again
-      if: ${{ !cancelled() && steps.login_2.outcome == 'failure' }}
+      if: ${{ inputs.username != '' && inputs.password != '' && !cancelled() && steps.login_2.outcome == 'failure' }}
       shell: bash
       run: |
         set -eu
@@ -94,7 +104,7 @@ runs:
         sleep "$delay"
 
     - name: Log in to the container registry (attempt 3)
-      if: ${{ !cancelled() && steps.login_2.outcome == 'failure' }}
+      if: ${{ inputs.username != '' && inputs.password != '' && !cancelled() && steps.login_2.outcome == 'failure' }}
       uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
       with:
         registry: ${{ inputs.registry }}

--- a/.github/actions/upload-file-artifact/action.yml
+++ b/.github/actions/upload-file-artifact/action.yml
@@ -1,5 +1,5 @@
 name: Upload file artifact
-description: Publish one already-compressed file for jobs in this workflow run
+description: Publish one nonempty file as a direct Actions artifact
 
 inputs:
   name:
@@ -8,6 +8,10 @@ inputs:
   path:
     description: Exact path of the nonempty file to publish
     required: true
+  retention-days:
+    description: Days to retain the artifact; defaults to the short CI lifetime
+    required: false
+    default: "1"
 
 outputs:
   artifact-id:
@@ -49,10 +53,12 @@ runs:
         artifact_size=$(stat --format=%s "$ARTIFACT_PATH")
         echo "Uploading $ARTIFACT_NAME ($artifact_size bytes)" | tee -a "$GITHUB_STEP_SUMMARY"
 
-    # Both current callers produce tar archives whose contents are already
-    # compressed (Docker's image layers use gzip; Anneal uses zstd). Version 7's
-    # direct-file mode avoids a redundant ZIP on upload and extraction on every
-    # consumer. Keep this coordinated with download-artifact v8 in
+    # Large workflow-local callers produce tar archives whose contents are
+    # already compressed (Docker's image layers use gzip; Anneal uses zstd), so
+    # they keep the one-day default. The tiny benchmark JSON consumed by
+    # docs.yml explicitly opts into longer retention. Version 7's direct-file
+    # mode avoids a redundant ZIP on upload and extraction. Keep this
+    # coordinated with download-artifact v8 in
     # `../download-artifact-with-retry/action.yml`, which understands direct
     # artifacts and verifies their service-provided digest.
     - name: Upload artifact
@@ -62,7 +68,7 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
         if-no-files-found: error
-        retention-days: 1
+        retention-days: ${{ inputs.retention-days }}
         archive: false
         # Artifacts are immutable. Delete an artifact with the same validated
         # name first so "Re-run all jobs" can republish it under a new ID.

--- a/.github/scripts/check-workflow-permissions.py
+++ b/.github/scripts/check-workflow-permissions.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Reject write-capable tokens in workflows which execute proposed changes.
+
+The repository's workflow validators own GitHub schema validation. This
+checker owns one additional policy: workflows triggered by ``pull_request``
+or ``merge_group`` must explicitly cap their token permissions at read-only.
+
+YAML syntax is intentionally handled by the pinned mikefarah/yq binary which
+``ci/check_actions.sh`` supplies. Keeping parsing outside this script avoids a
+partial YAML implementation in security-sensitive code. The remaining Python
+operates only on decoded objects and fails closed on shapes whose authority it
+cannot establish.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+
+_UNTRUSTED_EVENTS = frozenset({"merge_group", "pull_request"})
+_WORKFLOW_SUFFIXES = frozenset({".yaml", ".yml"})
+
+
+@dataclasses.dataclass(frozen=True)
+class Issue:
+    location: str
+    message: str
+
+
+class WorkflowLoadError(ValueError):
+    """Raised when a workflow cannot be decoded unambiguously."""
+
+
+class _DuplicateKey(ValueError):
+    pass
+
+
+def _object_without_duplicate_keys(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKey(f"duplicate mapping key {key!r}")
+        result[key] = value
+    return result
+
+
+def load_workflow(path: pathlib.Path, yq: str) -> Any:
+    """Decodes exactly one YAML document using the supplied yq binary.
+
+    yq resolves YAML anchors, aliases, tags, and merge keys before producing
+    JSON. Its JSON output can still contain duplicate object members, so the
+    JSON loader must reject duplicates rather than silently keeping the last
+    value. Parsing one JSON value also makes multiple YAML documents fail with
+    ``Extra data`` instead of inspecting only one of them.
+    """
+
+    try:
+        result = subprocess.run(
+            [
+                yq,
+                "eval",
+                "--output-format=json",
+                "--no-colors",
+                ".",
+                "--",
+                str(path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise WorkflowLoadError(f"could not execute yq: {error}") from error
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"yq exited with status {result.returncode}"
+        raise WorkflowLoadError(detail)
+
+    try:
+        return json.loads(
+            result.stdout,
+            object_pairs_hook=_object_without_duplicate_keys,
+        )
+    except _DuplicateKey as error:
+        raise WorkflowLoadError(str(error)) from error
+    except json.JSONDecodeError as error:
+        if error.msg == "Extra data":
+            detail = "expected exactly one YAML document"
+        else:
+            detail = f"yq produced invalid JSON: {error}"
+        raise WorkflowLoadError(detail) from error
+
+
+def _job_location(name: str) -> str:
+    return f".jobs[{json.dumps(name)}]"
+
+
+def _events(value: Any) -> tuple[set[str], list[Issue]]:
+    if isinstance(value, str):
+        return {value}, []
+    if isinstance(value, list):
+        if all(isinstance(event, str) for event in value):
+            return set(value), []
+        return set(), [
+            Issue(".on", "workflow trigger list must contain only event names")
+        ]
+    if isinstance(value, Mapping):
+        # JSON object keys are strings. yq has already resolved aliases and
+        # explicit YAML tags, so an aliased ``pull_request`` key is visible
+        # here just like a literal one.
+        return set(value), []
+    return set(), [
+        Issue(
+            ".on",
+            "workflow triggers must be a string, list, or mapping",
+        )
+    ]
+
+
+def _permission_issues(
+    value: Any, *, location: str, owner: str
+) -> list[Issue]:
+    if value == "read-all":
+        return []
+    if value == "write-all":
+        return [Issue(location, f"{owner} grants `write-all`")]
+    if not isinstance(value, Mapping):
+        return [
+            Issue(location, f"cannot safely interpret {owner} permissions")
+        ]
+
+    issues: list[Issue] = []
+    for scope, permission in value.items():
+        scope_location = f"{location}[{json.dumps(scope)}]"
+        if permission == "write":
+            issues.append(
+                Issue(scope_location, f"{owner} grants `{scope}: write`")
+            )
+        elif not isinstance(permission, str) or permission not in {
+            "none",
+            "read",
+        }:
+            issues.append(
+                Issue(
+                    scope_location,
+                    f"cannot safely interpret {owner} permission "
+                    f"`{scope}: {permission}`",
+                )
+            )
+    return issues
+
+
+def analyze_workflow(workflow: Any) -> list[Issue]:
+    """Returns security or ambiguity findings for one decoded workflow."""
+
+    if not isinstance(workflow, Mapping):
+        return [Issue("$", "workflow document must be a mapping")]
+    if "on" not in workflow:
+        return [Issue(".on", "workflow has no top-level `on` key")]
+
+    events, issues = _events(workflow["on"])
+    if issues:
+        return issues
+
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, Mapping):
+        issues.append(Issue(".jobs", "workflow `jobs` must be a mapping"))
+        jobs = {}
+    else:
+        for name, job in jobs.items():
+            location = _job_location(name)
+            if not isinstance(job, Mapping):
+                issues.append(Issue(location, "job must be a mapping"))
+
+    if not events.intersection(_UNTRUSTED_EVENTS):
+        return sorted(issues, key=lambda issue: (issue.location, issue.message))
+
+    # Without a workflow-level cap, jobs which omit ``permissions`` inherit the
+    # repository or organization default. That default is mutable external
+    # state and may be read/write, so explicit job permissions are not enough
+    # to establish a safe baseline.
+    if "permissions" not in workflow:
+        issues.append(
+            Issue(
+                ".permissions",
+                "untrusted workflow must declare explicit top-level "
+                "`permissions`",
+            )
+        )
+    else:
+        issues.extend(
+            _permission_issues(
+                workflow["permissions"],
+                location=".permissions",
+                owner="workflow",
+            )
+        )
+
+    for name, job in jobs.items():
+        if not isinstance(job, Mapping) or "permissions" not in job:
+            continue
+        location = f"{_job_location(name)}.permissions"
+        issues.extend(
+            _permission_issues(
+                job["permissions"],
+                location=location,
+                owner=f"job `{name}`",
+            )
+        )
+
+    return sorted(issues, key=lambda issue: (issue.location, issue.message))
+
+
+def _workflow_paths(arguments: Iterable[str]) -> tuple[list[pathlib.Path], list[str]]:
+    paths: list[pathlib.Path] = []
+    errors: list[str] = []
+    seen: set[pathlib.Path] = set()
+    for argument in arguments:
+        candidate = pathlib.Path(argument)
+        if candidate.is_dir():
+            discovered = sorted(
+                path
+                for path in candidate.rglob("*")
+                if path.is_file() and path.suffix.lower() in _WORKFLOW_SUFFIXES
+            )
+            if not discovered:
+                errors.append(f"{candidate}: directory contains no workflow YAML files")
+            candidates = discovered
+        elif candidate.is_file():
+            candidates = [candidate]
+        else:
+            errors.append(f"{candidate}: no such workflow file or directory")
+            continue
+
+        for path in candidates:
+            resolved = path.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                paths.append(path)
+    return paths, errors
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--yq",
+        default=os.environ.get("YQ", "yq"),
+        help="mikefarah/yq binary supplied by ci/check_actions.sh",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="workflow YAML files or directories to scan recursively",
+    )
+    arguments = parser.parse_args(argv)
+
+    paths, errors = _workflow_paths(arguments.paths)
+    for error in errors:
+        print(error, file=sys.stderr)
+
+    failed = bool(errors)
+    for path in paths:
+        try:
+            workflow = load_workflow(path, arguments.yq)
+        except WorkflowLoadError as error:
+            print(f"{path}: {error}", file=sys.stderr)
+            failed = True
+            continue
+        for issue in analyze_workflow(workflow):
+            print(
+                f"{path}:{issue.location}: {issue.message}",
+                file=sys.stderr,
+            )
+            failed = True
+    return int(failed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ensure-yq.sh
+++ b/.github/scripts/ensure-yq.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+set -eo pipefail
+
+script_name=".github/scripts/ensure-yq.sh"
+yq_version=4.44.1
+
+# ci.yml supplies YQ_VERSION to every hosted installation. Local hooks do not,
+# so this script also owns the default. Reject a hosted mismatch in either
+# direction instead of silently running different YAML parsers in different
+# policy checks.
+if [ -n "${YQ_VERSION:-}" ] && [ "$YQ_VERSION" != "$yq_version" ]; then
+    echo "$script_name: YQ_VERSION must match the v$yq_version helper pin" >&2
+    exit 1
+fi
+
+yq_expected_version="yq (https://github.com/mikefarah/yq/) version v$yq_version"
+yq_bin="${YQ:-}"
+if [ -z "$yq_bin" ]; then
+    yq_bin="$(command -v yq || true)"
+fi
+if [ -n "$yq_bin" ] && \
+    [ "$("$yq_bin" --version 2>/dev/null || true)" != "$yq_expected_version" ]; then
+    if [ -n "${YQ:-}" ]; then
+        echo "$script_name: YQ must be mikefarah/yq v$yq_version" >&2
+        exit 1
+    fi
+    yq_bin=""
+fi
+
+sha256_file() {
+    if command -v sha256sum >/dev/null; then
+        sha256sum "$1" | cut -d ' ' -f 1
+    elif command -v shasum >/dev/null; then
+        shasum -a 256 "$1" | cut -d ' ' -f 1
+    else
+        echo "$script_name: sha256sum or shasum is required" >&2
+        return 1
+    fi
+}
+
+if [ -z "$yq_bin" ]; then
+    # These are SHA-256 values for the uncompressed binaries in the checksum
+    # manifest attached to the v4.44.1 release. A yq upgrade must update the
+    # version, URLs, and all four hashes together.
+    case "$(uname -s)/$(uname -m)" in
+        Linux/x86_64)
+            yq_platform=linux_amd64
+            yq_sha256=6dc2d0cd4e0caca5aeffd0d784a48263591080e4a0895abe69f3a76eb50d1ba3
+            ;;
+        Linux/aarch64 | Linux/arm64)
+            yq_platform=linux_arm64
+            yq_sha256=8c12fcc10e14774ca6624cc282f092a526568b036fe1192258c3aecbad56d063
+            ;;
+        Darwin/x86_64)
+            yq_platform=darwin_amd64
+            yq_sha256=114d0fab983929a76b39d792dea339b07631e0fb2f195d9e43815f907308e309
+            ;;
+        Darwin/arm64)
+            yq_platform=darwin_arm64
+            yq_sha256=638ea9b4e7a89e12159e5077556f0d10559b49df3ec67504dd2a567fec2bb47e
+            ;;
+        *)
+            echo "$script_name: yq v$yq_version has no pinned binary for $(uname -s)/$(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+
+    yq_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zerocopy/yq-v$yq_version-$yq_platform"
+    yq_bin="$yq_dir/yq"
+    yq_actual_sha256=""
+    if [ -f "$yq_bin" ]; then
+        yq_actual_sha256="$(sha256_file "$yq_bin")"
+    fi
+    if [ "$yq_actual_sha256" != "$yq_sha256" ]; then
+        if ! command -v curl >/dev/null; then
+            echo "$script_name: curl is required to install yq" >&2
+            exit 1
+        fi
+
+        echo "$script_name: yq not found, installing..." >&2
+        yq_tmp="$(mktemp -d "${TMPDIR:-/tmp}/zerocopy-yq.XXXXXXXX")"
+        trap 'rm -rf "$yq_tmp"' EXIT
+        yq_download="$yq_tmp/yq"
+        curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+            --connect-timeout 15 --max-time 30 \
+            --retry 5 --retry-all-errors --retry-max-time 60 \
+            --output "$yq_download" \
+            "https://github.com/mikefarah/yq/releases/download/v${yq_version}/yq_${yq_platform}"
+        yq_actual_sha256="$(sha256_file "$yq_download")"
+        if [ "$yq_actual_sha256" != "$yq_sha256" ]; then
+            echo "$script_name: yq checksum mismatch: expected $yq_sha256, got $yq_actual_sha256" >&2
+            exit 1
+        fi
+
+        mkdir -p "$yq_dir"
+        yq_candidate="$yq_dir/.yq.$$"
+        install -m 0755 "$yq_download" "$yq_candidate"
+        mv -f "$yq_candidate" "$yq_bin"
+        rm -rf "$yq_tmp"
+        trap - EXIT
+    fi
+fi
+
+printf '%s\n' "$yq_bin"

--- a/.github/scripts/test_check_workflow_permissions.py
+++ b/.github/scripts/test_check_workflow_permissions.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import os
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+_SCRIPT = pathlib.Path(__file__).with_name("check-workflow-permissions.py")
+_SPEC = importlib.util.spec_from_file_location("check_workflow_permissions", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+checker = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = checker
+_SPEC.loader.exec_module(checker)
+
+_YQ = os.environ.get("YQ", "yq")
+
+
+def _workflow(source: str) -> str:
+    return textwrap.dedent(source).lstrip()
+
+
+class WorkflowPermissionTests(unittest.TestCase):
+    def analyze(self, source: str) -> list[checker.Issue]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "workflow.yml"
+            path.write_text(_workflow(source), encoding="utf-8")
+            workflow = checker.load_workflow(path, _YQ)
+        return checker.analyze_workflow(workflow)
+
+    def assert_safe(self, source: str) -> None:
+        self.assertEqual(self.analyze(source), [])
+
+    def assert_finding(self, source: str, fragment: str) -> None:
+        issues = self.analyze(source)
+        self.assertTrue(issues, "expected a workflow-permission finding")
+        self.assertTrue(
+            any(fragment in issue.message for issue in issues),
+            f"{fragment!r} not found in {[issue.message for issue in issues]!r}",
+        )
+
+    def assert_parse_error(self, source: str, fragment: str) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "workflow.yml"
+            path.write_text(_workflow(source), encoding="utf-8")
+            with self.assertRaisesRegex(checker.WorkflowLoadError, fragment):
+                checker.load_workflow(path, _YQ)
+
+    def test_safe_read_permissions(self) -> None:
+        self.assert_safe(
+            """
+            name: Safe
+            on:
+              pull_request:
+              merge_group:
+            permissions:
+              contents: read
+            jobs:
+              test:
+                permissions:
+                  actions: read
+                  contents: none
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+        self.assert_safe(
+            """
+            name: Empty but harmless
+            on: pull_request
+            permissions: read-all
+            jobs: {}
+            """
+        )
+
+    def test_compact_trigger_forms(self) -> None:
+        for trigger in (
+            "pull_request",
+            "[push, pull_request]",
+            "{push: {}, merge_group: {types: [checks_requested]}}",
+        ):
+            with self.subTest(trigger=trigger):
+                self.assert_safe(
+                    f"""
+                    name: Compact
+                    on: {trigger}
+                    permissions: {{contents: read}}
+                    jobs:
+                      test:
+                        runs-on: ubuntu-latest
+                        steps: []
+                    """
+                )
+
+    def test_yaml_aliases_and_tags_are_resolved(self) -> None:
+        self.assert_finding(
+            """
+            name: &pr pull_request
+            on:
+              *pr:
+            permissions: {contents: write}
+            jobs: {}
+            """,
+            "workflow grants `contents: write`",
+        )
+        self.assert_finding(
+            """
+            on:
+              !!str pull_request:
+            permissions: {contents: write}
+            jobs: {}
+            """,
+            "workflow grants `contents: write`",
+        )
+        self.assert_safe(
+            """
+            on: pull_request
+            permissions: &read_only
+              contents: read
+            jobs:
+              test:
+                permissions: *read_only
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+    def test_top_level_write_permission(self) -> None:
+        self.assert_finding(
+            """
+            name: Unsafe
+            on: [push, pull_request]
+            permissions:
+              contents: write
+            jobs: {}
+            """,
+            "workflow grants `contents: write`",
+        )
+        self.assert_finding(
+            """
+            name: Unsafe
+            on: merge_group
+            permissions: write-all
+            jobs: {}
+            """,
+            "workflow grants `write-all`",
+        )
+
+    def test_untrusted_workflow_requires_explicit_permission_cap(self) -> None:
+        for event in ("pull_request", "merge_group"):
+            for jobs in (
+                "jobs: {}",
+                """jobs:
+  test:
+    permissions: {contents: read}
+    runs-on: ubuntu-latest
+    steps: []""",
+            ):
+                with self.subTest(event=event, jobs=jobs):
+                    self.assert_finding(
+                        f"""
+                        name: Inherits mutable repository default
+                        on: {event}
+                        {textwrap.indent(jobs, " " * 24).lstrip()}
+                        """,
+                        "must declare explicit top-level `permissions`",
+                    )
+
+        self.assert_safe(
+            """
+            name: Explicitly no token permissions
+            on: merge_group
+            permissions: {}
+            jobs: {}
+            """
+        )
+
+    def test_job_write_permission(self) -> None:
+        self.assert_finding(
+            """
+            name: Unsafe job
+            on:
+              merge_group:
+            permissions: {}
+            jobs:
+              publish:
+                permissions: {packages: write, contents: read}
+                runs-on: ubuntu-latest
+                steps: []
+            """,
+            "job `publish` grants `packages: write`",
+        )
+
+    def test_unrelated_workflow_may_write(self) -> None:
+        self.assert_safe(
+            """
+            name: Trusted workflow may inherit repository policy
+            on: push
+            jobs: {}
+            """
+        )
+        self.assert_safe(
+            """
+            name: Trusted deployment
+            on:
+              push:
+                branches: [main]
+              workflow_dispatch:
+            permissions: write-all
+            jobs:
+              publish:
+                permissions:
+                  contents: write
+                runs-on: ubuntu-latest
+                steps: []
+            """
+        )
+
+    def test_non_permission_write_values_are_ignored(self) -> None:
+        self.assert_safe(
+            """
+            name: Words are not authority
+            on: pull_request
+            permissions: {contents: read}
+            env:
+              ACCESS: write
+            jobs:
+              test:
+                permissions:
+                  contents: read
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: example/action@0123456789abcdef
+                    with:
+                      permissions: write
+                      contents: write
+                  - name: Mention permissions in a script
+                    run: |
+                      permissions:
+                        contents: write
+            """
+        )
+
+    def test_ambiguous_permission_shapes_fail_closed(self) -> None:
+        for permissions in (
+            "${{ fromJSON(inputs.permissions) }}",
+            "[contents, read]",
+            "null",
+        ):
+            with self.subTest(permissions=permissions):
+                self.assert_finding(
+                    f"""
+                    name: Ambiguous
+                    on: pull_request
+                    permissions: {permissions}
+                    jobs: {{}}
+                    """,
+                    "cannot safely interpret workflow permissions",
+                )
+
+        for permission in ("[read]", "{level: read}"):
+            with self.subTest(permission=permission):
+                self.assert_finding(
+                    f"""
+                    name: Ambiguous scope
+                    on: pull_request
+                    permissions: {{contents: {permission}}}
+                    jobs: {{}}
+                    """,
+                    "cannot safely interpret workflow permission",
+                )
+
+    def test_invalid_decoded_shapes_fail_closed(self) -> None:
+        for source, fragment in (
+            (
+                """
+                on: [pull_request, 1]
+                permissions: {}
+                jobs: {}
+                """,
+                "trigger list must contain only event names",
+            ),
+            (
+                """
+                on: pull_request
+                permissions: {}
+                jobs: []
+                """,
+                "workflow `jobs` must be a mapping",
+            ),
+            (
+                """
+                on: pull_request
+                permissions: {}
+                jobs: {test: null}
+                """,
+                "job must be a mapping",
+            ),
+        ):
+            with self.subTest(fragment=fragment):
+                self.assert_finding(source, fragment)
+
+        self.assert_finding("[]", "workflow document must be a mapping")
+
+    def test_duplicate_keys_and_multiple_documents_are_rejected(self) -> None:
+        self.assert_parse_error(
+            """
+            on: push
+            on: pull_request
+            permissions: {}
+            jobs: {}
+            """,
+            "duplicate mapping key 'on'",
+        )
+        self.assert_parse_error(
+            """
+            on: pull_request
+            permissions: {contents: read, contents: write}
+            jobs: {}
+            """,
+            "duplicate mapping key 'contents'",
+        )
+        self.assert_parse_error(
+            """
+            on: push
+            jobs: {}
+            ---
+            on: pull_request
+            permissions: {contents: write}
+            jobs: {}
+            """,
+            "expected exactly one YAML document",
+        )
+
+    def test_malformed_yaml_is_rejected(self) -> None:
+        self.assert_parse_error(
+            """
+            on: [pull_request
+            permissions: {}
+            jobs: {}
+            """,
+            ".+",
+        )
+
+    def test_cli_accepts_directories_and_paths_with_spaces(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="workflow permissions ") as directory:
+            root = pathlib.Path(directory)
+            (root / "safe.yml").write_text(
+                _workflow(
+                    """
+                    on: pull_request
+                    permissions: read-all
+                    jobs: {}
+                    """
+                ),
+                encoding="utf-8",
+            )
+            nested = root / "nested directory"
+            nested.mkdir()
+            (nested / "unsafe workflow.yaml").write_text(
+                _workflow(
+                    """
+                    on: merge_group
+                    permissions: {contents: write}
+                    jobs: {}
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                result = checker.main(["--yq", _YQ, str(root)])
+            self.assertEqual(result, 1)
+            self.assertIn("unsafe workflow.yaml", stderr.getvalue())
+            self.assertIn("contents: write", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_workflow_artifacts.py
+++ b/.github/scripts/test_workflow_artifacts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Regression tests for cross-workflow Actions artifact contracts."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def named_step(workflow: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    before, found, remainder = workflow.partition(marker)
+    del before
+    if not found:
+        raise ValueError(f"workflow has no step named {name!r}")
+    next_step = re.search(r"(?m)^      - (?:name|uses):", remainder)
+    if next_step is not None:
+        remainder = remainder[: next_step.start()]
+    return marker + remainder
+
+
+def named_job(workflow: str, name: str) -> str:
+    jobs = list(
+        re.finditer(r"(?m)^  (?P<name>[A-Za-z0-9_-]+):\n", workflow)
+    )
+    for index, match in enumerate(jobs):
+        if match.group("name") != name:
+            continue
+        end = jobs[index + 1].start() if index + 1 < len(jobs) else None
+        return workflow[match.start() : end]
+    raise ValueError(f"workflow has no job named {name!r}")
+
+
+class WorkflowArtifactTests(unittest.TestCase):
+    def test_trusted_review_binds_manifest_to_release_metadata(self) -> None:
+        release = read(".github/workflows/anneal-release.yml")
+        review = named_step(release, "Validate and summarize release inputs")
+        apply_patch = "git apply anneal-release-final.patch"
+        validator = "trusted/anneal/v1/tools/validate-release-artifacts.py"
+        manifest = "--cargo-toml source/anneal/v1/Cargo.toml"
+        allowlist = "trusted/anneal/v1/tools/check-release-pr-files.py"
+
+        self.assertIn(apply_patch, review)
+        self.assertIn(validator, review)
+        self.assertIn(manifest, review)
+        self.assertIn(allowlist, review)
+        self.assertLess(review.index(apply_patch), review.index(validator))
+        self.assertLess(review.index(validator), review.index(allowlist))
+
+    def test_manual_release_artifacts_outlive_environment_approval(self) -> None:
+        release = read(".github/workflows/anneal-release.yml")
+        retention_name = "ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS"
+        self.assertIn(f'{retention_name}: "90"', release)
+        retention = f"retention-days: ${{{{ env.{retention_name} }}}}"
+        expected_uploads = {
+            "prepare-release-source": 1,
+            "build-toolchains": 2,
+            "prepare-release-pr": 1,
+        }
+        for job_name, expected_count in expected_uploads.items():
+            with self.subTest(job=job_name):
+                block = named_job(release, job_name)
+                upload_count = block.count("uses: actions/upload-artifact@")
+                self.assertEqual(upload_count, expected_count)
+                self.assertEqual(block.count(retention), upload_count)
+                self.assertEqual(
+                    block.count("overwrite: true"), upload_count
+                )
+
+    def test_benchmark_survives_delayed_paired_workflow_rerun(self) -> None:
+        anneal = read(".github/workflows/anneal.yml")
+        uploader = read(".github/actions/upload-file-artifact/action.yml")
+        docs = read(".github/workflows/docs.yml")
+
+        producer_name = (
+            "ANNEAL_BENCHMARK_ARTIFACT: "
+            "anneal-ci-duration-benchmarks-${{ github.run_id }}.json"
+        )
+        self.assertIn(producer_name, anneal)
+        upload = named_step(anneal, "Upload CI duration benchmarks")
+        self.assertIn("uses: ./.github/actions/upload-file-artifact", upload)
+        self.assertIn("name: ${{ env.ANNEAL_BENCHMARK_ARTIFACT }}", upload)
+        self.assertIn("path: ${{ env.ANNEAL_BENCHMARK_ARTIFACT }}", upload)
+        self.assertIn("retention-days: 90", upload)
+
+        self.assertRegex(
+            uploader,
+            r"(?m)^  retention-days:\n"
+            r"    description: .+\n"
+            r"    required: false\n"
+            r'    default: "1"$',
+        )
+        self.assertIn(
+            "retention-days: ${{ inputs.retention-days }}", uploader
+        )
+
+        consumer_name = (
+            "BENCHMARK_ARTIFACT: "
+            "anneal-ci-duration-benchmarks-"
+            "${{ needs.coordinate.outputs.anneal_run_id }}.json"
+        )
+        self.assertIn(consumer_name, docs)
+        self.assertIn("name: ${{ env.BENCHMARK_ARTIFACT }}", docs)
+        self.assertIn(
+            "run-id: ${{ needs.coordinate.outputs.anneal_run_id }}", docs
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/anneal-release.yml
+++ b/.github/workflows/anneal-release.yml
@@ -26,6 +26,12 @@ on:
 
 permissions: {}
 
+env:
+  # The manual toolchain release can wait behind matrix work and environment
+  # approval. Keep every intermediate artifact available for the same long
+  # window; `.github/scripts/test_workflow_artifacts.py` owns this contract.
+  ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS: "90"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -122,32 +128,72 @@ jobs:
           TAG="anneal-v$VERSION"
           gh release create "$TAG" --generate-notes
 
-  prepare-release-source:
-    name: Prepare release source patch
-    if: github.event_name == 'workflow_dispatch'
+  resolve-release-source:
+    name: Resolve release source
+    # The workflow definition and trusted validators must come from main. The
+    # independently selected source ref remains an explicit input below.
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      base_sha: ${{ steps.prepare.outputs.base_sha }}
-      short_base_sha: ${{ steps.prepare.outputs.short_base_sha }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
     steps:
-      - name: Checkout
+      # This job resolves the operator-selected ref but executes no code from
+      # it. Its outputs are therefore safe to pass into privileged jobs; do not
+      # move selected-branch scripts into this job after the output step.
+      - name: Checkout selected ref without executing it
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Resolve immutable identifiers
+        id: resolve
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid Anneal version: $VERSION" >&2
+            exit 1
+          fi
+
+          BASE_SHA="$(git rev-parse HEAD)"
+          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Checkout did not resolve to a commit SHA: $BASE_SHA" >&2
+            exit 1
+          fi
+          SHORT_BASE_SHA="${BASE_SHA:0:12}"
+          TAG_NAME="anneal-toolchains-v${VERSION}-${GITHUB_RUN_ID}-${SHORT_BASE_SHA}"
+
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+  prepare-release-source:
+    name: Prepare release source patch
+    needs: resolve-release-source
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-release-source.outputs.base_sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
       - name: Prepare version bump patch
-        id: prepare
         env:
           VERSION: ${{ github.event.inputs.version }}
         run: |
           set -eo pipefail
-          BASE_SHA="$(git rev-parse HEAD)"
-          SHORT_BASE_SHA="${BASE_SHA:0:12}"
-
           ./ci/release_anneal_version.sh "$VERSION"
 
           python3 anneal/v1/tools/check-release-pr-files.py \
@@ -164,56 +210,24 @@ jobs:
             exit 1
           fi
 
-          echo "base_sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "short_base_sha=${SHORT_BASE_SHA}" >> "$GITHUB_OUTPUT"
-
       - name: Upload release source patch
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: anneal-release-source-patch
           path: anneal-release-source.patch
           if-no-files-found: error
-          retention-days: 1
+          retention-days: ${{ env.ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS }}
+          # A rerun can observe an artifact written by an earlier attempt whose
+          # upload response was lost. Replace that exact-name artifact so the
+          # release remains resumable instead of failing on a name conflict.
+          overwrite: true
 
-  create-release:
-    name: Create toolchain artifact release
-    needs: prepare-release-source
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required to create a GitHub release
-    outputs:
-      tag_name: ${{ steps.tag.outputs.tag_name }}
-    steps:
-      - name: Create Release
-        id: tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ github.event.inputs.version }}
-          GH_REPO: ${{ github.repository }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          BASE_SHA: ${{ needs.prepare-release-source.outputs.base_sha }}
-          SHORT_BASE_SHA: ${{ needs.prepare-release-source.outputs.short_base_sha }}
-        run: |
-          set -eo pipefail
-          TAG_NAME="anneal-toolchains-v${VERSION}-${GITHUB_RUN_ID}-${SHORT_BASE_SHA}"
-          gh release create "$TAG_NAME" \
-            --repo "$GH_REPO" \
-            --target "$BASE_SHA" \
-            --title "$TAG_NAME" \
-            --notes "Machine-generated Anneal toolchain artifacts for cargo-anneal ${VERSION}, built from ${BASE_SHA} after applying the generated release version-bump patch." \
-            --draft \
-            --prerelease \
-            --latest=false
-          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
-
-  publish-artifacts:
-    name: Publish toolchain artifact (${{ matrix.target }})
-    needs: [prepare-release-source, create-release]
+  build-toolchains:
+    name: Build toolchain artifact (${{ matrix.target }})
+    needs: resolve-release-source
     if: github.event_name == 'workflow_dispatch'
     permissions:
-      actions: read # Required to download the release source patch.
-      contents: write # This is required to upload assets to a release.
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -239,20 +253,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release-source.outputs.base_sha }}
+          ref: ${{ needs.resolve-release-source.outputs.base_sha }}
           persist-credentials: false
-
-      - name: Download release source patch
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: anneal-release-source-patch
-          path: .
-
-      - name: Apply release source patch
-        run: |
-          set -eo pipefail
-          git apply --check anneal-release-source.patch
-          git apply anneal-release-source.patch
 
       - name: Free up disk space
         if: runner.os == 'Linux'
@@ -272,11 +274,13 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Build and publish toolchain artifact
+      # Toolchain contents depend only on the selected commit's flake inputs,
+      # not on cargo-anneal's requested package version. Build the exact commit
+      # and leave version-patch processing to a separate unprivileged job.
+      - name: Build toolchain artifact
         env:
-          GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ needs.create-release.outputs.tag_name }}
+          TAG_NAME: ${{ needs.resolve-release-source.outputs.tag_name }}
           TARGET: ${{ matrix.target }}
           CARGO_OS: ${{ matrix.cargo_os }}
           CARGO_ARCH: ${{ matrix.cargo_arch }}
@@ -284,7 +288,7 @@ jobs:
           set -eo pipefail
           ARCHIVE_NAME="anneal-toolchain-${TARGET}.tar.zst"
           MAX_GITHUB_RELEASE_ASSET_SIZE=2147483647
-          mkdir -p anneal/target anneal/v1/release-download-check anneal/v1/release-metadata
+          mkdir -p anneal/target anneal/v1/release-metadata
 
           nix build ./anneal#omnibus-archive-ci --out-link "anneal/target/${ARCHIVE_NAME}"
           cp -L "anneal/target/${ARCHIVE_NAME}" "anneal/v1/${ARCHIVE_NAME}"
@@ -295,17 +299,9 @@ jobs:
             exit 1
           fi
 
-          gh release upload "$TAG_NAME" "anneal/v1/${ARCHIVE_NAME}" --repo "$GH_REPO" --clobber
-          gh release download "$TAG_NAME" \
-            --repo "$GH_REPO" \
-            --pattern "$ARCHIVE_NAME" \
-            --dir anneal/v1/release-download-check \
-            --clobber
-          cmp "anneal/v1/${ARCHIVE_NAME}" "anneal/v1/release-download-check/${ARCHIVE_NAME}"
-
           url="https://github.com/${GH_REPO}/releases/download/${TAG_NAME}/${ARCHIVE_NAME}"
           python3 anneal/v1/tools/collect-release-archive-metadata.py \
-            --archive "anneal/v1/release-download-check/${ARCHIVE_NAME}" \
+            --archive "anneal/v1/${ARCHIVE_NAME}" \
             --target "$TARGET" \
             --os "$CARGO_OS" \
             --arch "$CARGO_ARCH" \
@@ -316,31 +312,41 @@ jobs:
         if: always() && runner.os == 'Linux'
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=1
 
+      - name: Upload toolchain archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: anneal-toolchain-${{ matrix.target }}.tar.zst
+          path: anneal/v1/anneal-toolchain-${{ matrix.target }}.tar.zst
+          if-no-files-found: error
+          retention-days: ${{ env.ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS }}
+          archive: false
+          overwrite: true
+
       - name: Upload toolchain metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: anneal-toolchain-metadata-${{ matrix.target }}
+          name: ${{ matrix.target }}.json
           path: anneal/v1/release-metadata/${{ matrix.target }}.json
           if-no-files-found: error
-          retention-days: 1
+          retention-days: ${{ env.ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS }}
+          archive: false
+          overwrite: true
 
-  release-version-action:
-    # This job handles manual release triggers. It updates version numbers and
-    # exocrate archive metadata, then creates a PR for review.
-    name: Release new Anneal version
-    needs: [prepare-release-source, create-release, publish-artifacts]
+  prepare-release-pr:
+    # Selected-branch helper scripts create the final reviewable patch here,
+    # before any repository or release write credential is introduced.
+    name: Prepare final release PR patch
+    needs: [resolve-release-source, prepare-release-source, build-toolchains]
     if: github.event_name == 'workflow_dispatch'
     permissions:
       actions: read # Required to download toolchain metadata artifacts.
-      contents: write # Required by the fork-only create-pull-request fallback.
-      issues: write # Required to label the generated release PR.
-      pull-requests: write # Required to create pull requests
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.prepare-release-source.outputs.base_sha }}
+          ref: ${{ needs.resolve-release-source.outputs.base_sha }}
           persist-credentials: false
 
       - name: Download release source patch
@@ -358,13 +364,13 @@ jobs:
       - name: Download toolchain metadata
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: anneal-toolchain-metadata-*
+          pattern: '*.json'
           path: anneal/v1/release-metadata
           merge-multiple: true
 
       - name: Update Anneal archive metadata
         env:
-          TAG_NAME: ${{ needs.create-release.outputs.tag_name }}
+          TAG_NAME: ${{ needs.resolve-release-source.outputs.tag_name }}
         run: |
           set -eo pipefail
           python3 anneal/v1/tools/update-exocrate-metadata.py \
@@ -383,6 +389,344 @@ jobs:
             --allowed anneal/v1/Cargo.toml \
             --allowed anneal/v1/README.md \
             --required anneal/v1/Cargo.toml
+
+      - name: Create final release PR patch
+        run: |
+          set -euo pipefail
+          git diff --binary > anneal-release-final.patch
+          if [ ! -s anneal-release-final.patch ]; then
+            echo "Final release PR patch is empty" >&2
+            exit 1
+          fi
+
+      - name: Upload final release PR patch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: anneal-release-final-patch
+          path: anneal-release-final.patch
+          if-no-files-found: error
+          retention-days: ${{ env.ANNEAL_RELEASE_ARTIFACT_RETENTION_DAYS }}
+          overwrite: true
+
+  review-release:
+    name: Review release inputs
+    needs: [resolve-release-source, prepare-release-pr, build-toolchains]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      # `github.workflow_sha` identifies the trusted workflow definition. The
+      # validators from this checkout inspect selected-branch outputs as data;
+      # no helper from the operator-selected branch executes in this job.
+      - name: Checkout trusted validators
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+
+      - name: Checkout selected source without executing it
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-release-source.outputs.base_sha }}
+          path: source
+          persist-credentials: false
+
+      - name: Download final release PR patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: anneal-release-final-patch
+          path: source
+
+      - name: Download toolchain metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: '*.json'
+          path: release-metadata
+          merge-multiple: true
+
+      - name: Validate and summarize release inputs
+        env:
+          BASE_SHA: ${{ needs.resolve-release-source.outputs.base_sha }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ needs.resolve-release-source.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          cd source
+          git apply --check anneal-release-final.patch
+          git apply anneal-release-final.patch
+          rm anneal-release-final.patch
+          cd ..
+
+          # The final patch is produced by selected-branch code. Validate not
+          # only the artifact records themselves, but also that the patched
+          # manifest embeds those exact URLs and hashes. Keep this comparison
+          # in the trusted checkout and after patch application.
+          python3 trusted/anneal/v1/tools/validate-release-artifacts.py \
+            --metadata-dir release-metadata \
+            --cargo-toml source/anneal/v1/Cargo.toml \
+            --tag "$TAG_NAME" \
+            --repository "$GH_REPO"
+
+          cd source
+          python3 ../trusted/anneal/v1/tools/check-release-pr-files.py \
+            --context "Trusted release review" \
+            --include-untracked \
+            --allowed anneal/v1/Cargo.lock \
+            --allowed anneal/v1/Cargo.toml \
+            --allowed anneal/v1/README.md \
+            --required anneal/v1/Cargo.toml
+
+          {
+            echo "## Anneal toolchain release"
+            echo
+            echo "- Source: \`$BASE_SHA\`"
+            echo "- Tag: \`$TAG_NAME\`"
+            echo
+            echo '### Release PR changes'
+            echo '```'
+            git diff --stat
+            echo '```'
+            echo
+            echo '### Toolchain archives'
+            jq -r \
+              '"- \(.target): \(.sha256) (\(.filename))"' \
+              ../release-metadata/*.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-release-assets:
+    name: Publish toolchain release
+    needs: [resolve-release-source, review-release]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout trusted validators
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+
+      - name: Download toolchain archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: anneal-toolchain-*.tar.zst
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download toolchain metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: '*.json'
+          path: release-metadata
+          merge-multiple: true
+
+      - name: Validate untrusted release artifacts
+        env:
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ needs.resolve-release-source.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          python3 trusted/anneal/v1/tools/validate-release-artifacts.py \
+            --metadata-dir release-metadata \
+            --archive-dir release-assets \
+            --tag "$TAG_NAME" \
+            --repository "$GH_REPO"
+
+      - name: Create or reconcile the toolchain release
+        env:
+          BASE_SHA: ${{ needs.resolve-release-source.outputs.base_sha }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ needs.resolve-release-source.outputs.tag_name }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if RELEASE="$(
+            gh release view "$TAG_NAME" \
+              --repo "$GH_REPO" \
+              --json isDraft,isPrerelease,tagName,targetCommitish 2>/dev/null
+          )"; then
+            if [ "$(jq -r .tagName <<< "$RELEASE")" != "$TAG_NAME" ] \
+                || [ "$(jq -r .isPrerelease <<< "$RELEASE")" != true ] \
+                || [ "$(jq -r .targetCommitish <<< "$RELEASE")" != "$BASE_SHA" ]; then
+              echo "Existing release has unexpected metadata: $RELEASE" >&2
+              exit 1
+            fi
+          else
+            gh release create "$TAG_NAME" \
+              --repo "$GH_REPO" \
+              --target "$BASE_SHA" \
+              --title "$TAG_NAME" \
+              --notes "Machine-generated Anneal toolchain artifacts for cargo-anneal ${VERSION}, built from exact source commit ${BASE_SHA}." \
+              --draft \
+              --prerelease \
+              --latest=false
+            RELEASE="$(
+              jq -cn --arg BASE_SHA "$BASE_SHA" '{
+                isDraft: true,
+                isPrerelease: true,
+                targetCommitish: $BASE_SHA
+              }'
+            )"
+          fi
+
+          IS_DRAFT="$(jq -r .isDraft <<< "$RELEASE")"
+          CHECK_DIR="$(mktemp -d)"
+          trap 'rm -rf "$CHECK_DIR"' EXIT
+          for ASSET in release-assets/*; do
+            NAME="${ASSET##*/}"
+            rm -f "$CHECK_DIR/$NAME"
+            if gh release download "$TAG_NAME" \
+                --repo "$GH_REPO" \
+                --pattern "$NAME" \
+                --dir "$CHECK_DIR" \
+                --clobber 2>/dev/null \
+                && cmp "$ASSET" "$CHECK_DIR/$NAME"; then
+              echo "Existing release asset matches: $NAME"
+              continue
+            fi
+
+            if [ "$IS_DRAFT" != true ]; then
+              echo "Published release has a missing or mismatched $NAME" >&2
+              exit 1
+            fi
+            gh release upload "$TAG_NAME" "$ASSET" \
+              --repo "$GH_REPO" \
+              --clobber
+            rm -f "$CHECK_DIR/$NAME"
+            gh release download "$TAG_NAME" \
+              --repo "$GH_REPO" \
+              --pattern "$NAME" \
+              --dir "$CHECK_DIR" \
+              --clobber
+            cmp "$ASSET" "$CHECK_DIR/$NAME"
+          done
+
+          EXPECTED_ASSETS="$(
+            find release-assets -mindepth 1 -maxdepth 1 -type f \
+              -printf '%f\n' | sort
+          )"
+          ACTUAL_ASSETS="$(
+            gh release view "$TAG_NAME" \
+              --repo "$GH_REPO" \
+              --json assets \
+              --jq '.assets[].name' \
+              | sort
+          )"
+          if [ "$ACTUAL_ASSETS" != "$EXPECTED_ASSETS" ]; then
+            echo "Release has an unexpected asset set" >&2
+            printf 'Expected:\n%s\nActual:\n%s\n' \
+              "$EXPECTED_ASSETS" "$ACTUAL_ASSETS" >&2
+            exit 1
+          fi
+
+          if [ "$IS_DRAFT" = true ]; then
+            gh release edit "$TAG_NAME" \
+              --repo "$GH_REPO" \
+              --draft=false
+          fi
+          if [ "$(
+            gh release view "$TAG_NAME" --repo "$GH_REPO" --json isDraft \
+              --jq .isDraft
+          )" != false ]; then
+            echo "Toolchain release is still a draft" >&2
+            exit 1
+          fi
+
+          # GitHub creates a missing tag only when a draft is published. The
+          # draft's exact target was checked above; now verify the resulting
+          # ref actually resolves to that commit before downstream PR CI starts
+          # consuming its public URLs.
+          TAG_SHA="$(
+            gh api "repos/$GH_REPO/commits/$TAG_NAME" --jq .sha
+          )"
+          if [ "$TAG_SHA" != "$BASE_SHA" ]; then
+            echo "Release tag points at $TAG_SHA, expected $BASE_SHA" >&2
+            exit 1
+          fi
+
+          for METADATA in release-metadata/*.json; do
+            URL="$(jq -r .url "$METADATA")"
+            AVAILABLE=false
+            for ATTEMPT in {1..10}; do
+              if curl --fail --silent --show-error --location --head "$URL" \
+                  >/dev/null; then
+                AVAILABLE=true
+                break
+              fi
+              echo "Asset is not public yet (attempt $ATTEMPT): $URL"
+              sleep 6
+            done
+            if [ "$AVAILABLE" != true ]; then
+              echo "Release asset did not become public: $URL" >&2
+              exit 1
+            fi
+          done
+
+  submit-release-pr:
+    name: Submit Anneal release PR
+    needs: [resolve-release-source, prepare-release-pr, publish-release-assets]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      # This checkout is treated only as Git data. Before the bot token is
+      # passed to the pinned PR action, inline trusted workflow code applies
+      # and constrains the prepared patch without running repository scripts.
+      - name: Checkout selected source without executing it
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.resolve-release-source.outputs.base_sha }}
+          persist-credentials: false
+
+      - name: Download final release PR patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: anneal-release-final-patch
+          path: .
+
+      - name: Apply and constrain release PR patch
+        run: |
+          set -euo pipefail
+          git apply --check anneal-release-final.patch
+          git apply anneal-release-final.patch
+          rm anneal-release-final.patch
+          git diff --check
+
+          mapfile -t CHANGED < <(git diff --name-only)
+          if [ "${#CHANGED[@]}" -eq 0 ]; then
+            echo "Release patch changed no tracked files" >&2
+            exit 1
+          fi
+          FOUND_MANIFEST=false
+          for PATH in "${CHANGED[@]}"; do
+            case "$PATH" in
+              anneal/v1/Cargo.lock|anneal/v1/Cargo.toml|anneal/v1/README.md)
+                ;;
+              *)
+                echo "Release patch changed unexpected path: $PATH" >&2
+                exit 1
+                ;;
+            esac
+            if [ "$PATH" = anneal/v1/Cargo.toml ]; then
+              FOUND_MANIFEST=true
+            fi
+          done
+          if [ "$FOUND_MANIFEST" != true ]; then
+            echo "Release patch did not change anneal/v1/Cargo.toml" >&2
+            exit 1
+          fi
 
       - name: Submit PR
         id: submit-pr-upstream
@@ -422,22 +766,13 @@ jobs:
       - name: Add labels
         if: steps.submit-pr-upstream.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.submit-pr-upstream.outputs.pull-request-number }}
         run: gh pr edit "$PR_NUMBER" --add-label "hide-from-release-notes"
 
       - name: Add labels (fork test)
         if: steps.submit-pr-fork.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.submit-pr-fork.outputs.pull-request-number }}
         run: gh pr edit "$PR_NUMBER" --add-label "hide-from-release-notes"
-
-      - name: Publish toolchain artifact release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ needs.create-release.outputs.tag_name }}
-        run: |
-          set -eo pipefail
-          gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false

--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -28,6 +28,10 @@ env:
   # the same filename after downloading by immutable artifact ID. Keep the
   # filename centralized here; the ID, not this name, selects the artifact.
   ANNEAL_TOOLCHAIN_ARCHIVE: anneal-exocrate.tar.zst
+  # This run-derived filename is the producer/consumer contract with the
+  # trusted publisher in `.github/workflows/docs.yml`. The test job may create
+  # the data, but only that post-CI workflow can write benchmark history.
+  ANNEAL_BENCHMARK_ARTIFACT: anneal-ci-duration-benchmarks-${{ github.run_id }}.json
   # Keep these bounded, download-only retry counts coordinated with ci.yml and
   # its Dockerfile. Neither setting reruns a build or test command.
   CARGO_NET_RETRY: "10"
@@ -62,6 +66,7 @@ jobs:
             anneal/v1/tools/test_exocrate_metadata_helpers.py \
             anneal/v1/tools/test_release_pr_files.py \
             anneal/v1/tools/collect-release-archive-metadata.py \
+            anneal/v1/tools/validate-release-artifacts.py \
             anneal/v1/tools/update-exocrate-metadata.py \
             anneal/tests/test_prune_lake_cache.py \
             anneal/prune-lake-cache.py \
@@ -82,7 +87,7 @@ jobs:
     needs: v2_nix_cache
     permissions:
       actions: read # Required to download the toolchain artifact.
-      contents: write # Required to push benchmark data to the storage branch
+      contents: read
     env:
       ANNEAL_TOOLCHAIN_DIR: ${{ github.workspace }}/anneal/v1/target/anneal-toolchain
       __ZEROCOPY_LOCAL_DEV: 1
@@ -155,25 +160,26 @@ jobs:
             '[
               $test[0][0],
               $total[0][0]
-            ]' > output.json
+            ]' > "$ANNEAL_BENCHMARK_ARTIFACT"
 
-      - name: Store CI duration benchmarks
-        # Only trusted main-branch pushes to the canonical repository can
-        # update the benchmark-data branch. Pull requests from forks receive a
-        # read-only GITHUB_TOKEN, and forks running this workflow should not try
-        # to publish benchmark history for google/zerocopy.
-        if: github.event_name == 'push' && github.repository == 'google/zerocopy' && github.ref == 'refs/heads/main'
-        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+      - name: Upload CI duration benchmarks
+        # This job runs PR-controlled code and therefore never receives write
+        # permission. On canonical main, publish its small result as an
+        # immutable Actions artifact. `docs.yml` selects this exact run only
+        # after both CI workflows succeed, validates the JSON, and performs the
+        # privileged benchmark-data update.
+        if: |
+          github.event_name == 'push' &&
+          github.repository == 'google/zerocopy' &&
+          github.ref == 'refs/heads/main'
+        uses: ./.github/actions/upload-file-artifact
         with:
-          name: CI Durations
-          tool: 'customSmallerIsBetter'
-          output-file-path: output.json
-          gh-pages-branch: benchmark-data
-          auto-push: true
-          save-data-file: true
-          benchmark-data-dir-path: dashboard
-          fail-on-alert: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ env.ANNEAL_BENCHMARK_ARTIFACT }}
+          path: ${{ env.ANNEAL_BENCHMARK_ARTIFACT }}
+          # docs.yml may pair this successful Anneal run with a delayed rerun
+          # of core CI. This JSON is tiny, so retain it long enough for that
+          # recovery path instead of inheriting the one-day matrix default.
+          retention-days: 90
 
   verify_examples:
     name: Verify V1 example (${{ matrix.example }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # All yq consumers install one parser version. `ensure-yq.sh` has the same
+  # default for local hooks and rejects a mismatch here, so changing either
+  # side of this cross-file contract fails CI until both are updated.
+  YQ_VERSION: "4.44.1"
   # These are bounded, client-native retries for recognized transient download
   # failures. They never rerun a Cargo or rustup command, so deterministic build
   # and test failures still fail immediately. Keep these values coordinated
@@ -860,6 +864,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Check GitHub Actions
     steps:
+      - name: Install yq (for YAML parsing)
+        # Keep this pin coordinated with `ensure-yq.sh`.
+        # FIXME(https://github.com/mikefarah/yq/issues/2587): Remove
+        # `GONOSUMDB` once this bug is fixed.
+        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v${YQ_VERSION}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -913,9 +922,10 @@ jobs:
     name: Check that all toolchains listed in Cargo.toml are tested in CI
     steps:
       - name: Install yq (for YAML parsing)
+        # Keep this pin coordinated with `ensure-yq.sh`.
         # FIXME(https://github.com/mikefarah/yq/issues/2587): Remove
         # `GONOSUMDB` once this bug is fixed.
-        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v4.44.1
+        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v${YQ_VERSION}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -927,9 +937,10 @@ jobs:
     name: Check all-jobs-succeeded depends on all jobs
     steps:
       - name: Install yq (for YAML parsing)
+        # Keep this pin coordinated with `ensure-yq.sh`.
         # FIXME(https://github.com/mikefarah/yq/issues/2587): Remove
         # `GONOSUMDB` once this bug is fixed.
-        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v4.44.1
+        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v${YQ_VERSION}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -960,9 +971,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install yq (for YAML parsing)
+        # Keep this pin coordinated with `ensure-yq.sh`.
         # FIXME(https://github.com/mikefarah/yq/issues/2587): Remove
         # `GONOSUMDB` once this bug is fixed.
-        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v4.44.1
+        run: GONOSUMDB=github.com/mikefarah/yq/v4 go install github.com/mikefarah/yq/v4@v${YQ_VERSION}
       - name: Install ripgrep
         run: ./.github/scripts/install-apt-packages.sh ripgrep
       - name: Run dependency check
@@ -1007,7 +1019,9 @@ jobs:
       image_artifact_id: ${{ steps.upload_image.outputs.artifact-id }}
     permissions:
       contents: read
-      packages: write # required to push docker caches to ghcr.io
+      # This job runs on PR and merge-group source, so it may consume but never
+      # mutate the shared cache. `publish-ci-cache.yml` owns the write token.
+      packages: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1015,18 +1029,6 @@ jobs:
 
       - name: Set up Docker
         uses: ./.github/actions/setup-docker-with-retry
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Generate sanitized Docker tag
-        id: docker_tag
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        shell: bash
-        run: |
-          echo "tag=${REF_NAME//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build, cache, and export image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -1040,12 +1042,7 @@ jobs:
           # upload-file-artifact's direct (non-ZIP) transfer. This path and tag
           # are coupled to the workflow-level producer/consumer values above.
           outputs: type=docker,dest=${{ runner.temp }}/${{ env.ZC_CI_IMAGE_ARCHIVE }},compression=gzip
-          cache-from: |
-            type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:${{ steps.docker_tag.outputs.tag }}
-            type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main
-          # External pull requests have read-only package permissions, so they
-          # can consume GHCR caches but cannot export updated cache layers.
-          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:{0},mode=max', steps.docker_tag.outputs.tag) || '' }}
+          cache-from: type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main
 
       # Uploading is the producer's final gate. Matrix jobs cannot start until
       # this succeeds and the job exposes its artifact ID, so no runner is spent

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -144,10 +144,86 @@ jobs:
             .[] | select(.name == "Anneal Tests") | "anneal_run_id=\(.id)"
           ' <<< "$RUNS" >> "$GITHUB_OUTPUT"
 
+  publish-benchmarks:
+    name: Publish CI duration benchmarks
+    runs-on: ubuntu-latest
+    needs: coordinate
+    if: needs.coordinate.outputs.deploy == 'true'
+    permissions:
+      actions: read
+      contents: write
+    env:
+      # Keep this filename formula coordinated with
+      # `ANNEAL_BENCHMARK_ARTIFACT` in `anneal.yml`. Including the authorized
+      # run ID prevents this privileged job from selecting another run's data.
+      BENCHMARK_ARTIFACT: anneal-ci-duration-benchmarks-${{ needs.coordinate.outputs.anneal_run_id }}.json
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.coordinate.outputs.sha }}
+          persist-credentials: false
+
+      - name: Download benchmark input from the authorized Anneal run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ env.BENCHMARK_ARTIFACT }}
+          path: ${{ runner.temp }}/benchmarks
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.coordinate.outputs.anneal_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate untrusted benchmark input
+        env:
+          BENCHMARK_DIR: ${{ runner.temp }}/benchmarks
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED="$BENCHMARK_DIR/$BENCHMARK_ARTIFACT"
+
+          mapfile -d '' FILES < <(
+            find "$BENCHMARK_DIR" -mindepth 1 -maxdepth 1 -print0
+          )
+          if [ "${#FILES[@]}" -ne 1 ] \
+              || [ "${FILES[0]}" != "$EXPECTED" ] \
+              || [ ! -f "$EXPECTED" ] \
+              || [ -L "$EXPECTED" ]; then
+            echo "Benchmark artifact did not contain exactly $EXPECTED" >&2
+            exit 1
+          fi
+
+          jq -e '
+            type == "array"
+            and length == 2
+            and .[0].name == "Test Time"
+            and .[1].name == "Total CI Duration (All Steps)"
+            and all(.[ ];
+              (keys | sort) == ["name", "unit", "value"]
+              and .unit == "seconds"
+              and (.value | type) == "number"
+              and .value >= 0
+              and .value < 604800
+            )
+          ' "$EXPECTED" >/dev/null
+
+      - name: Store CI duration benchmarks
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          name: CI Durations
+          tool: 'customSmallerIsBetter'
+          output-file-path: ${{ runner.temp }}/benchmarks/${{ env.BENCHMARK_ARTIFACT }}
+          gh-pages-branch: benchmark-data
+          auto-push: true
+          save-data-file: true
+          benchmark-data-dir-path: dashboard
+          fail-on-alert: false
+          github-token: ${{ github.token }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: coordinate
+    # Benchmark publication updates the branch copied below, so do not race the
+    # branch checkout against that privileged write.
+    needs: [coordinate, publish-benchmarks]
     if: needs.coordinate.outputs.deploy == 'true'
     defaults:
       run:

--- a/.github/workflows/publish-ci-cache.yml
+++ b/.github/workflows/publish-ci-cache.yml
@@ -1,0 +1,94 @@
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+# PR and merge-queue workflows must never receive package write permission.
+# After core CI succeeds on canonical main, this default-branch workflow
+# rebuilds the same Dockerfile and alone updates the shared BuildKit cache.
+
+name: Publish CI Docker cache
+on:
+  # This name is coupled to the top-level `name` in `ci.yml`. Unlike a direct
+  # PR trigger, workflow_run executes this workflow's trusted default-branch
+  # definition, so checked source cannot grant itself the write token below.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows: ["Build & Tests"]
+    types: [completed]
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: publish-ci-docker-cache
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    name: Authorize canonical main
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'google/zerocopy' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.authorize.outputs.sha }}
+    steps:
+      - name: Require the current main SHA
+        id: authorize
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN_SHA="$(
+            gh api \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$REPOSITORY/git/ref/heads/main" \
+              --jq .object.sha
+          )"
+          if [ "$MAIN_SHA" != "$SOURCE_SHA" ]; then
+            echo "Refusing to publish a stale cache for $SOURCE_SHA" >&2
+            exit 1
+          fi
+          echo "sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish main cache
+    runs-on: ubuntu-latest
+    needs: authorize
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CARGO_NET_RETRY: "10"
+      RUSTUP_MAX_RETRIES: "10"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.sha }}
+          persist-credentials: false
+
+      - name: Set up authenticated Docker
+        uses: ./.github/actions/setup-docker-with-retry
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and publish main cache
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: .github/workflows/Dockerfile
+          provenance: false
+          cache-from: type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main
+          cache-to: type=registry,ref=ghcr.io/google/zerocopy/zerocopy-ci-cache:main,mode=max

--- a/anneal/v1/tools/check-release-flow-dry-run.sh
+++ b/anneal/v1/tools/check-release-flow-dry-run.sh
@@ -94,11 +94,25 @@ for target in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64; do
 EOF
 done
 
+python3 anneal/v1/tools/validate-release-artifacts.py \
+  --metadata-dir anneal/v1/release-metadata \
+  --tag "$TAG_NAME" \
+  --repository google/zerocopy
+
 python3 anneal/v1/tools/update-exocrate-metadata.py \
   --cargo-toml anneal/v1/Cargo.toml \
   --metadata-dir anneal/v1/release-metadata \
   --expected-release-tag "$TAG_NAME" \
   --require-all
+
+# Use the same trusted semantic comparison as the review job. A loose URL or
+# platform-shape check here could pass while the actual release boundary would
+# reject the generated patch, or vice versa.
+python3 anneal/v1/tools/validate-release-artifacts.py \
+  --metadata-dir anneal/v1/release-metadata \
+  --cargo-toml anneal/v1/Cargo.toml \
+  --tag "$TAG_NAME" \
+  --repository google/zerocopy
 
 rm -rf anneal/v1/release-metadata
 
@@ -110,60 +124,63 @@ python3 anneal/v1/tools/check-release-pr-files.py \
   --allowed anneal/v1/README.md \
   --required anneal/v1/Cargo.toml
 
-python3 - "$TAG_NAME" <<'PY'
-import pathlib
-import sys
-import tomllib
-
-tag = sys.argv[1]
-manifest = tomllib.loads(pathlib.Path("anneal/v1/Cargo.toml").read_text(encoding="utf-8"))
-exocrate = manifest["package"]["metadata"]["exocrate"]
-expected = {
-    ("linux", "x86_64"),
-    ("linux", "aarch64"),
-    ("macos", "x86_64"),
-    ("macos", "aarch64"),
-}
-
-actual = {(os_name, arch) for os_name, by_arch in exocrate.items() for arch in by_arch}
-if actual != expected:
-    raise SystemExit(f"unexpected exocrate platforms: expected {expected}, got {actual}")
-
-for os_name, arch in sorted(expected):
-    metadata = exocrate[os_name][arch]
-    sha256 = metadata.get("sha256")
-    url = metadata.get("url")
-    if not isinstance(sha256, str) or len(sha256) != 64 or any(c not in "0123456789abcdef" for c in sha256):
-        raise SystemExit(f"invalid sha256 for {os_name}.{arch}: {sha256!r}")
-    if not isinstance(url, str) or f"/releases/download/{tag}/" not in url:
-        raise SystemExit(f"invalid URL for {os_name}.{arch}: {url!r}")
-PY
-
 python3 - <<'PY'
 import pathlib
 
 workflow = pathlib.Path(".github/workflows/anneal-release.yml").read_text(encoding="utf-8")
 
-create_release = 'gh release create "$TAG_NAME"'
-if create_release not in workflow:
-    raise SystemExit("release workflow no longer creates a toolchain release with TAG_NAME")
+def job(name: str, next_name: str | None) -> str:
+    start = workflow.index(f"  {name}:\n")
+    end = len(workflow) if next_name is None else workflow.index(f"  {next_name}:\n")
+    return workflow[start:end]
 
-create_release_index = workflow.index(create_release)
-publish_release_index = workflow.find('gh release edit "$TAG_NAME"')
-if publish_release_index == -1:
-    raise SystemExit("release workflow must publish the draft toolchain release after uploads succeed")
-if publish_release_index < create_release_index:
-    raise SystemExit("release workflow publishes the toolchain release before creating it")
 
-create_release_block = workflow[create_release_index:publish_release_index]
-if "--draft" not in create_release_block:
-    raise SystemExit(
-        "toolchain release must be created as a draft so GitHub immutable releases still allow asset uploads"
-    )
+resolve = job("resolve-release-source", "prepare-release-source")
+prepare = job("prepare-release-source", "build-toolchains")
+build = job("build-toolchains", "prepare-release-pr")
+prepare_pr = job("prepare-release-pr", "review-release")
+review = job("review-release", "publish-release-assets")
+publish = job("publish-release-assets", "submit-release-pr")
+submit = job("submit-release-pr", None)
 
-publish_release_block = workflow[publish_release_index:publish_release_index + 500]
-if "--draft=false" not in publish_release_block:
-    raise SystemExit("toolchain release publish step must pass --draft=false")
+for name, block in {
+    "resolve-release-source": resolve,
+    "prepare-release-source": prepare,
+    "build-toolchains": build,
+    "prepare-release-pr": prepare_pr,
+    "review-release": review,
+}.items():
+    if "contents: write" in block or "GOOGLE_PR_CREATION_BOT_TOKEN" in block:
+        raise SystemExit(f"unprivileged {name} job gained a repository credential")
+
+if "nix build" not in build or "gh release" in build or "GH_TOKEN" in build:
+    raise SystemExit("toolchain builders must build without release credentials")
+if "git apply anneal-release-source.patch" in build:
+    raise SystemExit("toolchain builders must build the exact selected commit")
+if "validate-release-artifacts.py" not in review:
+    raise SystemExit("release review must validate matrix-produced metadata")
+
+if "environment: release" not in publish or "contents: write" not in publish:
+    raise SystemExit("asset publisher must use the release environment and write token")
+for forbidden in (
+    "nix build",
+    "release_anneal_version.sh",
+    "update-exocrate-metadata.py",
+    "GOOGLE_PR_CREATION_BOT_TOKEN",
+):
+    if forbidden in publish:
+        raise SystemExit(f"asset publisher executes or receives forbidden input: {forbidden}")
+if "validate-release-artifacts.py" not in publish:
+    raise SystemExit("asset publisher must validate archives with trusted code")
+if '--draft' not in publish or '--draft=false' not in publish:
+    raise SystemExit("asset publisher must stage a draft before publishing it")
+
+if "GOOGLE_PR_CREATION_BOT_TOKEN" not in submit:
+    raise SystemExit("PR submitter is missing the bot credential")
+if "gh release" in submit or "nix build" in submit:
+    raise SystemExit("PR submitter must not hold release-asset authority")
+if workflow.index("  publish-release-assets:\n") > workflow.index("  submit-release-pr:\n"):
+    raise SystemExit("toolchain assets must be public before the release PR is submitted")
 PY
 
 echo "Anneal release dry-run checks passed."

--- a/anneal/v1/tools/test_validate_release_artifacts.py
+++ b/anneal/v1/tools/test_validate_release_artifacts.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Unit tests for trusted Anneal release artifact validation."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TOOLS = Path(__file__).resolve().parent
+TAG = "anneal-toolchains-v1.2.3-456-deadbeefcafe"
+REPOSITORY = "google/zerocopy"
+
+
+def load_validator():
+    path = TOOLS / "validate-release-artifacts.py"
+    spec = importlib.util.spec_from_file_location("validate_release_artifacts", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_validator()
+
+
+class ValidateReleaseArtifactsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.metadata_dir = self.root / "metadata"
+        self.archive_dir = self.root / "archives"
+        self.metadata_dir.mkdir()
+        self.archive_dir.mkdir()
+        self.metadata = {}
+        self.cargo_toml = self.root / "Cargo.toml"
+
+        for target, (os_name, arch) in validator.EXPECTED_TARGETS.items():
+            filename = validator.archive_filename(target)
+            contents = f"archive contents for {target}\n".encode()
+            (self.archive_dir / filename).write_bytes(contents)
+            metadata = {
+                "target": target,
+                "os": os_name,
+                "arch": arch,
+                "filename": filename,
+                "sha256": hashlib.sha256(contents).hexdigest(),
+                "url": validator.release_url(REPOSITORY, TAG, filename),
+            }
+            self.metadata[target] = metadata
+            self._write_metadata(target)
+        self._write_cargo_toml(self._manifest_metadata())
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def _metadata_path(self, target: str) -> Path:
+        return self.metadata_dir / f"{target}.json"
+
+    def _write_metadata(self, target: str) -> None:
+        self._metadata_path(target).write_text(
+            json.dumps(self.metadata[target], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _manifest_metadata(self):
+        exocrate = {}
+        for target, (os_name, arch) in validator.EXPECTED_TARGETS.items():
+            exocrate.setdefault(os_name, {})[arch] = {
+                "sha256": self.metadata[target]["sha256"],
+                "url": self.metadata[target]["url"],
+            }
+        return exocrate
+
+    def _write_cargo_toml(self, exocrate) -> None:
+        lines = ['[package]', 'name = "cargo-anneal-test"', ""]
+        for os_name, by_arch in sorted(exocrate.items()):
+            for arch, values in sorted(by_arch.items()):
+                lines.append(
+                    f"[package.metadata.exocrate.{os_name}.{arch}]"
+                )
+                for key, value in sorted(values.items()):
+                    lines.append(f"{key} = {json.dumps(value)}")
+                lines.append("")
+        self.cargo_toml.write_text("\n".join(lines), encoding="utf-8")
+
+    def _validate(self, *, with_archives: bool = True):
+        return validator.validate_release_artifacts(
+            metadata_dir=self.metadata_dir,
+            archive_dir=self.archive_dir if with_archives else None,
+            tag=TAG,
+            repository=REPOSITORY,
+        )
+
+    def test_accepts_exact_metadata_and_archives(self) -> None:
+        self.assertEqual(self._validate(), self.metadata)
+
+    def test_archive_validation_is_optional(self) -> None:
+        for archive in self.archive_dir.iterdir():
+            archive.unlink()
+        self.assertEqual(self._validate(with_archives=False), self.metadata)
+
+    def test_cargo_manifest_matches_validated_metadata(self) -> None:
+        metadata = self._validate(with_archives=False)
+        validator.validate_cargo_exocrate_metadata(
+            self.cargo_toml, metadata
+        )
+
+    def test_cargo_manifest_rejects_mismatched_url_and_hash(self) -> None:
+        metadata = self._validate(with_archives=False)
+        cases = {
+            "url": "https://attacker.example/archive.tar.zst",
+            "sha256": "0" * 64,
+        }
+        for key, value in cases.items():
+            with self.subTest(key=key):
+                exocrate = self._manifest_metadata()
+                exocrate["linux"]["x86_64"][key] = value
+                self._write_cargo_toml(exocrate)
+                with self.assertRaisesRegex(
+                    validator.ValidationError,
+                    rf"linux\.x86_64\.{key} is",
+                ):
+                    validator.validate_cargo_exocrate_metadata(
+                        self.cargo_toml, metadata
+                    )
+
+    def test_cargo_manifest_requires_exact_platform_shape(self) -> None:
+        metadata = self._validate(with_archives=False)
+        cases = []
+
+        missing_arch = self._manifest_metadata()
+        del missing_arch["linux"]["aarch64"]
+        cases.append((missing_arch, "has architectures"))
+
+        extra_platform = self._manifest_metadata()
+        extra_platform["windows"] = copy.deepcopy(
+            extra_platform["linux"]
+        )
+        cases.append((extra_platform, "has platforms"))
+
+        extra_key = self._manifest_metadata()
+        extra_key["linux"]["x86_64"]["unexpected"] = "value"
+        cases.append((extra_key, "has keys"))
+
+        non_string = self._manifest_metadata()
+        non_string["linux"]["x86_64"]["sha256"] = 1
+        cases.append((non_string, "sha256 is 1"))
+
+        for exocrate, message in cases:
+            with self.subTest(message=message):
+                self._write_cargo_toml(exocrate)
+                with self.assertRaisesRegex(
+                    validator.ValidationError, message
+                ):
+                    validator.validate_cargo_exocrate_metadata(
+                        self.cargo_toml, metadata
+                    )
+
+    def test_cargo_manifest_rejects_invalid_toml_and_table_shapes(self) -> None:
+        metadata = self._validate(with_archives=False)
+        cases = [
+            ("not valid = [", "invalid Cargo manifest"),
+            (
+                "[package]\nmetadata = 1\n",
+                "package.metadata must be a table",
+            ),
+            (
+                "[package.metadata]\nexocrate = 1\n",
+                "package.metadata.exocrate must be a table",
+            ),
+            (
+                "[package.metadata.exocrate]\nlinux = 1\nmacos = 1\n",
+                "package.metadata.exocrate.linux must be a table",
+            ),
+            (
+                "[package.metadata.exocrate.linux]\n"
+                "aarch64 = 1\nx86_64 = 1\n"
+                "[package.metadata.exocrate.macos]\n"
+                "aarch64 = 1\nx86_64 = 1\n",
+                "package.metadata.exocrate.linux.aarch64 must be a table",
+            ),
+            (
+                "[package]\nname = 'first'\nname = 'duplicate'\n",
+                "invalid Cargo manifest",
+            ),
+        ]
+        for contents, message in cases:
+            with self.subTest(message=message):
+                self.cargo_toml.write_text(contents, encoding="utf-8")
+                with self.assertRaisesRegex(
+                    validator.ValidationError, message
+                ):
+                    validator.validate_cargo_exocrate_metadata(
+                        self.cargo_toml, metadata
+                    )
+
+    def test_cargo_manifest_must_be_a_bounded_regular_file(self) -> None:
+        metadata = self._validate(with_archives=False)
+        real_manifest = self.root / "real-Cargo.toml"
+        self.cargo_toml.replace(real_manifest)
+        self.cargo_toml.symlink_to(real_manifest)
+        with self.assertRaisesRegex(
+            validator.ValidationError, "regular non-symlink"
+        ):
+            validator.validate_cargo_exocrate_metadata(
+                self.cargo_toml, metadata
+            )
+
+        self.cargo_toml.unlink()
+        with self.cargo_toml.open("wb") as manifest:
+            manifest.truncate(validator.MAX_CARGO_TOML_SIZE + 1)
+        with self.assertRaisesRegex(
+            validator.ValidationError, "maximum is 1048576 bytes"
+        ):
+            validator.validate_cargo_exocrate_metadata(
+                self.cargo_toml, metadata
+            )
+
+    def test_metadata_directory_must_have_exact_files(self) -> None:
+        target = "linux-x86_64"
+        path = self._metadata_path(target)
+        path.unlink()
+        with self.assertRaisesRegex(validator.ValidationError, "missing linux-x86_64.json"):
+            self._validate()
+
+        self._write_metadata(target)
+        (self.metadata_dir / "extra.json").write_text("{}", encoding="utf-8")
+        with self.assertRaisesRegex(validator.ValidationError, "unexpected extra.json"):
+            self._validate()
+
+    def test_archive_directory_must_have_exact_files(self) -> None:
+        target = "linux-x86_64"
+        filename = validator.archive_filename(target)
+        path = self.archive_dir / filename
+        path.unlink()
+        with self.assertRaisesRegex(validator.ValidationError, f"missing {filename}"):
+            self._validate()
+
+        path.write_bytes(b"archive contents for linux-x86_64\n")
+        (self.archive_dir / "extra.tar.zst").write_bytes(b"extra")
+        with self.assertRaisesRegex(validator.ValidationError, "unexpected extra.tar.zst"):
+            self._validate()
+
+    def test_rejects_non_object_and_inexact_json_schema(self) -> None:
+        target = "linux-x86_64"
+        path = self._metadata_path(target)
+        cases = [
+            ([], "one JSON object"),
+            (
+                {
+                    key: value
+                    for key, value in self.metadata[target].items()
+                    if key != "url"
+                },
+                "missing url",
+            ),
+            ({**self.metadata[target], "size": 123}, "unexpected size"),
+        ]
+        for value, message in cases:
+            with self.subTest(message=message):
+                path.write_text(json.dumps(value), encoding="utf-8")
+                with self.assertRaisesRegex(validator.ValidationError, message):
+                    self._validate()
+
+    def test_rejects_duplicate_json_keys(self) -> None:
+        target = "linux-x86_64"
+        metadata = self.metadata[target]
+        self._metadata_path(target).write_text(
+            "{"
+            f'"target": {json.dumps(target)}, "target": {json.dumps(target)}, '
+            + ", ".join(
+                f"{json.dumps(key)}: {json.dumps(value)}"
+                for key, value in metadata.items()
+                if key != "target"
+            )
+            + "}",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(validator.ValidationError, "duplicate JSON key 'target'"):
+            self._validate()
+
+    def test_all_metadata_values_must_be_strings(self) -> None:
+        target = "linux-x86_64"
+        for key in validator.EXPECTED_METADATA_KEYS:
+            with self.subTest(key=key):
+                original = self.metadata[target][key]
+                self.metadata[target][key] = 1
+                self._write_metadata(target)
+                with self.assertRaisesRegex(
+                    validator.ValidationError, f"non-string values for: {key}"
+                ):
+                    self._validate()
+                self.metadata[target][key] = original
+
+    def test_rejects_unreasonably_large_metadata(self) -> None:
+        target = "linux-x86_64"
+        with self._metadata_path(target).open("wb") as metadata:
+            metadata.truncate(validator.MAX_METADATA_FILE_SIZE + 1)
+        with self.assertRaisesRegex(validator.ValidationError, "maximum is 65536 bytes"):
+            self._validate()
+
+    def test_rejects_wrong_target_platform_filename_and_url(self) -> None:
+        target = "linux-x86_64"
+        filename = validator.archive_filename(target)
+        wrong_values = {
+            "target": "linux-aarch64",
+            "os": "macos",
+            "arch": "aarch64",
+            "filename": "anneal-toolchain-linux-x86_64.zip",
+            "url": validator.release_url(REPOSITORY, "another-tag", filename),
+        }
+        for key, wrong_value in wrong_values.items():
+            with self.subTest(key=key):
+                original = self.metadata[target][key]
+                self.metadata[target][key] = wrong_value
+                self._write_metadata(target)
+                with self.assertRaisesRegex(validator.ValidationError, f"has {key}="):
+                    self._validate()
+                self.metadata[target][key] = original
+
+    def test_url_must_exactly_match_repository_and_tag(self) -> None:
+        target = "linux-x86_64"
+        filename = validator.archive_filename(target)
+        url = self.metadata[target]["url"]
+        for wrong_url in (
+            url.replace("google/zerocopy", "attacker/zerocopy"),
+            url.replace(TAG, TAG + "-other"),
+            url.replace("https://", "http://"),
+            url + "?download=1",
+            validator.release_url(REPOSITORY, TAG, filename + ".other"),
+        ):
+            with self.subTest(url=wrong_url):
+                self.metadata[target]["url"] = wrong_url
+                self._write_metadata(target)
+                with self.assertRaisesRegex(validator.ValidationError, "has url="):
+                    self._validate()
+        self.metadata[target]["url"] = url
+
+    def test_sha256_must_be_lowercase_hex(self) -> None:
+        target = "linux-x86_64"
+        for sha256 in ("a" * 63, "A" * 64, "g" * 64):
+            with self.subTest(sha256=sha256):
+                self.metadata[target]["sha256"] = sha256
+                self._write_metadata(target)
+                with self.assertRaisesRegex(validator.ValidationError, "64 lowercase hexadecimal"):
+                    self._validate()
+
+    def test_archive_hash_must_match_metadata(self) -> None:
+        target = "linux-x86_64"
+        (self.archive_dir / validator.archive_filename(target)).write_bytes(b"tampered")
+        with self.assertRaisesRegex(validator.ValidationError, "has sha256"):
+            self._validate()
+
+    def test_archive_must_not_exceed_github_asset_limit(self) -> None:
+        self.assertEqual(validator.GITHUB_RELEASE_ASSET_SIZE_LIMIT, 2_147_483_647)
+        target = "linux-x86_64"
+        path = self.archive_dir / validator.archive_filename(target)
+        with path.open("wb") as archive:
+            archive.truncate(validator.GITHUB_RELEASE_ASSET_SIZE_LIMIT + 1)
+        with self.assertRaisesRegex(validator.ValidationError, "must not exceed 2147483647 bytes"):
+            self._validate()
+
+    def test_metadata_and_archives_must_be_regular_non_symlink_files(self) -> None:
+        target = "linux-x86_64"
+        metadata_path = self._metadata_path(target)
+        real_metadata = self.root / "real-metadata.json"
+        metadata_path.replace(real_metadata)
+        metadata_path.symlink_to(real_metadata)
+        with self.assertRaisesRegex(validator.ValidationError, "regular non-symlink"):
+            self._validate()
+
+        metadata_path.unlink()
+        real_metadata.replace(metadata_path)
+        archive_path = self.archive_dir / validator.archive_filename(target)
+        real_archive = self.root / "real-archive.tar.zst"
+        archive_path.replace(real_archive)
+        archive_path.symlink_to(real_archive)
+        with self.assertRaisesRegex(validator.ValidationError, "regular non-symlink"):
+            self._validate()
+
+    def test_directories_must_not_be_symlinks(self) -> None:
+        real_metadata_dir = self.root / "real-metadata"
+        self.metadata_dir.replace(real_metadata_dir)
+        self.metadata_dir.symlink_to(real_metadata_dir, target_is_directory=True)
+        with self.assertRaisesRegex(validator.ValidationError, "non-symlink directory"):
+            self._validate()
+
+    def test_cli_accepts_optional_archive_directory_and_reports_errors(self) -> None:
+        arguments = [
+            "--metadata-dir",
+            str(self.metadata_dir),
+            "--archive-dir",
+            str(self.archive_dir),
+            "--cargo-toml",
+            str(self.cargo_toml),
+            "--tag",
+            TAG,
+            "--repository",
+            REPOSITORY,
+        ]
+        self.assertEqual(validator.main(arguments), 0)
+
+        self.metadata["linux-x86_64"]["url"] = "https://example.com/archive"
+        self._write_metadata("linux-x86_64")
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.assertEqual(validator.main(arguments), 1)
+        self.assertIn("error:", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/anneal/v1/tools/validate-release-artifacts.py
+++ b/anneal/v1/tools/validate-release-artifacts.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Validate untrusted Anneal release metadata and, optionally, archives.
+
+This helper is intended to run from a trusted workflow checkout. Metadata and
+archives produced by release matrix jobs are untrusted inputs: do not move this
+validation into the checkout used to build those inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tomllib
+from pathlib import Path
+
+
+# Keep this in sync with the release matrix in
+# .github/workflows/anneal-release.yml and the exocrate sections in
+# anneal/v1/Cargo.toml. Exact validation is deliberate: adding or renaming a
+# release platform must fail until every consumer of the platform matrix has
+# been reviewed and updated together.
+EXPECTED_TARGETS = {
+    "linux-x86_64": ("linux", "x86_64"),
+    "linux-aarch64": ("linux", "aarch64"),
+    "macos-x86_64": ("macos", "x86_64"),
+    "macos-aarch64": ("macos", "aarch64"),
+}
+
+# collect-release-archive-metadata.py is the producer of this schema. Keep the
+# two helpers coordinated; accepting unknown keys would let a producer change
+# meaning without requiring a corresponding change to this trusted validator.
+EXPECTED_METADATA_KEYS = frozenset(
+    {"target", "os", "arch", "filename", "sha256", "url"}
+)
+
+# GitHub documents a maximum size of 2 GiB minus one byte for a single release
+# asset. Check the actual file, rather than trusting matrix-produced metadata.
+GITHUB_RELEASE_ASSET_SIZE_LIMIT = 2_147_483_647
+MAX_METADATA_FILE_SIZE = 64 * 1024
+MAX_CARGO_TOML_SIZE = 1024 * 1024
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+
+
+class ValidationError(Exception):
+    """An untrusted release artifact did not match the trusted contract."""
+
+
+def archive_filename(target: str) -> str:
+    return f"anneal-toolchain-{target}.tar.zst"
+
+
+def release_url(repository: str, tag: str, filename: str) -> str:
+    return f"https://github.com/{repository}/releases/download/{tag}/{filename}"
+
+
+def _require_directory(path: Path, description: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as error:
+        raise ValidationError(f"cannot inspect {description} {path}: {error}") from error
+    if not stat.S_ISDIR(mode):
+        raise ValidationError(f"{description} is not a non-symlink directory: {path}")
+
+
+def _require_regular_file(path: Path, description: str) -> os.stat_result:
+    try:
+        file_stat = path.lstat()
+    except OSError as error:
+        raise ValidationError(f"cannot inspect {description} {path}: {error}") from error
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ValidationError(f"{description} is not a regular non-symlink file: {path}")
+    return file_stat
+
+
+def _require_exact_directory_entries(
+    directory: Path, expected_names: set[str], description: str
+) -> dict[str, Path]:
+    _require_directory(directory, f"{description} directory")
+    try:
+        entries = {entry.name: entry for entry in directory.iterdir()}
+    except OSError as error:
+        raise ValidationError(
+            f"cannot list {description} directory {directory}: {error}"
+        ) from error
+
+    actual_names = set(entries)
+    missing = sorted(expected_names - actual_names)
+    unexpected = sorted(actual_names - expected_names)
+    errors = []
+    if missing:
+        errors.append("missing " + ", ".join(missing))
+    if unexpected:
+        errors.append("unexpected " + ", ".join(unexpected))
+    if errors:
+        raise ValidationError(f"invalid {description} directory {directory}: {'; '.join(errors)}")
+    return entries
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValidationError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_json_constant(value: str):
+    raise ValidationError(f"invalid JSON constant {value!r}")
+
+
+def _load_json(path: Path) -> object:
+    file_stat = _require_regular_file(path, "metadata file")
+    if file_stat.st_size > MAX_METADATA_FILE_SIZE:
+        raise ValidationError(
+            f"metadata file {path} is {file_stat.st_size} bytes; "
+            f"maximum is {MAX_METADATA_FILE_SIZE} bytes"
+        )
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise ValidationError(f"cannot read metadata file {path}: {error}") from error
+    try:
+        return json.loads(
+            contents,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (json.JSONDecodeError, ValidationError) as error:
+        raise ValidationError(f"invalid metadata file {path}: {error}") from error
+
+
+def _validate_metadata(
+    path: Path, target: str, platform: tuple[str, str], tag: str, repository: str
+) -> dict[str, str]:
+    value = _load_json(path)
+    if not isinstance(value, dict):
+        raise ValidationError(f"metadata file {path} must contain one JSON object")
+
+    actual_keys = set(value)
+    missing = sorted(EXPECTED_METADATA_KEYS - actual_keys)
+    unexpected = sorted(actual_keys - EXPECTED_METADATA_KEYS)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected " + ", ".join(unexpected))
+        raise ValidationError(f"metadata file {path} has invalid keys: {'; '.join(details)}")
+
+    non_strings = sorted(key for key, item in value.items() if not isinstance(item, str))
+    if non_strings:
+        raise ValidationError(
+            f"metadata file {path} has non-string values for: {', '.join(non_strings)}"
+        )
+
+    # The exact key and type checks above establish this narrower runtime type.
+    metadata: dict[str, str] = value
+    os_name, arch = platform
+    filename = archive_filename(target)
+    expected_fields = {
+        "target": target,
+        "os": os_name,
+        "arch": arch,
+        "filename": filename,
+        "url": release_url(repository, tag, filename),
+    }
+    for key, expected in expected_fields.items():
+        if metadata[key] != expected:
+            raise ValidationError(
+                f"metadata file {path} has {key}={metadata[key]!r}; expected {expected!r}"
+            )
+
+    if SHA256_RE.fullmatch(metadata["sha256"]) is None:
+        raise ValidationError(
+            f"metadata file {path} sha256 must be 64 lowercase hexadecimal characters"
+        )
+    return metadata
+
+
+def _sha256_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    try:
+        with path.open("rb") as archive:
+            for chunk in iter(lambda: archive.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    except OSError as error:
+        raise ValidationError(f"cannot read archive file {path}: {error}") from error
+    return hasher.hexdigest()
+
+
+def _validate_archive(path: Path, expected_sha256: str) -> None:
+    file_stat = _require_regular_file(path, "archive file")
+    if file_stat.st_size > GITHUB_RELEASE_ASSET_SIZE_LIMIT:
+        raise ValidationError(
+            f"archive file {path} is {file_stat.st_size} bytes; GitHub release assets "
+            f"must not exceed {GITHUB_RELEASE_ASSET_SIZE_LIMIT} bytes"
+        )
+
+    actual_sha256 = _sha256_file(path)
+    if actual_sha256 != expected_sha256:
+        raise ValidationError(
+            f"archive file {path} has sha256 {actual_sha256}; expected {expected_sha256}"
+        )
+
+
+def _load_cargo_toml(path: Path) -> dict[str, object]:
+    file_stat = _require_regular_file(path, "Cargo manifest")
+    if file_stat.st_size > MAX_CARGO_TOML_SIZE:
+        raise ValidationError(
+            f"Cargo manifest {path} is {file_stat.st_size} bytes; "
+            f"maximum is {MAX_CARGO_TOML_SIZE} bytes"
+        )
+    try:
+        contents = path.read_text(encoding="utf-8")
+        value = tomllib.loads(contents)
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as error:
+        raise ValidationError(f"invalid Cargo manifest {path}: {error}") from error
+    return value
+
+
+def _require_table(value: object, path: str, manifest: Path) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValidationError(
+            f"Cargo manifest {manifest} {path} must be a table"
+        )
+    return value
+
+
+def validate_cargo_exocrate_metadata(
+    cargo_toml: Path, metadata: dict[str, dict[str, str]]
+) -> None:
+    """Bind cargo-anneal's embedded archive metadata to validated artifacts."""
+
+    manifest = _load_cargo_toml(cargo_toml)
+    package = _require_table(manifest.get("package"), "package", cargo_toml)
+    package_metadata = _require_table(
+        package.get("metadata"), "package.metadata", cargo_toml
+    )
+    exocrate = _require_table(
+        package_metadata.get("exocrate"),
+        "package.metadata.exocrate",
+        cargo_toml,
+    )
+
+    expected_by_platform = {
+        (os_name, arch): {
+            "sha256": metadata[target]["sha256"],
+            "url": metadata[target]["url"],
+        }
+        for target, (os_name, arch) in EXPECTED_TARGETS.items()
+    }
+    expected_os_names = {os_name for os_name, _ in expected_by_platform}
+    actual_os_names = set(exocrate)
+    if actual_os_names != expected_os_names:
+        raise ValidationError(
+            f"Cargo manifest {cargo_toml} package.metadata.exocrate has "
+            f"platforms {sorted(actual_os_names)}; expected "
+            f"{sorted(expected_os_names)}"
+        )
+
+    for os_name in sorted(expected_os_names):
+        by_arch = _require_table(
+            exocrate[os_name],
+            f"package.metadata.exocrate.{os_name}",
+            cargo_toml,
+        )
+        expected_arches = {
+            arch
+            for platform_os, arch in expected_by_platform
+            if platform_os == os_name
+        }
+        actual_arches = set(by_arch)
+        if actual_arches != expected_arches:
+            raise ValidationError(
+                f"Cargo manifest {cargo_toml} "
+                f"package.metadata.exocrate.{os_name} has architectures "
+                f"{sorted(actual_arches)}; expected {sorted(expected_arches)}"
+            )
+
+        for arch in sorted(expected_arches):
+            path = f"package.metadata.exocrate.{os_name}.{arch}"
+            values = _require_table(by_arch[arch], path, cargo_toml)
+            expected_values = expected_by_platform[(os_name, arch)]
+            if set(values) != set(expected_values):
+                raise ValidationError(
+                    f"Cargo manifest {cargo_toml} {path} has keys "
+                    f"{sorted(values)}; expected {sorted(expected_values)}"
+                )
+            for key, expected in expected_values.items():
+                actual = values[key]
+                if not isinstance(actual, str) or actual != expected:
+                    raise ValidationError(
+                        f"Cargo manifest {cargo_toml} {path}.{key} is "
+                        f"{actual!r}; expected {expected!r}"
+                    )
+
+
+def validate_release_artifacts(
+    metadata_dir: Path,
+    tag: str,
+    repository: str,
+    archive_dir: Path | None = None,
+) -> dict[str, dict[str, str]]:
+    """Validate and return metadata indexed by its exact release target."""
+
+    expected_metadata_names = {f"{target}.json" for target in EXPECTED_TARGETS}
+    metadata_entries = _require_exact_directory_entries(
+        metadata_dir, expected_metadata_names, "metadata"
+    )
+
+    metadata = {
+        target: _validate_metadata(
+            metadata_entries[f"{target}.json"], target, platform, tag, repository
+        )
+        for target, platform in EXPECTED_TARGETS.items()
+    }
+
+    if archive_dir is not None:
+        expected_archive_names = {archive_filename(target) for target in EXPECTED_TARGETS}
+        archive_entries = _require_exact_directory_entries(
+            archive_dir, expected_archive_names, "archive"
+        )
+        for target in EXPECTED_TARGETS:
+            filename = archive_filename(target)
+            _validate_archive(archive_entries[filename], metadata[target]["sha256"])
+
+    return metadata
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--metadata-dir", required=True, type=Path)
+    parser.add_argument("--archive-dir", type=Path)
+    parser.add_argument("--cargo-toml", type=Path)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--repository", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        metadata = validate_release_artifacts(
+            metadata_dir=args.metadata_dir,
+            archive_dir=args.archive_dir,
+            tag=args.tag,
+            repository=args.repository,
+        )
+        if args.cargo_toml is not None:
+            validate_cargo_exocrate_metadata(args.cargo_toml, metadata)
+    except ValidationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check_actions.sh
+++ b/ci/check_actions.sh
@@ -108,14 +108,26 @@ failed=0
 # and Python sources already have their own repository checks, and enabling
 # actionlint's optional external integrations would make results depend on
 # whichever shellcheck/pyflakes versions happen to be installed on the host.
-# Run the GitHub-aware parser before the action-validator pass below: both
-# validators must accept a workflow before it is considered valid.
+# Run the GitHub-aware parser before the repository permission policy below:
+# both parsers must accept a workflow before it is considered valid.
 if ! output=$("$actionlint_bin" -shellcheck= -pyflakes= 2>&1); then
     echo "$script_name: ❌ actionlint validation failed" >&2
     echo "$output" | sed "s|^|$script_name:   |" >&2
     failed=1
 fi
 
+yq_bin="$(./.github/scripts/ensure-yq.sh)"
+export YQ="$yq_bin"
+
+# Pull request and merge-group jobs execute proposed repository code. Keep
+# their GITHUB_TOKEN read-only even for same-repository PRs, whose tokens are
+# not automatically downgraded like fork tokens. The checker is deliberately
+# separate from individual workflows so a future publishing optimization
+# cannot silently reintroduce write authority.
+python3 .github/scripts/check-workflow-permissions.py \
+  --yq "$yq_bin" .github/workflows
+python3 .github/scripts/test_check_workflow_permissions.py
+python3 .github/scripts/test_workflow_artifacts.py
 python3 .github/actions/require-successful-jobs/test_check.py
 python3 githooks/test_pre_push.py
 


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Same-repository PRs previously gave the core image builder
package-write authority, and Anneal tests received repository-write
authority only to store timing data. Make both producers read-only.
Publish the Docker cache from a successful default-branch workflow and
validated benchmarks from the trusted docs coordinator.

Add a semantic workflow check which rejects any write-capable
GITHUB_TOKEN in pull-request or merge-group workflows. This makes the
trust boundary a repository invariant instead of a job convention.

Split manual Anneal toolchain releases into immutable source
resolution, unprivileged patch and archive production, trusted artifact
review, release publication, and PR submission. Validate the archive
set, metadata, hashes, URLs, sizes, release target, and final patch at
each boundary. Bind the patched manifest's archive URLs and hashes to
the exact validated artifacts. No job which executes selected-branch
code receives a write credential.

Make asset publication resumable: reuse a correctly targeted draft,
accept matching assets, repair missing draft assets, and reject any
mismatch before publishing the prerelease and opening its release PR.




---

- 　  #3561
- 　  #3560
- 　  #3559
- 　  #3558
- 👉 #3557
- 　  #3556
- 　  #3551
- 　  #3555


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v2..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v2..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v1..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v3)|[vs Base](/google/zerocopy/compare/G5beb3b8009067383ec63f493b4115323..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v1..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v2)|[vs Base](/google/zerocopy/compare/G5beb3b8009067383ec63f493b4115323..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v2)|
|v1|||[vs Base](/google/zerocopy/compare/G5beb3b8009067383ec63f493b4115323..gherrit/Gb02b26ae5d20d53b66325769f509c0b1/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gb02b26ae5d20d53b66325769f509c0b1 && git checkout -b pr-Gb02b26ae5d20d53b66325769f509c0b1 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gb02b26ae5d20d53b66325769f509c0b1 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gb02b26ae5d20d53b66325769f509c0b1 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gb02b26ae5d20d53b66325769f509c0b1
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gb02b26ae5d20d53b66325769f509c0b1","parent":"G5beb3b8009067383ec63f493b4115323","child":"Gad49134f1df2f7aecc9a671ecfa38616"} -->