### PR TITLE
Preserve source bytes after failed try_transmute

### DIFF
--- a/zerocopy/src/macros.rs
+++ b/zerocopy/src/macros.rs
@@ -1471,6 +1471,19 @@ mod tests {
         // its `PanicOnDrop` temporary, which would cause a panic.
         assert_eq!(y.as_ref().map_err(|p| &p.src.0), Err::<&bool, _>(&2u8));
         mem::forget(y);
+
+        #[derive(Debug, TryFromBytes)]
+        #[repr(C, align(8))]
+        struct PaddedBool(bool);
+
+        // A failed transmutation must return every source byte, including
+        // bytes which would be padding in the destination type.
+        let src = [2u8, 1, 2, 3, 4, 5, 6, 7];
+        let x: Result<PaddedBool, _> = try_transmute!(src);
+        assert_eq!(x.unwrap_err().into_src(), src);
+
+        let x: Result<PaddedBool, _> = try_transmute!([0u8; 8]);
+        assert!(!x.unwrap().0);
     }
 
     #[test]

--- a/zerocopy/src/util/macro_util.rs
+++ b/zerocopy/src/util/macro_util.rs
@@ -28,7 +28,7 @@ use core::{marker::PhantomData, mem, num::Wrapping};
 
 use crate::{
     pointer::{
-        cast::CastSized,
+        cast::CastSizedExact,
         invariant::{Aligned, Initialized, Valid},
         BecauseImmutable,
     },
@@ -529,30 +529,64 @@ where
 {
     static_assert!(Src, Dst => mem::size_of::<Dst>() == mem::size_of::<Src>());
 
-    let mu_src = mem::MaybeUninit::new(src);
-    // SAFETY: `MaybeUninit` has no validity requirements.
-    let mu_dst: mem::MaybeUninit<ReadOnly<Dst>> =
-        unsafe { crate::util::transmute_unchecked(mu_src) };
-
-    let ptr = Ptr::from_ref(&mu_dst);
-
-    // SAFETY: Since `Src: IntoBytes`, and since `size_of::<Src>() ==
-    // size_of::<Dst>()` by the preceding assertion, all of `mu_dst`'s bytes are
-    // initialized. `MaybeUninit` has no validity requirements, so even if
-    // `ptr` is used to mutate its referent (which it actually can't be - it's
-    // a shared `ReadOnly` pointer), that won't violate its referent's validity.
-    let ptr = unsafe { ptr.assume_validity::<Initialized>() };
-    if Dst::is_bit_valid(ptr.cast::<_, CastSized, _>()) {
-        // SAFETY: Since `Dst::is_bit_valid`, we know that `ptr`'s referent is
-        // bit-valid for `Dst`. `ptr` points to `mu_dst`, and no intervening
-        // operations have mutated it, so it is a bit-valid `Dst`.
-        Ok(ReadOnly::into_inner(unsafe { mu_dst.assume_init() }))
+    let src = mem::ManuallyDrop::new(ReadOnly::new(src));
+    let mut ptr =
+        Ptr::from_ref(&*src).transmute_with::<ReadOnly<Dst>, Initialized, CastSizedExact, _>();
+    if Dst::is_bit_valid(ptr.reborrow_shared()) {
+        // SAFETY: `read_unaligned` requires that `ptr` be valid for reads and
+        // point to a properly initialized `ReadOnly<Dst>` [1]. `ptr` was
+        // derived from a live reference to `src`; `CastSizedExact` preserves
+        // that reference's address, provenance, and exact byte extent. Thus,
+        // the entire range remains live and valid for reads. The reference is
+        // non-null even when `ReadOnly<Dst>` is zero-sized, and the cast
+        // preserves that address, satisfying [1]'s explicit ZST requirement.
+        //
+        // `Src: IntoBytes` and the `ReadOnly<Src>` bridge let `transmute_with`
+        // establish that every byte in that exact range is initialized.
+        // `Dst::is_bit_valid` then established that the same bytes are
+        // bit-valid for `Dst`, and thus for `ReadOnly<Dst>`. The candidate was
+        // a shared `ReadOnly` pointer, so it could not mutate the bytes; no
+        // operation occurs between validation and this read which could do so.
+        // Alignment is not an additional precondition because [1] expressly
+        // permits unaligned pointers.
+        //
+        // `read_unaligned` leaves the source memory unchanged and makes a
+        // bitwise copy [1]. The source is wrapped in `ManuallyDrop`, which
+        // inhibits its destructor [2]. After this read, neither `src` nor
+        // `ptr` is used to access the inner value, and the wrapper's eventual
+        // drop does not drop it. Thus, only the returned `Dst` is subsequently
+        // used or dropped; there is no duplicate ownership use.
+        //
+        // [1] Per https://doc.rust-lang.org/1.56.0/std/ptr/fn.read_unaligned.html:
+        //
+        //     Reads the value from `src` without moving it. This leaves the
+        //     memory in `src` unchanged.
+        //
+        //     Unlike `read`, `read_unaligned` works with unaligned pointers.
+        //
+        //     Behavior is undefined if any of the following conditions are
+        //     violated:
+        //
+        //     * `src` must be valid for reads.
+        //
+        //     * `src` must point to a properly initialized value of type `T`.
+        //
+        //     Like `read`, `read_unaligned` creates a bitwise copy of `T`,
+        //     regardless of whether `T` is `Copy`. If `T` is not `Copy`, using
+        //     both the returned value and the value at `*src` can violate
+        //     memory safety.
+        //
+        //     Note that even if `T` has size `0`, the pointer must be non-null.
+        //
+        // [2] Per https://doc.rust-lang.org/1.56.0/std/mem/struct.ManuallyDrop.html:
+        //
+        //     A wrapper to inhibit compiler from automatically calling `T`'s
+        //     destructor.
+        let dst = unsafe { core::ptr::read_unaligned(ptr.as_inner().as_ptr()) };
+        Ok(ReadOnly::into_inner(dst))
     } else {
-        // SAFETY: `MaybeUninit` has no validity requirements.
-        let mu_src: mem::MaybeUninit<Src> = unsafe { crate::util::transmute_unchecked(mu_dst) };
-        // SAFETY: `mu_dst`/`mu_src` was constructed from `src` and never
-        // modified, so it is still bit-valid.
-        Err(ValidityError::new(unsafe { mu_src.assume_init() }))
+        let src = ReadOnly::into_inner(mem::ManuallyDrop::into_inner(src));
+        Err(ValidityError::new(src))
     }
 }
 

--- a/zerocopy/tests/ui/transmute_mut.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_mut.msrv.stderr
@@ -82,9 +82,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
 87  | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&mut [u8], &mut [u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:694:1
+   ::: $WORKSPACE/src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:814:14
+   --> src/util/macro_util.rs:848:14
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-814 |         Dst: FromBytes + IntoBytes,
+848 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:814:26
+   --> src/util/macro_util.rs:848:26
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-814 |         Dst: FromBytes + IntoBytes,
+848 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:813:14
+   --> src/util/macro_util.rs:847:14
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-812 |     where
-813 |         Src: FromBytes + IntoBytes,
+846 |     where
+847 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:813:26
+   --> src/util/macro_util.rs:847:26
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-812 |     where
-813 |         Src: FromBytes + IntoBytes,
+846 |     where
+847 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `zerocopy::util::macr
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:694:1
+   ::: src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:814:14
+   --> $WORKSPACE/src/util/macro_util.rs:848:14
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-814 |         Dst: FromBytes + IntoBytes,
+848 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:814:26
+   --> $WORKSPACE/src/util/macro_util.rs:848:26
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-814 |         Dst: FromBytes + IntoBytes,
+848 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:813:14
+   --> $WORKSPACE/src/util/macro_util.rs:847:14
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-812 |     where
-813 |         Src: FromBytes + IntoBytes,
+846 |     where
+847 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:813:26
+   --> $WORKSPACE/src/util/macro_util.rs:847:26
     |
-811 |     pub fn transmute_mut(self) -> &'a mut Dst
+845 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-812 |     where
-813 |         Src: FromBytes + IntoBytes,
+846 |     where
+847 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:694:1
+   ::: $WORKSPACE/src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_ref.msrv.stderr
@@ -188,9 +188,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
 84  | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&[u8], &[u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:694:1
+   ::: $WORKSPACE/src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `zerocopy::util::macr
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:694:1
+   ::: src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:694:1
+   ::: $WORKSPACE/src/util/macro_util.rs:728:1
     |
-694 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:837:14
+   --> src/util/macro_util.rs:871:14
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:837:29
+   --> src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:836:14
+   --> src/util/macro_util.rs:870:14
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-835 |     where
-836 |         Src: FromBytes + IntoBytes,
+869 |     where
+870 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:837:29
+   --> src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:836:26
+   --> src/util/macro_util.rs:870:26
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-835 |     where
-836 |         Src: FromBytes + IntoBytes,
+869 |     where
+870 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:837:29
+   --> src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:837:14
+   --> $WORKSPACE/src/util/macro_util.rs:871:14
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:837:29
+   --> $WORKSPACE/src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:836:14
+   --> $WORKSPACE/src/util/macro_util.rs:870:14
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-835 |     where
-836 |         Src: FromBytes + IntoBytes,
+869 |     where
+870 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:837:29
+   --> $WORKSPACE/src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:836:26
+   --> $WORKSPACE/src/util/macro_util.rs:870:26
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-835 |     where
-836 |         Src: FromBytes + IntoBytes,
+869 |     where
+870 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:837:29
+   --> $WORKSPACE/src/util/macro_util.rs:871:29
     |
-834 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-837 |         Dst: TryFromBytes + IntoBytes,
+871 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:757:14
+   --> src/util/macro_util.rs:791:14
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-757 |         Dst: TryFromBytes + Immutable,
+791 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:757:29
+   --> src/util/macro_util.rs:791:29
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-757 |         Dst: TryFromBytes + Immutable,
+791 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:756:14
+   --> src/util/macro_util.rs:790:14
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-755 |     where
-756 |         Src: IntoBytes + Immutable,
+789 |     where
+790 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:756:26
+   --> src/util/macro_util.rs:790:26
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-755 |     where
-756 |         Src: IntoBytes + Immutable,
+789 |     where
+790 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:757:14
+   --> $WORKSPACE/src/util/macro_util.rs:791:14
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-757 |         Dst: TryFromBytes + Immutable,
+791 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:757:29
+   --> $WORKSPACE/src/util/macro_util.rs:791:29
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-757 |         Dst: TryFromBytes + Immutable,
+791 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:756:14
+   --> $WORKSPACE/src/util/macro_util.rs:790:14
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-755 |     where
-756 |         Src: IntoBytes + Immutable,
+789 |     where
+790 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:756:26
+   --> $WORKSPACE/src/util/macro_util.rs:790:26
     |
-754 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-755 |     where
-756 |         Src: IntoBytes + Immutable,
+789 |     where
+790 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Validate the destination in place so a typed move cannot discard destination
padding before the original source is returned.

Closes #3632

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3634


**Latest Update:** v5 — [Compare vs v4](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|
|v5|[vs v4](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v3..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v2..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v1..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v5)|
|v4||[vs v3](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v3..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v2..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v1..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v4)|
|v3|||[vs v2](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v2..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v1..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v3)|
|v2||||[vs v1](/google/zerocopy/compare/gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v1..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v2)|
|v1|||||[vs Base](/google/zerocopy/compare/main..gherrit/Gosc7u5x37moad4qkehnrpfuziq62ctz3/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gosc7u5x37moad4qkehnrpfuziq62ctz3 && git checkout -b pr-Gosc7u5x37moad4qkehnrpfuziq62ctz3 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gosc7u5x37moad4qkehnrpfuziq62ctz3 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gosc7u5x37moad4qkehnrpfuziq62ctz3 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gosc7u5x37moad4qkehnrpfuziq62ctz3
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gosc7u5x37moad4qkehnrpfuziq62ctz3","parent":null,"child":null} -->