### PR TITLE
[derive] Use parent visibility for KnownLayout field helper structs

### DIFF
--- a/zerocopy/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy/zerocopy-derive/src/derive/known_layout.rs
@@ -142,7 +142,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
             fields.iter().map(|(_vis, name, _ty)| field_index(name)).collect();
 
         // Define the collection of type-level field handles.
-        let field_defs = field_indices.iter().zip(fields).map(|(idx, (vis, _, _))| {
+        let field_defs = field_indices.iter().zip(fields).map(|(idx, _)| {
             quote! {
                 #vis struct #idx;
             }

--- a/zerocopy/zerocopy-derive/tests/issue_known_layout_priv_in_pub.rs
+++ b/zerocopy/zerocopy-derive/tests/issue_known_layout_priv_in_pub.rs
@@ -1,0 +1,29 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![deny(warnings)]
+
+include!("include.rs");
+
+macro_rules! foo {
+    () => {
+        #[derive(imp::KnownLayout)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(C)]
+        pub struct Foo([imp::u8]);
+    };
+}
+
+foo! {}
+
+#[test]
+fn test_known_layout_priv_in_pub() {
+    // Compilation is enough to verify the fix
+}


### PR DESCRIPTION
The `KnownLayout` derive macro generates type-level field handle helper structs (`__Zerocopy_Field_0`, etc.) to track field types. Previously, these helper structs were declared with the visibility of the individual field.

When deriving `KnownLayout` on a public struct containing one or more private fields, the helper structs were generated as private. This triggered the `E0446 (private type in public interface)` compiler error because a public type (`Foo`) was implementing a public trait (`Field<__Zerocopy_Field_0>`) using the private helper struct.

This commit resolves the issue by declaring the helper structs using the visibility of the parent struct rather than the fields. This ensures that the helper structs are always exactly as visible as the type implementing the trait.

Add a regression test to verify compiling a public struct with a private field inside a macro under strict deny-by-default warnings.

This is a preliminary fix before #3568.