### PR TITLE
Normalize raw derive attributes

### DIFF
--- a/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
@@ -257,3 +257,39 @@ please let us know you use this feature: https://github.com/google/zerocopy/disc
         .build();
     Ok(quote!(#cfg_compile_error #impl_block))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn derive(input: syn::DeriveInput) -> TokenStream {
+        let ctx = Ctx::try_from_derive_input(input).unwrap();
+        derive_into_bytes(&ctx, Trait::IntoBytes).unwrap()
+    }
+
+    #[test]
+    fn raw_repr_matches_ordinary_repr() {
+        let ordinary = derive(parse_quote! {
+            #[repr(C)]
+            #[repr(align(8))]
+            struct Response {
+                status: u8,
+            }
+        });
+        let raw = derive(parse_quote! {
+            #[repr(C)]
+            #[r#repr(r#align(8))]
+            struct Response {
+                status: u8,
+            }
+        });
+
+        let ordinary = ordinary.to_string();
+        let raw = raw.to_string();
+
+        // In particular, both expansions contain the padding check which
+        // prevents the resulting type from implementing `IntoBytes`.
+        assert!(ordinary.contains("PaddingFree"));
+        assert_eq!(ordinary, raw);
+    }
+}

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -763,3 +763,41 @@ unsafe fn gen_trivial_is_bit_valid_unchecked(ctx: &Ctx) -> proc_macro2::TokenStr
         }
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn derive_error(input: DeriveInput) -> String {
+        let ctx = Ctx::try_from_derive_input(input).unwrap();
+        match derive_try_from_bytes(&ctx, Trait::TryFromBytes) {
+            Ok(_) => panic!("expected derive to reject conflicting representations"),
+            Err(error) => error.to_string(),
+        }
+    }
+
+    #[test]
+    fn raw_repr_conflict_matches_ordinary_repr() {
+        let ordinary = derive_error(parse_quote! {
+            #[repr(C, align(8))]
+            #[repr(u8)]
+            enum Packet {
+                Value(core::num::NonZeroU8),
+                End,
+            }
+        });
+        let raw = derive_error(parse_quote! {
+            #[repr(C, align(8))]
+            #[r#repr(r#u8)]
+            enum Packet {
+                Value(core::num::NonZeroU8),
+                End,
+            }
+        });
+
+        // Rejecting both spellings prevents generating a validator whose
+        // synthetic enum layout disagrees with the compiler's actual layout.
+        assert_eq!(ordinary, "this conflicts with another representation hint");
+        assert_eq!(ordinary, raw);
+    }
+}

--- a/zerocopy/zerocopy-derive/src/repr.rs
+++ b/zerocopy/zerocopy-derive/src/repr.rs
@@ -20,6 +20,8 @@ use syn::{
     MetaList,
 };
 
+use crate::util::{path_is_ident, to_ident_str};
+
 /// The computed representation of a type.
 ///
 /// This is the result of processing all `#[repr(...)]` attributes on a type, if
@@ -524,11 +526,11 @@ impl RawRepr {
         let mut reprs = Vec::new();
         for attr in attrs {
             // Ignore documentation attributes.
-            if attr.path().is_ident("doc") {
+            if path_is_ident(attr.path(), "doc") {
                 continue;
             }
             if let Meta::List(ref meta_list) = attr.meta {
-                if meta_list.path.is_ident("repr") {
+                if path_is_ident(&meta_list.path, "repr") {
                     let parsed: Punctuated<Meta, Comma> =
                         match meta_list.parse_args_with(Punctuated::parse_terminated) {
                             Ok(parsed) => parsed,
@@ -578,7 +580,8 @@ impl RawRepr {
         };
 
         use RawRepr::*;
-        Ok(match (ident.to_string().as_str(), list) {
+        let ident = to_ident_str(ident);
+        Ok(match (ident.as_str(), list) {
             ("u8", None) => U8,
             ("u16", None) => U16,
             ("u32", None) => U32,
@@ -743,7 +746,40 @@ mod tests {
         use PrimitiveRepr::*;
         let nz = |n: u32| NonZeroU32::new(n).unwrap();
 
+        // Rust treats raw identifiers and their ordinary spellings as the
+        // same representation hints. Exercise every spelling recognized by
+        // `RawRepr::from_meta` so that adding a hint cannot accidentally
+        // reintroduce raw-identifier-sensitive parsing.
+        macro_rules! test_raw_repr {
+            ($ordinary:meta, $raw:meta => $expected:expr) => {{
+                let ordinary: Meta = parse_quote!($ordinary);
+                let raw: Meta = parse_quote!($raw);
+                assert_eq!(RawRepr::from_meta(&ordinary).ok().unwrap(), $expected);
+                assert_eq!(RawRepr::from_meta(&raw).ok().unwrap(), $expected);
+            }};
+        }
+
+        test_raw_repr!(transparent, r#transparent => RawRepr::Transparent);
+        test_raw_repr!(C, r#C => RawRepr::C);
+        test_raw_repr!(Rust, r#Rust => RawRepr::Rust);
+        test_raw_repr!(u8, r#u8 => RawRepr::U8);
+        test_raw_repr!(u16, r#u16 => RawRepr::U16);
+        test_raw_repr!(u32, r#u32 => RawRepr::U32);
+        test_raw_repr!(u64, r#u64 => RawRepr::U64);
+        test_raw_repr!(u128, r#u128 => RawRepr::U128);
+        test_raw_repr!(usize, r#usize => RawRepr::Usize);
+        test_raw_repr!(i8, r#i8 => RawRepr::I8);
+        test_raw_repr!(i16, r#i16 => RawRepr::I16);
+        test_raw_repr!(i32, r#i32 => RawRepr::I32);
+        test_raw_repr!(i64, r#i64 => RawRepr::I64);
+        test_raw_repr!(i128, r#i128 => RawRepr::I128);
+        test_raw_repr!(isize, r#isize => RawRepr::Isize);
+        test_raw_repr!(align(2), r#align(2) => RawRepr::Align(nz(2)));
+        test_raw_repr!(packed, r#packed => RawRepr::Packed);
+        test_raw_repr!(packed(2), r#packed(2) => RawRepr::PackedN(nz(2)));
+
         test!(#[repr(transparent)] => StructUnionRepr::Transparent(s()));
+        test!(#[r#repr(r#transparent)] => StructUnionRepr::Transparent(s()));
         test!(#[repr()] => StructUnionRepr::Compound(Rust.into(), None));
         test!(#[repr(packed)] => StructUnionRepr::Compound(Rust.into(), Some(Packed(nz(1)).into())));
         test!(#[repr(packed(2))] => StructUnionRepr::Compound(Rust.into(), Some(Packed(nz(2)).into())));
@@ -754,6 +790,8 @@ mod tests {
         test!(#[repr(C, packed(2))] => StructUnionRepr::Compound(C.into(), Some(Packed(nz(2)).into())));
         test!(#[repr(C, align(1))] => StructUnionRepr::Compound(C.into(), Some(Align(nz(1)).into())));
         test!(#[repr(C, align(2))] => StructUnionRepr::Compound(C.into(), Some(Align(nz(2)).into())));
+        test!(#[r#repr(r#C, r#align(2))] => StructUnionRepr::Compound(C.into(), Some(Align(nz(2)).into())));
+        test!(#[r#repr(r#C, r#packed(2))] => StructUnionRepr::Compound(C.into(), Some(Packed(nz(2)).into())));
 
         test!(#[repr(transparent)] => EnumRepr::Transparent(s()));
         test!(#[repr()] => EnumRepr::Compound(Rust.into(), None));

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -92,9 +92,9 @@ impl Ctx {
 
         for attr in &ast.attrs {
             if let Meta::List(ref meta_list) = attr.meta {
-                if meta_list.path.is_ident("zerocopy") {
+                if path_is_ident(&meta_list.path, "zerocopy") {
                     attr.parse_nested_meta(|meta| {
-                        if meta.path.is_ident("crate") {
+                        if path_is_ident(&meta.path, "crate") {
                             let expr = meta.value().and_then(ParseBuffer::parse);
                             if let Ok(Expr::Lit(ExprLit { lit: Lit::Str(lit), .. })) = expr {
                                 if let Ok(mut path_lit) = lit.parse_with(Path::parse_mod_style) {
@@ -125,7 +125,7 @@ impl Ctx {
                             ));
                         }
 
-                        if meta.path.is_ident("on_error") {
+                        if path_is_ident(&meta.path, "on_error") {
                             on_error_span = Some(meta.path.span());
                             let value = meta.value()?;
                             let s: LitStr = value.parse()?;
@@ -318,6 +318,18 @@ pub(crate) fn to_ident_str(t: &impl ToString) -> String {
         stripped.to_string()
     } else {
         s
+    }
+}
+
+/// Does `path` consist solely of the identifier `expected`?
+///
+/// Unlike [`Path::is_ident`], this treats a raw identifier and its ordinary
+/// spelling as the same identifier. Rust applies that same normalization when
+/// interpreting attribute names and arguments.
+pub(crate) fn path_is_ident(path: &Path, expected: &str) -> bool {
+    match path.get_ident() {
+        Some(ident) => to_ident_str(ident) == expected,
+        None => false,
     }
 }
 
@@ -979,5 +991,44 @@ pub(crate) mod testutil {
                 path_str
             );
         }
+    }
+
+    #[test]
+    fn test_path_is_ident() {
+        use syn::parse_str;
+
+        for (expected, ordinary, raw) in [
+            ("doc", "doc", "r#doc"),
+            ("repr", "repr", "r#repr"),
+            ("zerocopy", "zerocopy", "r#zerocopy"),
+            ("on_error", "on_error", "r#on_error"),
+        ] {
+            let ordinary = parse_str::<syn::Path>(ordinary).unwrap();
+            let raw = parse_str::<syn::Path>(raw).unwrap();
+            assert!(super::path_is_ident(&ordinary, expected));
+            assert!(super::path_is_ident(&raw, expected));
+        }
+
+        // `r#crate` is forbidden by Rust's raw identifier grammar.
+        let crate_path = parse_str::<syn::Path>("crate").unwrap();
+        assert!(super::path_is_ident(&crate_path, "crate"));
+
+        for path in ["::zerocopy", "module::zerocopy"] {
+            let path = parse_str::<syn::Path>(path).unwrap();
+            assert!(!super::path_is_ident(&path, "zerocopy"));
+        }
+    }
+
+    #[test]
+    fn test_raw_zerocopy_attributes() {
+        let ast: syn::DeriveInput = syn::parse_quote! {
+            #[r#zerocopy(crate = "renamed", r#on_error = "skip")]
+            struct Foo;
+        };
+
+        let ctx = super::Ctx::try_from_derive_input(ast).unwrap();
+        let path = &ctx.zerocopy_crate;
+        assert_eq!(quote::quote!(#path).to_string(), ":: renamed");
+        assert!(ctx.skip_on_error);
     }
 }

--- a/zerocopy/zerocopy-derive/tests/raw_identifiers.rs
+++ b/zerocopy/zerocopy-derive/tests/raw_identifiers.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+// See comment in `include.rs` for why we disable the prelude.
+#![no_implicit_prelude]
+#![allow(warnings)]
+
+include!("include.rs");
+
+// A generic `IntoBytes` type needs a recognized non-align representation.
+// These definitions ensure that ordinary and raw `repr` spellings select the
+// same transparent-layout proof, and separately exercise the raw spelling of
+// the derive helper attribute's name.
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(transparent)]
+struct OrdinaryTransparent<T>(T);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[r#repr(r#transparent)]
+struct RawTransparent<T>(T);
+
+#[derive(imp::IntoBytes)]
+#[r#zerocopy(crate = "zerocopy_renamed")]
+#[repr(transparent)]
+struct RawHelperTransparent<T>(T);
+
+util_assert_impl_all!(OrdinaryTransparent<u8>: imp::IntoBytes);
+util_assert_impl_all!(RawTransparent<u8>: imp::IntoBytes);
+util_assert_impl_all!(RawHelperTransparent<u8>: imp::IntoBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct Wire([u8; 2]);
+
+#[derive(imp::Immutable, imp::KnownLayout, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum OrdinaryPacket {
+    Value(imp::core::num::NonZeroU8),
+    End,
+}
+
+#[derive(imp::Immutable, imp::KnownLayout, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[r#repr(r#u8)]
+enum RawPacket {
+    Value(imp::core::num::NonZeroU8),
+    End,
+}
+
+#[test]
+fn test_enum_try_from_bytes() {
+    // The `Value` payload is at byte offset one and is zero, so the candidate
+    // is invalid. Both spellings must generate the same field validator.
+    let bytes = [0, 0];
+    util::test_is_bit_valid::<OrdinaryPacket, _>(Wire(bytes), false);
+    util::test_is_bit_valid::<RawPacket, _>(Wire(bytes), false);
+}
+
+#[derive(imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+#[repr(align(8))]
+struct OrdinaryAligned(u8);
+
+#[derive(imp::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+#[r#repr(r#align(8))]
+struct RawAligned(u8);
+
+#[test]
+fn test_known_layout() {
+    let ordinary = <OrdinaryAligned as imp::KnownLayout>::size_for_metadata(());
+    let raw = <RawAligned as imp::KnownLayout>::size_for_metadata(());
+    let ordinary_size = imp::core::mem::size_of::<OrdinaryAligned>();
+    let raw_size = imp::core::mem::size_of::<RawAligned>();
+    imp::assert_eq!(ordinary_size, 8);
+    imp::assert_eq!(raw_size, 8);
+    imp::assert_eq!(ordinary, imp::Some(ordinary_size));
+    imp::assert_eq!(raw, imp::Some(raw_size));
+    imp::assert_eq!(ordinary, raw);
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Rust accepts raw identifier spellings for representation attributes, but the
derive parser compared their token spelling literally. As a result, it could
ignore compiler-applied layout constraints and emit unsafe trait impls for the
wrong layout.

Normalize raw identifiers when matching attributes and representation hints,
including Zerocopy helper attributes. Add parser-level and end-to-end tests for
IntoBytes, TryFromBytes, and KnownLayout behavior.

Closes #3620

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 　  #3635
- 　  #3631
- 👉 #3624


**Latest Update:** v7 — [Compare vs v6](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|
|v7|[vs v6](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs v5](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs v4](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs v3](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs v2](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v7)|
|v6||[vs v5](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|[vs v4](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|[vs v3](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|[vs v2](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v6)|
|v5|||[vs v4](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v5)|
|v4||||[vs v3](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v4)|
|v3|||||[vs v2](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v3)|
|v2||||||[vs v1](/google/zerocopy/compare/gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v2)|
|v1|||||||[vs Base](/google/zerocopy/compare/main..gherrit/Gzghu5ypldjnatumvxfh6zygvwuqht3av/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gzghu5ypldjnatumvxfh6zygvwuqht3av && git checkout -b pr-Gzghu5ypldjnatumvxfh6zygvwuqht3av FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gzghu5ypldjnatumvxfh6zygvwuqht3av && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gzghu5ypldjnatumvxfh6zygvwuqht3av && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gzghu5ypldjnatumvxfh6zygvwuqht3av
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gzghu5ypldjnatumvxfh6zygvwuqht3av","parent":null,"child":"Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck"} -->