### PR TITLE
Extract slice metadata without references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           # which a particular feature is supported.
           "no-zerocopy-simd-x86-avx12-1-89-0",
           "no-zerocopy-core-error-1-81-0",
+          "no-zerocopy-slice-ptr-len-1-79-0",
           "no-zerocopy-diagnostic-on-unimplemented-1-78-0",
           "no-zerocopy-generic-bounds-in-const-fn-1-61-0",
           "no-zerocopy-target-has-atomics-1-60-0",
@@ -120,6 +121,8 @@ jobs:
             feature_profile: "all"
           - toolchain: "no-zerocopy-core-error-1-81-0"
             feature_profile: "all"
+          - toolchain: "no-zerocopy-slice-ptr-len-1-79-0"
+            feature_profile: "all"
           - toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
             feature_profile: "all"
           - toolchain: "no-zerocopy-generic-bounds-in-const-fn-1-61-0"
@@ -146,6 +149,8 @@ jobs:
             toolchain: "no-zerocopy-simd-x86-avx12-1-89-0"
           - crate: "zerocopy-derive"
             toolchain: "no-zerocopy-core-error-1-81-0"
+          - crate: "zerocopy-derive"
+            toolchain: "no-zerocopy-slice-ptr-len-1-79-0"
           - crate: "zerocopy-derive"
             toolchain: "no-zerocopy-diagnostic-on-unimplemented-1-78-0"
           - crate: "zerocopy-derive"

--- a/zerocopy/Cargo.toml
+++ b/zerocopy/Cargo.toml
@@ -60,6 +60,9 @@ no-zerocopy-simd-x86-avx12-1-89-0 = "1.89.0"
 # From 1.81.0, Rust supports the `core::error::Error` trait.
 no-zerocopy-core-error-1-81-0 = "1.81.0"
 
+# From 1.79.0, Rust supports extracting the length from a raw slice pointer.
+no-zerocopy-slice-ptr-len-1-79-0 = "1.79.0"
+
 # From 1.78.0, Rust supports the `#[diagnostic::on_unimplemented]` attribute.
 no-zerocopy-diagnostic-on-unimplemented-1-78-0 = "1.78.0"
 

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -1073,29 +1073,85 @@ unsafe impl<T> KnownLayout for [T] {
 
     #[inline(always)]
     fn pointer_to_metadata(ptr: *mut [T]) -> usize {
-        #[allow(clippy::as_conversions)]
-        let slc = ptr as *const [()];
+        #[cfg(not(no_zerocopy_slice_ptr_len_1_79_0))]
+        {
+            ptr.len()
+        }
 
-        // SAFETY:
-        // - `()` has alignment 1, so `slc` is trivially aligned.
-        // - `slc` was derived from a non-null pointer.
-        // - The size is 0 regardless of the length, so it is sound to
-        //   materialize a reference regardless of location.
-        // - By invariant, `self.ptr` has valid provenance.
-        let slc = unsafe { &*slc };
+        #[cfg(no_zerocopy_slice_ptr_len_1_79_0)]
+        {
+            // `*mut [T]::len` was not stable before Rust 1.79. In every Rust
+            // version from our 1.56 MSRV through 1.78, `Hash for *mut T`
+            // decomposes a raw pointer and passes its address and metadata to
+            // the hasher in that order [1]. `Hash for usize` passes its value
+            // to `Hasher::write_usize` [2]. Capture those two values to obtain
+            // a candidate for the slice length without dereferencing `ptr` or
+            // constructing a reference.
+            //
+            // This historical `Hash` implementation is only used to produce a
+            // candidate. Before returning it, we reconstruct a raw slice and
+            // authenticate the candidate with `ptr::eq`, which compares slice
+            // lengths as well as addresses [3]. Thus, an unexpected `Hash`
+            // implementation cannot cause us to return incorrect metadata; it
+            // can only fail to produce an authenticated candidate.
+            //
+            // [1] Per https://doc.rust-lang.org/1.56.0/src/core/hash/mod.rs.html#776-782:
+            //
+            //   let (address, metadata) = self.to_raw_parts();
+            //   state.write_usize(address as usize);
+            //   metadata.hash(state);
+            //
+            // [2] Per https://doc.rust-lang.org/1.56.0/src/core/hash/mod.rs.html#628-656:
+            //
+            //   fn hash<H: Hasher>(&self, state: &mut H) {
+            //       state.$meth(*self)
+            //   }
+            //   ...
+            //   (usize, write_usize),
+            //
+            // [3] Per https://doc.rust-lang.org/1.56.0/std/ptr/fn.eq.html:
+            //
+            //   Slices are also compared by their length (fat pointers).
+            struct MetadataHasher {
+                values: [usize; 2],
+                writes: usize,
+                valid: bool,
+            }
 
-        // This is correct because the preceding `as` cast preserves the number
-        // of slice elements. [1]
-        //
-        // [1] Per https://doc.rust-lang.org/reference/expressions/operator-expr.html#pointer-to-pointer-cast:
-        //
-        //   For slice types like `[T]` and `[U]`, the raw pointer types `*const
-        //   [T]`, `*mut [T]`, `*const [U]`, and `*mut [U]` encode the number of
-        //   elements in this slice. Casts between these raw pointer types
-        //   preserve the number of elements. ... The same holds for `str` and
-        //   any compound type whose unsized tail is a slice type, such as
-        //   struct `Foo(i32, [u8])` or `(u64, Foo)`.
-        slc.len()
+            impl Hasher for MetadataHasher {
+                #[inline(always)]
+                fn finish(&self) -> u64 {
+                    0
+                }
+
+                #[inline(always)]
+                fn write(&mut self, _bytes: &[u8]) {
+                    self.valid = false;
+                }
+
+                #[inline(always)]
+                fn write_usize(&mut self, value: usize) {
+                    match self.values.get_mut(self.writes) {
+                        Some(slot) => *slot = value,
+                        None => self.valid = false,
+                    }
+                    self.writes = self.writes.saturating_add(1);
+                }
+            }
+
+            let mut hasher = MetadataHasher { values: [0; 2], writes: 0, valid: true };
+            core::hash::Hash::hash(&ptr, &mut hasher);
+            assert!(
+                hasher.valid && hasher.writes == 2,
+                "unexpected raw-pointer Hash implementation"
+            );
+
+            let elems = hasher.values[1];
+            #[allow(clippy::as_conversions)]
+            let reconstructed = ptr::slice_from_raw_parts_mut(ptr as *mut T, elems);
+            assert!(ptr::eq(ptr, reconstructed), "captured value is not raw-slice metadata");
+            elems
+        }
     }
 }
 
@@ -6535,6 +6591,58 @@ mod tests {
         test!([()], layout(0, 1, Some(0), true));
         test!([u8], layout(0, 1, Some(1), true));
         test!(str, layout(0, 1, Some(1), true));
+    }
+
+    #[test]
+    fn test_known_layout_pointer_to_metadata() {
+        fn test<T>(data: *mut T, elems: usize) {
+            let ptr = ptr::slice_from_raw_parts_mut(data, elems);
+            assert_eq!(<[T] as KnownLayout>::pointer_to_metadata(ptr), elems);
+        }
+
+        for elems in [0, 1, usize::MAX] {
+            test(ptr::null_mut::<u8>(), elems);
+        }
+
+        test(NonNull::<u8>::dangling().as_ptr(), 0);
+
+        let mut bytes = [1, 2, 3];
+        test(bytes.as_mut_ptr(), bytes.len());
+        assert_eq!(bytes, [1, 2, 3]);
+
+        test(NonNull::<()>::dangling().as_ptr(), usize::MAX);
+
+        // Retaining and inspecting a raw pointer after freeing its allocation
+        // is safe so long as the pointer is not dereferenced.
+        let deallocated = {
+            let mut byte = Box::new(0u8);
+            let ptr: *mut u8 = &mut *byte;
+            drop(byte);
+            ptr
+        };
+        test(deallocated, 3);
+
+        // Metadata extraction requires neither element storage nor alignment
+        // for `T`; it does not access the pointer's referent.
+        test(NonNull::<u8>::dangling().as_ptr().cast::<u64>(), usize::MAX);
+    }
+
+    #[cfg(feature = "derive")]
+    #[test]
+    fn test_known_layout_pointer_to_metadata_derive() {
+        #[derive(KnownLayout)]
+        #[repr(C)]
+        struct Dst {
+            prefix: u8,
+            trailing: [u8],
+        }
+
+        for elems in [0, 1, usize::MAX] {
+            let ptr = ptr::slice_from_raw_parts_mut(ptr::null_mut::<u8>(), elems);
+            #[allow(clippy::as_conversions)]
+            let ptr = ptr as *mut Dst;
+            assert_eq!(Dst::pointer_to_metadata(ptr), elems);
+        }
     }
 
     #[cfg(feature = "derive")]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

KnownLayout's slice implementation materialized a shared reference solely to
read raw pointer metadata. That is invalid for null, dangling, unaligned, or
otherwise non-dereferenceable slice pointers even though metadata extraction
itself must accept them.

Use the safe raw-slice pointer length API on Rust 1.79 and newer. On older
supported compilers, capture a metadata candidate through raw-pointer hashing
and authenticate it with raw slice pointer equality before returning it.
Strengthen the implementer contract and cover null, dangling, deallocated,
unaligned, derived-DST, and boundary-toolchain cases.

Closes #3615

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3629


**Latest Update:** v3 — [Compare vs v2](/google/zerocopy/compare/gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v2..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v3)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v2 | v1 |Base|
|:---|:---|:---|:---|
|v3|[vs v2](/google/zerocopy/compare/gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v2..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v1..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v3)|
|v2||[vs v1](/google/zerocopy/compare/gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v1..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v2)|
|v1|||[vs Base](/google/zerocopy/compare/main..gherrit/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw && git checkout -b pr-Gro7m5vgpfdcy3pxtpl52hnbgworclnzw FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gro7m5vgpfdcy3pxtpl52hnbgworclnzw
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gro7m5vgpfdcy3pxtpl52hnbgworclnzw","parent":null,"child":null} -->