### PR TITLE
Authenticate Exocrate archives before extraction

### DIFF
--- a/exocrate/src/lib.rs
+++ b/exocrate/src/lib.rs
@@ -134,6 +134,33 @@
 //! installations. All installed versions will be stored somewhere inside the directories designated
 //! by one of the [`Location`] variants, but there are no other guarantees about how these
 //! directory trees are managed at this time.
+//!
+//! Installation directories and their ancestors must not be namespace-mutable by untrusted code
+//! while an installation is in progress.
+//!
+//! The absolute installation path produced by any [`Location`] must not contain `@` or its Unicode
+//! compatibility forms U+FE6B and U+FF20. No location may resolve to `@@stage.tmp` or anything
+//! beneath it, including abandoned work and periods when no installation is active. Symlink,
+//! junction, mount, and other aliases which conceal such a path are unsupported.
+//!
+//! Calls which may install into directories with the same parent must be serialized within a
+//! process. Separate processes coordinate through lock files, but not every supported lock backend
+//! excludes another thread in the process which already holds the lock.
+//!
+//! Installers which share a parent directory must all use a compatible Exocrate staging protocol.
+//! In particular, an older Exocrate build must not manage `@@stage.tmp`, anything beneath it, or
+//! `@@stage.lck` as a target in a parent used by this version. At the parent's first use, each of
+//! those reserved entries must either be absent or already be a valid entry created by a compatible
+//! Exocrate process. Thereafter, only compatible Exocrate processes may create or mutate those
+//! entries; no other actor may forge, replace, alias, or mount over them. No entry inside the work
+//! tree may be a hard link to, bind mount of, or other non-symbolic alias for a path outside that
+//! tree. Ordinary symbolic links in an archive are permitted because cleanup does not follow them.
+//! The reservation is permanent, including while no installation is in progress.
+//!
+//! A process exit may leave at most one parent-wide work directory, which a later compatible
+//! installer reclaims. An interrupted or failed initial claim write, or power loss before that
+//! claim becomes durable, can leave an indeterminate claim. That case fails closed and may require
+//! manual cleanup rather than risking deletion of an unclaimed path.
 
 mod sync;
 
@@ -164,6 +191,14 @@ pub enum Location {
     /// otherwise in the current working directory.
     LocalDev,
     /// A caller-provided base directory.
+    ///
+    /// The resulting absolute installation path may not contain `@` or its
+    /// Unicode compatibility forms U+FE6B and U+FF20, which are reserved for
+    /// staging infrastructure. It must never resolve to `@@stage.tmp` or
+    /// anything beneath it. Once a parent has been used by this Exocrate
+    /// version, that exclusion is permanent. The path and its ancestors must
+    /// not be namespace-mutable by untrusted code while an installation is in
+    /// progress.
     Custom(PathBuf),
 }
 
@@ -193,6 +228,12 @@ impl Config {
     }
 
     /// Resolves the dependency directory, installing it if needed.
+    ///
+    /// # Concurrency
+    ///
+    /// Calls which may install into directories with the same parent must be
+    /// serialized within a process. Separate processes are synchronized by
+    /// lock files.
     pub fn resolve_installation_dir_or_install(
         &self,
         location: Location,
@@ -263,7 +304,8 @@ impl Config {
         };
 
         parts.extend(self.rel_dir_path);
-        Ok(parts.join(self.version_slug))
+        let path = parts.join(self.version_slug);
+        validate_installation_path(&path)
     }
 
     /// Creates a new `Config` after validating `rel_dir_path` and
@@ -271,7 +313,9 @@ impl Config {
     ///
     /// `rel_dir_path` is the relative path of the directory
     /// containing the dependencies, stored as a sequence of path
-    /// components for cross-platform compatibility.
+    /// components for cross-platform compatibility. Components must not
+    /// contain `@` or its Unicode compatibility forms U+FE6B and U+FF20,
+    /// which are reserved for staging directories.
     ///
     /// Dependencies are stored in `<rel_dir_path>`. In production
     /// use, this is relative to the user cache directory. In
@@ -280,7 +324,8 @@ impl Config {
     /// working directory.
     ///
     /// `version_slug` is a unique identifier for this version of
-    /// the dependencies.
+    /// the dependencies. Like `rel_dir_path` components, it must not contain a
+    /// reserved staging marker.
     pub const fn new(rel_dir_path: &'static [&'static str], version_slug: &'static str) -> Self {
         let mut i = 0;
         while i < rel_dir_path.len() {
@@ -293,6 +338,21 @@ impl Config {
 
         Self { rel_dir_path, version_slug }
     }
+}
+
+fn validate_installation_path(path: &Path) -> IoResult<PathBuf> {
+    // `absolute` resolves a relative base against the current directory
+    // without requiring the installation path to exist. This matters for all
+    // `Location` variants: environment-derived paths can themselves be inside
+    // an abandoned staging directory.
+    let absolute = std::path::absolute(path)?;
+    if sync::path_contains_reserved_staging_marker(&absolute) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Installation paths must not contain a reserved staging marker",
+        ));
+    }
+    Ok(absolute)
 }
 
 /// Validates a single path component.
@@ -311,9 +371,14 @@ impl Config {
 /// - contains a character reserved on Windows
 /// - is a Windows-reserved device name (matched by its stem)
 /// - contains a null byte
+/// - contains a marker reserved for staging directories
 const fn validate_path(part: &str) {
     let bytes = part.as_bytes();
 
+    assert!(
+        !sync::is_reserved_staging_name(part),
+        "Error: `Config` path components must not contain a reserved staging marker.",
+    );
     assert!(bytes.len() <= 255, "Error: each `rel_dir_path` component must not exceed 255 bytes.");
     assert!(!bytes.is_empty(), "rel_dir_path component must not be empty");
     assert!(
@@ -388,9 +453,13 @@ const fn validate_path(part: &str) {
     }
 }
 
-/// Extracts the `.tar.zst` from `reader` and installs it at `dst`, optionally
-/// validating its hash.
-fn install(mut reader: impl Read, dst: &Path, expected_sha256: Option<[u8; 32]>) -> IoResult<()> {
+/// Copies `reader` into an automatically removed temporary file in
+/// `spool_dir`, validates its hash, and rewinds it for reading.
+fn spool_authenticated_archive(
+    mut reader: impl Read,
+    spool_dir: &Path,
+    expected_sha256: [u8; 32],
+) -> IoResult<std::fs::File> {
     struct HashingReader<R> {
         reader: R,
         hasher: sha2::Sha256,
@@ -404,31 +473,38 @@ fn install(mut reader: impl Read, dst: &Path, expected_sha256: Option<[u8; 32]>)
         }
     }
 
+    let mut hash_reader = HashingReader { reader: &mut reader, hasher: sha2::Sha256::new() };
+    let mut archive_file = tempfile::tempfile_in(spool_dir)?;
+
+    // Read and authenticate the complete compressed stream before allowing its
+    // contents to affect the staging directory. The temporary file ensures
+    // that the bytes which are extracted are the same bytes which were
+    // authenticated.
+    std::io::copy(&mut hash_reader, &mut archive_file)?;
+
+    let hash: [u8; 32] = sha2::Digest::finalize(hash_reader.hasher).into();
+    if hash != expected_sha256 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "SHA-256 hash mismatch"));
+    }
+
+    std::io::Seek::rewind(&mut archive_file)?;
+    Ok(archive_file)
+}
+
+/// Extracts the `.tar.zst` from `reader` and installs it at `dst`, validating
+/// its hash before extraction when an expected hash is provided.
+fn install(mut reader: impl Read, dst: &Path, expected_sha256: Option<[u8; 32]>) -> IoResult<()> {
     sync::ManagedDirName::new(dst)
         .check_exists_or_create(|target_dir| {
             if let Some(expected) = expected_sha256 {
-                let mut hash_reader = HashingReader { reader, hasher: sha2::Sha256::new() };
-                {
-                    let decoder = zstd::stream::read::Decoder::new(&mut hash_reader)?;
-                    let mut archive = tar::Archive::new(decoder);
-                    archive.unpack(target_dir)?;
-                }
-
-                // Ensure any remaining trailing bytes in the stream are read
-                // and hashed. Zstd may skip trailing data which isn't necessary
-                // to decompress, but we need to account for it in the hash, or
-                // else a valid archive could fail to hash properly if that
-                // archive contains trailing data which isn't required for
-                // decompression.
-                std::io::copy(&mut hash_reader, &mut std::io::sink())?;
-
-                let hash: [u8; 32] = sha2::Digest::finalize(hash_reader.hasher).into();
-                if hash != expected {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "SHA-256 hash mismatch",
-                    ));
-                }
+                // Keep the complete compressed archive on the installation
+                // filesystem rather than consuming space in the system
+                // temporary directory. `tempfile_in` removes it when this
+                // branch ends, before the staging directory is promoted.
+                let archive_file = spool_authenticated_archive(&mut reader, target_dir, expected)?;
+                let decoder = zstd::stream::read::Decoder::new(archive_file)?;
+                let mut archive = tar::Archive::new(decoder);
+                archive.unpack(target_dir)?;
             } else {
                 let decoder = zstd::stream::read::Decoder::new(&mut reader)?;
                 let mut archive = tar::Archive::new(decoder);
@@ -711,6 +787,21 @@ mod tests {
         assert!(dst.is_dir());
         assert_eq!(fs::read_to_string(dst.join("hello.txt")).unwrap(), "hello world");
         assert_eq!(fs::read(dst.join("nested/dir/data.bin")).unwrap(), b"\x01\x02\x03");
+        assert_eq!(fs::read_dir(&dst).unwrap().count(), 2);
+    }
+
+    #[test]
+    fn test_authenticated_archive_spool_uses_requested_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let not_a_directory = temp.path().join("not-a-directory");
+        fs::write(&not_a_directory, "file").unwrap();
+        let archive = b"archive bytes";
+
+        // A helper which ignored `not_a_directory` and used the system
+        // temporary directory would succeed here.
+        let result =
+            spool_authenticated_archive(&archive[..], &not_a_directory, compute_sha256(archive));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -736,10 +827,12 @@ mod tests {
         assert!(result.is_err());
 
         assert!(!dst.exists());
+        let target_lock = dst.with_file_name("install_target.lock");
+        let (_, staging_lock) = sync::ManagedDirName::new(&dst).staging_paths();
         let entries: Vec<_> = fs::read_dir(temp.path())
             .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|n| n != "install_target.lock")
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path != &target_lock && path != &staging_lock)
             .collect();
         assert!(entries.is_empty());
     }
@@ -774,12 +867,29 @@ mod tests {
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
 
         assert!(!dst.exists());
+        let target_lock = dst.with_file_name("install_target.lock");
+        let (_, staging_lock) = sync::ManagedDirName::new(&dst).staging_paths();
         let entries: Vec<_> = fs::read_dir(temp.path())
             .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|n| n != "install_target.lock")
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path != &target_lock && path != &staging_lock)
             .collect();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_install_hash_mismatch_precedes_archive_parsing() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let invalid_data = b"definitely not a valid zstd or tar";
+        let mut incorrect_hash = compute_sha256(invalid_data);
+        incorrect_hash[0] ^= 1;
+
+        let error = install(&invalid_data[..], &dst, Some(incorrect_hash)).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), "SHA-256 hash mismatch");
+        assert!(!dst.exists());
     }
 
     #[test]
@@ -793,11 +903,12 @@ mod tests {
         let mut corrupted_archive = valid_tar_zst.clone();
         corrupted_archive.extend_from_slice(b"trailing garbage data");
 
-        // Even though the archive unpacks successfully, the trailing bytes should be
-        // read and hashed, causing a hash mismatch.
+        // The trailing bytes must be read and hashed before archive parsing,
+        // causing a hash mismatch without unpacking the archive.
         let result = install(corrupted_archive.as_slice(), &dst, Some(expected_hash));
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+        assert!(!dst.exists());
     }
 
     #[test]
@@ -925,6 +1036,68 @@ mod tests {
 
         assert_eq!(config.rel_dir_path, &["tool", "deps"]);
         assert_eq!(config.version_slug, "v1");
+    }
+
+    #[test]
+    fn test_config_new_rejects_reserved_staging_names() {
+        for version_slug in [
+            "@Ab12CdE.tmp",
+            "@aB12cDe.TMP",
+            "@Ab12CdE.tmp. ",
+            "@ABCDEF\u{212a}.tmp",
+            " @Ab12CdE.tmp",
+            "\u{200c}@Ab12CdE.tmp",
+            "\u{fe6b}Ab12CdE.tmp",
+            "\u{ff20}Ab12CdE.tmp",
+            "other\u{fe6b}reserved_name",
+            "other\u{ff20}reserved_name",
+            "other@reserved_name",
+        ] {
+            let result = std::panic::catch_unwind(|| Config::new(&["tool"], version_slug));
+            assert!(result.is_err(), "{version_slug:?}");
+        }
+
+        let config = Config::new(&["tool"], "_v_1");
+        assert_eq!(config.version_slug, "_v_1");
+    }
+
+    #[test]
+    fn test_config_new_rejects_staging_marker_in_rel_dir_path() {
+        for rel_dir_path in [
+            &["@Ab12CdE.tmp"][..],
+            &["tool", "@Ab12CdE.tmp"][..],
+            &["tool", "\u{200c}@Ab12CdE.tmp", "deps"][..],
+            &["tool", "\u{fe6b}Ab12CdE.tmp", "deps"][..],
+            &["tool", "\u{ff20}Ab12CdE.tmp", "deps"][..],
+            &["tool@cache", "deps"][..],
+        ] {
+            let result = std::panic::catch_unwind(|| Config::new(rel_dir_path, "v1"));
+            assert!(result.is_err(), "{rel_dir_path:?}");
+        }
+    }
+
+    #[test]
+    fn test_installation_path_rejects_staging_namespace_ancestors() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = Config::new(&["tool"], "v1");
+
+        for reserved in ["@@stage.tmp", "dir@stage", "dir\u{fe6b}stage", "dir\u{ff20}stage"] {
+            let error = validate_installation_path(Path::new(reserved).join("target").as_path())
+                .unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput, "{reserved:?}");
+
+            let error = config.dir_path(Location::Custom(temp.path().join(reserved))).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput, "{reserved:?}");
+        }
+
+        assert_eq!(
+            config.dir_path(Location::Custom(temp.path().join("custom"))).unwrap(),
+            temp.path().join("custom/tool/v1"),
+        );
+        assert_eq!(
+            config.dir_path(Location::Custom(PathBuf::from("custom"))).unwrap(),
+            std::path::absolute("custom/tool/v1").unwrap(),
+        );
     }
 
     #[test]

--- a/exocrate/src/sync.rs
+++ b/exocrate/src/sync.rs
@@ -9,9 +9,50 @@
 
 use std::{
     fs::{self, File, OpenOptions},
-    io::Result as IoResult,
+    io::{Read as _, Result as IoResult, Seek as _, SeekFrom, Write as _},
     path::{Path, PathBuf},
 };
+
+const STAGING_MARKER: u8 = b'@';
+const STAGING_WORK_NAME: &str = "@@stage.tmp";
+const STAGING_LOCK_NAME: &str = "@@stage.lck";
+const STAGING_PROTOCOL_CLAIM: &[u8] = b"exocrate staging protocol 1\n";
+
+/// Returns whether `name` belongs to the namespace reserved for staging
+/// directories.
+///
+/// Staging names contain `@`, and no managed target may do so. Reserving the
+/// marker wherever it appears, including its two Unicode compatibility forms
+/// (U+FE6B and U+FF20), avoids relying on platform-specific case folding,
+/// Unicode normalization, ignored formatting characters, or
+/// trailing-dot-and-space normalization when deciding whether a target can
+/// alias a staging directory.
+pub(crate) const fn is_reserved_staging_name(name: &str) -> bool {
+    contains_staging_marker(name.as_bytes())
+}
+
+/// Returns whether any part of `path` belongs to the staging namespace.
+pub(crate) fn path_contains_reserved_staging_marker(path: &Path) -> bool {
+    contains_staging_marker(path.as_os_str().as_encoded_bytes())
+}
+
+const fn contains_staging_marker(bytes: &[u8]) -> bool {
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == STAGING_MARKER {
+            return true;
+        }
+        if bytes.len() - i >= 3
+            && bytes[i] == 0xef
+            && ((bytes[i + 1] == 0xb9 && bytes[i + 2] == 0xab)
+                || (bytes[i + 1] == 0xbc && bytes[i + 2] == 0xa0))
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
 
 /// A directory managed by this library.
 ///
@@ -33,13 +74,18 @@ pub(crate) struct ManagedDir<'a> {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ManagedDirName<'a> {
-    // INVARIANT: `path.file_name().is_some()`.
+    // INVARIANT: `path.file_name()` exists and contains no reserved staging
+    // marker.
     path: &'a Path,
 }
 
 impl<'a> ManagedDirName<'a> {
     pub(crate) fn new(path: &'a Path) -> Self {
-        assert!(path.file_name().is_some(), "ManagedDirName path must have a filename");
+        let file_name = path.file_name().expect("ManagedDirName path must have a filename");
+        assert!(
+            !contains_staging_marker(file_name.as_encoded_bytes()),
+            "ManagedDirName filename must not contain a reserved staging marker",
+        );
         Self { path }
     }
 
@@ -62,10 +108,17 @@ impl<'a> ManagedDirName<'a> {
 
     /// Checks if the directory exists, creating it if not.
     ///
+    /// `populate` is always given a freshly-created staging directory. A later
+    /// installation in the same parent removes a staging directory abandoned
+    /// by an earlier installation before atomically creating the empty
+    /// directory passed to `populate`.
+    ///
     /// # Concurrency
     ///
     /// `check_exists_or_create` is **not** concurrency-safe if multiple
     /// concurrent calls are made *from the same process*.
+    /// Missing-target installations in separate processes which share a parent
+    /// directory serialize while they use that parent's staging path.
     pub(crate) fn check_exists_or_create(
         self,
         populate: impl FnOnce(&Path) -> IoResult<()>,
@@ -74,60 +127,125 @@ impl<'a> ManagedDirName<'a> {
             return Ok(dir);
         }
 
-        if let Some(parent) = self.path.parent() {
-            // NOTE: `create_dir_all` is safe to call concurrently with other
-            // processes attempting to create the same directory:
-            //
-            //  Notable exception [to the error conditions] is made for
-            //  situations where any of the directories specified in the path
-            //  could not be created as it was being created concurrently. Such
-            //  cases are considered to be successful. That is, calling
-            //  create_dir_all concurrently from multiple threads or processes
-            //  is guaranteed not to fail due to a race condition with itself.
-            fs::create_dir_all(parent)?;
-        }
+        let parent = self
+            .path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+
+        // NOTE: `create_dir_all` is safe to call concurrently with other
+        // processes attempting to create the same directory:
+        //
+        //  Notable exception [to the error conditions] is made for situations
+        //  where any of the directories specified in the path could not be
+        //  created as it was being created concurrently. Such cases are
+        //  considered to be successful. That is, calling create_dir_all
+        //  concurrently from multiple threads or processes is guaranteed not
+        //  to fail due to a race condition with itself.
+        fs::create_dir_all(parent)?;
 
         let lock_file_path = self.lock_path();
-        let lock_file =
-            OpenOptions::new().read(true).write(true).create(true).open(&lock_file_path)?;
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_file_path)?;
 
         <_ as fs2::FileExt>::lock_exclusive(&lock_file)?;
 
-        let staging_dir = self.staging();
+        struct LockGuard(File);
 
-        struct StagingGuard<'a> {
-            staging_dir: &'a Path,
-            lock_file: File,
-            completed: bool,
-        }
-
-        impl Drop for StagingGuard<'_> {
+        impl Drop for LockGuard {
             fn drop(&mut self) {
-                if !self.completed {
-                    let _ = fs::remove_dir_all(&self.staging_dir);
-                }
-                let _ = <_ as fs2::FileExt>::unlock(&self.lock_file);
+                let _ = <_ as fs2::FileExt>::unlock(&self.0);
             }
         }
 
-        // A guard that will clean up even if `populate` panics.
-        let mut guard = StagingGuard { staging_dir: &staging_dir, lock_file, completed: false };
+        let _lock_guard = LockGuard(lock_file);
 
-        // Handle the case where, while we were waiting to acquire the lock,
-        // another process populated the directory.
+        // Handle the case where another process populated the directory while
+        // we were waiting for the target lock. Do this before creating staging
+        // infrastructure so an already-complete target is not hidden by an
+        // unrelated staging-path error.
         if let Ok(dir) = self.check_exists() {
-            guard.completed = true;
             return Ok(dir);
         }
 
-        // Clean up from any previous failed attempt to populate the directory.
-        let _ = fs::remove_dir_all(&guard.staging_dir);
-        fs::create_dir_all(&guard.staging_dir)?;
+        let (staging_path, staging_lock_path) = self.staging_paths();
 
-        populate(&guard.staging_dir)?;
+        // The target lock synchronizes installations of this target. The
+        // persistent parent-wide lock additionally ensures that every
+        // cooperating process which uses this staging protocol is excluded
+        // before the shared path is inspected, removed, populated, or
+        // promoted.
+        let staging_lock = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&staging_lock_path)
+        {
+            Ok(lock) => lock,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let metadata = fs::symlink_metadata(&staging_lock_path)?;
+                if !metadata.file_type().is_file() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "Exocrate staging lock is not a regular file",
+                    ));
+                }
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .truncate(false)
+                    .open(&staging_lock_path)?
+            }
+            Err(error) => return Err(error),
+        };
+        <_ as fs2::FileExt>::lock_exclusive(&staging_lock)?;
+        let mut staging_lock_guard = LockGuard(staging_lock);
 
-        fs::rename(&guard.staging_dir, self.path).map_err(|e| {
-            std::io::Error::new(
+        // The lock file also claims this parent-wide staging namespace. Before
+        // the first claim, an older Exocrate version could legitimately have
+        // installed a target named `STAGING_WORK_NAME`. Refuse to delete such
+        // a pre-existing occupant. Once claimed, cooperating versions reserve
+        // both staging names and may reclaim the work path after process
+        // death.
+        claim_staging_protocol(&mut staging_lock_guard.0, &staging_path)?;
+
+        // Handle the case where another process populated the directory while
+        // we were waiting for either lock.
+        if let Ok(dir) = self.check_exists() {
+            return Ok(dir);
+        }
+
+        remove_staging_work(&staging_path)?;
+
+        // Unlike `create_dir_all`, `create_dir` proves that this attempt starts
+        // with a new, empty directory rather than reusing residual contents.
+        fs::create_dir(&staging_path)?;
+
+        struct StagingGuard(Option<PathBuf>);
+
+        impl Drop for StagingGuard {
+            fn drop(&mut self) {
+                if let Some(path) = &self.0 {
+                    let _ = remove_staging_work(path);
+                }
+            }
+        }
+
+        let mut staging_guard = StagingGuard(Some(staging_path));
+        populate(staging_guard.0.as_deref().expect("staging cleanup must be armed"))?;
+
+        // Disarm path-based cleanup before the rename. If the process exits in
+        // this small window, the next lock holder reclaims the work path. After
+        // a successful rename, no cleanup guard remains which could delete a
+        // later occupant of the now-vacant source path.
+        let staging_path = staging_guard.0.take().expect("staging cleanup must be armed");
+        if let Err(e) = fs::rename(&staging_path, self.path) {
+            let _ = remove_staging_work(&staging_path);
+            return Err(std::io::Error::new(
                 e.kind(),
                 format!(
                     "Failed to rename staging directory to target path (this indicates a {}): {}",
@@ -138,18 +256,19 @@ impl<'a> ManagedDirName<'a> {
                     },
                     e
                 ),
-            )
-        })?;
+            ));
+        }
 
-        guard.completed = true;
         Ok(ManagedDir { path: self.path })
     }
 
-    fn staging(&self) -> PathBuf {
-        let mut file_name =
-            self.path.file_name().expect("ManagedDirName path must have a filename").to_os_string();
-        file_name.push(".staging");
-        self.path.with_file_name(file_name)
+    /// Returns the parent-wide work-directory and lock-file paths.
+    pub(super) fn staging_paths(&self) -> (PathBuf, PathBuf) {
+        // All names are valid 8.3 filenames and contain the reserved staging
+        // marker. The doubled marker also makes the work path disjoint from the
+        // single-marker random namespace used by earlier Exocrate versions.
+        // They are a versioned cross-process protocol and must remain stable.
+        (self.path.with_file_name(STAGING_WORK_NAME), self.path.with_file_name(STAGING_LOCK_NAME))
     }
 
     // NOTE: It's important that `lock_path` returns a lock path whose name
@@ -162,11 +281,221 @@ impl<'a> ManagedDirName<'a> {
     }
 }
 
+/// Claims the parent-wide staging namespace, or validates an earlier claim.
+///
+/// The caller holds `lock` exclusively. An empty lock file represents either
+/// an interrupted first claim or an as-yet-unclaimed parent. In that state, a
+/// work-path occupant is preserved and reported instead of deleted. Exact
+/// versioned claim bytes authorize compatible Exocrate processes to reclaim
+/// the shared work path; every other lock-file state fails closed.
+fn claim_staging_protocol(lock: &mut File, work_path: &Path) -> IoResult<()> {
+    let len = lock.metadata()?.len();
+    if len == STAGING_PROTOCOL_CLAIM.len() as u64 {
+        let mut claim = [0; STAGING_PROTOCOL_CLAIM.len()];
+        lock.seek(SeekFrom::Start(0))?;
+        lock.read_exact(&mut claim)?;
+        if claim.as_slice() == STAGING_PROTOCOL_CLAIM {
+            return Ok(());
+        }
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Unrecognized Exocrate staging protocol claim",
+        ));
+    }
+    if len != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Unrecognized Exocrate staging protocol claim",
+        ));
+    }
+
+    match fs::symlink_metadata(work_path) {
+        Ok(_) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "Unclaimed path occupies Exocrate's reserved staging namespace",
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    lock.seek(SeekFrom::Start(0))?;
+    lock.write_all(STAGING_PROTOCOL_CLAIM)?;
+    lock.sync_data()
+}
+
+/// Makes every directory in a protocol-owned staging tree traversable and
+/// every non-symlink Windows entry writable, without following symlinks.
+///
+/// Archive entries can legitimately have mode 000 on Unix or the read-only
+/// attribute on Windows. If a process exits after extracting such an entry,
+/// these permissions must not make the single shared work path permanently
+/// unreclaimable. The caller holds the parent-wide lock, and Exocrate's public
+/// contract excludes concurrent mutation, non-symbolic aliases, and mounts in
+/// this reserved tree; those premises make the path-based metadata and
+/// permission operations stable.
+fn make_staging_tree_removable(path: &Path) -> IoResult<()> {
+    let mut pending = vec![path.to_owned()];
+    while let Some(path) = pending.pop() {
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error),
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+
+        #[cfg(unix)]
+        if metadata.is_dir() {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(permissions.mode() | 0o700);
+            fs::set_permissions(&path, permissions)?;
+        }
+
+        #[cfg(windows)]
+        if metadata.permissions().readonly() {
+            let mut permissions = metadata.permissions();
+            permissions.set_readonly(false);
+            fs::set_permissions(&path, permissions)?;
+        }
+
+        if metadata.is_dir() {
+            for entry in fs::read_dir(&path)? {
+                pending.push(entry?.path());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Removes an earlier attempt's staging path without following symlinks.
+fn remove_staging_work(path: &Path) -> IoResult<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(_) => {
+            make_staging_tree_removable(path)?;
+            let metadata = match fs::symlink_metadata(path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => return Err(error),
+            };
+            let result =
+                if metadata.is_dir() { fs::remove_dir_all(path) } else { fs::remove_file(path) };
+            match result {
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Ok(()) => Ok(()),
+                Err(error) => Err(error),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, path::Path};
 
     use super::*;
+
+    fn has_old_random_staging_shape(name: &str) -> bool {
+        let bytes = name.as_bytes();
+        bytes.len() == 12
+            && bytes[0] == b'@'
+            && bytes[1..8].iter().all(u8::is_ascii_alphanumeric)
+            && &bytes[8..] == b".tmp"
+    }
+
+    fn parent_entries_except_metadata(target: &Path) -> Vec<PathBuf> {
+        let managed = ManagedDirName::new(target);
+        let target_lock = managed.lock_path();
+        let (_, staging_lock) = managed.staging_paths();
+        fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path != &target_lock && path != &staging_lock)
+            .collect()
+    }
+
+    #[test]
+    fn test_staging_name_namespace() {
+        let managed = ManagedDirName::new(Path::new("install_target"));
+        let (staging, staging_lock) = managed.staging_paths();
+        let staging = staging.file_name().unwrap().to_str().unwrap();
+        let staging_lock = staging_lock.file_name().unwrap().to_str().unwrap();
+
+        // These names are a persistent cross-process protocol. Changing them
+        // can strand staging data left by another Exocrate process.
+        assert_eq!(staging, "@@stage.tmp");
+        assert_eq!(staging_lock, "@@stage.lck");
+        assert_eq!(STAGING_PROTOCOL_CLAIM, b"exocrate staging protocol 1\n");
+        assert!(is_reserved_staging_name(staging));
+        assert!(is_reserved_staging_name(staging_lock));
+        assert!(staging.len() <= 12);
+        assert!(staging_lock.len() <= 12);
+        assert!(staging.split_once('.').unwrap().0.len() <= 8);
+        assert!(staging_lock.split_once('.').unwrap().0.len() <= 8);
+        assert!(!has_old_random_staging_shape(staging));
+        assert!(staging_lock.ends_with(".lck"));
+
+        for name in [
+            "@Ab12CdE.tmp",
+            "@aB12cDe.TMP",
+            "@Ab12CdE.tmp. ",
+            "@ABCDEF\u{212a}.tmp",
+            " @Ab12CdE.tmp",
+            "\u{200c}@Ab12CdE.tmp",
+            "\u{fe6b}Ab12CdE.tmp",
+            "\u{ff20}Ab12CdE.tmp",
+            "other\u{fe6b}reserved_name",
+            "other\u{ff20}reserved_name",
+            "other@reserved_name",
+        ] {
+            assert!(is_reserved_staging_name(name), "{name:?}");
+        }
+
+        for name in ["", "install_target", "_Ab12CdE.tmp", "v1_tmp", "caf\u{e9}"] {
+            assert!(!is_reserved_staging_name(name), "{name:?}");
+        }
+
+        assert!(has_old_random_staging_shape("@Ab12CdE.tmp"));
+        for name in [
+            "@Ab12Cd.tmp",
+            "@Ab12CdEf.tmp",
+            "@Ab12C-E.tmp",
+            "@Ab12CdE.TMP",
+            "@Ab12CdE.tmp. ",
+            "@ABCDEF\u{212a}.tmp",
+            "\u{200c}@Ab12CdE.tmp",
+        ] {
+            assert!(!has_old_random_staging_shape(name), "{name:?}");
+        }
+    }
+
+    #[test]
+    fn test_reserved_staging_names_cannot_be_managed_targets() {
+        for name in [
+            STAGING_WORK_NAME,
+            STAGING_LOCK_NAME,
+            "@Ab12CdE.tmp",
+            "@aB12cDe.TMP",
+            "@Ab12CdE.tmp. ",
+            "@ABCDEF\u{212a}.tmp",
+            " @Ab12CdE.tmp",
+            "\u{200c}@Ab12CdE.tmp",
+            "\u{fe6b}Ab12CdE.tmp",
+            "\u{ff20}Ab12CdE.tmp",
+            "other\u{fe6b}reserved_name",
+            "other\u{ff20}reserved_name",
+            "other@reserved_name",
+        ] {
+            let result = std::panic::catch_unwind(|| ManagedDirName::new(Path::new(name)));
+            assert!(result.is_err(), "{name:?}");
+        }
+    }
 
     #[test]
     fn test_check_exists_or_create_success() {
@@ -183,6 +512,53 @@ mod tests {
 
         assert_eq!(dir.path, dst.as_path());
         assert!(dst.is_dir());
+        assert_eq!(fs::read_to_string(dst.join("data.txt")).unwrap(), "success content");
+        let (_, staging_lock) = managed.staging_paths();
+        assert_eq!(fs::read(staging_lock).unwrap(), STAGING_PROTOCOL_CLAIM);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_check_exists_or_create_uses_normal_directory_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let reference = temp.path().join("reference");
+        fs::create_dir(&reference).unwrap();
+        let expected = fs::metadata(&reference).unwrap().permissions().mode() & 0o777;
+
+        let dst = temp.path().join("install_target");
+        ManagedDirName::new(&dst).check_exists_or_create(|_| Ok(())).unwrap();
+        let actual = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_generated_staging_name_cannot_be_managed_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let mut observed_staging = false;
+
+        managed
+            .check_exists_or_create(|staging| {
+                observed_staging = true;
+                let name = staging.file_name().unwrap().to_str().unwrap();
+                assert_eq!(name, STAGING_WORK_NAME);
+                assert!(is_reserved_staging_name(name));
+
+                // Before this namespace was reserved, another configuration
+                // could treat this live staging path as its completed target.
+                let result = std::panic::catch_unwind(|| ManagedDirName::new(staging));
+                assert!(result.is_err());
+
+                fs::write(staging.join("data.txt"), "success content")?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert!(observed_staging);
         assert_eq!(fs::read_to_string(dst.join("data.txt")).unwrap(), "success content");
     }
 
@@ -219,17 +595,250 @@ mod tests {
 
         let res = managed.check_exists_or_create(|staging| {
             fs::write(staging.join("partial.txt"), "partial").unwrap();
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "simulated error"))
+            Err(std::io::Error::other("simulated error"))
         });
         assert!(res.is_err());
 
         assert!(!dst.exists());
-        let entries: Vec<_> = fs::read_dir(temp.path())
-            .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|n| n != "install_target.lock")
-            .collect();
-        assert!(entries.is_empty());
+        let (staging, _) = managed.staging_paths();
+        assert!(!staging.exists());
+        assert!(parent_entries_except_metadata(&dst).is_empty());
+    }
+
+    #[test]
+    fn test_unclaimed_staging_occupant_is_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("old-install.txt"), "preserve").unwrap();
+
+        let mut populated = false;
+        let error = managed
+            .check_exists_or_create(|_| {
+                populated = true;
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(!populated);
+        assert_eq!(fs::read_to_string(staging.join("old-install.txt")).unwrap(), "preserve");
+        assert_eq!(fs::metadata(staging_lock).unwrap().len(), 0);
+        assert!(!dst.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_unclaimed_dangling_staging_symlink_is_preserved() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        let missing_referent = temp.path().join("missing");
+        symlink(&missing_referent, &staging).unwrap();
+
+        let error = managed.check_exists_or_create(|_| Ok(())).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert!(fs::symlink_metadata(staging).unwrap().file_type().is_symlink());
+        assert_eq!(fs::metadata(staging_lock).unwrap().len(), 0);
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_non_regular_staging_lock_is_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        fs::create_dir(&staging_lock).unwrap();
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("unknown.txt"), "preserve").unwrap();
+
+        let error = managed.check_exists_or_create(|_| Ok(())).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(fs::read_to_string(staging.join("unknown.txt")).unwrap(), "preserve");
+        assert!(staging_lock.is_dir());
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_unknown_staging_claim_is_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        let unknown_claim = vec![b'x'; STAGING_PROTOCOL_CLAIM.len()];
+        fs::write(&staging_lock, &unknown_claim).unwrap();
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("unknown.txt"), "preserve").unwrap();
+
+        let error = managed.check_exists_or_create(|_| Ok(())).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(fs::read_to_string(staging.join("unknown.txt")).unwrap(), "preserve");
+        assert_eq!(fs::read(staging_lock).unwrap(), unknown_claim);
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_preexisting_empty_staging_lock_is_claimed() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        fs::write(&staging_lock, []).unwrap();
+
+        managed.check_exists_or_create(|_| Ok(())).unwrap();
+
+        assert!(dst.is_dir());
+        assert!(!staging.exists());
+        assert_eq!(fs::read(staging_lock).unwrap(), STAGING_PROTOCOL_CLAIM);
+    }
+
+    #[test]
+    fn test_existing_staging_claim_allows_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (staging, staging_lock) = managed.staging_paths();
+        fs::write(&staging_lock, STAGING_PROTOCOL_CLAIM).unwrap();
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("partial.txt"), "partial").unwrap();
+
+        managed
+            .check_exists_or_create(|staging| fs::write(staging.join("complete.txt"), "complete"))
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(dst.join("complete.txt")).unwrap(), "complete");
+        assert!(!dst.join("partial.txt").exists());
+        assert!(!staging.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_staging_lock_symlink_is_rejected_without_writing_through() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (_, staging_lock) = managed.staging_paths();
+        let referent = temp.path().join("referent");
+        fs::write(&referent, []).unwrap();
+        symlink(&referent, &staging_lock).unwrap();
+
+        let error = managed.check_exists_or_create(|_| Ok(())).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(fs::metadata(referent).unwrap().len(), 0);
+        assert!(fs::symlink_metadata(staging_lock).unwrap().file_type().is_symlink());
+        assert!(!dst.exists());
+    }
+
+    #[test]
+    fn test_stale_non_directory_staging_is_not_reused() {
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (stale_staging, _) = managed.staging_paths();
+        let _ = managed.check_exists_or_create(|_| Err(std::io::Error::other("claim only")));
+        fs::write(&stale_staging, "poison").unwrap();
+
+        let mut next_staging = None;
+        managed
+            .check_exists_or_create(|staging| {
+                next_staging = Some(staging.to_owned());
+                assert!(fs::read_dir(staging)?.next().is_none());
+                fs::write(staging.join("official.txt"), "official")?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(next_staging.unwrap(), stale_staging);
+        assert_eq!(fs::read_to_string(dst.join("official.txt")).unwrap(), "official");
+        assert!(!dst.join("poison").exists());
+        assert!(!stale_staging.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_stale_staging_symlink_is_removed_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let managed = ManagedDirName::new(&dst);
+        let (stale_staging, _) = managed.staging_paths();
+        let _ = managed.check_exists_or_create(|_| Err(std::io::Error::other("claim only")));
+        let referent = temp.path().join("referent");
+        fs::create_dir(&referent).unwrap();
+        fs::write(referent.join("preserve.txt"), "preserve").unwrap();
+        symlink(&referent, &stale_staging).unwrap();
+
+        managed.check_exists_or_create(|_| Ok(())).unwrap();
+
+        assert_eq!(fs::read_to_string(referent.join("preserve.txt")).unwrap(), "preserve");
+        assert!(!stale_staging.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_make_staging_tree_removable_handles_deep_modes_without_following_symlinks() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let temp = tempfile::tempdir().unwrap();
+        let staging = temp.path().join("staging");
+        let outer = staging.join("outer");
+        let inner = outer.join("inner");
+        fs::create_dir_all(&inner).unwrap();
+        fs::write(inner.join("entry.txt"), "entry").unwrap();
+
+        let referent = temp.path().join("referent");
+        fs::create_dir(&referent).unwrap();
+        fs::write(referent.join("preserve.txt"), "preserve").unwrap();
+        fs::set_permissions(&referent, fs::Permissions::from_mode(0o500)).unwrap();
+        symlink(&referent, inner.join("link")).unwrap();
+
+        fs::set_permissions(&inner, fs::Permissions::from_mode(0o000)).unwrap();
+        fs::set_permissions(&outer, fs::Permissions::from_mode(0o000)).unwrap();
+
+        make_staging_tree_removable(&staging).unwrap();
+
+        assert_eq!(fs::metadata(&outer).unwrap().permissions().mode() & 0o700, 0o700);
+        assert_eq!(fs::metadata(&inner).unwrap().permissions().mode() & 0o700, 0o700);
+        assert!(fs::symlink_metadata(inner.join("link")).unwrap().file_type().is_symlink());
+        assert_eq!(fs::metadata(&referent).unwrap().permissions().mode() & 0o777, 0o500);
+
+        remove_staging_work(&staging).unwrap();
+        assert_eq!(fs::read_to_string(referent.join("preserve.txt")).unwrap(), "preserve");
+        fs::set_permissions(referent, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_make_staging_tree_removable_clears_readonly_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let staging = temp.path().join("staging");
+        let nested = staging.join("nested");
+        let entry = nested.join("entry.txt");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(&entry, "entry").unwrap();
+        for path in [&nested, &entry] {
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_readonly(true);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+
+        make_staging_tree_removable(&staging).unwrap();
+
+        assert!(!fs::metadata(nested).unwrap().permissions().readonly());
+        assert!(!fs::metadata(entry).unwrap().permissions().readonly());
     }
 
     #[test]
@@ -258,12 +867,9 @@ mod tests {
         assert!(res.is_err());
 
         assert!(!dst.exists());
-        let entries: Vec<_> = fs::read_dir(temp.path())
-            .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|n| n != "install_target.lock")
-            .collect();
-        assert!(entries.is_empty());
+        let (staging, _) = managed.staging_paths();
+        assert!(!staging.exists());
+        assert!(parent_entries_except_metadata(&dst).is_empty());
     }
 
     #[test]
@@ -280,12 +886,163 @@ mod tests {
         });
         assert!(res.is_err());
 
-        let entries: Vec<_> = fs::read_dir(temp.path())
-            .unwrap()
-            .map(|e| e.unwrap().file_name())
-            .filter(|n| n != "install_target.lock" && n != "install_target")
-            .collect();
-        assert!(entries.is_empty());
+        let (staging, _) = managed.staging_paths();
+        assert!(!staging.exists());
+        assert_eq!(parent_entries_except_metadata(&dst), [dst]);
+    }
+
+    const CRASH_RECOVERY_DST: &str = "EXOCRATE_TEST_CRASH_RECOVERY_DST";
+    const CONCURRENT_PARENT_DST: &str = "EXOCRATE_TEST_CONCURRENT_PARENT_DST";
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_check_exists_or_create_recovers_after_process_exit() {
+        if let Some(dst) = std::env::var_os(CRASH_RECOVERY_DST) {
+            let dst = PathBuf::from(dst);
+            let managed = ManagedDirName::new(&dst);
+            let _ = managed.check_exists_or_create(|staging| -> IoResult<()> {
+                fs::write(staging.join("partial.txt"), "partial")?;
+                let protected = staging.join("protected");
+                fs::create_dir(&protected)?;
+                fs::write(protected.join("entry.txt"), "protected")?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt as _;
+
+                    fs::set_permissions(&protected, fs::Permissions::from_mode(0o000))?;
+                }
+                #[cfg(windows)]
+                for path in [protected.join("entry.txt"), protected] {
+                    let mut permissions = fs::metadata(&path)?.permissions();
+                    permissions.set_readonly(true);
+                    fs::set_permissions(path, permissions)?;
+                }
+                std::process::exit(86);
+            });
+            panic!("child installation unexpectedly returned");
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let dst = temp.path().join("install_target");
+        let child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("sync::tests::test_check_exists_or_create_recovers_after_process_exit")
+            .arg("--nocapture")
+            .env(CRASH_RECOVERY_DST, &dst)
+            .output()
+            .unwrap();
+        assert_eq!(
+            child.status.code(),
+            Some(86),
+            "child stdout:\n{}\nchild stderr:\n{}",
+            String::from_utf8_lossy(&child.stdout),
+            String::from_utf8_lossy(&child.stderr),
+        );
+
+        let (staging, _) = ManagedDirName::new(&dst).staging_paths();
+        assert_eq!(fs::read_to_string(staging.join("partial.txt")).unwrap(), "partial");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            assert_eq!(
+                fs::metadata(staging.join("protected")).unwrap().permissions().mode() & 0o777,
+                0
+            );
+        }
+        #[cfg(windows)]
+        assert!(
+            fs::metadata(staging.join("protected/entry.txt")).unwrap().permissions().readonly()
+        );
+        assert!(!dst.exists());
+
+        ManagedDirName::new(&dst)
+            .check_exists_or_create(|retry_staging| {
+                assert_eq!(retry_staging, staging);
+                assert!(fs::read_dir(retry_staging)?.next().is_none());
+                fs::write(retry_staging.join("official.txt"), "official")?;
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(fs::read_to_string(dst.join("official.txt")).unwrap(), "official");
+        assert!(!dst.join("partial.txt").exists());
+        assert!(!staging.exists());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_first_use_serializes_across_processes() {
+        if let Some(dst) = std::env::var_os(CONCURRENT_PARENT_DST) {
+            let dst = PathBuf::from(dst);
+            ManagedDirName::new(&dst)
+                .check_exists_or_create(|staging| fs::write(staging.join("complete.txt"), "done"))
+                .unwrap();
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let test_name = "sync::tests::test_first_use_serializes_across_processes";
+        let mut children = Vec::new();
+        for i in 0..8 {
+            let dst = temp.path().join(format!("target_{i}"));
+            let child = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(test_name)
+                .arg("--nocapture")
+                .env(CONCURRENT_PARENT_DST, &dst)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap();
+            children.push((dst, child));
+        }
+
+        for (dst, child) in children {
+            let output = child.wait_with_output().unwrap();
+            assert!(
+                output.status.success(),
+                "child stdout:\n{}\nchild stderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+            assert_eq!(fs::read_to_string(dst.join("complete.txt")).unwrap(), "done");
+        }
+
+        let (staging, staging_lock) =
+            ManagedDirName::new(&temp.path().join("target_0")).staging_paths();
+        assert!(!staging.exists());
+        assert_eq!(fs::read(staging_lock).unwrap(), STAGING_PROTOCOL_CLAIM);
+    }
+
+    #[test]
+    fn test_abandoned_staging_is_reclaimed_by_next_parent_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let target_a = temp.path().join("target_a");
+        let target_b = temp.path().join("target_b");
+        let managed_a = ManagedDirName::new(&target_a);
+        let managed_b = ManagedDirName::new(&target_b);
+        let (staging_a, staging_lock_a) = managed_a.staging_paths();
+        let (staging_b, staging_lock_b) = managed_b.staging_paths();
+        assert_eq!(staging_a, staging_b);
+        assert_eq!(staging_lock_a, staging_lock_b);
+
+        let _ = managed_a.check_exists_or_create(|_| Err(std::io::Error::other("claim only")));
+        fs::create_dir(&staging_a).unwrap();
+        fs::write(staging_a.join("a.partial"), "partial a").unwrap();
+
+        managed_b
+            .check_exists_or_create(|staging| {
+                assert_eq!(staging, staging_b);
+                assert!(fs::read_dir(staging)?.next().is_none());
+                fs::write(staging.join("b.complete"), "complete b")?;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(fs::read_to_string(target_b.join("b.complete")).unwrap(), "complete b");
+        assert!(!target_a.exists());
+        assert!(!target_b.join("a.partial").exists());
+        assert!(!staging_b.exists());
     }
 
     #[test]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Exocrate previously unpacked a remote archive before checking its pinned SHA-256. If cleanup of a rejected archive failed, a later authentic download could reuse and promote residual attacker-controlled files.

Spool and authenticate the complete compressed stream before parsing it, then extract those exact bytes. Use one versioned, parent-wide staging slot whose claim-bearing lock serializes cooperating installers and bounds process-crash residue without adopting an unclaimed path. Reserve the staging namespace from every absolute installation path and fail closed on unknown protocol state.

Normalize protocol-owned directory permissions before recovery cleanup without following symlinks. Add regressions for authentication order, first-use races, process exit, permission-restricted residue, migration collisions, panic and rename cleanup, and filesystem-name normalization.

Closes #3612

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3627


**Latest Update:** v4 — [Compare vs v3](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v3..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v4)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|
|v4|[vs v3](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v3..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v4)|[vs v2](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v2..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v4)|[vs v1](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v1..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v4)|
|v3||[vs v2](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v2..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v3)|[vs v1](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v1..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v3)|
|v2|||[vs v1](/google/zerocopy/compare/gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v1..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v2)|
|v1||||[vs Base](/google/zerocopy/compare/main..gherrit/Glahihffrli3s5lgyhtbnivg7cwjftslj/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Glahihffrli3s5lgyhtbnivg7cwjftslj && git checkout -b pr-Glahihffrli3s5lgyhtbnivg7cwjftslj FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Glahihffrli3s5lgyhtbnivg7cwjftslj && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Glahihffrli3s5lgyhtbnivg7cwjftslj && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Glahihffrli3s5lgyhtbnivg7cwjftslj
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Glahihffrli3s5lgyhtbnivg7cwjftslj","parent":null,"child":null} -->