### PR TITLE
Qualify KnownLayout metadata extraction

### DIFF
--- a/zerocopy/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy/zerocopy-derive/src/derive/known_layout.rs
@@ -81,7 +81,7 @@ fn derive_known_layout_for_repr_c_struct<'a>(
 
             #[inline(always)]
             fn pointer_to_metadata(ptr: *mut Self) -> <Self as #zerocopy_crate::KnownLayout>::PointerMetadata {
-                <#trailing_field_ty>::pointer_to_metadata(ptr as *mut _)
+                <#trailing_field_ty as #zerocopy_crate::KnownLayout>::pointer_to_metadata(ptr as *mut _)
             }
         }
     };

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/known_layout_repr_c_struct.expected.rs
@@ -45,7 +45,7 @@ const _: () = {
         fn pointer_to_metadata(
             ptr: *mut Self,
         ) -> <Self as ::zerocopy::KnownLayout>::PointerMetadata {
-            <U>::pointer_to_metadata(ptr as *mut _)
+            <U as ::zerocopy::KnownLayout>::pointer_to_metadata(ptr as *mut _)
         }
     }
     #[allow(missing_debug_implementations)]
@@ -130,7 +130,7 @@ const _: () = {
                 U,
             > as ::zerocopy::util::macro_util::Field<
                 __Zerocopy_Field_1,
-            >>::Type as ::zerocopy::KnownLayout>::MaybeUninit>::pointer_to_metadata(
+            >>::Type as ::zerocopy::KnownLayout>::MaybeUninit as ::zerocopy::KnownLayout>::pointer_to_metadata(
                 ptr as *mut _,
             )
         }

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -58,10 +58,11 @@ macro_rules! test {
             let ts: proc_macro2::TokenStream = quote::quote!( $($i)* );
             let ast = syn::parse2::<syn::DeriveInput>(ts).unwrap();
             let ctx = crate::Ctx::try_from_derive_input(ast).unwrap();
-            let res = $name(&ctx, crate::util::Trait::$name);
+            let res = $name(&ctx, crate::util::Trait::$name).into_ts();
+            crate::util::testutil::check_hygiene(res.clone());
             let expected_toks = quote::quote!( $($o)* );
             let expected = pretty_print(expected_toks);
-            let actual = pretty_print(res.into_ts().into());
+            let actual = pretty_print(res);
             assert_eq_or_diff(&expected, &actual);
         }
     };
@@ -75,8 +76,9 @@ macro_rules! test {
             let ts: proc_macro2::TokenStream = quote::quote!( $($i)* );
             let ast = syn::parse2::<syn::DeriveInput>(ts).unwrap();
             let ctx = crate::Ctx::try_from_derive_input(ast).unwrap();
-            let res = $name(&ctx, crate::util::Trait::$name);
-            let actual = pretty_print(res.into_ts().into());
+            let res = $name(&ctx, crate::util::Trait::$name).into_ts();
+            crate::util::testutil::check_hygiene(res.clone());
+            let actual = pretty_print(res);
 
             if std::env::var("ZEROCOPY_BLESS").is_ok() {
                 let path = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -890,17 +890,39 @@ pub(crate) mod testutil {
     pub(crate) fn check_hygiene(ts: TokenStream) {
         struct AmbiguousItemVisitor;
 
+        fn panic_ambiguous_path(path: &impl quote::ToTokens) -> ! {
+            panic!(
+                "Found ambiguous path `{}` in generated output. \
+                 All associated item access must be fully qualified (e.g., `<Self as Trait>::Item`) \
+                 to prevent hygiene issues.",
+                quote::quote!(#path)
+            );
+        }
+
         impl<'ast> Visit<'ast> for AmbiguousItemVisitor {
+            fn visit_expr_path(&mut self, i: &'ast syn::ExprPath) {
+                if let Some(qself) = &i.qself {
+                    if qself.position == 0 {
+                        panic_ambiguous_path(i);
+                    }
+                }
+                visit::visit_expr_path(self, i);
+            }
+
             fn visit_path(&mut self, i: &'ast syn::Path) {
                 if i.segments.len() > 1 && i.segments.first().unwrap().ident == "Self" {
-                    panic!(
-                    "Found ambiguous path `{}` in generated output. \
-                     All associated item access must be fully qualified (e.g., `<Self as Trait>::Item`) \
-                     to prevent hygiene issues.",
-                    quote::quote!(#i)
-                );
+                    panic_ambiguous_path(i);
                 }
                 visit::visit_path(self, i);
+            }
+
+            fn visit_type_path(&mut self, i: &'ast syn::TypePath) {
+                if let Some(qself) = &i.qself {
+                    if qself.position == 0 {
+                        panic_ambiguous_path(i);
+                    }
+                }
+                visit::visit_type_path(self, i);
             }
         }
 
@@ -923,6 +945,26 @@ pub(crate) mod testutil {
         check_hygiene(quote::quote! {
             fn foo() {
                 let _ = Self::Ambiguous;
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Found ambiguous path `< T > :: Ambiguous`")]
+    fn test_check_hygiene_type_relative_expr_failure() {
+        check_hygiene(quote::quote! {
+            fn foo<T>() {
+                let _ = <T>::Ambiguous;
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Found ambiguous path `< T > :: Ambiguous`")]
+    fn test_check_hygiene_type_relative_type_failure() {
+        check_hygiene(quote::quote! {
+            fn foo<T>() {
+                let _: <T>::Ambiguous;
             }
         });
     }

--- a/zerocopy/zerocopy-derive/tests/hygiene.rs
+++ b/zerocopy/zerocopy-derive/tests/hygiene.rs
@@ -112,3 +112,23 @@ mod issue_2177 {
 
     define!(Foo, u8);
 }
+
+// Regression test for #3621. An inherent method on a concrete trailing field
+// must not be selected in place of `KnownLayout::pointer_to_metadata`.
+mod issue_3621 {
+    use super::_zerocopy;
+
+    #[derive(_zerocopy::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Inner([u8]);
+
+    impl Inner {
+        fn pointer_to_metadata() {}
+    }
+
+    #[derive(_zerocopy::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Outer(Inner);
+}

--- a/zerocopy/zerocopy-derive/tests/struct_known_layout.rs
+++ b/zerocopy/zerocopy-derive/tests/struct_known_layout.rs
@@ -129,3 +129,32 @@ struct RawIdentifier {
 }
 
 util_assert_impl_all!(RawIdentifier: imp::KnownLayout);
+
+// Regression test for #3621. An inherent method on a concrete trailing field
+// must not be selected in place of `KnownLayout::pointer_to_metadata`.
+mod issue_3621 {
+    use super::imp;
+
+    #[derive(imp::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Inner([u8]);
+
+    impl Inner {
+        fn pointer_to_metadata(_ptr: *mut Self) -> usize {
+            8
+        }
+    }
+
+    #[derive(imp::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Outer(Inner);
+
+    #[test]
+    fn pointer_to_metadata_uses_known_layout_impl() {
+        let mut bytes = [0u8];
+        let ptr = &mut bytes[..] as *mut [u8] as *mut Inner as *mut Outer;
+        imp::assert_eq!(<Outer as imp::KnownLayout>::pointer_to_metadata(ptr), 1);
+    }
+}


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Generated KnownLayout implementations called pointer_to_metadata through a
concrete trailing type. A same-named inherent method could therefore capture
the call and supply metadata that violates the unsafe trait's layout contract.

Emit a fully trait-qualified call for both the derived type and its generated
MaybeUninit form. Extend the output hygiene check to reject unqualified
associated-item syntax, and add compile-time and semantic regressions for an
inherent-method collision.

Closes #3621

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 　  #3629
- 👉 #3625


**Latest Update:** v2 — [Compare vs v1](/google/zerocopy/compare/gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v1..gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v2)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v1 |Base|
|:---|:---|:---|
|v2|[vs v1](/google/zerocopy/compare/gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v1..gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v2)|
|v1||[vs Base](/google/zerocopy/compare/main..gherrit/Gkpenpjjuex55evmm52puxsa34xtjgc7t/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gkpenpjjuex55evmm52puxsa34xtjgc7t && git checkout -b pr-Gkpenpjjuex55evmm52puxsa34xtjgc7t FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gkpenpjjuex55evmm52puxsa34xtjgc7t && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gkpenpjjuex55evmm52puxsa34xtjgc7t && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gkpenpjjuex55evmm52puxsa34xtjgc7t
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gkpenpjjuex55evmm52puxsa34xtjgc7t","parent":null,"child":"Gro7m5vgpfdcy3pxtpl52hnbgworclnzw"} -->