### PR TITLE
[derive] Allow `missing_debug_implementations` on `KnownLayout` helpers

### DIFF
--- a/zerocopy/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy/zerocopy-derive/src/derive/known_layout.rs
@@ -144,6 +144,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
         // Define the collection of type-level field handles.
         let field_defs = field_indices.iter().zip(fields).map(|(idx, (vis, _, _))| {
             quote! {
+                #[allow(missing_debug_implementations)]
                 #vis struct #idx;
             }
         });
@@ -200,6 +201,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
             // `#ty`, not `__ZerocopyKnownLayoutMaybeUninit` (see #2116).
             #repr
             #[doc(hidden)]
+            #[allow(missing_debug_implementations)]
             #vis struct __ZerocopyKnownLayoutMaybeUninit<#params> (
                 #(#core::mem::MaybeUninit<
                     <#ident #ty_generics as

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
@@ -48,7 +48,9 @@ const _: () = {
             <U>::pointer_to_metadata(ptr as *mut _)
         }
     }
+    #[allow(missing_debug_implementations)]
     struct __Zerocopy_Field_0;
+    #[allow(missing_debug_implementations)]
     struct __Zerocopy_Field_1;
     unsafe impl<T, U> ::zerocopy::util::macro_util::Field<__Zerocopy_Field_0>
     for Foo<T, U> {
@@ -61,6 +63,7 @@ const _: () = {
     #[repr(C)]
     #[repr(align(2))]
     #[doc(hidden)]
+    #[allow(missing_debug_implementations)]
     struct __ZerocopyKnownLayoutMaybeUninit<T, U>(
         ::zerocopy::util::macro_util::core_reexport::mem::MaybeUninit<
             <Foo<T, U> as ::zerocopy::util::macro_util::Field<__Zerocopy_Field_0>>::Type,

--- a/zerocopy/zerocopy-derive/tests/ui/issue_known_layout_missing_debug.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_known_layout_missing_debug.msrv.stderr
@@ -1,0 +1,38 @@
+error: private type `__Zerocopy_Field_0` in public interface (error E0446)
+  --> $DIR/issue_known_layout_missing_debug.rs:17:38
+   |
+17 |           #[derive(::core::fmt::Debug, ::zerocopy_renamed::KnownLayout)]
+   |  ______________________________________^
+18 | |
+19 | |         #[zerocopy(crate = "zerocopy_renamed")]
+20 | |         #[repr(C)]
+21 | |         pub struct Foo([::core::primitive::u8]);
+   | |___________^
+...
+25 |   foo! {}
+   |   ------- in this macro invocation
+   |
+note: the lint level is defined here
+  --> $DIR/issue_known_layout_missing_debug.rs:13:24
+   |
+13 | #![cfg_attr(msrv, deny(private_in_public))]
+   |                        ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: private type `__Zerocopy_Field_0` in public interface (error E0446)
+  --> $DIR/issue_known_layout_missing_debug.rs:17:38
+   |
+17 |         #[derive(::core::fmt::Debug, ::zerocopy_renamed::KnownLayout)]
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+25 | foo! {}
+   | ------- in this macro invocation
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+   = note: this error originates in the derive macro `::zerocopy_renamed::KnownLayout` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_known_layout_missing_debug.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_known_layout_missing_debug.rs
@@ -1,0 +1,28 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+//@[nightly,stable] check-pass
+
+#![no_implicit_prelude]
+#![deny(missing_debug_implementations)]
+#![cfg_attr(msrv, deny(private_in_public))]
+
+macro_rules! foo {
+    () => {
+        #[derive(::core::fmt::Debug, ::zerocopy_renamed::KnownLayout)]
+        //~[msrv]^ ERROR: private type
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(C)]
+        pub struct Foo([::core::primitive::u8]);
+    };
+}
+
+foo! {}
+//~[msrv]^ ERROR: private type
+
+fn main() {}


### PR DESCRIPTION
Add `#[allow(missing_debug_implementations)]` to `__ZerocopyKnownLayoutMaybeUninit` and the generated field handle structs to prevent compile errors when the derive target is inside a macro and the crate has `#[deny(missing_debug_implementations)]`.

Fixes #3567