### PR TITLE
Make pointer Read witnesses unsafe

### DIFF
--- a/zerocopy/src/pointer/invariant.rs
+++ b/zerocopy/src/pointer/invariant.rs
@@ -253,16 +253,20 @@ unsafe impl<ST: ?Sized, DT: ?Sized> CastableFrom<ST, Initialized, Initialized> f
 ///
 /// # Safety
 ///
-/// `T: Read<A, R>` if either of the following conditions holds:
+/// Implementors must ensure that either of the following conditions holds:
 /// - `A` is [`Exclusive`]
-/// - `T` implements [`Immutable`](crate::Immutable)
+/// - `Self` implements [`Immutable`](crate::Immutable)
 ///
 /// As a consequence, if `T: Read<A, R>`, then any `Ptr<T, (A, ...)>` is
 /// permitted to perform unsynchronized reads from its referent.
-pub trait Read<A: Aliasing, R> {}
+pub unsafe trait Read<A: Aliasing, R> {}
 
-impl<A: Aliasing, T: ?Sized + crate::Immutable> Read<A, BecauseImmutable> for T {}
-impl<T: ?Sized> Read<Exclusive, BecauseExclusive> for T {}
+// SAFETY: `T: Immutable`, satisfying the second condition of `Read`'s safety
+// contract.
+unsafe impl<A: Aliasing, T: ?Sized + crate::Immutable> Read<A, BecauseImmutable> for T {}
+// SAFETY: The aliasing argument is `Exclusive`, satisfying the first condition
+// of `Read`'s safety contract.
+unsafe impl<T: ?Sized> Read<Exclusive, BecauseExclusive> for T {}
 
 /// Unsynchronized reads are permitted because only one live [`Ptr`](crate::Ptr)
 /// or reference may exist to the referent bytes at a time.


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The public Read witness is trusted by pointer conversions to prove that
unsynchronized reads are permitted, but downstream code could previously
implement it without taking responsibility for that invariant.

Make Read an unsafe trait, document its implementor obligation, and justify
the two built-in implementations.

Closes #3613

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3622


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v3..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v3..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v2..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v1..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v2..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v1..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v1..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gugofjuaaownqfvbulg6lh72eul7phdgb/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gugofjuaaownqfvbulg6lh72eul7phdgb && git checkout -b pr-Gugofjuaaownqfvbulg6lh72eul7phdgb FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gugofjuaaownqfvbulg6lh72eul7phdgb && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gugofjuaaownqfvbulg6lh72eul7phdgb && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gugofjuaaownqfvbulg6lh72eul7phdgb
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gugofjuaaownqfvbulg6lh72eul7phdgb","parent":null,"child":null} -->