### PR TITLE
[derive] Allow `clippy::empty_enums` on generated field tokens

### DIFF
--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -813,6 +813,12 @@ pub(crate) fn const_block(items: impl IntoIterator<Item = Option<TokenStream>>) 
             non_snake_case,
             non_ascii_idents,
             clippy::missing_inline_in_public_items,
+            // The derives emit one uninhabited `enum ẕ<field> {}` per field
+            // as a type-level field token. Since `never_type` stabilized
+            // (rust-lang/rust#155499), `clippy::empty_enums` fires on every
+            // empty enum, and because derive output carries call-site spans
+            // the lint lands on the user's `#[derive(...)]` line. See #3414.
+            clippy::empty_enums,
         )]
         #[deny(ambiguous_associated_items)]
         // While there are not currently any warnings that this suppresses


### PR DESCRIPTION
Fixes #3414.

### What breaks

Since rust-lang/rust#155499 stabilized `never_type` (nightly-2026-08-25 onward), `clippy::empty_enums` — which is guarded on `cx.tcx.features().never_type()` — fires on every uninhabited enum, `#![feature(never_type)]` or not. The derives emit one `enum ẕ<field> {}` per struct/union field as a type-level field token (`derive_has_field_struct_union` in `derive/try_from_bytes.rs`), and derive output carries call-site spans, so the diagnostic lands on the user's `#[derive(FromBytes)]` line:

```
error: enum with no variants
  --> src/ntfs/boot_sector.rs:15:30
   |
15 | #[derive(Debug, Clone, Copy, FromBytes, Immutable, KnownLayout)]
   |                              ^^^^^^^^^
   = note: `-D clippy::empty-enums` implied by `-D clippy::nursery`
   = note: this error originates in the derive macro `FromBytes`
```

A downstream crate that denies `clippy::nursery` (or `pedantic` on older clippy, where the lint lived) cannot pass clippy on current nightlies without an `#[allow]` around every derive site. Clippy's external-macro suppression does not help because the span is the call site.

### Fix

Add `clippy::empty_enums` to the `#[allow(...)]` list of the generated `const _: () = { … }` block in `util.rs`, next to the existing `clippy::missing_inline_in_public_items`. The exemption is scoped to macro output only; user code keeps the lint.

### Verification

Downstream workspace with `clippy::nursery = deny` (14 `FromBytes` derive sites): `cargo +nightly-2026-08-29 clippy --workspace --all-targets --all-features -- -D warnings` goes from 14 errors to clean with this change applied via `[patch.crates-io]`.
