### PR TITLE
[ci] Make UI tests follow Cargo feature selection

### DIFF
--- a/tools/cargo-zerocopy/src/main.rs
+++ b/tools/cargo-zerocopy/src/main.rs
@@ -28,6 +28,12 @@ use std::{
 
 use toml::{map::Map, Value};
 
+// Cargo test executables inherit these variables from the delegated process.
+// `testutil::UiTestRunner` reuses the exact outer feature selection when it
+// recursively builds artifacts for UI fixtures.
+const UI_TEST_FEATURE_ARG_COUNT_ENV: &str = "ZEROCOPY_UI_TEST_FEATURE_ARG_COUNT";
+const UI_TEST_FEATURE_ARG_ENV_PREFIX: &str = "ZEROCOPY_UI_TEST_FEATURE_ARG_";
+
 #[derive(Debug)]
 enum Error {
     NoArguments,
@@ -264,6 +270,47 @@ fn install_targets_or_exit(version: &str, targets: &[String]) -> Result<(), Erro
     )
 }
 
+// Capture Cargo feature-selection arguments before the test-binary separator.
+// Preserve their spelling and order: repeated feature options are additive,
+// and replaying the original arguments delegates their semantics back to
+// Cargo.
+fn capture_feature_selection_args(args: &[String]) -> Vec<String> {
+    let mut captured = Vec::new();
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            break;
+        }
+
+        if arg == "--features" || arg == "-F" {
+            captured.push(arg.clone());
+            if let Some(value) = args.get(index + 1) {
+                captured.push(value.clone());
+                index += 1;
+            }
+        } else if arg == "--all-features"
+            || arg == "--no-default-features"
+            || arg.starts_with("--features=")
+            || (arg.starts_with("-F") && arg.len() > 2)
+        {
+            captured.push(arg.clone());
+        }
+
+        index += 1;
+    }
+
+    captured
+}
+
+fn set_ui_test_feature_args(command: &mut Command, args: &[String]) {
+    command.env(UI_TEST_FEATURE_ARG_COUNT_ENV, args.len().to_string());
+    for (index, arg) in args.iter().enumerate() {
+        command.env(format!("{}{}", UI_TEST_FEATURE_ARG_ENV_PREFIX, index), arg);
+    }
+}
+
 fn get_rustflags(name: &str) -> String {
     // See #1792 for context on zerocopy_derive_union_into_bytes.
     let mut flags =
@@ -331,6 +378,7 @@ fn delegate_cargo() -> Result<(), Error> {
                 }
 
                 let args_vec = args.collect::<Vec<_>>();
+                let feature_selection_args = capture_feature_selection_args(&args_vec);
                 let mut i = 0;
                 while i < args_vec.len() {
                     let arg = &args_vec[i];
@@ -379,6 +427,7 @@ fn delegate_cargo() -> Result<(), Error> {
                 // RUSTDOCFLAGS.
                 let mut cmd = rustup(["run", version, "cargo"], Some(("RUSTFLAGS", &rustflags)));
                 cmd.env("RUSTDOCFLAGS", &rustdocflags);
+                set_ui_test_feature_args(&mut cmd, &feature_selection_args);
 
                 if env::var("CARGO_TARGET_DIR").is_ok() {
                     eprintln!("[cargo-zerocopy] WARNING: `CARGO_TARGET_DIR` is set - this may cause `cargo-zerocopy` to behave unexpectedly");
@@ -439,6 +488,75 @@ fn delegate_cargo() -> Result<(), Error> {
                 Err(Error::UnrecognizedArgument(arg.to_string()))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, process::Command};
+
+    use super::{capture_feature_selection_args, set_ui_test_feature_args};
+
+    fn strings(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    #[test]
+    fn captures_feature_selection_before_separator() {
+        let args = strings(&[
+            "test",
+            "--all-features",
+            "--features",
+            "alloc,derive",
+            "-Fsimd",
+            "-F",
+            "std",
+            "--no-default-features",
+            "--features=float-nightly",
+            "--",
+            "--features",
+            "ignored-test-argument",
+        ]);
+
+        assert_eq!(
+            capture_feature_selection_args(&args),
+            strings(&[
+                "--all-features",
+                "--features",
+                "alloc,derive",
+                "-Fsimd",
+                "-F",
+                "std",
+                "--no-default-features",
+                "--features=float-nightly",
+            ])
+        );
+    }
+
+    #[test]
+    fn exports_indexed_ui_test_feature_args() {
+        fn configured_env<'a>(command: &'a Command, key: &str) -> Option<&'a OsStr> {
+            command
+                .get_envs()
+                .find(|(configured, _)| *configured == OsStr::new(key))
+                .and_then(|(_, value)| value)
+        }
+        fn assert_env(command: &Command, key: &str, value: &str) {
+            assert_eq!(configured_env(command, key), Some(OsStr::new(value)));
+        }
+
+        let mut command = Command::new("cargo");
+        set_ui_test_feature_args(&mut command, &strings(&["--features", "", "-Fμ"]));
+        assert_eq!(command.get_envs().count(), 4);
+        assert_env(&command, "ZEROCOPY_UI_TEST_FEATURE_ARG_0", "--features");
+        assert_env(&command, "ZEROCOPY_UI_TEST_FEATURE_ARG_1", "");
+        assert_env(&command, "ZEROCOPY_UI_TEST_FEATURE_ARG_2", "-Fμ");
+        assert_env(&command, "ZEROCOPY_UI_TEST_FEATURE_ARG_COUNT", "3");
+
+        let mut command = Command::new("cargo");
+        set_ui_test_feature_args(&mut command, &[]);
+        assert_eq!(command.get_envs().count(), 1);
+        assert_env(&command, "ZEROCOPY_UI_TEST_FEATURE_ARG_COUNT", "0");
     }
 }
 

--- a/tools/ui-runner/src/main.rs
+++ b/tools/ui-runner/src/main.rs
@@ -112,6 +112,14 @@ fn main() {
 
     config.stderr_filter(r"[^']*\.long-type-\d+\.txt", b"$OUT_DIR/long-type-HASH.txt");
 
+    // rustc summarizes long implementation-candidate lists as "and N
+    // others". The exact count changes when a CI feature profile enables more
+    // implementations, even when the diagnostic under test is unchanged.
+    // Normalize only that summary so one toolchain snapshot can exercise every
+    // feature profile without hiding differences in the candidates rustc does
+    // print.
+    config.stderr_filter(r"and \d+ others", b"and $$OTHER_TYPES others");
+
     // NOTE: We intentionally don't respect `RUSTFLAGS` here, as it is too
     // unreliable. Recall that we are only compiling the crate under test,
     // not zerocopy itself. Zerocopy has already been compiled by the time

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -128,6 +128,20 @@ zerocopy-derive = { version = "=0.8.56", path = "zerocopy-derive", optional = tr
 [target.'cfg(any())'.dependencies]
 zerocopy-derive = { version = "=0.8.56", path = "zerocopy-derive" }
 
+# The UI suite needs the `derive` feature, so let Cargo skip this integration
+# test when that feature is disabled.
+[[test]]
+name = "ui"
+path = "tests/ui.rs"
+required-features = ["derive"]
+
+# This target requires LLVM tooling and is exercised by its dedicated CI job.
+# Exclude it from Cargo's ordinary unfiltered test selection.
+[[test]]
+name = "codegen"
+path = "tests/codegen.rs"
+test = false
+
 [dev-dependencies]
 # FIXME(#381) Remove this dependency once we have our own layout gadgets.
 elain = "0.3.0"

--- a/zerocopy/build.rs
+++ b/zerocopy/build.rs
@@ -91,6 +91,9 @@ fn main() {
         println!(
             "cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)"
         );
+        println!(
+            "cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN, values(\"msrv\", \"stable\", \"nightly\"))"
+        );
         println!("cargo:rustc-check-cfg=cfg(__ZEROCOPY_INTERNAL_USE_ONLY_DEV_MODE)");
         println!("cargo:rustc-check-cfg=cfg(coverage_nightly)");
         println!("cargo:rustc-check-cfg=cfg(zerocopy_inline_always)");

--- a/zerocopy/tests/ui.rs
+++ b/zerocopy/tests/ui.rs
@@ -6,29 +6,35 @@
 // This file may not be copied, modified, or distributed except according to
 // those terms.
 
-// Many of our UI tests require the "derive" feature to function properly. In
-// particular:
+// Many of our UI tests require the "derive" feature to function properly. Cargo
+// enforces that requirement for this entire integration target. In particular:
 // - Some tests directly include `zerocopy-derive/tests/include.rs`, which
 //   derives traits on the `AU16` type.
 // - The file `invalid-impls.rs` directly includes `src/util/macros.rs` in order
 //   to test the `impl_or_verify!` macro which is defined in that file.
 //   Specifically, it tests the verification portion of that macro, which is
-//   enabled when `cfg(any(feature = "derive", test))`. While `--cfg test` is of
-//   course passed to the code in the file you're reading right now, `trybuild`
-//   does not pass `--cfg test` when it invokes Cargo. As a result, this
-//   `trybuild` test only tests the correct behavior when the "derive" feature
-//   is enabled.
-#![cfg(feature = "derive")]
+//   enabled when `cfg(any(feature = "derive", test))`. While `--cfg test` is
+//   passed to this integration test, the fixture compiler does not receive it.
+//   The fixtures therefore require the real "derive" feature.
 
 use testutil::UiTestRunner;
 
 #[test]
-#[cfg_attr(miri, ignore)]
+#[cfg_attr(
+    any(
+        miri,
+        coverage_nightly,
+        not(any(
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv",
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "stable",
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "nightly",
+        )),
+    ),
+    ignore
+)]
 fn test_ui() {
-    // FIXME: Instead of manually passing `--features derive` when building, we
-    // should just pass whatever is passed to us.
     UiTestRunner::new()
-        .rustc_arg("--cfg=feature=\"derive\"") // For tests that check #cfg(feature = "derive")
+        .use_outer_features()
         .rustc_arg("-Wwarnings") // To reflect typical user experience in stderr
         .run();
 }

--- a/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:77:24
    |
@@ -49,7 +49,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 141 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_zeros`
   --> $DIR/diagnostic-not-implemented.rs:78:24
    |
@@ -79,7 +79,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 128 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_immutable`
   --> $DIR/diagnostic-not-implemented.rs:79:23
    |
@@ -109,7 +109,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_into_bytes`
   --> $DIR/diagnostic-not-implemented.rs:80:24
    |
@@ -137,7 +137,7 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AU16
              AtomicBool
              AtomicI16
-           and 65 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_known_layout`
   --> $DIR/diagnostic-not-implemented.rs:81:26
    |
@@ -165,7 +165,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 153 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_try_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:82:28
    |
@@ -195,7 +195,7 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_unaligned`
   --> $DIR/diagnostic-not-implemented.rs:83:23
    |
@@ -245,7 +245,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `Foo::write_obj`
   --> $DIR/diagnostic-not-implemented.rs:73:37
    |

--- a/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
+++ b/zerocopy/tests/ui/diagnostic-not-implemented.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:77:24
    |
@@ -49,7 +49,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 141 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_from_zeros`
   --> $DIR/diagnostic-not-implemented.rs:78:24
    |
@@ -79,7 +79,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 128 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_immutable`
   --> $DIR/diagnostic-not-implemented.rs:79:23
    |
@@ -109,7 +109,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_into_bytes`
   --> $DIR/diagnostic-not-implemented.rs:80:24
    |
@@ -137,7 +137,7 @@ help: the trait `KnownLayout` is not implemented for `NotZerocopy`
              AU16
              AtomicBool
              AtomicI16
-           and 65 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_known_layout`
   --> $DIR/diagnostic-not-implemented.rs:81:26
    |
@@ -165,7 +165,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 153 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_try_from_bytes`
   --> $DIR/diagnostic-not-implemented.rs:82:28
    |
@@ -195,7 +195,7 @@ help: the trait `zerocopy::Unaligned` is not implemented for `NotZerocopy`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required by a bound in `takes_unaligned`
   --> $DIR/diagnostic-not-implemented.rs:83:23
    |
@@ -245,7 +245,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `Foo::write_obj`
   --> $DIR/diagnostic-not-implemented.rs:73:37
    |

--- a/zerocopy/tests/ui/include_value.nightly.stderr
+++ b/zerocopy/tests/ui/include_value.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> $DIR/include_value.rs:17:5
    |

--- a/zerocopy/tests/ui/include_value.stable.stderr
+++ b/zerocopy/tests/ui/include_value.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy<u32>`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `NOT_FROM_BYTES::transmute`
   --> $DIR/include_value.rs:17:5
    |

--- a/zerocopy/tests/ui/transmute.nightly.stderr
+++ b/zerocopy/tests/ui/transmute.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> $DIR/transmute.rs:17:41
    |
@@ -56,7 +56,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> $DIR/transmute.rs:21:32
    |

--- a/zerocopy/tests/ui/transmute.stable.stderr
+++ b/zerocopy/tests/ui/transmute.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `FromBytes` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 79 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::transmute`
   --> $DIR/transmute.rs:17:41
    |
@@ -56,7 +56,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 68 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::transmute`
   --> $DIR/transmute.rs:21:32
    |

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -39,7 +39,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:814:14
     |
@@ -73,7 +73,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:814:26
     |
@@ -149,7 +149,7 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:813:14
     |
@@ -183,7 +183,7 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> src/util/macro_util.rs:813:26
     |

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -39,7 +39,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:814:14
     |
@@ -73,7 +73,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:814:26
     |
@@ -149,7 +149,7 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 85 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:813:14
     |
@@ -183,7 +183,7 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 74 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:813:26
     |

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -102,7 +102,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
   --> $DIR/transmute_ref.rs:40:35
    |
@@ -136,7 +136,7 @@ help: the trait `Immutable` is not implemented for `DstB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
   --> $DIR/transmute_ref.rs:48:34
    |
@@ -242,7 +242,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -271,7 +271,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -303,7 +303,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |
@@ -334,7 +334,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -102,7 +102,7 @@ help: the trait `FromBytes` is not implemented for `DstA`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_FROM_BYTES::AssertDstIsFromBytes`
   --> $DIR/transmute_ref.rs:40:35
    |
@@ -136,7 +136,7 @@ help: the trait `Immutable` is not implemented for `DstB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `DST_NOT_IMMUTABLE::AssertDstIsImmutable`
   --> $DIR/transmute_ref.rs:48:34
    |
@@ -242,7 +242,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -271,7 +271,7 @@ help: the trait `IntoBytes` is not implemented for `SrcA`
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_AS_BYTES::AssertSrcIsIntoBytes`
   --> $DIR/transmute_ref.rs:70:33
    |
@@ -303,7 +303,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |
@@ -334,7 +334,7 @@ help: the trait `Immutable` is not implemented for `SrcB`
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
 note: required by a bound in `SRC_NOT_IMMUTABLE::AssertSrcIsImmutable`
   --> $DIR/transmute_ref.rs:79:34
    |

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -49,7 +49,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
    --> src/util/macro_util.rs:528:10
     |
@@ -83,7 +83,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -114,7 +114,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
    --> src/util/macro_util.rs:527:10
     |

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -49,7 +49,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
    --> $WORKSPACE/src/util/macro_util.rs:528:10
     |
@@ -83,7 +83,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -114,7 +114,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
    --> $WORKSPACE/src/util/macro_util.rs:527:10
     |

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:14
     |
@@ -53,7 +53,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |
@@ -85,7 +85,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -115,7 +115,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -146,7 +146,7 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 80 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:836:14
     |
@@ -180,7 +180,7 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |
@@ -212,7 +212,7 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:836:26
     |
@@ -244,7 +244,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> src/util/macro_util.rs:837:29
     |

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:14
     |
@@ -53,7 +53,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |
@@ -85,7 +85,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -115,7 +115,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 156 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -146,7 +146,7 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 80 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:836:14
     |
@@ -180,7 +180,7 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |
@@ -212,7 +212,7 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:836:26
     |
@@ -244,7 +244,7 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 69 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
    --> $WORKSPACE/src/util/macro_util.rs:837:29
     |

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -36,7 +36,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:757:14
     |
@@ -70,7 +70,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:757:29
     |
@@ -104,7 +104,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -134,7 +134,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> src/error.rs:590:45
     |
@@ -165,7 +165,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:756:14
     |
@@ -197,7 +197,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> src/util/macro_util.rs:756:26
     |

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -36,7 +36,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:757:14
     |
@@ -70,7 +70,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:757:29
     |
@@ -104,7 +104,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -134,7 +134,7 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 153 others
+            and $OTHER_TYPES others
 note: required by a bound in `ValidityError`
    --> $WORKSPACE/src/error.rs:590:45
     |
@@ -165,7 +165,7 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicI64
               AtomicI8
               AtomicIsize
-            and 68 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:756:14
     |
@@ -197,7 +197,7 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D)
               (A, B, C, D, E)
               (A, B, C, D, E, F)
-            and 128 others
+            and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
    --> $WORKSPACE/src/util/macro_util.rs:756:26
     |

--- a/zerocopy/testutil/src/lib.rs
+++ b/zerocopy/testutil/src/lib.rs
@@ -11,6 +11,36 @@
 
 use std::{env, path::PathBuf, process::Command};
 
+const UI_TEST_FEATURE_ARG_COUNT_ENV: &str = "ZEROCOPY_UI_TEST_FEATURE_ARG_COUNT";
+const UI_TEST_FEATURE_ARG_ENV_PREFIX: &str = "ZEROCOPY_UI_TEST_FEATURE_ARG_";
+
+fn decode_feature_selection_args(
+    count: Option<&str>,
+    mut get_arg: impl FnMut(usize) -> Option<String>,
+) -> Result<Vec<String>, String> {
+    let count = match count {
+        Some(count) => count,
+        None => return Ok(Vec::new()),
+    };
+    let count = count
+        .parse::<usize>()
+        .map_err(|_| format!("{} must be a non-negative integer", UI_TEST_FEATURE_ARG_COUNT_ENV))?;
+    (0..count)
+        .map(|index| {
+            get_arg(index)
+                .ok_or_else(|| format!("missing {}{}", UI_TEST_FEATURE_ARG_ENV_PREFIX, index))
+        })
+        .collect()
+}
+
+fn outer_feature_selection_args() -> Vec<String> {
+    let count = env::var(UI_TEST_FEATURE_ARG_COUNT_ENV).ok();
+    decode_feature_selection_args(count.as_deref(), |index| {
+        env::var(format!("{}{}", UI_TEST_FEATURE_ARG_ENV_PREFIX, index)).ok()
+    })
+    .unwrap_or_else(|error| panic!("invalid UI feature-argument protocol: {}", error))
+}
+
 #[derive(Debug)]
 pub enum ToolchainVersion {
     /// The version listed as our MSRV (ie, the `package.rust-version` key in
@@ -70,6 +100,7 @@ pub struct UiTestRunner {
     rustc_args: Vec<String>,
     tests_dir: String,
     tests_subdir: Option<String>,
+    use_outer_features: bool,
 }
 
 impl Default for UiTestRunner {
@@ -88,11 +119,17 @@ impl UiTestRunner {
             rustc_args: Vec::new(),
             tests_dir: "tests".to_string(), // Default prefix
             tests_subdir: None,
+            use_outer_features: false,
         }
     }
 
     pub fn rustc_arg(mut self, arg: impl Into<String>) -> Self {
         self.rustc_args.push(arg.into());
+        self
+    }
+
+    pub fn use_outer_features(mut self) -> Self {
+        self.use_outer_features = true;
         self
     }
 
@@ -123,6 +160,7 @@ impl UiTestRunner {
         let mut rlib_path = None;
         let mut derive_lib_path = None;
         let mut static_assertions_path = None;
+        let mut zerocopy_features = None;
 
         let mut command = Command::new("cargo");
         command.current_dir(workspace_root.clone());
@@ -194,15 +232,13 @@ impl UiTestRunner {
             ]);
         }
 
-        let mut args = vec![
-            "build",
-            "-p",
-            "zerocopy",
-            "--features",
-            "derive",
-            "--tests",
-            "--message-format=json",
-        ];
+        command.args(["build", "--locked", "--offline", "-p", "zerocopy"]);
+        if self.use_outer_features {
+            command.args(outer_feature_selection_args());
+        }
+        // Both UI suites require the derive proc macro. Cargo feature options
+        // are additive, so this retains the outer selection when present.
+        command.args(["--features", "derive", "--tests", "--message-format=json"]);
 
         // `cargo-zerocopy` uses `ZEROCOPY_UI_TEST_TARGET` to pass the value of
         // any `--target` CLI argument. Here, we use this target when building
@@ -210,11 +246,8 @@ impl UiTestRunner {
         let target = env::var("ZEROCOPY_UI_TEST_TARGET").ok();
 
         if let Some(ref t) = target {
-            args.push("--target");
-            args.push(t);
+            command.args(["--target", t]);
         }
-
-        command.args(args);
 
         let output = command.output().expect("Failed to execute cargo build for artifacts");
         if !output.status.success() {
@@ -239,9 +272,19 @@ impl UiTestRunner {
                 if artifact.target.name == "zerocopy"
                     && artifact.target.kind.iter().any(|k| k == "lib")
                 {
+                    let mut features = artifact.features.clone();
+                    features.sort();
+                    features.dedup();
                     for file in artifact.filenames {
                         if file.extension() == Some("rlib") {
+                            if let Some(ref previous) = zerocopy_features {
+                                assert_eq!(
+                                    previous, &features,
+                                    "zerocopy artifacts used different features"
+                                );
+                            }
                             rlib_path = Some(file);
+                            zerocopy_features = Some(features.clone());
                         }
                     }
                 } else if artifact.target.name == "zerocopy-derive"
@@ -269,6 +312,12 @@ impl UiTestRunner {
         let derive_lib_path = derive_lib_path.expect("failed to find zerocopy_derive proc-macro");
         let static_assertions_path =
             static_assertions_path.expect("failed to find static_assertions rlib");
+        let zerocopy_features =
+            zerocopy_features.expect("failed to find zerocopy artifact features");
+        assert!(
+            zerocopy_features.iter().any(|feature| feature == "derive"),
+            "UI artifact build did not enable its required derive feature"
+        );
 
         let mut build_command = Command::new("rustup");
 
@@ -285,6 +334,7 @@ impl UiTestRunner {
             "stable",
             "cargo",
             "build",
+            "--locked",
             "--manifest-path=tools/ui-runner/Cargo.toml",
             "--message-format=json",
         ]);
@@ -316,6 +366,12 @@ impl UiTestRunner {
 
         for arg in &self.rustc_args {
             command.arg(format!("--rustc-arg={}", arg));
+        }
+
+        // Cargo's artifact message is authoritative for the complete feature
+        // closure. Give each fixture exactly the cfgs Cargo gave zerocopy.
+        for feature in &zerocopy_features {
+            command.arg(format!("--rustc-arg=--cfg=feature={:?}", feature));
         }
 
         command.env("ZEROCOPY_RLIB_PATH", rlib_path);
@@ -354,5 +410,31 @@ impl UiTestRunner {
 
         let mut proc = command.spawn().expect("Failed to spawn ui-runner");
         assert!(proc.wait().unwrap().success(), "ui-runner failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_feature_selection_args;
+
+    #[test]
+    fn decodes_indexed_feature_arguments() {
+        let values = ["", ":", "μ", "--features=derive,simd-nightly"];
+        assert_eq!(
+            decode_feature_selection_args(Some("4"), |index| {
+                values.get(index).map(|value| (*value).to_string())
+            })
+            .unwrap(),
+            values.iter().map(|value| (*value).to_string()).collect::<Vec<_>>()
+        );
+        assert!(decode_feature_selection_args(None, |_| panic!("must not read an argument"))
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_feature_argument_protocol() {
+        assert!(decode_feature_selection_args(Some("invalid"), |_| None).is_err());
+        assert!(decode_feature_selection_args(Some("1"), |_| None).is_err());
     }
 }

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -25,6 +25,8 @@ exclude = [".*", "tests/enum_from_bytes.rs", "tests/ui-nightly/enum_from_bytes_u
 # See #1792 for more context.
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)',
+  'cfg(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN, values("msrv", "stable", "nightly"))',
+  'cfg(coverage_nightly)',
   'cfg(zerocopy_derive_union_into_bytes)',
   'cfg(zerocopy_unstable_linux)',
 ] }

--- a/zerocopy/zerocopy-derive/tests/ui.rs
+++ b/zerocopy/zerocopy-derive/tests/ui.rs
@@ -9,7 +9,18 @@
 use testutil::UiTestRunner;
 
 #[test]
-#[cfg_attr(miri, ignore)]
+#[cfg_attr(
+    any(
+        miri,
+        coverage_nightly,
+        not(any(
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv",
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "stable",
+            __ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "nightly",
+        )),
+    ),
+    ignore
+)]
 fn ui() {
     // This tests the behavior when `--cfg zerocopy_derive_union_into_bytes` is
     // present.

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.nightly.stderr
@@ -19,7 +19,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 154 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::TryFromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -60,7 +60,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 142 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -101,7 +101,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -142,7 +142,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/derive_transparent.rs:24:10
    |
@@ -181,7 +181,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocop
              F32<O>
              F64<O>
              I128<O>
-           and 27 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::Unaligned`
   --> $DIR/derive_transparent.rs:24:32
    |

--- a/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/derive_transparent.stable.stderr
@@ -19,7 +19,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 154 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::TryFromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -55,7 +55,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 142 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `FromZeros`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -91,7 +91,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/derive_transparent.rs:24:21
    |
@@ -127,7 +127,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/derive_transparent.rs:24:10
    |
@@ -161,7 +161,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `NotZerocop
              F32<O>
              F64<O>
              I128<O>
-           and 27 others
+           and $OTHER_TYPES others
 note: required for `TransparentStruct<NotZerocopy>` to implement `zerocopy_renamed::Unaligned`
   --> $DIR/derive_transparent.rs:24:32
    |

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -334,7 +334,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -360,7 +360,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -391,7 +391,7 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -422,7 +422,7 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -453,7 +453,7 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 142 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -479,7 +479,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -594,7 +594,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
 note: required for `FooU8` to implement `FromBytes`
    --> $DIR/enum.rs:247:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -310,7 +310,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -332,7 +332,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: Immutable` is not satisfied
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 137 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -359,7 +359,7 @@ help: the trait `TryFromBytes` is not implemented for `NotTryFromBytes`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -386,7 +386,7 @@ help: the trait `TryFromBytes` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 157 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -413,7 +413,7 @@ help: the trait `FromZeros` is not implemented for `NotFromZeros`
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 142 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -435,7 +435,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -542,7 +542,7 @@ error[E0277]: the trait bound `bool: FromBytes` is not satisfied
               (A, B, C, D, E, F)
               (A, B, C, D, E, F, G)
               (A, B, C, D, E, F, G, H)
-            and 79 others
+            and $OTHER_TYPES others
 note: required for `FooU8` to implement `FromBytes`
    --> $DIR/enum.rs:247:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -58,7 +58,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -89,7 +89,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -120,7 +120,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -151,7 +151,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -182,7 +182,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -213,7 +213,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -242,7 +242,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -271,7 +271,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -300,7 +300,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 29 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -329,7 +329,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/late_compile_pass.rs:54:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -54,7 +54,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -81,7 +81,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -108,7 +108,7 @@ help: the trait `zerocopy_renamed::TryFromBytes` is not implemented for `NotZero
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 156 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -135,7 +135,7 @@ help: the trait `FromZeros` is not implemented for `NotZerocopy`
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 143 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -162,7 +162,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -189,7 +189,7 @@ help: the trait `zerocopy_renamed::IntoBytes` is not implemented for `NotZerocop
              AtomicI64
              AtomicI8
              AtomicIsize
-           and 69 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,7 +214,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -239,7 +239,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 29 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -264,7 +264,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 29 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `Unaligned` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -289,7 +289,7 @@ help: the trait `zerocopy_renamed::FromBytes` is not implemented for `NotZerocop
              (A, B, C, D, E, F)
              (A, B, C, D, E, F, G)
              (A, B, C, D, E, F, G, H)
-           and 80 others
+           and $OTHER_TYPES others
 note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
   --> $DIR/late_compile_pass.rs:54:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/msrv_specific.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/msrv_specific.nightly.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required for `IntoBytes1<AU16>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/msrv_specific.rs:25:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/msrv_specific.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/msrv_specific.stable.stderr
@@ -27,7 +27,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
              F32<O>
              F64<O>
              I128<O>
-           and 26 others
+           and $OTHER_TYPES others
 note: required for `IntoBytes1<AU16>` to implement `zerocopy_renamed::IntoBytes`
   --> $DIR/msrv_specific.rs:25:10
    |

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -200,7 +200,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -229,7 +229,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -253,7 +253,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -279,7 +279,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
@@ -359,7 +359,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -538,7 +538,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtN
               AU16
               AtomicBool
               AtomicI16
-            and 73 others
+            and $OTHER_TYPES others
 note: required by a bound in `SplitAt`
    --> src/split_at.rs:63:0
     = note: this error originates in the derive macro `SplitAt` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -589,7 +589,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
    --> $DIR/struct.rs:232:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -187,7 +187,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -212,7 +212,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `NotKnown
              AU16
              AtomicBool
              AtomicI16
-           and 73 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: this error originates in the derive macro `KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -232,7 +232,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
    = note: consider using `--verbose` to print the full type name to the console
@@ -254,7 +254,7 @@ error[E0277]: the trait bound `UnsafeCell<u8>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 130 others
+           and $OTHER_TYPES others
    = note: required for `[UnsafeCell<u8>; 0]` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'
@@ -330,7 +330,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -505,7 +505,7 @@ help: the trait `zerocopy_renamed::KnownLayout` is not implemented for `SplitAtN
               AU16
               AtomicBool
               AtomicI16
-            and 73 others
+            and $OTHER_TYPES others
 note: required by a bound in `SplitAt`
    --> $WORKSPACE/src/split_at.rs:63:27
     |
@@ -557,7 +557,7 @@ help: the trait `zerocopy_renamed::Unaligned` is not implemented for `AU16`
               F32<O>
               F64<O>
               I128<O>
-            and 26 others
+            and $OTHER_TYPES others
 note: required for `IntoBytes11<AU16>` to implement `zerocopy_renamed::IntoBytes`
    --> $DIR/struct.rs:232:10
     |

--- a/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 129 others
+           and $OTHER_TYPES others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'

--- a/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `UnsafeCell<()>: zerocopy_renamed::Immutable` is n
              (A, B, C, D)
              (A, B, C, D, E)
              (A, B, C, D, E, F)
-           and 129 others
+           and $OTHER_TYPES others
    = note: required for `ManuallyDrop<UnsafeCell<()>>` to implement `zerocopy_renamed::Immutable`
    = help: see issue #48214
    = note: the full name for the type has been written to '/long-type-HASH.txt'


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

*Authored by Codex, posting via joshlf's account*

Declare UI and codegen eligibility in Cargo.toml so ordinary cargo test can select the right integration targets without workflow filters.

Capture the exact outer feature arguments, replay them for nested UI artifact builds, and derive fixture cfgs from Cargo's resolved feature set. Limit expensive UI execution to canonical toolchains and normalize rustc's unstable candidate-count summary.


Tests: canonical expected-output regeneration; cargo-zerocopy unit tests; testutil tests on stable and MSRV; root UI on stable/nightly/all-features; unsupported-toolchain UI ignore.


---

- 　  #3564
- 　  #3563
- 👉 #3562


**Latest Update:** v18 — [Compare vs v17](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v17 | v16 | v15 | v14 | v13 | v12 | v11 | v10 | v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v18|[v17](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v16](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v15](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v14](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v13](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v18)|
|v17||[v16](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v15](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v14](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v13](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v17)|
|v16|||[v15](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v14](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v13](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v16)|
|v15||||[v14](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v13](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v15)|
|v14|||||[v13](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v14)|
|v13||||||[v12](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v13)|
|v12|||||||[v11](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v12)|
|v11||||||||[v10](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v11)|
|v10|||||||||[v9](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v10)|
|v9||||||||||[v8](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v9)|
|v8|||||||||||[v7](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v8)|
|v7||||||||||||[v6](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v7)|
|v6|||||||||||||[v5](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v6)|
|v5||||||||||||||[v4](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5)|[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v5)|
|v4|||||||||||||||[v3](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4)|[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v4)|
|v3||||||||||||||||[v2](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3)|[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v3)|
|v2|||||||||||||||||[v1](/google/zerocopy/compare/gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2)|[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v2)|
|v1||||||||||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gbev6nw7raszgypqdblfidkxigyoc5bsa/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gbev6nw7raszgypqdblfidkxigyoc5bsa && git checkout -b pr-Gbev6nw7raszgypqdblfidkxigyoc5bsa FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gbev6nw7raszgypqdblfidkxigyoc5bsa && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gbev6nw7raszgypqdblfidkxigyoc5bsa && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gbev6nw7raszgypqdblfidkxigyoc5bsa
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gbev6nw7raszgypqdblfidkxigyoc5bsa","parent":null,"child":"Gardn5uywc5klgqu5tsahc6obbadppv2b"} -->