### PR TITLE
Seal derive padding witnesses

### DIFF
--- a/zerocopy/src/util/macro_util.rs
+++ b/zerocopy/src/util/macro_util.rs
@@ -50,6 +50,18 @@ pub unsafe trait Field<Index> {
     type Type: ?Sized;
 }
 
+// Seal the complete predicates, including their const parameters. Thus,
+// `PaddingFree<T, N>` implies `N == 0`, and `DynamicPaddingFree<T, B>` implies
+// `B == false`, and `unsafe` code can rely for its soundness on these
+// implications.
+mod padding_seal {
+    pub trait PaddingFree<T: ?Sized, const PADDING_BYTES: usize> {}
+    impl<T: ?Sized> PaddingFree<T, 0> for () {}
+
+    pub trait DynamicPaddingFree<T: ?Sized, const HAS_PADDING: bool> {}
+    impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+}
+
 #[cfg_attr(
     not(no_zerocopy_diagnostic_on_unimplemented_1_78_0),
     diagnostic::on_unimplemented(
@@ -60,7 +72,10 @@ pub unsafe trait Field<Index> {
         note = "consider using `#[repr(packed)]` to remove padding"
     )
 )]
-pub trait PaddingFree<T: ?Sized, const PADDING_BYTES: usize> {}
+pub trait PaddingFree<T: ?Sized, const PADDING_BYTES: usize>:
+    padding_seal::PaddingFree<T, PADDING_BYTES>
+{
+}
 impl<T: ?Sized> PaddingFree<T, 0> for () {}
 
 // FIXME(#1112): In the slice DST case, we should delegate to *both*
@@ -78,7 +93,10 @@ impl<T: ?Sized> PaddingFree<T, 0> for () {}
         note = "consider using `#[repr(packed)]` to remove padding"
     )
 )]
-pub trait DynamicPaddingFree<T: ?Sized, const HAS_PADDING: bool> {}
+pub trait DynamicPaddingFree<T: ?Sized, const HAS_PADDING: bool>:
+    padding_seal::DynamicPaddingFree<T, HAS_PADDING>
+{
+}
 impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
 
 #[cfg(__ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS)]

--- a/zerocopy/tests/ui/transmute_mut.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_mut.msrv.stderr
@@ -82,9 +82,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
 87  | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&mut [u8], &mut [u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:848:14
+   --> src/util/macro_util.rs:866:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+866 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:848:26
+   --> src/util/macro_util.rs:866:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+866 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:847:14
+   --> src/util/macro_util.rs:865:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+864 |     where
+865 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:847:26
+   --> src/util/macro_util.rs:865:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+864 |     where
+865 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `zerocopy::util::macr
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:728:1
+   ::: src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:848:14
+   --> $WORKSPACE/src/util/macro_util.rs:866:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+866 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:848:26
+   --> $WORKSPACE/src/util/macro_util.rs:866:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+866 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:847:14
+   --> $WORKSPACE/src/util/macro_util.rs:865:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+864 |     where
+865 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:847:26
+   --> $WORKSPACE/src/util/macro_util.rs:865:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+863 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+864 |     where
+865 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_ref.msrv.stderr
@@ -188,9 +188,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
 84  | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&[u8], &[u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `zerocopy::util::macr
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:728:1
+   ::: src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:746:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+746 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/try_transmute.msrv.stderr
+++ b/zerocopy/tests/ui/try_transmute.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
     |
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:528:10
+   --> $WORKSPACE/src/util/macro_util.rs:546:10
     |
-528 |     Dst: TryFromBytes,
+546 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -43,9 +43,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
     |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
     |
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:527:10
+   --> $WORKSPACE/src/util/macro_util.rs:545:10
     |
-527 |     Src: IntoBytes,
+545 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -51,12 +51,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
-   --> src/util/macro_util.rs:528:10
+   --> src/util/macro_util.rs:546:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+543 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
 ...
-528 |     Dst: TryFromBytes,
+546 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -116,12 +116,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
-   --> src/util/macro_util.rs:527:10
+   --> src/util/macro_util.rs:545:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+543 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
-526 | where
-527 |     Src: IntoBytes,
+544 | where
+545 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -51,12 +51,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:528:10
+   --> $WORKSPACE/src/util/macro_util.rs:546:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+543 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
 ...
-528 |     Dst: TryFromBytes,
+546 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -116,12 +116,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:527:10
+   --> $WORKSPACE/src/util/macro_util.rs:545:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+543 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
-526 | where
-527 |     Src: IntoBytes,
+544 | where
+545 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:14
+   --> src/util/macro_util.rs:889:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:870:14
+   --> src/util/macro_util.rs:888:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+887 |     where
+888 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:870:26
+   --> src/util/macro_util.rs:888:26
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+887 |     where
+888 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:14
+   --> $WORKSPACE/src/util/macro_util.rs:889:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:870:14
+   --> $WORKSPACE/src/util/macro_util.rs:888:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+887 |     where
+888 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:870:26
+   --> $WORKSPACE/src/util/macro_util.rs:888:26
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+887 |     where
+888 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:889:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+886 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+889 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:791:14
+   --> src/util/macro_util.rs:809:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+809 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:791:29
+   --> src/util/macro_util.rs:809:29
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+809 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:790:14
+   --> src/util/macro_util.rs:808:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+807 |     where
+808 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:790:26
+   --> src/util/macro_util.rs:808:26
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+807 |     where
+808 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:791:14
+   --> $WORKSPACE/src/util/macro_util.rs:809:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+809 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:791:29
+   --> $WORKSPACE/src/util/macro_util.rs:809:29
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+809 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:790:14
+   --> $WORKSPACE/src/util/macro_util.rs:808:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+807 |     where
+808 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:790:26
+   --> $WORKSPACE/src/util/macro_util.rs:808:26
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+806 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+807 |     where
+808 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -500,7 +500,7 @@ error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -519,7 +519,7 @@ error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -538,7 +538,7 @@ error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -570,7 +570,7 @@ error[E0277]: `IntoBytes7` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes7, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes7, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -452,9 +452,9 @@ error[E0277]: `IntoBytes1` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes1, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes1, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -470,9 +470,9 @@ error[E0277]: `IntoBytes2` has 3 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 3>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -488,9 +488,9 @@ error[E0277]: `IntoBytes3` has 2 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes3, 2>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -519,9 +519,9 @@ error[E0277]: `IntoBytes7` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes7, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes7, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.msrv.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `(): macro_util::padding_seal::PaddingFree<Padded, 3_usize>` is not satisfied
+  --> $DIR/padding_free_witness.rs:22:6
+   |
+22 | impl zerocopy_renamed::util::macro_util::PaddingFree<Padded, 3> for () {}
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `macro_util::padding_seal::PaddingFree<Padded, 3_usize>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as macro_util::padding_seal::PaddingFree<T, 0_usize>>
+note: required by a bound in `PaddingFree`
+  --> $WORKSPACE/src/util/macro_util.rs:76:5
+   |
+76 |     padding_seal::PaddingFree<T, PADDING_BYTES>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PaddingFree`
+
+error[E0277]: the trait bound `(): macro_util::padding_seal::PaddingFree<Padded, 3_usize>` is not satisfied
+  --> $DIR/padding_free_witness.rs:13:21
+   |
+13 | #[derive(Immutable, IntoBytes)]
+   |                     ^^^^^^^^^ the trait `macro_util::padding_seal::PaddingFree<Padded, 3_usize>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as macro_util::padding_seal::PaddingFree<T, 0_usize>>
+   = help: see issue #48214
+   = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.nightly.stderr
@@ -1,0 +1,40 @@
+error[E0277]: the trait bound `(): PaddingFree<Padded, 3>` is not satisfied
+  --> $DIR/padding_free_witness.rs:13:21
+   |
+13 | #[derive(Immutable, IntoBytes)]
+   |                     ^^^^^^^^^ unsatisfied trait bound
+   |
+   = note: `()` implements similarly named trait `zerocopy::util::macro_util::PaddingFree`, but not `zerocopy::util::macro_util::padding_seal::PaddingFree<Padded, 3>`
+help: the trait `PaddingFree<Padded, 3>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> src/util/macro_util.rs:59:4
+   = help: see issue #48214
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+   = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+11 + #![feature(trivial_bounds)]
+   |
+
+error[E0277]: the trait bound `(): PaddingFree<Padded, 3>` is not satisfied
+  --> $DIR/padding_free_witness.rs:22:69
+   |
+22 | impl zerocopy_renamed::util::macro_util::PaddingFree<Padded, 3> for () {}
+   |                                                                     ^^ unsatisfied trait bound
+   |
+   = note: `()` implements similarly named trait `zerocopy::util::macro_util::PaddingFree`, but not `zerocopy::util::macro_util::padding_seal::PaddingFree<Padded, 3>`
+help: the trait `PaddingFree<Padded, 3>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> src/util/macro_util.rs:59:4
+note: required by a bound in `zerocopy::util::macro_util::PaddingFree`
+  --> src/util/macro_util.rs:75:0
+   = note: `PaddingFree` is a "sealed trait", because to implement it you also need to implement `zerocopy::util::macro_util::padding_seal::PaddingFree`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following type implements the trait:
+             ()
+   = note: the full name for the type has been written to '/long-type-HASH.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(dead_code)]
+#![forbid(unsafe_code)]
+
+use zerocopy_renamed::{Immutable, IntoBytes};
+
+#[derive(Immutable, IntoBytes)]
+//~^ ERROR: the trait bound
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct Padded {
+    tag: u8,
+    value: u32,
+}
+
+impl zerocopy_renamed::util::macro_util::PaddingFree<Padded, 3> for () {}
+//~^ ERROR: the trait bound
+
+fn main() {}

--- a/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/padding_free_witness.stable.stderr
@@ -1,0 +1,43 @@
+error[E0277]: the trait bound `(): macro_util::padding_seal::PaddingFree<Padded, 3>` is not satisfied
+  --> $DIR/padding_free_witness.rs:13:21
+   |
+13 | #[derive(Immutable, IntoBytes)]
+   |                     ^^^^^^^^^ the trait `macro_util::padding_seal::PaddingFree<Padded, 3>` is not implemented for `()`
+   |
+   = note: `()` implements similarly named trait `PaddingFree`, but not `macro_util::padding_seal::PaddingFree<Padded, 3>`
+help: the trait `PaddingFree<Padded, 3>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> $WORKSPACE/src/util/macro_util.rs:59:5
+   |
+59 |     impl<T: ?Sized> PaddingFree<T, 0> for () {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: see issue #48214
+   = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `(): macro_util::padding_seal::PaddingFree<Padded, 3>` is not satisfied
+  --> $DIR/padding_free_witness.rs:22:69
+   |
+22 | impl zerocopy_renamed::util::macro_util::PaddingFree<Padded, 3> for () {}
+   |                                                                     ^^ the trait `macro_util::padding_seal::PaddingFree<Padded, 3>` is not implemented for `()`
+   |
+   = note: `()` implements similarly named trait `PaddingFree`, but not `macro_util::padding_seal::PaddingFree<Padded, 3>`
+help: the trait `PaddingFree<Padded, 3>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> $WORKSPACE/src/util/macro_util.rs:59:5
+   |
+59 |     impl<T: ?Sized> PaddingFree<T, 0> for () {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `PaddingFree`
+  --> $WORKSPACE/src/util/macro_util.rs:76:5
+   |
+75 | pub trait PaddingFree<T: ?Sized, const PADDING_BYTES: usize>:
+   |           ----------- required by a bound in this trait
+76 |     padding_seal::PaddingFree<T, PADDING_BYTES>
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PaddingFree`
+   = note: `PaddingFree` is a "sealed trait", because to implement it you also need to implement `zerocopy::util::macro_util::padding_seal::PaddingFree`, which is not accessible; this is usually done to force you to use one of the provided types that already implement it
+   = help: the following type implements the trait:
+             ()
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.nightly.stderr
@@ -378,7 +378,7 @@ error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -397,7 +397,7 @@ error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
-   --> src/util/macro_util.rs:64:0
+   --> src/util/macro_util.rs:79:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -419,7 +419,7 @@ note: required because it appears within the type `IntoBytes4`
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `zerocopy_renamed::util::macro_util::__size_of::Sized`
 note: required by a bound in `zerocopy_renamed::util::macro_util::__size_of::size_of`
-   --> src/util/macro_util.rs:308:4
+   --> src/util/macro_util.rs:326:4
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `[u8]` is unsized
@@ -433,7 +433,7 @@ error[E0277]: `[u8]` is unsized
     = note: `IntoBytes` does not require the fields of `#[repr(packed)]` types to be `Sized`
     = note: required for `[u8]` to implement `zerocopy_renamed::util::macro_util::__size_of::Sized`
 note: required by a bound in `zerocopy_renamed::util::macro_util::__size_of::size_of`
-   --> src/util/macro_util.rs:308:4
+   --> src/util/macro_util.rs:326:4
 
 error[E0277]: `IntoBytes5` has one or more padding bytes
    --> $DIR/struct.rs:172:10
@@ -446,7 +446,7 @@ error[E0277]: `IntoBytes5` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
-   --> src/util/macro_util.rs:82:0
+   --> src/util/macro_util.rs:100:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -465,7 +465,7 @@ error[E0277]: `IntoBytes6` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
-   --> src/util/macro_util.rs:82:0
+   --> src/util/macro_util.rs:100:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -484,7 +484,7 @@ error[E0277]: `IntoBytes7` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
-   --> src/util/macro_util.rs:82:0
+   --> src/util/macro_util.rs:100:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
@@ -503,7 +503,7 @@ error[E0277]: `IntoBytes13` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes13, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes13, false>` is implemented for it
-   --> src/util/macro_util.rs:82:0
+   --> src/util/macro_util.rs:100:0
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/struct.stable.stderr
@@ -345,9 +345,9 @@ error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -363,9 +363,9 @@ error[E0277]: `IntoBytes3` has 1 total byte(s) of padding
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes3, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes3, 0>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:64:1
+   --> $WORKSPACE/src/util/macro_util.rs:79:1
     |
- 64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+ 79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -384,9 +384,9 @@ note: required because it appears within the type `IntoBytes4`
     |        ^^^^^^^^^^
     = note: required for `IntoBytes4` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`
-   --> $WORKSPACE/src/util/macro_util.rs:308:29
+   --> $WORKSPACE/src/util/macro_util.rs:326:29
     |
-308 |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
+326 |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -401,9 +401,9 @@ error[E0277]: `[u8]` is unsized
     = note: `IntoBytes` does not require the fields of `#[repr(packed)]` types to be `Sized`
     = note: required for `[u8]` to implement `macro_util::__size_of::Sized`
 note: required by a bound in `macro_util::__size_of::size_of`
-   --> $WORKSPACE/src/util/macro_util.rs:308:29
+   --> $WORKSPACE/src/util/macro_util.rs:326:29
     |
-308 |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
+326 |     pub const fn size_of<T: Sized + ?core::marker::Sized>() -> usize {
     |                             ^^^^^ required by this bound in `size_of`
 
 error[E0277]: `IntoBytes5` has one or more padding bytes
@@ -417,9 +417,9 @@ error[E0277]: `IntoBytes5` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes5, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes5, false>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:82:1
+   --> $WORKSPACE/src/util/macro_util.rs:100:1
     |
- 82 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+100 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -435,9 +435,9 @@ error[E0277]: `IntoBytes6` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes6, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes6, false>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:82:1
+   --> $WORKSPACE/src/util/macro_util.rs:100:1
     |
- 82 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+100 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -453,9 +453,9 @@ error[E0277]: `IntoBytes7` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes7, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes7, false>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:82:1
+   --> $WORKSPACE/src/util/macro_util.rs:100:1
     |
- 82 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+100 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -471,9 +471,9 @@ error[E0277]: `IntoBytes13` has one or more padding bytes
     = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `DynamicPaddingFree<IntoBytes13, true>` is not implemented for `()`
       but trait `DynamicPaddingFree<IntoBytes13, false>` is implemented for it
-   --> $WORKSPACE/src/util/macro_util.rs:82:1
+   --> $WORKSPACE/src/util/macro_util.rs:100:1
     |
- 82 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
+100 | impl<T: ?Sized> DynamicPaddingFree<T, false> for () {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = help: see issue #48214
     = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.nightly.stderr
@@ -100,7 +100,7 @@ error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
    = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-  --> src/util/macro_util.rs:64:0
+  --> src/util/macro_util.rs:79:0
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable

--- a/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/union.stable.stderr
@@ -96,9 +96,9 @@ error[E0277]: `IntoBytes2` has 1 total byte(s) of padding
    = note: consider using `#[repr(packed)]` to remove padding
 help: the trait `PaddingFree<IntoBytes2, 1>` is not implemented for `()`
       but trait `PaddingFree<IntoBytes2, 0>` is implemented for it
-  --> $WORKSPACE/src/util/macro_util.rs:64:1
+  --> $WORKSPACE/src/util/macro_util.rs:79:1
    |
-64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+79 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: see issue #48214
    = note: this error originates in the derive macro `IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

The IntoBytes derive relies on const-generic padding witnesses, but
downstream safe code could implement the public witness traits for nonzero
padding values and make the derive emit an unsound impl.

Require private predicates over the complete type-and-const tuple, with
implementations only for zero static padding and false dynamic padding. Add
compile-fail tests showing that direct false witness implementations no longer
satisfy the authentic Zerocopy traits.

Closes #3614

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3623


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v3..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v3..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v2..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v1..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v2..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v1..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v1..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Gowln6kqlymxhdw2dwz5uf46fnryyxouu/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gowln6kqlymxhdw2dwz5uf46fnryyxouu && git checkout -b pr-Gowln6kqlymxhdw2dwz5uf46fnryyxouu FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gowln6kqlymxhdw2dwz5uf46fnryyxouu && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gowln6kqlymxhdw2dwz5uf46fnryyxouu && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gowln6kqlymxhdw2dwz5uf46fnryyxouu
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gowln6kqlymxhdw2dwz5uf46fnryyxouu","parent":null,"child":null} -->