### PR TITLE
Reject context-dependent enum discriminants

### DIFF
--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -1411,6 +1411,17 @@ where
 ///     discriminant values are specified.
 ///   - The fields of that variant must be `FromZeros`.
 ///
+/// When this derive needs to reproduce an enum's explicit discriminants in
+/// generated code to implement its `TryFromBytes` supertrait, it accepts only
+/// integer or byte literals, arithmetic and bitwise operations whose operands
+/// recursively use this grammar, unary `-` and `!`, grouping, and `.to_le()` or
+/// `.to_be()` directly on an explicitly typed integer literal. Paths (including
+/// paths to constants), macros, general calls and method calls, casts, and
+/// control-flow expressions are rejected. A fieldless enum whose variants
+/// exhaust every discriminant of its representation uses a validator that
+/// accepts every bit pattern without inspecting or copying discriminants, so
+/// this restriction does not apply.
+///
 /// This analysis is subject to change. Unsafe code may *only* rely on the
 /// documented [safety conditions] of `FromZeros`, and must *not* rely on the
 /// implementation details of this derive.
@@ -1633,6 +1644,16 @@ pub unsafe trait Immutable {
 ///     V2 = 10u32.to_le(),
 /// }
 /// ```
+///
+/// When this derive needs to reproduce an enum's explicit discriminants in
+/// generated code, it accepts only integer or byte literals, arithmetic and
+/// bitwise operations whose operands recursively use this grammar, unary `-`
+/// and `!`, grouping, and `.to_le()` or `.to_be()` directly on an explicitly
+/// typed integer literal. Paths (including paths to constants), macros,
+/// general calls and method calls, casts, and control-flow expressions are
+/// rejected. The original enum and generated helper evaluate each copied
+/// discriminant independently, so the derive cannot assume that an arbitrary
+/// const expression produces the same value both times.
 ///
 /// [safety conditions]: trait@TryFromBytes#safety
 #[cfg(any(feature = "derive", test))]
@@ -3901,6 +3922,17 @@ pub unsafe trait FromZeros: TryFromBytes {
 ///     bit pattern is a valid one).
 ///   - Its fields must be `FromBytes`.
 ///
+/// When this derive needs to reproduce an enum's explicit discriminants in
+/// generated code to implement its `TryFromBytes` supertrait, it accepts only
+/// integer or byte literals, arithmetic and bitwise operations whose operands
+/// recursively use this grammar, unary `-` and `!`, grouping, and `.to_le()` or
+/// `.to_be()` directly on an explicitly typed integer literal. Paths (including
+/// paths to constants), macros, general calls and method calls, casts, and
+/// control-flow expressions are rejected. A fieldless enum whose variants
+/// exhaust every discriminant of its representation uses a validator that
+/// accepts every bit pattern without inspecting or copying discriminants, so
+/// this restriction does not apply.
+///
 /// This analysis is subject to change. Unsafe code may *only* rely on the
 /// documented [safety conditions] of `FromBytes`, and must *not* rely on the
 /// implementation details of this derive.
@@ -5529,6 +5561,16 @@ fn mut_from_prefix_suffix<T: FromBytes + IntoBytes + KnownLayout + ?Sized>(
 /// # */
 /// }
 /// ```
+///
+/// When this derive reproduces an enum's explicit discriminants in generated
+/// code, it accepts only integer or byte literals, arithmetic and bitwise
+/// operations whose operands recursively use this grammar, unary `-` and `!`,
+/// grouping, and `.to_le()` or `.to_be()` directly on an explicitly typed
+/// integer literal. Paths (including paths to constants), macros, general
+/// calls and method calls, casts, and control-flow expressions are rejected.
+/// The original enum and generated helper evaluate each copied discriminant
+/// independently, so the derive cannot assume that an arbitrary const
+/// expression produces the same value both times.
 ///
 /// [safety conditions]: trait@IntoBytes#safety
 ///

--- a/zerocopy/zerocopy-derive/src/derive/from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/from_bytes.rs
@@ -7,9 +7,12 @@ use syn::{
 };
 
 use crate::{
-    derive::try_from_bytes::derive_try_from_bytes,
+    derive::try_from_bytes::{derive_try_from_bytes, validate_try_from_bytes_generation},
     repr::{CompoundRepr, EnumRepr, Repr, Spanned},
-    util::{enum_size_from_repr, Ctx, FieldBounds, ImplBlockBuilder, Trait, TraitBound},
+    util::{
+        enum_has_full_discriminant_domain, enum_size_from_repr, Ctx, FieldBounds, ImplBlockBuilder,
+        Trait, TraitBound,
+    },
 };
 /// Returns `Ok(index)` if variant `index` of the enum has a discriminant of
 /// zero. If `Err(bool)` is returned, the boolean is true if the enum has
@@ -89,6 +92,14 @@ pub(crate) fn find_zero_variant(enm: &DataEnum) -> Result<usize, bool> {
     Err(has_unknown_discriminants)
 }
 pub(crate) fn derive_from_zeros(ctx: &Ctx, top_level: Trait) -> Result<TokenStream, Error> {
+    // `derive_try_from_bytes` handles `on_error = "skip"` itself. Preflight
+    // this error so that we do not then emit a `FromZeros` impl without its
+    // required `TryFromBytes` supertrait impl.
+    if ctx.skip_on_error {
+        if let Err(error) = validate_try_from_bytes_generation(ctx, top_level.clone()) {
+            return ctx.error_or_skip(error);
+        }
+    }
     let try_from_bytes = derive_try_from_bytes(ctx, top_level)?;
     let from_zeros = match &ctx.ast.data {
         Data::Struct(strct) => derive_from_zeros_struct(ctx, strct),
@@ -98,6 +109,13 @@ pub(crate) fn derive_from_zeros(ctx: &Ctx, top_level: Trait) -> Result<TokenStre
     Ok(IntoIterator::into_iter([try_from_bytes, from_zeros]).collect())
 }
 pub(crate) fn derive_from_bytes(ctx: &Ctx, top_level: Trait) -> Result<TokenStream, Error> {
+    // As above, skip the whole supertrait chain if its first impl cannot be
+    // generated soundly.
+    if ctx.skip_on_error {
+        if let Err(error) = validate_try_from_bytes_generation(ctx, top_level.clone()) {
+            return ctx.error_or_skip(error);
+        }
+    }
     let from_zeros = derive_from_zeros(ctx, top_level)?;
     let from_bytes = match &ctx.ast.data {
         Data::Struct(strct) => derive_from_bytes_struct(ctx, strct),
@@ -107,11 +125,13 @@ pub(crate) fn derive_from_bytes(ctx: &Ctx, top_level: Trait) -> Result<TokenStre
 
     Ok(IntoIterator::into_iter([from_zeros, from_bytes]).collect())
 }
+
 fn derive_from_zeros_struct(ctx: &Ctx, strct: &DataStruct) -> TokenStream {
     ImplBlockBuilder::new(ctx, strct, Trait::FromZeros, FieldBounds::ALL_SELF).build()
 }
 fn derive_from_zeros_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Error> {
     let repr = EnumRepr::from_attrs(&ctx.ast.attrs)?;
+    let has_full_discriminant_domain = enum_has_full_discriminant_domain(&repr, enm);
 
     // We don't actually care what the repr is; we just care that it's one of
     // the allowed ones.
@@ -128,16 +148,33 @@ fn derive_from_zeros_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Erro
         }
     }
 
-    let zero_variant = match find_zero_variant(enm) {
-        Ok(index) => enm.variants.iter().nth(index).unwrap(),
-        // Has unknown variants
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let field_bounds = match find_zero_variant(enm) {
+        Ok(index) => {
+            let zero_variant = enm.variants.iter().nth(index).unwrap();
+            let explicit_bounds = zero_variant
+                .fields
+                .iter()
+                .map(|field| {
+                    let ty = &field.ty;
+                    parse_quote! { #ty: #zerocopy_crate::FromZeros }
+                })
+                .collect::<Vec<WherePredicate>>();
+            FieldBounds::Explicit(explicit_bounds)
+        }
+        // If every value in the integer representation is used, one variant
+        // has discriminant zero even when a non-literal expression prevents
+        // us from identifying it. Conservatively require every variant field
+        // to be `FromZeros`; fieldless enums add no bounds.
+        Err(true) if has_full_discriminant_domain => FieldBounds::ALL_SELF,
+        // Has unknown variants and not every tag is represented.
         Err(true) => {
             return ctx.error_or_skip(Error::new_spanned(
                 &ctx.ast,
                 "FromZeros only supported on enums with a variant that has a discriminant of `0`\n\
-                help: This enum has discriminants which are not literal integers. One of those may \
-                define or imply which variant has a discriminant of zero. Use a literal integer to \
-                define or imply the variant with a discriminant of zero.",
+                    help: This enum has discriminants which are not literal integers. One of those may \
+                    define or imply which variant has a discriminant of zero. Use a literal integer to \
+                    define or imply the variant with a discriminant of zero.",
             ));
         }
         // Does not have unknown variants
@@ -149,18 +186,7 @@ fn derive_from_zeros_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Erro
         }
     };
 
-    let zerocopy_crate = &ctx.zerocopy_crate;
-    let explicit_bounds = zero_variant
-        .fields
-        .iter()
-        .map(|field| {
-            let ty = &field.ty;
-            parse_quote! { #ty: #zerocopy_crate::FromZeros }
-        })
-        .collect::<Vec<WherePredicate>>();
-
-    Ok(ImplBlockBuilder::new(ctx, enm, Trait::FromZeros, FieldBounds::Explicit(explicit_bounds))
-        .build())
+    Ok(ImplBlockBuilder::new(ctx, enm, Trait::FromZeros, field_bounds).build())
 }
 fn derive_from_zeros_union(ctx: &Ctx, unn: &DataUnion) -> TokenStream {
     let field_type_trait_bounds = FieldBounds::All(&[TraitBound::Slf]);

--- a/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
@@ -202,7 +202,10 @@ fn derive_into_bytes_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Erro
         ));
     }
 
-    let tag_type_definition = generate_tag_enum(ctx, &repr, enm);
+    let tag_type_definition = match generate_tag_enum(ctx, &repr, enm) {
+        Ok(tag_type_definition) => tag_type_definition,
+        Err(error) => return ctx.error_or_skip(error),
+    };
     Ok(ImplBlockBuilder::new(ctx, enm, Trait::IntoBytes, FieldBounds::ALL_SELF)
         .padding_check(PaddingCheck::Enum { tag_type_definition })
         .build())

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -10,8 +10,8 @@ use syn::{
 use crate::{
     repr::{EnumRepr, StructUnionRepr},
     util::{
-        const_block, enum_size_from_repr, generate_tag_enum, Ctx, DataExt, FieldBounds,
-        ImplBlockBuilder, Trait, TraitBound,
+        const_block, enum_could_be_from_bytes, generate_tag_enum, validate_tag_enum_discriminants,
+        Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait, TraitBound,
     },
 };
 fn tag_ident(variant_ident: &Ident) -> Ident {
@@ -200,7 +200,7 @@ pub(crate) fn derive_is_bit_valid(
     repr: &EnumRepr,
 ) -> Result<TokenStream, Error> {
     let trait_path = Trait::TryFromBytes.crate_path(ctx);
-    let tag_enum = generate_tag_enum(ctx, repr, data);
+    let tag_enum = generate_tag_enum(ctx, repr, data)?;
     let tag_consts = generate_tag_consts(data);
 
     let (outer_tag_type, inner_tag_type) = if repr.is_c() {
@@ -443,7 +443,30 @@ pub(crate) fn derive_is_bit_valid(
         }
     })
 }
+/// Validates any input syntax that `TryFromBytes` code generation will copy
+/// into a helper definition.
+///
+/// Keep this separate from code generation so supertrait derives can reject
+/// the entire generated impl chain when `on_error = "skip"` is requested.
+pub(crate) fn validate_try_from_bytes_generation(ctx: &Ctx, top_level: Trait) -> Result<(), Error> {
+    let enm = match &ctx.ast.data {
+        Data::Enum(enm) => enm,
+        Data::Struct(_) | Data::Union(_) => return Ok(()),
+    };
+    let repr = EnumRepr::from_attrs(&ctx.ast.attrs)?;
+    let generates_tag_enum = try_gen_trivial_is_bit_valid(ctx, top_level).is_none()
+        && !enum_could_be_from_bytes(&repr, enm);
+    if generates_tag_enum {
+        validate_tag_enum_discriminants(enm)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn derive_try_from_bytes(ctx: &Ctx, top_level: Trait) -> Result<TokenStream, Error> {
+    if let Err(error) = validate_try_from_bytes_generation(ctx, top_level.clone()) {
+        return ctx.error_or_skip(error);
+    }
+
     match &ctx.ast.data {
         Data::Struct(strct) => derive_try_from_bytes_struct(ctx, strct, top_level),
         Data::Enum(enm) => derive_try_from_bytes_enum(ctx, enm, top_level),
@@ -673,9 +696,7 @@ fn derive_try_from_bytes_enum(
     // then it *could* be `FromBytes` (even if the user hasn't derived
     // `FromBytes`). This holds if, for `repr(uN)` or `repr(iN)`, there are 2^N
     // variants.
-    let could_be_from_bytes = enum_size_from_repr(&repr)
-        .map(|size| enm.fields().is_empty() && enm.variants.len() == 1usize << size)
-        .unwrap_or(false);
+    let could_be_from_bytes = enum_could_be_from_bytes(&repr, enm);
 
     let trivial_is_bit_valid = try_gen_trivial_is_bit_valid(ctx, top_level);
     let extra = match (trivial_is_bit_valid, could_be_from_bytes) {
@@ -685,8 +706,7 @@ fn derive_try_from_bytes_enum(
         (None, true) => unsafe { gen_trivial_is_bit_valid_unchecked(ctx) },
         (None, false) => match derive_is_bit_valid(ctx, enm, &repr) {
             Ok(extra) => extra,
-            Err(_) if ctx.skip_on_error => return Ok(TokenStream::new()),
-            Err(e) => return Err(e),
+            Err(e) => return ctx.error_or_skip(e),
         },
     };
 
@@ -766,7 +786,41 @@ unsafe fn gen_trivial_is_bit_valid_unchecked(ctx: &Ctx) -> proc_macro2::TokenStr
 
 #[cfg(test)]
 mod tests {
+    use quote::{format_ident, quote};
+
     use super::*;
+
+    fn context_dependent_enum(variant_count: usize) -> Ctx {
+        let remaining_variants = (2..variant_count).map(|index| format_ident!("V{}", index));
+        let ast = syn::parse2(quote! {
+            #[repr(u8)]
+            enum Enum {
+                V0 = 0,
+                V1 = Self::TAG,
+                #(#remaining_variants,)*
+            }
+        })
+        .unwrap();
+        Ctx::try_from_derive_input(ast).unwrap().skip_on_error()
+    }
+
+    #[test]
+    fn test_validation_only_when_try_from_bytes_generates_tag_enum() {
+        // An exhaustive fieldless u8 enum gets a trivial validator, so its
+        // discriminants are never copied into a helper enum.
+        assert!(validate_try_from_bytes_generation(
+            &context_dependent_enum(256),
+            Trait::TryFromBytes,
+        )
+        .is_ok());
+
+        // A nonexhaustive enum needs the helper and must pass validation.
+        assert!(validate_try_from_bytes_generation(
+            &context_dependent_enum(255),
+            Trait::TryFromBytes,
+        )
+        .is_err());
+    }
 
     fn derive_error(input: DeriveInput) -> String {
         let ctx = Ctx::try_from_derive_input(input).unwrap();

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -344,6 +344,91 @@ fn test_try_from_bytes_enum() {
     }
 }
 
+#[test]
+fn test_context_dependent_enum_discriminants() {
+    test! {
+        TryFromBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = Self::TAG,
+            }
+        } expands to {
+            ::core::compile_error! {
+                "`Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum"
+            }
+        } no_build
+    }
+
+    test! {
+        IntoBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = Self::TAG,
+            }
+        } expands to {
+            ::core::compile_error! {
+                "`Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum"
+            }
+        } no_build
+    }
+
+    test! {
+        TryFromBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = tag!(),
+            }
+        } expands to {
+            ::core::compile_error! {
+                "macros are not supported in enum discriminants because their expansion cannot be preserved in Zerocopy's generated helper enum"
+            }
+        } no_build
+    }
+
+    test! {
+        TryFromBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = TAG,
+            }
+        } expands to {
+            ::core::compile_error! {
+                "paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently"
+            }
+        } no_build
+    }
+
+    test! {
+        TryFromBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = match 0 {
+                    ___ZEROCOPY_TAG_Baz if true => 0,
+                    _ => 1,
+                },
+                Baz = 2,
+            }
+        } expands to {
+            ::core::compile_error! {
+                "this expression is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum"
+            }
+        } no_build
+    }
+
+    test! {
+        TryFromBytes {
+            #[repr(u8)]
+            enum Foo {
+                Bar = crate::CUSTOM + 1u8,
+            }
+        } expands to {
+            ::core::compile_error! {
+                "paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently"
+            }
+        } no_build
+    }
+}
+
 // This goes at the bottom because it's so verbose and it makes scrolling past
 // other code a pain.
 #[test]

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -835,16 +835,304 @@ pub(crate) fn const_block(items: impl IntoIterator<Item = Option<TokenStream>>) 
         };
     }
 }
-pub(crate) fn generate_tag_enum(ctx: &Ctx, repr: &EnumRepr, data: &DataEnum) -> TokenStream {
-    let zerocopy_crate = &ctx.zerocopy_crate;
-    let variants = data.variants.iter().map(|v| {
-        let ident = &v.ident;
-        if let Some((eq, discriminant)) = &v.discriminant {
-            quote! { #ident #eq #discriminant }
-        } else {
-            quote! { #ident }
+
+fn validate_tag_enum_discriminant(discriminant: &Expr) -> Result<(), Error> {
+    fn reject(syntax: impl ToTokens, message: &'static str) -> Result<(), Error> {
+        Err(Error::new_spanned(syntax, message))
+    }
+
+    fn validate_attrs(attrs: &[syn::Attribute]) -> Result<(), Error> {
+        match attrs.first() {
+            Some(attr) => reject(
+                attr,
+                "attributes are not supported in enum discriminants because their effect cannot \
+                 be preserved in Zerocopy's generated helper enum",
+            ),
+            None => Ok(()),
         }
-    });
+    }
+
+    fn has_supported_integer_suffix(integer: &syn::LitInt) -> bool {
+        matches!(
+            integer.suffix(),
+            "" | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "i8"
+                | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+        )
+    }
+
+    fn validate_path(path: &Path) -> Result<(), Error> {
+        if path.segments.iter().any(|segment| segment.ident == "Self") {
+            // In the original discriminant, `Self` denotes the type being
+            // derived. In the copied discriminant, it would denote the
+            // generated tag enum instead.
+            return reject(
+                path,
+                "`Self` is not supported in enum discriminants because its meaning cannot be \
+                 preserved in Zerocopy's generated helper enum",
+            );
+        }
+
+        // The original enum and generated helper enum evaluate copied
+        // discriminants independently. Even a fully-qualified constant path
+        // is not guaranteed to evaluate repeatably: safe const evaluation can
+        // be nondeterministic, and a path can introduce caller-defined types
+        // whose operators have caller-defined semantics. Restrict every leaf
+        // to syntax whose value is defined directly by the compiler.
+        reject(
+            path,
+            "paths are not supported in enum discriminants because Zerocopy's generated helper \
+             enum evaluates copied discriminants independently",
+        )
+    }
+
+    fn validate_endian_method_call(call: &syn::ExprMethodCall) -> Result<(), Error> {
+        validate_attrs(&call.attrs)?;
+        let integer = match call.receiver.as_ref() {
+            Expr::Lit(ExprLit { attrs, lit: Lit::Int(integer), .. }) if attrs.is_empty() => integer,
+            _ => {
+                return reject(
+                    call,
+                    "only `.to_le()` and `.to_be()` on explicitly typed integer literals are \
+                     supported in enum discriminants",
+                )
+            }
+        };
+        if !integer.suffix().is_empty()
+            && has_supported_integer_suffix(integer)
+            && (call.method == "to_le" || call.method == "to_be")
+            && call.turbofish.is_none()
+            && call.args.is_empty()
+        {
+            // These inherent primitive methods are selected entirely by the
+            // explicit literal suffix and cannot be affected by the helper
+            // enum's surrounding item or trait scope.
+            Ok(())
+        } else {
+            reject(
+                call,
+                "only `.to_le()` and `.to_be()` on explicitly typed integer literals are \
+                 supported in enum discriminants",
+            )
+        }
+    }
+
+    fn validate_expr(expr: &Expr) -> Result<(), Error> {
+        match expr {
+            Expr::Binary(binary) => {
+                validate_attrs(&binary.attrs)?;
+                match &binary.op {
+                    syn::BinOp::Add(_)
+                    | syn::BinOp::Sub(_)
+                    | syn::BinOp::Mul(_)
+                    | syn::BinOp::Div(_)
+                    | syn::BinOp::Rem(_)
+                    | syn::BinOp::BitXor(_)
+                    | syn::BinOp::BitAnd(_)
+                    | syn::BinOp::BitOr(_)
+                    | syn::BinOp::Shl(_)
+                    | syn::BinOp::Shr(_) => {}
+                    _ => {
+                        return reject(
+                            binary.op,
+                            "only arithmetic and bitwise operators are supported in enum \
+                             discriminants",
+                        )
+                    }
+                }
+                validate_expr(&binary.left)?;
+                validate_expr(&binary.right)
+            }
+            Expr::Group(group) => {
+                validate_attrs(&group.attrs)?;
+                validate_expr(&group.expr)
+            }
+            Expr::Lit(lit) => {
+                validate_attrs(&lit.attrs)?;
+                match &lit.lit {
+                    Lit::Byte(_) => Ok(()),
+                    Lit::Int(integer) if has_supported_integer_suffix(integer) => Ok(()),
+                    Lit::Int(integer) => reject(
+                        integer,
+                        "only unsuffixed or primitive-integer-suffixed literals are supported in \
+                         enum discriminants",
+                    ),
+                    Lit::Verbatim(literal) => reject(
+                        literal,
+                        "unparsed syntax is not supported in enum discriminants because its \
+                         meaning cannot be preserved in Zerocopy's generated helper enum",
+                    ),
+                    _ => reject(
+                        &lit.lit,
+                        "only integer and byte literals are supported in enum discriminants",
+                    ),
+                }
+            }
+            Expr::MethodCall(call) => validate_endian_method_call(call),
+            Expr::Paren(paren) => {
+                validate_attrs(&paren.attrs)?;
+                validate_expr(&paren.expr)
+            }
+            Expr::Path(path) => {
+                validate_attrs(&path.attrs)?;
+                if let Some(qself) = &path.qself {
+                    if matches!(qself.ty.as_ref(), Type::Path(ty) if ty.qself.is_none() && ty.path.is_ident("Self"))
+                    {
+                        return reject(
+                            &qself.ty,
+                            "`Self` is not supported in enum discriminants because its meaning \
+                             cannot be preserved in Zerocopy's generated helper enum",
+                        );
+                    }
+                    return reject(
+                        path,
+                        "qualified type-relative paths are not supported in enum discriminants \
+                         because their meaning cannot be preserved in Zerocopy's generated \
+                         helper enum",
+                    );
+                }
+                validate_path(&path.path)
+            }
+            Expr::Unary(unary) => {
+                validate_attrs(&unary.attrs)?;
+                match &unary.op {
+                    syn::UnOp::Neg(_) | syn::UnOp::Not(_) => validate_expr(&unary.expr),
+                    _ => reject(
+                        unary.op,
+                        "only negation and bitwise-not unary operators are supported in enum \
+                         discriminants",
+                    ),
+                }
+            }
+            Expr::Macro(mac) => {
+                // A macro can emit `Self` even if its invocation does not
+                // contain a `Self` token. Expanding it once in the original
+                // enum and again in the helper enum can produce different
+                // values.
+                reject(
+                    mac,
+                    "macros are not supported in enum discriminants because their expansion \
+                     cannot be preserved in Zerocopy's generated helper enum",
+                )
+            }
+            Expr::Verbatim(tokens) => reject(
+                tokens,
+                "unparsed syntax is not supported in enum discriminants because its meaning \
+                 cannot be preserved in Zerocopy's generated helper enum",
+            ),
+            _ => {
+                // This is a positive grammar. In particular, it rejects every
+                // pattern, binding, control-flow construct, call, non-endian
+                // method call, block item, macro, and current or future
+                // unparsed AST variant. Those constructs can resolve names
+                // differently after the expression is copied into the
+                // generated helper enum.
+                reject(
+                    expr,
+                    "this expression is not supported in enum discriminants because its meaning \
+                     cannot be preserved in Zerocopy's generated helper enum",
+                )
+            }
+        }
+    }
+
+    validate_expr(discriminant)
+}
+
+pub(crate) fn validate_tag_enum_discriminants(data: &DataEnum) -> Result<(), Error> {
+    for variant in &data.variants {
+        if let Some((_, discriminant)) = &variant.discriminant {
+            validate_tag_enum_discriminant(discriminant)?;
+        }
+    }
+    Ok(())
+}
+
+fn tag_enum_discriminant_lint_attrs(attrs: &[syn::Attribute]) -> Vec<TokenStream> {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            // A lint level explicitly attached to the source enum or one of
+            // its variants applies to its discriminants, but not to the
+            // generated helper enum. Copy only source-provided levels which
+            // can permit the primitive expressions admitted by
+            // `validate_tag_enum_discriminant`.
+            //
+            // In particular, do not add an unconditional `allow`: lowering a
+            // lint which an enclosing scope forbids is itself an error, even
+            // when the copied discriminant would not trigger that lint.
+            if !path_is_ident(attr.path(), "allow")
+                && !path_is_ident(attr.path(), "expect")
+                && !path_is_ident(attr.path(), "warn")
+            {
+                return None;
+            }
+
+            let nested = attr
+                .parse_args_with(
+                    syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+                )
+                .ok()?;
+            let lints = nested.iter().filter_map(|meta| match meta {
+                Meta::Path(path)
+                    if path_is_ident(path, "overflowing_literals")
+                        || path_is_ident(path, "arithmetic_overflow") =>
+                {
+                    Some(path)
+                }
+                _ => None,
+            });
+            let lints = lints.collect::<Vec<_>>();
+            if lints.is_empty() {
+                return None;
+            }
+
+            // `warn` lowers these deny-by-default lints, and `expect` also
+            // permits them while requiring a diagnostic in the source item.
+            // The helper only needs the permissive level. Reproducing `warn`
+            // would emit duplicate diagnostics, while reproducing `expect`
+            // could create a new unfulfilled expectation.
+            Some(quote_spanned! { attr.span()=> #[allow(#(#lints),*)] })
+        })
+        .collect()
+}
+
+pub(crate) fn generate_tag_enum(
+    ctx: &Ctx,
+    repr: &EnumRepr,
+    data: &DataEnum,
+) -> Result<TokenStream, Error> {
+    // This proof assumes that rustc does not let a later attribute macro
+    // replace the input item while retaining this derive's output. That is a
+    // compiler TCB premise; rust-lang/rust#148423 tracks its violation. A
+    // local check cannot distinguish later active attributes from arbitrary
+    // inert derive-helper attributes, and a partial attribute allowlist would
+    // not protect Zerocopy's other generated unsafe impls.
+    validate_tag_enum_discriminants(data)?;
+    let zerocopy_crate = &ctx.zerocopy_crate;
+    let discriminant_lint_attrs = tag_enum_discriminant_lint_attrs(&ctx.ast.attrs);
+    let variants = data
+        .variants
+        .iter()
+        .map(|v| -> Result<TokenStream, Error> {
+            let ident = &v.ident;
+            let variant_lint_attrs = tag_enum_discriminant_lint_attrs(&v.attrs);
+            if let Some((eq, discriminant)) = &v.discriminant {
+                Ok(quote! { #(#variant_lint_attrs)* #ident #eq #discriminant })
+            } else {
+                Ok(quote! { #(#variant_lint_attrs)* #ident })
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Don't include any `repr(align)` when generating the tag enum, as that
     // could add padding after the tag but before any variants, which is not the
@@ -854,8 +1142,9 @@ pub(crate) fn generate_tag_enum(ctx: &Ctx, repr: &EnumRepr, data: &DataEnum) -> 
         EnumRepr::Compound(c, _) => quote! { #c },
     };
 
-    quote! {
+    Ok(quote! {
         #repr
+        #(#discriminant_lint_attrs)*
         #[allow(dead_code)]
         pub enum ___ZerocopyTag {
             #(#variants,)*
@@ -866,8 +1155,17 @@ pub(crate) fn generate_tag_enum(ctx: &Ctx, repr: &EnumRepr, data: &DataEnum) -> 
         unsafe impl #zerocopy_crate::Immutable for ___ZerocopyTag {
             fn only_derive_is_allowed_to_implement_this_trait() {}
         }
-    }
+    })
 }
+
+pub(crate) fn enum_has_full_discriminant_domain(repr: &EnumRepr, enm: &DataEnum) -> bool {
+    enum_size_from_repr(repr).map(|size| enm.variants.len() == 1usize << size).unwrap_or(false)
+}
+
+pub(crate) fn enum_could_be_from_bytes(repr: &EnumRepr, enm: &DataEnum) -> bool {
+    enm.fields().is_empty() && enum_has_full_discriminant_domain(repr, enm)
+}
+
 pub(crate) fn enum_size_from_repr(repr: &EnumRepr) -> Result<usize, Error> {
     use CompoundRepr::*;
     use PrimitiveRepr::*;
@@ -979,6 +1277,131 @@ pub(crate) mod testutil {
                 let _: <T>::Ambiguous;
             }
         });
+    }
+
+    #[test]
+    fn test_validate_tag_enum_discriminant_accepts_stable_context() {
+        use syn::parse_quote;
+
+        for expr in [
+            parse_quote!(1),
+            parse_quote!(1 + 2),
+            parse_quote!(!0 & (1 << 2)),
+            parse_quote!(9_u32.to_le()),
+            parse_quote!(0x0800_u16.to_be()),
+        ] {
+            assert!(super::validate_tag_enum_discriminant(&expr).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_validate_tag_enum_discriminant_rejects_context_dependent_syntax() {
+        use syn::parse_quote;
+
+        for expr in [
+            parse_quote!(Self::TAG),
+            parse_quote!(1 + Self::TAG),
+            parse_quote!(<Self as crate::Tag>::TAG),
+            parse_quote!(TAG),
+            parse_quote!(module::TAG),
+            parse_quote!(crate::TAG),
+            parse_quote!(self::TAG),
+            parse_quote!(super::TAG),
+            parse_quote!(super::super::TAG),
+            parse_quote!(crate::CUSTOM + 1),
+            parse_quote!(crate::Type::TAG),
+            parse_quote!(::core::primitive::u8::MAX),
+            parse_quote!(<crate::Type>::TAG),
+            parse_quote!(<crate::Type as crate::Trait>::TAG),
+            parse_quote!(tag!()),
+            parse_quote!(1 + tag!()),
+            parse_quote!(crate::tag()),
+            parse_quote!(0_u8.count_ones()),
+            parse_quote!(0.to_le()),
+            parse_quote!((0_u8).to_le()),
+            parse_quote!(0 as u8),
+            parse_quote!(0_custom),
+            parse_quote!(if true { 0 } else { 1 }),
+            parse_quote!(match 0 {
+                ___ZEROCOPY_TAG_Raw if true => 0,
+                _ => 1,
+            }),
+            parse_quote!({
+                const TAG: u8 = 0;
+                TAG
+            }),
+            parse_quote!(crate::Tag::<u8>::VALUE),
+            parse_quote!(
+                #[cfg(any())]
+                1
+            ),
+            syn::Expr::Verbatim(quote::quote!(some future syntax)),
+        ] {
+            assert!(super::validate_tag_enum_discriminant(&expr).is_err());
+        }
+    }
+
+    #[test]
+    fn test_validate_tag_enum_discriminant_rejects_nested_verbatim_type() {
+        use syn::{Expr, Type};
+
+        // `syn` 2.0.56 accepts `dyn*` but represents it as `Type::Verbatim`.
+        // The `Self` token in this type must not evade structural validation.
+        let expr =
+            syn::parse_str::<Expr>("<dyn* crate::Marker<Self> as crate::Value>::VALUE").unwrap();
+        let ty = match &expr {
+            Expr::Path(path) => &path.qself.as_ref().unwrap().ty,
+            _ => panic!("expected an expression path"),
+        };
+        assert!(matches!(ty.as_ref(), Type::Verbatim(_)));
+        assert!(super::validate_tag_enum_discriminant(&expr).is_err());
+    }
+
+    #[test]
+    fn test_validate_tag_enum_discriminant_rejects_verbatim_literal() {
+        use syn::{parse_quote, Expr, Lit};
+
+        let mut expr: Expr = parse_quote!(0);
+        match &mut expr {
+            Expr::Lit(expr) => {
+                expr.lit = Lit::Verbatim(proc_macro2::Literal::u8_unsuffixed(0));
+            }
+            _ => panic!("expected a literal expression"),
+        }
+        assert!(super::validate_tag_enum_discriminant(&expr).is_err());
+    }
+
+    #[test]
+    fn test_tag_enum_discriminant_lint_attrs_normalize_permissive_levels() {
+        use syn::parse_quote;
+
+        let input = parse_quote! {
+            #[allow(overflowing_literals)]
+            #[warn(arithmetic_overflow)]
+            #[expect(overflowing_literals, reason = "checked on the source enum")]
+            #[deny(overflowing_literals)]
+            enum Foo {
+                #[warn(overflowing_literals)]
+                #[expect(arithmetic_overflow, reason = "checked on the source variant")]
+                #[deny(arithmetic_overflow)]
+                A = 0,
+            }
+        };
+        let ctx = super::Ctx::try_from_derive_input(input).unwrap();
+        let attrs = super::tag_enum_discriminant_lint_attrs(&ctx.ast.attrs);
+        assert_eq!(
+            quote::quote!(#(#attrs)*).to_string(),
+            "# [allow (overflowing_literals)] # [allow (arithmetic_overflow)] # [allow (overflowing_literals)]",
+        );
+        let variant = match &ctx.ast.data {
+            syn::Data::Enum(data) => &data.variants[0],
+            _ => unreachable!(),
+        };
+        let attrs = super::tag_enum_discriminant_lint_attrs(&variant.attrs);
+        assert_eq!(
+            quote::quote!(#(#attrs)*).to_string(),
+            "# [allow (overflowing_literals)] # [allow (arithmetic_overflow)]",
+        );
     }
 
     #[test]

--- a/zerocopy/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -29,6 +29,70 @@ fn test_foo() {
     imp::assert!(<Foo as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]).is_err());
 }
 
+#[allow(overflowing_literals)]
+#[derive(imp::Immutable, imp::IntoBytes, imp::KnownLayout, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum AllowedLiteralOverflow {
+    A = 256,
+}
+
+#[test]
+fn test_allowed_discriminant_overflow_is_reproduced() {
+    crate::util::test_is_bit_valid::<AllowedLiteralOverflow, _>([0u8], true);
+    crate::util::test_is_bit_valid::<AllowedLiteralOverflow, _>([1u8], false);
+}
+
+#[derive(imp::Immutable, imp::IntoBytes, imp::KnownLayout, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum VariantAllowedLiteralOverflow {
+    #[allow(overflowing_literals)]
+    A = 256,
+}
+
+#[test]
+fn test_variant_allowed_discriminant_overflow_is_reproduced() {
+    crate::util::test_is_bit_valid::<VariantAllowedLiteralOverflow, _>([0u8], true);
+    crate::util::test_is_bit_valid::<VariantAllowedLiteralOverflow, _>([1u8], false);
+}
+
+mod forbidden_overflow_lints {
+    #![forbid(arithmetic_overflow, overflowing_literals)]
+
+    #[derive(
+        super::imp::Immutable,
+        super::imp::IntoBytes,
+        super::imp::KnownLayout,
+        super::imp::TryFromBytes,
+    )]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum ValidDiscriminants {
+        Literal = 1,
+        Arithmetic = 1 + 1,
+    }
+}
+
+#[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+mod expected_overflow_lint {
+    #![deny(unfulfilled_lint_expectations)]
+
+    #[allow(unfulfilled_lint_expectations)]
+    #[expect(overflowing_literals)]
+    #[derive(
+        super::imp::Immutable,
+        super::imp::IntoBytes,
+        super::imp::KnownLayout,
+        super::imp::TryFromBytes,
+    )]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum ValidDiscriminant {
+        A = 1,
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(u16)]
@@ -78,8 +142,6 @@ fn test_baz() {
 // the code emitted by the derive.
 type i8 = bool;
 
-const THREE: ::core::primitive::i8 = 3;
-
 #[derive(Eq, PartialEq, Debug, imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
 #[repr(i8)]
@@ -87,7 +149,7 @@ enum Blah {
     A = 1,
     B = 0,
     C = 1 + 2,
-    D = 3 + THREE,
+    D = 3 + 3,
 }
 
 util_assert_impl_all!(Blah: imp::TryFromBytes);
@@ -113,6 +175,24 @@ fn test_blah() {
     imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[]).is_err());
     imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[4]).is_err());
     imp::assert!(<Blah as imp::TryFromBytes>::try_read_from_bytes(&[0, 0]).is_err());
+}
+
+#[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+#[derive(imp::KnownLayout, imp::Immutable, imp::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum LiteralDerivedDiscriminantPacket {
+    Flag(bool) = 2 - 1,
+    Raw(u8) = 0,
+}
+
+#[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+#[test]
+fn test_literal_derived_discriminants_validate_the_actual_variant() {
+    crate::util::test_is_bit_valid::<LiteralDerivedDiscriminantPacket, _>([0u8, 255], true);
+    crate::util::test_is_bit_valid::<LiteralDerivedDiscriminantPacket, _>([1u8, 0], true);
+    crate::util::test_is_bit_valid::<LiteralDerivedDiscriminantPacket, _>([1u8, 1], true);
+    crate::util::test_is_bit_valid::<LiteralDerivedDiscriminantPacket, _>([1u8, 2], false);
 }
 
 #[derive(
@@ -376,10 +456,60 @@ enum B {
     A2 { a: A },
 }
 
-#[derive(imp::TryFromBytes)]
-#[zerocopy(crate = "zerocopy_renamed")]
-#[repr(u8)]
-enum FooU8 {
+const FULL_DOMAIN_ZERO: u8 = 0;
+
+macro_rules! define_full_domain_enums {
+    ($first:ident, $($variant:ident,)*) => {
+        #[derive(imp::TryFromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(u8)]
+        enum FooU8 {
+            $first,
+            $($variant,)*
+        }
+
+        // `TryFromBytes` can use its trivial validator for a full-domain enum,
+        // and `FromZeros` knows that one of the fieldless variants represents
+        // zero even though it cannot evaluate the first discriminant itself.
+        #[derive(imp::FromBytes)]
+        #[zerocopy(on_error = "skip")]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(u8)]
+        enum FullDomainFromBytes {
+            $first = crate::FULL_DOMAIN_ZERO,
+            $($variant,)*
+        }
+
+        #[derive(imp::most_traits)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(u8)]
+        enum FullDomainMostTraits {
+            $first = crate::FULL_DOMAIN_ZERO,
+            $($variant,)*
+        }
+
+        #[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+        #[derive(imp::FromBytes)]
+        #[zerocopy(on_error = "skip")]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(u8)]
+        enum FullDomainWithFieldFromBytes {
+            $first(u8) = 0 + 0,
+            $($variant,)*
+        }
+
+        #[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+        #[derive(imp::most_traits)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(u8)]
+        enum FullDomainWithFieldMostTraits {
+            $first(u8) = 0 + 0,
+            $($variant,)*
+        }
+    };
+}
+
+define_full_domain_enums! {
     Variant0,
     Variant1,
     Variant2,
@@ -637,6 +767,29 @@ enum FooU8 {
     Variant254,
     Variant255,
 }
+
+util_assert_impl_all!(FullDomainFromBytes:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
+util_assert_impl_all!(FullDomainMostTraits:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
+#[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+util_assert_impl_all!(FullDomainWithFieldFromBytes:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
+#[cfg(not(__ZEROCOPY_INTERNAL_USE_ONLY_TOOLCHAIN = "msrv"))]
+util_assert_impl_all!(FullDomainWithFieldMostTraits:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
 
 #[test]
 fn test_trivial_is_bit_valid() {

--- a/zerocopy/zerocopy-derive/tests/on_error.rs
+++ b/zerocopy/zerocopy-derive/tests/on_error.rs
@@ -99,6 +99,92 @@ enum BadTryFromBytesEnum {
 
 util_assert_not_impl_any!(BadTryFromBytesEnum: imp::TryFromBytes);
 
+#[derive(imp::TryFromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ContextDependentTryFromBytes {
+    A = Self::TAG,
+}
+
+impl ContextDependentTryFromBytes {
+    const TAG: u8 = 0;
+}
+
+util_assert_not_impl_any!(ContextDependentTryFromBytes: imp::TryFromBytes);
+
+#[derive(imp::IntoBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ContextDependentIntoBytes {
+    A = Self::TAG,
+}
+
+impl ContextDependentIntoBytes {
+    const TAG: u8 = 0;
+}
+
+util_assert_not_impl_any!(ContextDependentIntoBytes: imp::IntoBytes);
+
+#[derive(imp::FromZeros)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ContextDependentFromZeros {
+    A = 0,
+    B = Self::TAG,
+}
+
+impl ContextDependentFromZeros {
+    const TAG: u8 = 1;
+}
+
+util_assert_not_impl_any!(ContextDependentFromZeros: imp::TryFromBytes, imp::FromZeros);
+
+#[derive(imp::FromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ContextDependentFromBytes {
+    A = 0,
+    B = Self::TAG,
+}
+
+impl ContextDependentFromBytes {
+    const TAG: u8 = 1;
+}
+
+util_assert_not_impl_any!(ContextDependentFromBytes:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
+
+#[derive(imp::most_traits)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ContextDependentMostTraits {
+    A = 0,
+    B = Self::TAG,
+}
+
+impl ContextDependentMostTraits {
+    const TAG: u8 = 1;
+}
+
+util_assert_impl_all!(ContextDependentMostTraits:
+    imp::KnownLayout,
+    imp::Immutable,
+    imp::Unaligned,
+);
+util_assert_not_impl_any!(ContextDependentMostTraits:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+    imp::IntoBytes,
+);
+
 // Invalid union for IntoBytes (invalid repr).
 #[derive(imp::IntoBytes)]
 #[zerocopy(on_error = "skip")]

--- a/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.msrv.stderr
@@ -6,5 +6,13 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enabl
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enable
+  --> $DIR/on_error.rs:20:10
+   |
+20 | #[derive(TryFromBytes)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 

--- a/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.nightly.stderr
@@ -6,5 +6,13 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enabl
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enable
+  --> $DIR/on_error.rs:20:10
+   |
+20 | #[derive(TryFromBytes)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 

--- a/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.rs
@@ -8,7 +8,7 @@
 
 extern crate zerocopy_renamed;
 
-use zerocopy_renamed::FromBytes;
+use zerocopy_renamed::{FromBytes, TryFromBytes};
 
 #[derive(FromBytes)]
 //~^ ERROR: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enable
@@ -16,5 +16,18 @@ use zerocopy_renamed::FromBytes;
 #[zerocopy(on_error = "skip")]
 #[repr(C)]
 struct Foo(bool);
+
+#[derive(TryFromBytes)]
+//~^ ERROR: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enable
+#[zerocopy(crate = "zerocopy_renamed")]
+#[zerocopy(on_error = "skip")]
+#[repr(u8)]
+enum ContextDependentDiscriminant {
+    A = Self::TAG,
+}
+
+impl ContextDependentDiscriminant {
+    const TAG: u8 = 0;
+}
 
 fn main() {}

--- a/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/cfgs/on_error.stable.stderr
@@ -6,5 +6,13 @@ error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enabl
    |
    = note: this error originates in the derive macro `FromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: `on_error` is experimental; pass '--cfg zerocopy_unstable_linux' to enable
+  --> $DIR/on_error.rs:20:10
+   |
+20 | #[derive(TryFromBytes)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `TryFromBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 

--- a/zerocopy/zerocopy-derive/tests/ui/enum.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.msrv.stderr
@@ -75,14 +75,13 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
 152 | |
 153 | | #[repr(i8)]
 154 | | enum FromZeros5 {
-155 | |     A = NEGATIVE_ONE,
+155 | |     A = -2,
 156 | |     B,
 157 | | }
     | |_^

--- a/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.nightly.stderr
@@ -98,14 +98,13 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-       help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
 152 | |
 153 | | #[repr(i8)]
 154 | | enum FromZeros5 {
-155 | |     A = NEGATIVE_ONE,
+155 | |     A = -2,
 156 | |     B,
 157 | | }
     | |_^

--- a/zerocopy/zerocopy-derive/tests/ui/enum.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.rs
@@ -145,14 +145,14 @@ enum FromZeros4 {
     B = 2,
 }
 
-const NEGATIVE_ONE: i8 = -1;
+// Keep this enum's lack of a zero discriminant apparent to the derive.
 
 #[derive(FromZeros)]
 #[zerocopy(crate = "zerocopy_renamed")]
 //~[msrv, stable, nightly]^ ERROR: FromZeros only supported on enums with a variant that has a discriminant of `0`
 #[repr(i8)]
 enum FromZeros5 {
-    A = NEGATIVE_ONE,
+    A = -2,
     B,
 }
 

--- a/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/enum.stable.stderr
@@ -75,14 +75,13 @@ error: FromZeros only supported on enums with a variant that has a discriminant 
     | |_^
 
 error: FromZeros only supported on enums with a variant that has a discriminant of `0`
-       help: This enum has discriminants which are not literal integers. One of those may define or imply which variant has a discriminant of zero. Use a literal integer to define or imply the variant with a discriminant of zero.
    --> $DIR/enum.rs:151:1
     |
 151 | / #[zerocopy(crate = "zerocopy_renamed")]
 152 | |
 153 | | #[repr(i8)]
 154 | | enum FromZeros5 {
-155 | |     A = NEGATIVE_ONE,
+155 | |     A = -2,
 156 | |     B,
 157 | | }
     | |_^

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3619.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3619.msrv.stderr
@@ -1,0 +1,67 @@
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:18:9
+   |
+18 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:30:9
+   |
+30 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:42:10
+   |
+42 |     A = <Self>::TAG,
+   |          ^^^^
+
+error: macros are not supported in enum discriminants because their expansion cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:60:9
+   |
+60 |     A = contextual_tag!(),
+   |         ^^^^^^^^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:74:9
+   |
+74 |     A = crate::TAG,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:85:9
+   |
+85 |     A = crate::TAG + 1,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:93:9
+   |
+93 |     A = TAG,
+   |         ^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:113:9
+    |
+113 |     A = ___ZerocopyTag::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^
+
+error: this expression is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+   --> $DIR/issue_3619.rs:122:9
+    |
+122 |       A = match 0 {
+    |  _________^
+123 | |
+124 | |         ___ZEROCOPY_TAG_Raw if true => 0,
+125 | |         _ => 1,
+126 | |     },
+    | |_____^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:134:9
+    |
+134 |     A = crate::TypeRelativePath::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3619.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3619.nightly.stderr
@@ -1,0 +1,73 @@
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:18:9
+   |
+18 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:30:9
+   |
+30 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:42:10
+   |
+42 |     A = <Self>::TAG,
+   |          ^^^^
+
+error: macros are not supported in enum discriminants because their expansion cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:60:9
+   |
+60 |     A = contextual_tag!(),
+   |         ^^^^^^^^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:74:9
+   |
+74 |     A = crate::TAG,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:85:9
+   |
+85 |     A = crate::TAG + 1,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:93:9
+   |
+93 |     A = TAG,
+   |         ^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:113:9
+    |
+113 |     A = ___ZerocopyTag::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^
+
+error: this expression is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+   --> $DIR/issue_3619.rs:122:9
+    |
+122 |       A = match 0 {
+    |  _________^
+123 | |
+124 | |         ___ZEROCOPY_TAG_Raw if true => 0,
+125 | |         _ => 1,
+126 | |     },
+    | |_____^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:134:9
+    |
+134 |     A = crate::TypeRelativePath::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+   --> $DIR/issue_3619.rs:147:18
+    |
+147 |     Flag(bool) = Self::TAG,
+    |                  ^^^^^^^^^
+
+error: aborting due to 11 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3619.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3619.rs
@@ -1,0 +1,155 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#[macro_use]
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum FacadeSelf {
+    A = Self::TAG,
+    //~^ ERROR: `Self` is not supported in enum discriminants
+}
+
+impl FacadeSelf {
+    const TAG: u8 = 0;
+}
+
+#[derive(zerocopy_derive::TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum DirectSelf {
+    A = Self::TAG,
+    //~^ ERROR: `Self` is not supported in enum discriminants
+}
+
+impl DirectSelf {
+    const TAG: u8 = 0;
+}
+
+#[derive(IntoBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum IntoBytesSelf {
+    A = <Self>::TAG,
+    //~^ ERROR: `Self` is not supported in enum discriminants
+}
+
+impl IntoBytesSelf {
+    const TAG: u8 = 0;
+}
+
+macro_rules! contextual_tag {
+    () => {
+        Self::TAG
+    };
+}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum MacroDiscriminant {
+    A = contextual_tag!(),
+    //~^ ERROR: macros are not supported in enum discriminants
+}
+
+impl MacroDiscriminant {
+    const TAG: u8 = 0;
+}
+
+const TAG: u8 = 0;
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum RootedConstant {
+    A = crate::TAG,
+    //~^ ERROR: paths are not supported in enum discriminants
+}
+
+// The path leaf is rejected even below an otherwise-supported operator. In
+// particular, such a leaf could have a caller-defined type and select a
+// caller-defined operator implementation.
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum RootedOperatorOperand {
+    A = crate::TAG + 1,
+    //~^ ERROR: paths are not supported in enum discriminants
+}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum UnqualifiedDiscriminant {
+    A = TAG,
+    //~^ ERROR: paths are not supported in enum discriminants
+}
+
+trait DefaultTag {
+    const TAG: u8 = 0;
+}
+
+impl<T> DefaultTag for T {}
+
+struct ___ZerocopyTag;
+
+impl ___ZerocopyTag {
+    const TAG: u8 = 1;
+}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum GeneratedNameCollision {
+    A = ___ZerocopyTag::TAG,
+    //~^ ERROR: paths are not supported in enum discriminants
+    B = 2,
+}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum PatternNameCollision {
+    A = match 0 {
+        //~^ ERROR: this expression is not supported in enum discriminants
+        ___ZEROCOPY_TAG_Raw if true => 0,
+        _ => 1,
+    },
+    Raw = 2,
+}
+
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum TypeRelativePath {
+    A = crate::TypeRelativePath::TAG,
+    //~^ ERROR: paths are not supported in enum discriminants
+}
+
+impl TypeRelativePath {
+    const TAG: u8 = 0;
+}
+
+#[cfg(not(msrv))]
+#[derive(TryFromBytes)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ReportShape {
+    Flag(bool) = Self::TAG,
+    //~[stable, nightly]^ ERROR: `Self` is not supported in enum discriminants
+    Raw(u8) = 1 - Self::TAG,
+}
+
+#[cfg(not(msrv))]
+impl ReportShape {
+    const TAG: u8 = 1;
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3619.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3619.stable.stderr
@@ -1,0 +1,73 @@
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:18:9
+   |
+18 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:30:9
+   |
+30 |     A = Self::TAG,
+   |         ^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:42:10
+   |
+42 |     A = <Self>::TAG,
+   |          ^^^^
+
+error: macros are not supported in enum discriminants because their expansion cannot be preserved in Zerocopy's generated helper enum
+  --> $DIR/issue_3619.rs:60:9
+   |
+60 |     A = contextual_tag!(),
+   |         ^^^^^^^^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:74:9
+   |
+74 |     A = crate::TAG,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:85:9
+   |
+85 |     A = crate::TAG + 1,
+   |         ^^^^^^^^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+  --> $DIR/issue_3619.rs:93:9
+   |
+93 |     A = TAG,
+   |         ^^^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:113:9
+    |
+113 |     A = ___ZerocopyTag::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^
+
+error: this expression is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+   --> $DIR/issue_3619.rs:122:9
+    |
+122 |       A = match 0 {
+    |  _________^
+123 | |
+124 | |         ___ZEROCOPY_TAG_Raw if true => 0,
+125 | |         _ => 1,
+126 | |     },
+    | |_____^
+
+error: paths are not supported in enum discriminants because Zerocopy's generated helper enum evaluates copied discriminants independently
+   --> $DIR/issue_3619.rs:134:9
+    |
+134 |     A = crate::TypeRelativePath::TAG,
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Self` is not supported in enum discriminants because its meaning cannot be preserved in Zerocopy's generated helper enum
+   --> $DIR/issue_3619.rs:147:18
+    |
+147 |     Flag(bool) = Self::TAG,
+    |                  ^^^^^^^^^
+
+error: aborting due to 11 previous errors
+


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Derives that validate enum tags copy explicit discriminants into a helper
enum. Context-dependent expressions can evaluate differently in that helper,
allowing the generated validator to accept an invalid original-enum tag.

Restrict copied discriminants to a compiler-defined, repeatable grammar of
integer and byte literals with primitive arithmetic and bitwise operations.
Reject paths, macros, calls, casts, attributes, and other context-bearing
forms before emitting any unsafe impl. Preserve the skip-on-error dependency
chain for exhaustive enums, including fieldful variants whose zero tag cannot
be identified syntactically, and add cross-toolchain regressions.

Closes #3619

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 　  #3635
- 👉 #3631


**Latest Update:** v10 — [Compare vs v9](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v9 | v8 | v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v10|[v9](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v8](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v7](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v6](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v5](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v10)|
|v9||[v8](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v7](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v6](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v5](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v9)|
|v8|||[v7](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v6](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v5](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v8)|
|v7||||[v6](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[v5](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v7)|
|v6|||||[v5](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v6)|
|v5||||||[v4](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5)|[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v5)|
|v4|||||||[v3](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4)|[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v4)|
|v3||||||||[v2](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3)|[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v3)|
|v2|||||||||[v1](/google/zerocopy/compare/gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2)|[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v2)|
|v1||||||||||[Base](/google/zerocopy/compare/main..gherrit/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck && git checkout -b pr-Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck","parent":null,"child":"Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn"} -->