### PR TITLE
[ci] Keep read-only checks from rewriting lockfiles

### DIFF
--- a/.github/scripts/test_locked_cargo_invocations.py
+++ b/.github/scripts/test_locked_cargo_invocations.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# You may not use this file except in compliance with those licenses.
+
+"""Regression tests for Cargo invocations outside cargo-zerocopy's grammar."""
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import unittest
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+YQ = os.environ.get("YQ", "yq")
+
+
+def workflow_object(name: str) -> dict[str, Any]:
+    """Decodes a workflow with the parser pinned by check_actions.sh."""
+
+    path = ROOT / ".github" / "workflows" / name
+    result = subprocess.run(
+        [
+            YQ,
+            "eval",
+            "--output-format=json",
+            "--no-colors",
+            ".",
+            "--",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    parsed = json.loads(result.stdout)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path} did not decode to a mapping")
+    return parsed
+
+
+class LockedCargoInvocationTests(unittest.TestCase):
+    def test_toolchain_metadata_is_locked_and_offline(self):
+        source = (
+            ROOT / "zerocopy" / "ci" / "check_all_toolchains_tested.sh"
+        ).read_text(encoding="utf-8")
+        # Ignore prose and join shell continuation lines before looking for
+        # commands. This covers both the original diff-based checker and its
+        # later assignment-based implementation without coupling to either.
+        source = "\n".join(
+            line
+            for line in source.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        source = re.sub(r"\\\n\s*", " ", source)
+        invocations = list(
+            re.finditer(
+                r"(?:^[ \t]*|[<(])"
+                r"(?P<prefix>\./cargo\.sh\s+\+stable|cargo)\s+metadata\b"
+                r"(?P<arguments>[^\n]*)",
+                source,
+                re.MULTILINE,
+            )
+        )
+        self.assertEqual(len(invocations), 1)
+        invocation = invocations[0]
+        self.assertEqual(
+            re.sub(r"\s+", " ", invocation.group("prefix")),
+            "./cargo.sh +stable",
+        )
+        arguments = invocation.group("arguments")
+        for flag in ("--locked", "--offline", "--no-deps"):
+            with self.subTest(flag=flag):
+                self.assertRegex(
+                    arguments,
+                    rf"(?:^|\s){re.escape(flag)}(?=\s|[|;)])",
+                )
+
+    def test_every_miri_nextest_run_has_an_inner_lock(self):
+        workflow = workflow_object("ci.yml")
+        runs = [
+            step["run"]
+            for job in workflow.get("jobs", {}).values()
+            for step in job.get("steps", [])
+            if isinstance(step, dict) and isinstance(step.get("run"), str)
+        ]
+        occurrences = []
+        for run in runs:
+            normalized = re.sub(r"\\\n\s*", " ", run)
+            occurrences.extend(
+                re.findall(r"\bmiri\s+nextest\s+run\b[^\n]*", normalized)
+            )
+        self.assertGreater(len(occurrences), 0)
+        for invocation in occurrences:
+            with self.subTest(invocation=invocation):
+                self.assertRegex(
+                    invocation,
+                    r"^miri\s+nextest\s+run\s+--locked(?:\s|$)",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -38,7 +38,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN cargo install cargo-nextest --locked                    && \
-    cargo install cargo-readme --version 3.2.0              && \
+    cargo install cargo-readme --locked --version '=3.2.0'  && \
     cargo install --locked action-validator --version 0.8.0 && \
     rm -rf /root/.cargo/registry /root/.cargo/git
 

--- a/.github/workflows/anneal.yml
+++ b/.github/workflows/anneal.yml
@@ -142,11 +142,11 @@ jobs:
 
       # Ensure `llms-full.txt` file is up-to-date.
       - name: Check doc generation
-        run: cargo run -p doc_gen -- --check
+        run: cargo run --locked -p doc_gen -- --check
         working-directory: anneal/v1
 
       - name: Install Anneal toolchain archive
-        run: cargo run setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
+        run: cargo run --locked setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
         working-directory: anneal/v1
 
       # Run unit tests separately, as they're much less likely to have bugs
@@ -154,7 +154,7 @@ jobs:
       # easier to skim (in particular, it's clear at a glance whether a failure
       # is due to unit or integration tests).
       - name: Run unit tests
-        run: cargo test --verbose --bin cargo-anneal
+        run: cargo test --locked --verbose --bin cargo-anneal
         working-directory: anneal/v1
 
       # We duplicate running unit tests since they're very cheap compared to
@@ -164,7 +164,7 @@ jobs:
       - name: Run all tests
         run: |
           start=$(date +%s)
-          cargo test --verbose
+          cargo test --locked --verbose
           end=$(date +%s)
           duration=$((end - start))
           echo "Test Time: $duration seconds"
@@ -259,7 +259,7 @@ jobs:
           expected-file: ${{ env.ANNEAL_TOOLCHAIN_ARCHIVE }}
 
       - name: Install Anneal toolchain archive
-        run: cargo run setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
+        run: cargo run --locked setup --local-archive "../target/$ANNEAL_TOOLCHAIN_ARCHIVE"
         working-directory: anneal/v1
 
       - name: Verify example
@@ -279,7 +279,7 @@ jobs:
 
           echo "Verifying $example (expect failure: $expect_failure)"
 
-          if cargo run verify --unsound-allow-is-valid --example "$example"; then
+          if cargo run --locked verify --unsound-allow-is-valid --example "$example"; then
             if [ "$expect_failure" -eq 1 ]; then
               echo "::error::Example $example succeeded but was expected to fail."
               exit 1
@@ -485,7 +485,8 @@ jobs:
           toolchain: nightly
 
       - name: Run V2 tests
-        run: cargo test --workspace --all-features # include, e.g., tests that assume exocrate prebuilt
+        # Include, e.g., tests that assume exocrate is prebuilt.
+        run: cargo test --locked --workspace --all-features
         working-directory: anneal
 
   # Used to signal to branch protections that all other jobs have succeeded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,7 @@ jobs:
         # borrows model to ensure we're compliant with both.
         for EXTRA_FLAGS in "" "-Zmiri-tree-borrows"; do
           MIRIFLAGS="$MIRIFLAGS $EXTRA_FLAGS" ./cargo.sh +$TOOLCHAIN \
-            miri nextest run \
+            miri nextest run --locked \
             --test-threads "$THREADS" \
             --package $CRATE \
             --target $TARGET \
@@ -606,7 +606,7 @@ jobs:
         # Include arguments passed during docs.rs deployments to make sure those
         # work properly.
         set -eo pipefail
-        METADATA_DOCS_RS_RUSTDOC_ARGS="$(env -u RUSTFLAGS -u RUSTDOCFLAGS ./cargo.sh +stable metadata --manifest-path Cargo.toml --no-deps --format-version 1 | \
+        METADATA_DOCS_RS_RUSTDOC_ARGS="$(env -u RUSTFLAGS -u RUSTDOCFLAGS ./cargo.sh +stable metadata --offline --manifest-path Cargo.toml --no-deps --format-version 1 | \
           jq -r ".packages[] | select(.name == \"zerocopy\").metadata.docs.rs.\"rustdoc-args\"[]" | tr '\n' ' ')"
         if [[ "$TOOLCHAIN" == "nightly" ]]; then
           export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS $RUSTDOCFLAGS"
@@ -721,8 +721,8 @@ jobs:
       - name: Generate code coverage
         run: |
           set -eo pipefail
-          ./cargo.sh +nightly install --version 0.8.0 cargo-llvm-cov
-          ./cargo.sh +nightly llvm-cov \
+          ./cargo.sh +nightly install --locked --version 0.8.0 cargo-llvm-cov
+          ./cargo.sh +nightly llvm-cov --locked \
             --package zerocopy \
             --target x86_64-unknown-linux-gnu \
             --all-features \
@@ -835,7 +835,7 @@ jobs:
       - name: Check avr-none target
         run: RUSTFLAGS='-C target-cpu=atmega328p' ./cargo.sh +nightly check --target=avr-none -Zbuild-std=core --features simd,simd-nightly,float-nightly,derive
       - name: Clippy check avr-none target
-        run: RUSTFLAGS='-C target-cpu=atmega328p' ./cargo.sh +nightly clippy --target=avr-none -Zbuild-std=core --features simd,simd-nightly,float-nightly,derive
+        run: RUSTFLAGS='-C target-cpu=atmega328p' ./cargo.sh +nightly clippy --locked --target=avr-none -Zbuild-std=core --features simd,simd-nightly,float-nightly,derive
 
   check_fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -263,7 +263,7 @@ jobs:
             export RUSTDOCFLAGS="-Z unstable-options --document-hidden-items $METADATA_DOCS_RS_RUSTDOC_ARGS"
 
             # TODO: Use `./cargo.sh` instead once we've debugged why it won't work.
-            cargo +$ZC_NIGHTLY_TOOLCHAIN doc --document-private-items --package zerocopy --all-features
+            cargo +$ZC_NIGHTLY_TOOLCHAIN doc --locked --offline --document-private-items --package zerocopy --all-features
 
       - name: Add HTML redirect to doc root
         # By default, Rustdoc doesn't redirect to the documentation root, so we

--- a/.github/workflows/roll-pinned-toolchain-versions.yml
+++ b/.github/workflows/roll-pinned-toolchain-versions.yml
@@ -108,8 +108,8 @@ jobs:
             # introduced on this new toolchain that we can fix automatically.
             # This is best-effort, so we don't let failure cause the whole job
             # to fail.
-            ./zerocopy/cargo.sh "+$VERSION_NAME" fix --allow-dirty --tests --package zerocopy $ZEROCOPY_FEATURES || true
-            ./zerocopy/cargo.sh "+$VERSION_NAME" fix --allow-dirty --tests --package zerocopy-derive             || true
+            ./zerocopy/cargo.sh "+$VERSION_NAME" fix --locked --allow-dirty --tests --package zerocopy $ZEROCOPY_FEATURES || true
+            ./zerocopy/cargo.sh "+$VERSION_NAME" fix --locked --allow-dirty --tests --package zerocopy-derive             || true
 
             ./tools/update-expected-test-output.sh
           }

--- a/anneal/v1/AGENTS.md
+++ b/anneal/v1/AGENTS.md
@@ -14,29 +14,37 @@ those terms. -->
 
 ## Basic commands
 
-1. Run with `cargo run verify`.
-2. Run unit tests with `cargo test --bin cargo-anneal`.
-3. Run all tests (including integration tests) with `./docker.sh cargo test`.
-4. Run a *specific* integration test fixture with `./docker.sh cargo test --test integration fixture_name`.
+1. Run with `cargo run --locked verify`.
+2. Run unit tests with `cargo test --locked --bin cargo-anneal`.
+3. Run all tests (including integration tests) with
+   `./docker.sh cargo test --locked`.
+4. Run a *specific* integration test fixture with
+   `./docker.sh cargo test --locked --test integration fixture_name`.
 
 ## Tips
 
-1. Integration tests are expensive. Prefer `cargo test --bin cargo-anneal` for quick verification and iteration,
-   and only run `./docker.sh cargo test --test integration` when you need to verify the integration tests.
-2. To see the generated Lean code for a module, use `cargo run expand`. This will run Aeneas and Anneal but skip verification, outputting the generated `.lean` definitions to the terminal.
+1. Integration tests are expensive. Prefer
+   `cargo test --locked --bin cargo-anneal` for quick verification and
+   iteration, and only run
+   `./docker.sh cargo test --locked --test integration` when you need to verify
+   the integration tests.
+2. To see the generated Lean code for a module, use
+   `cargo run --locked expand`. This will run Aeneas and Anneal but skip
+   verification, outputting the generated `.lean` definitions to the terminal.
    ```bash
-   cargo run expand --example abs
+   cargo run --locked expand --example abs
    ```
-3. To see where intermediate artifacts are placed on disk, run with `RUST_LOG=cargo_anneal=trace` as a fallback:
+3. To see where intermediate artifacts are placed on disk, run with
+   `RUST_LOG=cargo_anneal=trace` as a fallback:
   ```bash
-  RUST_LOG=cargo_anneal=trace cargo run verify --example abs
+  RUST_LOG=cargo_anneal=trace cargo run --locked verify --example abs
   ```
 
 ## Integration Testing
 
 1. **Updating Expected Output:** Anneal integration tests (stored in `tests/fixtures/<test_name>`) assert against an `expected.stderr` or `out.txt` file. When you intentionally change the behavior or output of a test, do not edit these files manually. Instead, run the integration test with `BLESS=1` to automatically overwrite the snapshot files:
    ```bash
-   BLESS=1 ./docker.sh cargo test --test integration fixture_name
+   BLESS=1 ./docker.sh cargo test --locked --test integration fixture_name
    ```
 
 2. **Allowing `sorry`:** While developing and ensuring Aeneas translates Rust correctly, you don't have to write the full Lean proof immediately. You can write `sorry` inside the `proof` block. However, you must pass `--allow-sorry` to Anneal so the verifier doesn't fail immediately on the unimplemented proof. For integration tests, this is done by adding `--allow-sorry` to the `args` array in the fixture's `anneal.toml`:
@@ -52,10 +60,10 @@ The `docker.sh` script should be used. It handles building and caching the Docke
 
 Simply prefix your normal Cargo tests with `./docker.sh`:
 ```bash
-./docker.sh cargo test --test integration
+./docker.sh cargo test --locked --test integration
 
 # You can pass standard environment variables. They will be forwarded!
-BLESS=1 ./docker.sh cargo test --test integration
+BLESS=1 ./docker.sh cargo test --locked --test integration
 ```
 
 *(Under the hood, this evaluates your path and places you in the same working directory inside the container's bound `/workspace` volume)*
@@ -68,7 +76,7 @@ BLESS=1 ./docker.sh cargo test --test integration
    - If a test fails and you want to inspect the generated Lean code, use the `ANNEAL_KEEP_TEST_DIR=1` environment variable.
    - The test runner will preserve the directory and print its path to stderr:
      ```bash
-     ANNEAL_KEEP_TEST_DIR=1 ./docker.sh cargo test --test integration macro_edge_cases
+     ANNEAL_KEEP_TEST_DIR=1 ./docker.sh cargo test --locked --test integration macro_edge_cases
      ```
    - **Note:** Because the test runner operates inside Docker, the printed path will reside within the container's isolated `/cache` volume. To explore it, you must open a shell inside the container:
      ```bash

--- a/anneal/v1/Dockerfile
+++ b/anneal/v1/Dockerfile
@@ -1,11 +1,3 @@
-FROM python:3.11-slim AS extractor
-WORKDIR /app
-COPY anneal/v1/Cargo.toml ./
-# Remove the [workspace] section so it can be built as a standalone package.
-# Also inject tree-sitter dependencies used by doc_gen to cache them too.
-RUN sed '1,2d' Cargo.toml > Cargo.toml.no_workspace && \
-    sed -i '/^\[dependencies\]$/a tree-sitter = "0.25"\ntree-sitter-lean4 = "0.2"' Cargo.toml.no_workspace
-
 FROM ubuntu:24.04
 
 # Relocate toolchains so that non-root developers can access and write to them
@@ -53,9 +45,12 @@ ENV ANNEAL_INTEGRATION_TARGET_DIR=/cache/anneal_target
 ENV CARGO_TARGET_DIR=/opt/anneal_target
 WORKDIR /workspace/anneal/v1
 
-# Copy the workspace configuration (without workspace section) and lockfile.
-COPY --from=extractor --chown=anneal:anneal /app/Cargo.toml.no_workspace ./Cargo.toml
+# Copy the real workspace manifests and lockfile. In particular, do not merge
+# doc_gen's dependencies into cargo-anneal: that synthetic package is not what
+# Cargo.lock describes, so a locked build would correctly reject it.
+COPY --chown=anneal:anneal anneal/v1/Cargo.toml ./Cargo.toml
 COPY --chown=anneal:anneal anneal/v1/Cargo.lock ./
+COPY --chown=anneal:anneal anneal/v1/tools/doc_gen/Cargo.toml ./tools/doc_gen/Cargo.toml
 
 # Copy source files needed to compile dependency-heavy modules.
 COPY --chown=anneal:anneal anneal/v1/src/setup.rs ./src/
@@ -63,19 +58,21 @@ COPY --chown=anneal:anneal exocrate/Cargo.toml /workspace/exocrate/Cargo.toml
 COPY --chown=anneal:anneal exocrate/src /workspace/exocrate/src
 COPY --chown=anneal:anneal anneal/v1/build.rs ./
 
-# Create a minimal `main.rs` and a dummy test file.
-# This allows us to build dependencies in the image without copying the full
-# source tree, avoiding unnecessary container rebuilds when source files change.
+# Create minimal sources for both workspace members and a dummy test. This
+# builds their real locked dependency graph without copying frequently changing
+# source files into the dependency-cache layer.
 RUN echo 'mod setup; fn main() {}' > src/main.rs && \
-    mkdir tests && echo 'fn main() {}' > tests/integration.rs
+    mkdir tests tools/doc_gen/src && \
+    echo 'fn main() {}' > tests/integration.rs && \
+    echo 'fn main() {}' > tools/doc_gen/src/main.rs
 
 # Build dependencies to cache them in the image.
 # Note: We do not use `RUSTFLAGS='-Adead_code'` here (even though the dummy
 # `main.rs` has dead code) because doing so would cause Cargo to invalidate
 # this cache and rebuild everything when we later run commands *without*
 # that flag (which is the default).
-RUN cargo build && \
-    cargo build --tests
+RUN cargo build --locked --workspace && \
+    cargo build --locked --workspace --tests
 
 # Use a stable shared install root inside test containers. CI installs the
 # Nix-built archive here before invoking tests or examples.

--- a/anneal/v1/tests/ui.rs
+++ b/anneal/v1/tests/ui.rs
@@ -22,6 +22,7 @@ fn compile_and_find_binary(name: &str) -> PathBuf {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let status = Command::new("cargo")
         .arg("build")
+        .arg("--locked")
         .arg("--bin")
         .arg(name)
         .current_dir(manifest_dir)

--- a/anneal/v1/tools/doc_gen/src/main.rs
+++ b/anneal/v1/tools/doc_gen/src/main.rs
@@ -115,7 +115,7 @@ fn main() {
         let existing = fs::read_to_string(target_file).unwrap_or_default();
         if existing != full_txt {
             eprintln!(
-                "Error: {} is out of date. Please run `cargo run -p doc_gen` to update it.",
+                "Error: {} is out of date. Please run `cargo run --locked -p doc_gen` to update it.",
                 target_file
             );
             process::exit(1);

--- a/anneal/v1/tools/test_locked_cargo_infrastructure.py
+++ b/anneal/v1/tools/test_locked_cargo_infrastructure.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Copyright 2026 The Fuchsia Authors
+#
+# Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+# <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+# license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+"""Regression tests for Anneal's locked Docker dependency build."""
+
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+
+_ROOT = Path(__file__).resolve().parents[3]
+_DOCKERFILE = _ROOT / "anneal" / "v1" / "Dockerfile"
+_MANIFEST = _ROOT / "anneal" / "v1" / "Cargo.toml"
+
+
+class LockedCargoInfrastructureTest(unittest.TestCase):
+    def test_docker_cache_build_uses_the_real_locked_workspace(self):
+        dockerfile = _DOCKERFILE.read_text(encoding="utf-8")
+        for required in (
+            "COPY --chown=anneal:anneal anneal/v1/Cargo.toml ./Cargo.toml",
+            "COPY --chown=anneal:anneal anneal/v1/Cargo.lock ./",
+            "anneal/v1/tools/doc_gen/Cargo.toml ./tools/doc_gen/Cargo.toml",
+            "cargo build --locked --workspace",
+            "cargo build --locked --workspace --tests",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, dockerfile)
+
+        self.assertNotIn("Cargo.toml.no_workspace", dockerfile)
+        self.assertNotIn("sed '1,2d' Cargo.toml", dockerfile)
+
+    def test_repository_lock_resolves_both_workspace_members_offline(self):
+        result = subprocess.run(
+            [
+                "cargo",
+                "metadata",
+                "--locked",
+                "--offline",
+                "--no-deps",
+                "--format-version",
+                "1",
+                "--manifest-path",
+                str(_MANIFEST),
+            ],
+            cwd=_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        package_names = {
+            package["name"] for package in json.loads(result.stdout)["packages"]
+        }
+        self.assertEqual(package_names, {"cargo-anneal", "doc_gen"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/check_actions.sh
+++ b/ci/check_actions.sh
@@ -132,6 +132,7 @@ python3 .github/scripts/test_check_crate_version_change.py
 python3 .github/scripts/test_create_crates_release_plan.py
 python3 .github/scripts/test_reconcile_crates_release.py
 python3 .github/scripts/test_release_workflows.py
+python3 .github/scripts/test_locked_cargo_invocations.py
 python3 .github/actions/require-successful-jobs/test_check.py
 python3 githooks/test_pre_push.py
 
@@ -139,6 +140,13 @@ python3 githooks/test_pre_push.py
 # helper. Its fake-command tests verify timeouts, retries, failure propagation,
 # and argument validation without requiring root or network access.
 bash .github/scripts/test_install_apt_packages.sh
+
+# cargo-zerocopy is itself CI infrastructure. Its unit tests enforce the
+# default locked mode used by every Zerocopy build and test below. The tools
+# workspace is intentionally unvendored, so permit a fresh checkout to fetch
+# the exact dependencies recorded in its lockfile.
+cargo +stable test --locked --manifest-path tools/Cargo.toml \
+  -p cargo-zerocopy -p generate-readme
 
 # Files to exclude from validation (e.g., because they are not Actions/Workflows)
 # Use relative paths matching `find .github` output

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -10,6 +10,45 @@
 
 set -eo pipefail
 echo "Running pre-push git hook: $0"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# These checks are assertions about tracked source; none is allowed to rewrite
+# a first-party workspace lockfile as a side effect. Discover the inventory so
+# a newly added workspace is protected automatically. Vendored packages and
+# test fixtures own independent lockfiles which these repository checks never
+# use, so exclude those source snapshots from this workspace-level contract.
+LOCKFILES=()
+while IFS= read -r -d '' lockfile; do
+    case "$lockfile" in
+        */vendor/*|*/tests/fixtures/*) continue ;;
+    esac
+    LOCKFILES+=("$lockfile")
+done < <(git ls-files -z -- '*Cargo.lock')
+
+if [[ ${#LOCKFILES[@]} -eq 0 ]]; then
+    echo "No first-party Cargo.lock files found; refusing to run unguarded" >&2
+    exit 1
+fi
+
+lockfile_hash() {
+    local lockfile="$1"
+    if [[ -f "$lockfile" ]]; then
+        # Unlike sha256sum, `git hash-object` is available on both Linux and
+        # macOS wherever this Git hook can run. Bypass clean filters so the
+        # snapshot represents the bytes that a check could mutate on disk.
+        git hash-object --no-filters -- "$lockfile"
+    else
+        # Preserve a pre-existing deletion in the snapshot. If a check
+        # recreates the file, the post-check value will still differ.
+        echo '<missing>'
+    fi
+}
+
+LOCKFILE_HASHES_BEFORE=()
+for lockfile in "${LOCKFILES[@]}"; do
+    LOCKFILE_HASHES_BEFORE+=("$(lockfile_hash "$lockfile")")
+done
 
 # The checks below use cargo-zerocopy's pinned stable and nightly toolchains.
 # On a fresh machine, check_fmt.sh and both toolchain-policy checks can all
@@ -48,8 +87,21 @@ bootstrap_toolchain nightly
 #
 # Background all jobs and wait for them so they can run in parallel. Do not
 # launch them after a bootstrap failure: they could otherwise race to repair
-# the same incomplete toolchain state. Static script-inventory checks below
-# still run, including when bootstrap fails.
+# the same incomplete toolchain state. Static script-inventory and lockfile
+# checks below still run, including when bootstrap fails.
+wait_for_check() {
+    local name="$1"
+    local pid="$2"
+    local status
+    if wait "$pid"; then
+        return
+    else
+        status=$?
+    fi
+    echo "$name failed with status $status" >&2
+    CHECKS_FAILED=1
+}
+
 if [[ "$TOOLCHAINS_READY" -eq 1 ]]; then
     ./ci/check_actions.sh                                  & ACTIONS_PID=$!
     ./ci/check_fmt.sh                                      & FMT_PID=$!
@@ -60,17 +112,18 @@ if [[ "$TOOLCHAINS_READY" -eq 1 ]]; then
     ./zerocopy/ci/check_versions.sh              >/dev/null & VERSIONS_PID=$!
     ./zerocopy/ci/check_msrv_is_minimal.sh       >/dev/null & MSRV_PID=$!
 
-    # `wait <pid>` exits with the same status code as the job it's waiting for.
-    # Since we `set -e` above, this causes the hook to fail if a child does.
-    # A bare `wait` loses child statuses, so wait for each named process.
-    wait "$ACTIONS_PID"
-    wait "$FMT_PID"
-    wait "$TOOLCHAINS_PID"
-    wait "$JOB_DEPS_PID"
-    wait "$README_PID"
-    wait "$STALE_STDERR_PID"
-    wait "$VERSIONS_PID"
-    wait "$MSRV_PID"
+    # `wait` without a PID loses individual failures, while sequential bare
+    # waits under `set -e` abandon the remaining children after the first
+    # failure. Record each status explicitly so every child is reaped and every
+    # useful diagnostic has a chance to finish.
+    wait_for_check "ci/check_actions.sh" "$ACTIONS_PID"
+    wait_for_check "ci/check_fmt.sh" "$FMT_PID"
+    wait_for_check "ci/check_job_dependencies.sh" "$JOB_DEPS_PID"
+    wait_for_check "zerocopy/ci/check_all_toolchains_tested.sh" "$TOOLCHAINS_PID"
+    wait_for_check "zerocopy/ci/check_readme.sh" "$README_PID"
+    wait_for_check "zerocopy/ci/check_stale_stderr.sh" "$STALE_STDERR_PID"
+    wait_for_check "zerocopy/ci/check_versions.sh" "$VERSIONS_PID"
+    wait_for_check "zerocopy/ci/check_msrv_is_minimal.sh" "$MSRV_PID"
 fi
 
 # Ensure that this script calls all scripts in `ci/*` and `zerocopy/ci/*`. This
@@ -89,7 +142,10 @@ shopt -s extglob
 # zerocopy/ci/package_release_crates.sh, and test_release_workflows.py.
 GLOBIGNORE="./*/@(release_crate_version|check_todo|release_anneal_version|run_cargo_for_release).sh"
 for f in ./ci/*; do
-    grep "$f" githooks/pre-push >/dev/null || { echo "$f not called from githooks/pre-push" >&2 ; exit 1; }
+    grep "$f" githooks/pre-push >/dev/null || {
+        echo "$f not called from githooks/pre-push" >&2
+        CHECKS_FAILED=1
+    }
 done
 # The release helpers are exercised by the release-workflow tests rather than
 # run during every push. check_fmt.sh is called through the repository-wide
@@ -97,9 +153,23 @@ done
 # the release-workflow tests so a new CI helper cannot silently go unused.
 GLOBIGNORE="./zerocopy/ci/@(release_crate_version|package_release_crates|check_fmt).sh"
 for f in ./zerocopy/ci/*; do
-    grep "$f" githooks/pre-push >/dev/null || { echo "$f not called from githooks/pre-push" >&2 ; exit 1; }
+    grep "$f" githooks/pre-push >/dev/null || {
+        echo "$f not called from githooks/pre-push" >&2
+        CHECKS_FAILED=1
+    }
 done
 unset GLOBIGNORE
 shopt -u extglob
+
+# Keep this comparison at the end of the hook so any future synchronous check
+# added after the parallel fan-out remains inside the same mutation guard.
+for index in "${!LOCKFILES[@]}"; do
+    lockfile="${LOCKFILES[$index]}"
+    hash_after="$(lockfile_hash "$lockfile")"
+    if [[ "$hash_after" != "${LOCKFILE_HASHES_BEFORE[$index]}" ]]; then
+        echo "$lockfile was modified by a nominally read-only pre-push check" >&2
+        CHECKS_FAILED=1
+    fi
+done
 
 exit "$CHECKS_FAILED"

--- a/githooks/test_pre_push.py
+++ b/githooks/test_pre_push.py
@@ -8,7 +8,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-"""Regression tests for serialized pre-push toolchain bootstrap."""
+"""Regression tests for pre-push bootstrap, children, and lockfile accounting."""
 
 import os
 from pathlib import Path
@@ -20,6 +20,13 @@ import unittest
 
 _ROOT = Path(__file__).resolve().parents[1]
 _HOOK = _ROOT / "githooks" / "pre-push"
+_LOCKFILES = (
+    "anneal/Cargo.lock",
+    "anneal/v1/Cargo.lock",
+    "exocrate/Cargo.lock",
+    "tools/Cargo.lock",
+    "zerocopy/Cargo.lock",
+)
 _CHECKS = (
     "ci/check_actions.sh",
     "ci/check_fmt.sh",
@@ -43,7 +50,19 @@ if [[ -n "${CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN:-}" ]]; then
     echo "bootstrap auto-install setting leaked into $check" >&2
     exit 24
 fi
+if [[ "$check" == "${MUTATING_CHECK:-}" ]]; then
+    echo mutation >> "$MUTATE_LOCKFILE"
+fi
+if [[ "$check" == "${DELETING_CHECK:-}" ]]; then
+    rm -f "$DELETE_LOCKFILE"
+fi
+if [[ "$check" == "${SLOW_CHECK:-}" ]]; then
+    sleep 0.2
+fi
 touch "$MARKER_DIR/${check//\\//_}"
+if [[ "$check" == "${FAIL_CHECK:-}" ]]; then
+    exit 23
+fi
 """
 
 _CARGO_STUB = """\
@@ -64,7 +83,10 @@ if ! mkdir "$MARKER_DIR/cargo_bootstrap_lock"; then
     exit 42
 fi
 trap 'rmdir "$MARKER_DIR/cargo_bootstrap_lock"' EXIT
-printf '%s\n' "$invocation" >> "$MARKER_DIR/cargo_invocations"
+printf '%s\\n' "$invocation" >> "$MARKER_DIR/cargo_invocations"
+if [[ "$invocation" == "${MUTATING_CARGO_INVOCATION:-}" ]]; then
+    echo mutation >> "$MUTATE_LOCKFILE"
+fi
 sleep 0.05
 if [[ "$invocation" == "${FAIL_CARGO_INVOCATION:-}" ]]; then
     exit 23
@@ -81,6 +103,21 @@ class FakeRepository:
         (self.path / "githooks").mkdir()
         self.markers.mkdir()
         shutil.copy2(_HOOK, self.path / "githooks" / "pre-push")
+
+        for lockfile in _LOCKFILES:
+            path = self.path / lockfile
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(f"original {lockfile}\n", encoding="utf-8")
+
+        # The hook deliberately excludes checked-in dependency and fixture
+        # lockfiles from its first-party workspace inventory.
+        for lockfile in (
+            "zerocopy/vendor/example/Cargo.lock",
+            "anneal/v1/tests/fixtures/example/Cargo.lock",
+        ):
+            path = self.path / lockfile
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("source snapshot\n", encoding="utf-8")
 
         for check in _CHECKS:
             path = self.path / check
@@ -101,10 +138,17 @@ class FakeRepository:
         cargo.write_text(_CARGO_STUB, encoding="utf-8")
         cargo.chmod(0o755)
 
+        subprocess.run(
+            ["git", "init", "--quiet"], cwd=self.path, check=True
+        )
+        subprocess.run(
+            ["git", "add", "."], cwd=self.path, check=True
+        )
+
     def close(self):
         self._temporary_directory.cleanup()
 
-    def run_hook(self, **environment):
+    def run_hook(self, start_directory=".", **environment):
         child_environment = os.environ.copy()
         child_environment.pop(
             "CARGO_ZEROCOPY_AUTO_INSTALL_TOOLCHAIN", None
@@ -113,7 +157,7 @@ class FakeRepository:
         child_environment["MARKER_DIR"] = str(self.markers)
         return subprocess.run(
             ["bash", str(self.path / "githooks" / "pre-push")],
-            cwd=self.path,
+            cwd=self.path / start_directory,
             env=child_environment,
             text=True,
             stdout=subprocess.PIPE,
@@ -156,11 +200,11 @@ class PrePushTest(unittest.TestCase):
         self.repository.close()
 
     def cargo_invocations(self):
-        return (self.repository.markers / "cargo_invocations").read_text(
-            encoding="utf-8"
-        ).splitlines()
+        return (
+            self.repository.markers / "cargo_invocations"
+        ).read_text(encoding="utf-8").splitlines()
 
-    def test_bootstraps_toolchains_serially_before_checks(self):
+    def test_bootstraps_serially_and_leaves_every_lockfile_unchanged(self):
         result = self.repository.run_hook()
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
@@ -193,15 +237,23 @@ class PrePushTest(unittest.TestCase):
             protocol,
         )
 
-    def test_bootstrap_failure_does_not_launch_parallel_checks(self):
+    def test_can_run_from_a_repository_subdirectory(self):
+        result = self.repository.run_hook(start_directory="zerocopy")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_bootstrap_failure_still_guards_lockfiles(self):
+        lockfile = _LOCKFILES[-1]
         result = self.repository.run_hook(
-            FAIL_CARGO_INVOCATION="+stable --version"
+            FAIL_CARGO_INVOCATION="+stable --version",
+            MUTATING_CARGO_INVOCATION="+stable --version",
+            MUTATE_LOCKFILE=str(self.repository.path / lockfile),
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
             "zerocopy/cargo.sh +stable --version failed with status 23",
             result.stderr,
         )
+        self.assertIn(f"{lockfile} was modified", result.stderr)
         self.assertEqual(
             self.cargo_invocations(),
             ["+stable --version", "+nightly --version"],
@@ -210,6 +262,62 @@ class PrePushTest(unittest.TestCase):
             self.assertFalse(
                 (self.repository.markers / check.replace("/", "_")).exists()
             )
+
+    def test_each_first_party_lockfile_is_guarded_against_changes(self):
+        for operation in ("mutate", "delete"):
+            for lockfile in _LOCKFILES:
+                with self.subTest(operation=operation, lockfile=lockfile):
+                    self.repository.close()
+                    self.repository = FakeRepository()
+                    environment = (
+                        {
+                            "MUTATING_CHECK": "ci/check_actions.sh",
+                            "MUTATE_LOCKFILE": str(self.repository.path / lockfile),
+                        }
+                        if operation == "mutate"
+                        else {
+                            "DELETING_CHECK": "ci/check_actions.sh",
+                            "DELETE_LOCKFILE": str(self.repository.path / lockfile),
+                        }
+                    )
+                    result = self.repository.run_hook(**environment)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        f"{lockfile} was modified by a nominally read-only",
+                        result.stderr,
+                    )
+
+    def test_allows_preexisting_dirty_or_missing_lockfile(self):
+        lockfile = self.repository.path / _LOCKFILES[0]
+        lockfile.write_text("preexisting local edit\n", encoding="utf-8")
+        result = self.repository.run_hook()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        self.repository.close()
+        self.repository = FakeRepository()
+        (self.repository.path / _LOCKFILES[0]).unlink()
+        result = self.repository.run_hook()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_waits_for_every_child_after_an_early_failure(self):
+        slow_check = "zerocopy/ci/check_msrv_is_minimal.sh"
+        lockfile = _LOCKFILES[-1]
+        result = self.repository.run_hook(
+            FAIL_CHECK="ci/check_actions.sh",
+            SLOW_CHECK=slow_check,
+            MUTATING_CHECK=slow_check,
+            MUTATE_LOCKFILE=str(self.repository.path / lockfile),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ci/check_actions.sh failed with status 23", result.stderr)
+        self.assertIn(f"{lockfile} was modified", result.stderr)
+        self.assertTrue((self.repository.markers / slow_check.replace("/", "_")).is_file())
+
+    def test_reports_a_non_first_child_failure(self):
+        failed_check = "zerocopy/ci/check_stale_stderr.sh"
+        result = self.repository.run_hook(FAIL_CHECK=failed_check)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"{failed_check} failed with status 23", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -294,6 +294,77 @@ fn rustup<'a>(args: impl IntoIterator<Item = &'a str>, env: Option<(&str, &str)>
     cmd
 }
 
+fn cargo_subcommand_index(args: &[String]) -> Option<usize> {
+    let mut index = 0;
+    while let Some(arg) = args.get(index) {
+        if arg == "--" {
+            return None;
+        }
+
+        // These Cargo-global options consume the following argument. Keep
+        // this list coordinated with Cargo's global CLI when another such
+        // option is passed through cargo-zerocopy.
+        if matches!(arg.as_str(), "--color" | "--config" | "--explain" | "-C" | "-Z") {
+            index += 2;
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            index += 1;
+            continue;
+        }
+
+        return Some(index);
+    }
+    None
+}
+
+fn add_default_lock_mode(cmd: &mut Command, args: &mut Vec<String>) {
+    // Treat the lockfile as an input to every command delegated through this
+    // repository's Cargo wrapper.
+    //
+    // `--frozen` already implies `--locked`. Only inspect arguments before
+    // `--`, since a test binary or another delegated program may have its own
+    // unrelated argument with either spelling.
+    let cargo_args_end = args.iter().position(|arg| arg == "--").unwrap_or(args.len());
+    let lock_mode = if args[..cargo_args_end].iter().any(|arg| arg == "--frozen") {
+        Some("--frozen")
+    } else if args[..cargo_args_end].iter().any(|arg| arg == "--locked") {
+        Some("--locked")
+    } else {
+        None
+    };
+
+    // Cargo consumes global options before dispatching an external command.
+    // Clippy is a pinned rustup component and exposes Cargo's lock-mode flags,
+    // so put the effective mode in Clippy's own argument list. Do not do this
+    // for arbitrary `cargo-*` plugins: their argument languages are unrelated
+    // (for example, cargo-readme rejects `--locked`). Other Cargo-driving
+    // plugins must therefore spell their inner lock mode at their call sites.
+    // In particular, keep `.github/workflows/ci.yml` coordinated: Miri's inner
+    // flag must follow `miri nextest run`. The workflow contract test checks
+    // this across every job so moving the invocation cannot lose the flag.
+    if let Some(subcommand_index) = cargo_subcommand_index(&args[..cargo_args_end]) {
+        if args[subcommand_index] == "clippy" {
+            let forwarded = args[subcommand_index + 1..cargo_args_end]
+                .iter()
+                .any(|arg| arg == "--locked" || arg == "--frozen");
+            if !forwarded {
+                args.insert(subcommand_index + 1, lock_mode.unwrap_or("--locked").to_string());
+            }
+            return;
+        }
+    }
+
+    if lock_mode.is_none() {
+        cmd.arg("--locked");
+    }
+}
+
+fn cargo_pkgid(version: &str) -> Command {
+    rustup(["run", version, "cargo", "--locked", "--offline", "pkgid", "-p"], None)
+}
+
 fn delegate_cargo() -> Result<(), Error> {
     let mut args = env::args();
     let this = args.next().unwrap();
@@ -330,7 +401,7 @@ fn delegate_cargo() -> Result<(), Error> {
                     targets.push(t);
                 }
 
-                let args_vec = args.collect::<Vec<_>>();
+                let mut args_vec = args.collect::<Vec<_>>();
                 let mut i = 0;
                 while i < args_vec.len() {
                     let arg = &args_vec[i];
@@ -355,8 +426,6 @@ fn delegate_cargo() -> Result<(), Error> {
 
                 install_targets_or_exit(version, &targets)?;
 
-                let mut args = args_vec.into_iter();
-
                 let env_rustflags = env::vars()
                     .filter_map(|(k, v)| if k == "RUSTFLAGS" { Some(v) } else { None })
                     .next()
@@ -379,6 +448,8 @@ fn delegate_cargo() -> Result<(), Error> {
                 // RUSTDOCFLAGS.
                 let mut cmd = rustup(["run", version, "cargo"], Some(("RUSTFLAGS", &rustflags)));
                 cmd.env("RUSTDOCFLAGS", &rustdocflags);
+                add_default_lock_mode(&mut cmd, &mut args_vec);
+                let mut args = args_vec.into_iter();
 
                 if env::var("CARGO_TARGET_DIR").is_ok() {
                     eprintln!("[cargo-zerocopy] WARNING: `CARGO_TARGET_DIR` is set - this may cause `cargo-zerocopy` to behave unexpectedly");
@@ -388,9 +459,7 @@ fn delegate_cargo() -> Result<(), Error> {
 
                 // Computes the fully-qualified package name of workspace package `p`.
                 let fqpn = |p| {
-                    let output = rustup(["run", version, "cargo", "pkgid", "-p"], None)
-                        .arg(p)
-                        .output_or_exit();
+                    let output = cargo_pkgid(version).arg(p).output_or_exit();
                     String::from_utf8(output.stdout).unwrap().trim().to_string()
                 };
 
@@ -439,6 +508,83 @@ fn delegate_cargo() -> Result<(), Error> {
                 Err(Error::UnrecognizedArgument(arg.to_string()))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod lock_mode_tests {
+    use super::*;
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    fn command_args(args: &[&str]) -> (Vec<String>, Vec<String>) {
+        let mut args = strings(args);
+        let mut cmd = Command::new("cargo");
+        add_default_lock_mode(&mut cmd, &mut args);
+        let global = cmd.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect();
+        (global, args)
+    }
+
+    #[test]
+    fn defaults_to_locked() {
+        assert_eq!(command_args(&["test"]), (strings(&["--locked"]), strings(&["test"])));
+    }
+
+    #[test]
+    fn preserves_explicit_locked_or_frozen_mode() {
+        assert_eq!(
+            command_args(&["test", "--locked"]),
+            (Vec::new(), strings(&["test", "--locked"]))
+        );
+        assert_eq!(
+            command_args(&["--frozen", "test"]),
+            (Vec::new(), strings(&["--frozen", "test"]))
+        );
+    }
+
+    #[test]
+    fn forwards_lock_mode_to_clippy() {
+        assert_eq!(
+            command_args(&["clippy", "--tests"]),
+            (Vec::new(), strings(&["clippy", "--locked", "--tests"]))
+        );
+        assert_eq!(
+            command_args(&["--color", "always", "clippy"]),
+            (Vec::new(), strings(&["--color", "always", "clippy", "--locked"]))
+        );
+        assert_eq!(
+            command_args(&["--frozen", "clippy"]),
+            (Vec::new(), strings(&["--frozen", "clippy", "--frozen"]))
+        );
+        assert_eq!(
+            command_args(&["--locked", "--frozen", "clippy"]),
+            (Vec::new(), strings(&["--locked", "--frozen", "clippy", "--frozen"]))
+        );
+    }
+
+    #[test]
+    fn does_not_assume_other_plugin_argument_languages() {
+        assert_eq!(
+            command_args(&["readme", "--no-license"]),
+            (strings(&["--locked"]), strings(&["readme", "--no-license"]))
+        );
+    }
+
+    #[test]
+    fn ignores_test_binary_arguments() {
+        assert_eq!(
+            command_args(&["test", "--", "--locked"]),
+            (strings(&["--locked"]), strings(&["test", "--", "--locked"]))
+        );
+    }
+
+    #[test]
+    fn package_lookup_is_locked_and_offline() {
+        let cmd = cargo_pkgid("1.2.3");
+        let args = cmd.get_args().map(|arg| arg.to_string_lossy().into_owned()).collect::<Vec<_>>();
+        assert_eq!(args, ["run", "1.2.3", "cargo", "--locked", "--offline", "pkgid", "-p"]);
     }
 }
 

--- a/tools/generate-readme/src/main.rs
+++ b/tools/generate-readme/src/main.rs
@@ -30,7 +30,36 @@ const DISCLAIMER_FOOTER: &str = "\
 Disclaimer: Zerocopy is not an officially supported Google product.\
 ";
 
-fn main() {
+// cargo-readme includes this literal `v` in its `--version` output. Keep the
+// complete string pinned so an unrelated executable or output format cannot
+// accidentally satisfy the tool check.
+const CARGO_README_VERSION: &str = "cargo-readme v3.2.0";
+
+fn checked_stdout(
+    description: &str,
+    success: bool,
+    stdout: Vec<u8>,
+    stderr: &[u8],
+) -> Result<String, String> {
+    if !success {
+        return Err(format!("{description} failed: {}", String::from_utf8_lossy(stderr).trim()));
+    }
+    String::from_utf8(stdout)
+        .map_err(|error| format!("{description} emitted invalid UTF-8: {error}"))
+}
+
+fn check_cargo_readme_version(version: &str) -> Result<(), String> {
+    if version.trim() == CARGO_README_VERSION {
+        return Ok(());
+    }
+    Err(format!(
+        "expected {CARGO_README_VERSION:?}, got {:?}; install it with \
+         `cargo install --locked --version '=3.2.0' cargo-readme`",
+        version.trim(),
+    ))
+}
+
+fn generate_readme() -> Result<String, String> {
     let cwd = env::current_dir().unwrap();
     let readme_dir = env::var_os("ZEROCOPY_README_DIR").map(PathBuf::from).unwrap_or_else(|| {
         if cwd.join("zerocopy/Cargo.toml").exists() {
@@ -40,15 +69,33 @@ fn main() {
         }
     });
 
-    // This uses the `cargo readme` tool, which you can install via `cargo install
-    // cargo-readme --version 3.2.0`.
+    // This uses the exact `cargo readme` release installed by CI. Check PATH as
+    // well as documenting the installation command: developers can invoke this
+    // generator directly, without first running check_readme.sh.
+    let version_output = Command::new("cargo")
+        .current_dir(&readme_dir)
+        .args(["readme", "--version"])
+        .output()
+        .map_err(|error| format!("failed to run `cargo readme --version`: {error}"))?;
+    let version = checked_stdout(
+        "`cargo readme --version`",
+        version_output.status.success(),
+        version_output.stdout,
+        &version_output.stderr,
+    )?;
+    check_cargo_readme_version(&version)?;
+
     let output = Command::new("cargo")
         .current_dir(readme_dir)
         .args(["readme", "--no-license"])
         .output()
-        .unwrap();
-
-    let readme = String::from_utf8(output.stdout).unwrap();
+        .map_err(|error| format!("failed to run `cargo readme --no-license`: {error}"))?;
+    let readme = checked_stdout(
+        "`cargo readme --no-license`",
+        output.status.success(),
+        output.stdout,
+        &output.stderr,
+    )?;
 
     // This regex is used to strip code links like:
     //
@@ -60,5 +107,51 @@ fn main() {
         .unwrap()
         .replace_all(&readme, |caps: &Captures| caps[1].to_string());
 
-    println!("{}\n\n{}\n{}", COPYRIGHT_HEADER, body, DISCLAIMER_FOOTER);
+    Ok(format!("{}\n\n{}\n{}\n", COPYRIGHT_HEADER, body, DISCLAIMER_FOOTER))
+}
+
+fn main() {
+    match generate_readme() {
+        Ok(readme) => print!("{readme}"),
+        Err(error) => {
+            eprintln!("generate-readme: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_successful_utf8_output() {
+        assert_eq!(
+            checked_stdout("command", true, b"output\n".to_vec(), b"ignored"),
+            Ok("output\n".to_string())
+        );
+    }
+
+    #[test]
+    fn accepts_only_the_pinned_cargo_readme() {
+        assert_eq!(check_cargo_readme_version("cargo-readme v3.2.0\n"), Ok(()));
+        assert!(check_cargo_readme_version("cargo-readme 3.2.0\n").is_err());
+        let error = check_cargo_readme_version("cargo-readme v3.3.0\n").unwrap_err();
+        assert!(error.contains("expected \"cargo-readme v3.2.0\""));
+        assert!(error.contains("--version '=3.2.0'"));
+    }
+
+    #[test]
+    fn reports_command_failure_with_stderr() {
+        assert_eq!(
+            checked_stdout("command", false, Vec::new(), b"useful error\n"),
+            Err("command failed: useful error".to_string())
+        );
+    }
+
+    #[test]
+    fn reports_non_utf8_output() {
+        let error = checked_stdout("command", true, vec![0xff], b"").unwrap_err();
+        assert!(error.contains("command emitted invalid UTF-8"));
+    }
 }

--- a/zerocopy/AGENTS.md
+++ b/zerocopy/AGENTS.md
@@ -27,7 +27,10 @@ you **MUST** also read [agent_docs/reviewing.md](./agent_docs/reviewing.md).
 - **README Generation:** **DON'T** edit `README.md` directly. It is generated
   from `src/lib.rs`. Edit the top-level doc comment in `src/lib.rs` instead.
   - **To regenerate:**
-    `(cd .. && cargo -q run --manifest-path tools/Cargo.toml -p generate-readme) > README.md`
+    ```bash
+    (cd .. && cargo -q run --locked --manifest-path tools/Cargo.toml \
+      -p generate-readme) > README.md
+    ```
 
 <!-- TODO-check-disable -->
 - **TODOs:** **DON'T** use `TODO` comments unless you explicitly intend to block

--- a/zerocopy/cargo.sh
+++ b/zerocopy/cargo.sh
@@ -18,7 +18,7 @@ REPO_DIR="$(dirname "$ZEROCOPY_DIR")"
 # config does not apply to the unvendored tools workspace.
 (
   cd "$REPO_DIR"
-  env -u RUSTFLAGS -u CARGO_TARGET_DIR cargo +stable build --manifest-path tools/cargo-zerocopy/Cargo.toml -p cargo-zerocopy -q
+  env -u RUSTFLAGS -u CARGO_TARGET_DIR cargo +stable build --locked --manifest-path tools/cargo-zerocopy/Cargo.toml -p cargo-zerocopy -q
 )
 
 cd "$ZEROCOPY_DIR"

--- a/zerocopy/ci/check_all_toolchains_tested.sh
+++ b/zerocopy/ci/check_all_toolchains_tested.sh
@@ -17,10 +17,13 @@ cd "$(dirname "$0")/.."
 #
 # If the inputs to `diff` are not identical, `diff` exits with a
 # non-zero error code, which causes this script to fail (thanks to
-# `set -e`).
+# `set -e`). Metadata is an input to this read-only policy check: keep its
+# locked/offline invocation coordinated with
+# .github/scripts/test_locked_cargo_invocations.py.
 diff \
   <(yq -r '.jobs.build_test.strategy.matrix.toolchain | .[]' ../.github/workflows/ci.yml | \
     sort -u | grep -v '^\(msrv\|stable\|nightly\)$') \
-  <(cargo metadata -q --format-version 1 | \
+  <(./cargo.sh +stable metadata --quiet --locked --offline --no-deps \
+      --format-version 1 | \
     jq -r ".packages[] | select(.name == \"zerocopy\").metadata.\"build-rs\" | keys | .[]" | \
     sort -u) >&2

--- a/zerocopy/ci/check_msrv_is_minimal.sh
+++ b/zerocopy/ci/check_msrv_is_minimal.sh
@@ -70,4 +70,5 @@ if __name__ == "__main__":
     main()
 EOF
 
-cargo metadata --format-version 1 --no-deps | python3 -c "$PYTHON_SCRIPT"
+cargo metadata --locked --offline --format-version 1 --no-deps \
+  | python3 -c "$PYTHON_SCRIPT"

--- a/zerocopy/ci/check_readme.sh
+++ b/zerocopy/ci/check_readme.sh
@@ -16,8 +16,8 @@ cd "$(dirname "$0")/.."
 # suppress all errors from it.
 (
   cd ..
-  cargo install -q cargo-readme --version 3.2.0
+  cargo install -q --locked --version '=3.2.0' cargo-readme
 )
 
-diff <(cd .. && cargo -q run --manifest-path tools/Cargo.toml -p generate-readme) README.md >&2
+diff <(cd .. && cargo -q run --locked --manifest-path tools/Cargo.toml -p generate-readme) README.md >&2
 exit $?

--- a/zerocopy/ci/check_versions.sh
+++ b/zerocopy/ci/check_versions.sh
@@ -11,9 +11,14 @@
 set -eo pipefail
 cd "$(dirname "$0")/.."
 
+# This check only reads workspace package declarations. Avoid resolving or
+# downloading dependencies, and fail instead of rewriting Cargo.lock if the
+# manifests and lockfile disagree.
+METADATA="$(cargo metadata -q --locked --offline --no-deps --format-version 1)"
+
 # Usage: version <crate-name>
 function version {
-  cargo metadata -q --format-version 1 | jq -r ".packages[] | select(.name == \"$1\").version"
+  jq -r ".packages[] | select(.name == \"$1\").version" <<< "$METADATA"
 }
 
 ver_zerocopy=$(version zerocopy)
@@ -23,8 +28,8 @@ ver_zerocopy_derive=$(version zerocopy-derive)
 function dependency-version {
   KIND="$1"
   TARGET="$2"
-  cargo metadata -q --format-version 1 \
-    | jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select((.name == \"zerocopy-derive\") and .kind == $KIND and .target == $TARGET).req"
+  jq -r ".packages[] | select(.name == \"zerocopy\").dependencies[] | select((.name == \"zerocopy-derive\") and .kind == $KIND and .target == $TARGET).req" \
+    <<< "$METADATA"
 }
 
 # The non-dev dependency version (kind `null` filters out the dev

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -12,7 +12,8 @@
 // After updating the following doc comment, make sure to run the following
 // command to update `README.md` based on its contents:
 //
-//   (cd .. && cargo -q run --manifest-path tools/Cargo.toml -p generate-readme) > README.md
+//   (cd .. && cargo -q run --locked --manifest-path tools/Cargo.toml \
+//     -p generate-readme) > README.md
 
 //! ***<span style="font-size: 140%">Fast, safe, <span
 //! style="color:red;">compile error</span>. Pick two.</span>***

--- a/zerocopy/tests/codegen.rs
+++ b/zerocopy/tests/codegen.rs
@@ -44,6 +44,7 @@ fn run_codegen_test(bench_name: &str, target_cpu: &str, bless: bool) {
             .args([
                 "+nightly",
                 "asm",
+                "--locked",
                 "--quiet",
                 "-p",
                 "zerocopy",

--- a/zerocopy/testutil/src/lib.rs
+++ b/zerocopy/testutil/src/lib.rs
@@ -196,6 +196,8 @@ impl UiTestRunner {
 
         let mut args = vec![
             "build",
+            "--locked",
+            "--offline",
             "-p",
             "zerocopy",
             "--features",
@@ -285,6 +287,7 @@ impl UiTestRunner {
             "stable",
             "cargo",
             "build",
+            "--locked",
             "--manifest-path=tools/ui-runner/Cargo.toml",
             "--message-format=json",
         ]);

--- a/zerocopy/win-cargo.bat
+++ b/zerocopy/win-cargo.bat
@@ -13,7 +13,7 @@
 @set TEMP_RUSTFLAGS=%RUSTFLAGS%
 @set RUSTFLAGS=
 @pushd "%SCRIPT_DIR%.."
-@cargo +stable build --manifest-path tools\Cargo.toml -p cargo-zerocopy -q
+@cargo +stable build --locked --manifest-path tools\Cargo.toml -p cargo-zerocopy -q
 @set CARGO_ZEROCOPY_BUILD_STATUS=%ERRORLEVEL%
 @popd
 @set RUSTFLAGS=%TEMP_RUSTFLAGS%


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Treat each first-party `Cargo.lock` as an input to validation. Make
`cargo-zerocopy` add `--locked` by default, add the inner flag to Cargo
plugins that parse their own arguments, and use locked, offline
metadata where dependency resolution is unnecessary.

Pin `cargo-readme` exactly and reject the wrong executable before
generation. Build the Anneal dependency-cache image from its real
workspace manifests so the repository lockfile can be enforced.

Guard all five first-party lockfiles around pre-push checks. Reap every
parallel child even after failures, then report any lockfile changed by
a nominally read-only check. Discover the inventory dynamically so new
workspaces are protected automatically.

Bootstrap and developer-tool workspaces intentionally remain online: a
fresh checkout may need to fetch exact packages recorded in their
lockfiles. Nested Anneal builds of external user projects also remain
online. These operations use `--locked` but not `--offline`; release
scripts that deliberately regenerate lockfiles remain mutable.

Add focused tests for wrapper argument placement, generator failures,
the Anneal Docker contract, lockfile coverage, and complete child
reaping.




---

- 　  #3561
- 　  #3560
- 👉 #3559
- 　  #3558
- 　  #3557
- 　  #3556
- 　  #3551
- 　  #3555


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/G962fda37ab17edd0f53261c09bcf15eb/v2..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/G962fda37ab17edd0f53261c09bcf15eb/v2..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v3)|[vs v1](/google/zerocopy/compare/gherrit/G962fda37ab17edd0f53261c09bcf15eb/v1..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v3)|[vs Base](/google/zerocopy/compare/Gad49134f1df2f7aecc9a671ecfa38616..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/G962fda37ab17edd0f53261c09bcf15eb/v1..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v2)|[vs Base](/google/zerocopy/compare/Gad49134f1df2f7aecc9a671ecfa38616..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v2)|
|v1|||[vs Base](/google/zerocopy/compare/Gad49134f1df2f7aecc9a671ecfa38616..gherrit/G962fda37ab17edd0f53261c09bcf15eb/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G962fda37ab17edd0f53261c09bcf15eb && git checkout -b pr-G962fda37ab17edd0f53261c09bcf15eb FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G962fda37ab17edd0f53261c09bcf15eb && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G962fda37ab17edd0f53261c09bcf15eb && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G962fda37ab17edd0f53261c09bcf15eb
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"G962fda37ab17edd0f53261c09bcf15eb","parent":"Gad49134f1df2f7aecc9a671ecfa38616","child":"G386fde8c9c2d7c96a9f67f5f5a0f5a64"} -->