### PR TITLE
Reject derive inputs that capture generated helpers

### DIFF
--- a/zerocopy/src/util/macro_util.rs
+++ b/zerocopy/src/util/macro_util.rs
@@ -402,7 +402,10 @@ macro_rules! union_padding {
 /// How many padding bytes does the enum type `$t` have?
 ///
 /// `$disc` is the type of the enum tag, and `$ts` is a list of fields in each
-/// square-bracket-delimited variant. `$t` must be an enum, or else
+/// square-bracket-delimited variant. The `@tag_size` branch instead accepts an
+/// expression for the tag's size. It evaluates that expression in a lexical
+/// scope separate from `$ts`, so a generated tag definition cannot affect name
+/// resolution in user-provided field types. `$t` must be an enum, or else
 /// `enum_padding!`'s result may be meaningless. An enum has padding if any of
 /// its variant structs [1][2] contain padding, and so all of the variants of an
 /// enum must be "full" in order for the enum to not have padding.
@@ -418,6 +421,25 @@ macro_rules! union_padding {
 #[doc(hidden)] // `#[macro_export]` bypasses this module's `#[doc(hidden)]`.
 #[macro_export]
 macro_rules! enum_padding {
+    (@tag_size, $t:ty, $_align:expr, $packed:expr, $disc_size:expr, $([$($ts:ty),*]),*) => {{
+        // The tag definition is evaluated in the lexical scope of
+        // `$disc_size`, separate from the caller's field type tokens. This
+        // prevents generated tag names from capturing those field types.
+        #[allow(clippy::as_conversions)]
+        const _: [(); 1] = [(); $packed.is_none() as usize];
+        let mut max = (0, $disc_size);
+        $({
+            let padding = $crate::util::macro_util::size_of::<$t>()
+                - (
+                    max.1
+                    $(+ $crate::util::macro_util::size_of::<$ts>())*
+                );
+            if padding > max.0 {
+                max.0 = padding;
+            }
+        })*
+        max.0
+    }};
     ($t:ty, $_align:expr, $packed:expr, $disc:ty, $([$($ts:ty),*]),*) => {{
         // The `align` and `packed` directives are irrelevant. `$align` can be
         // ignored because regardless of if and how it is set, comparing the

--- a/zerocopy/tests/ui/transmute_mut.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_mut.msrv.stderr
@@ -82,9 +82,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
 87  | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&mut [u8], &mut [u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_mut.nightly.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:848:14
+   --> src/util/macro_util.rs:870:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+870 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:848:26
+   --> src/util/macro_util.rs:870:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+870 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:847:14
+   --> src/util/macro_util.rs:869:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+868 |     where
+869 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> src/util/macro_util.rs:847:26
+   --> src/util/macro_util.rs:869:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+868 |     where
+869 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `zerocopy::util::macr
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:728:1
+   ::: src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/transmute_mut.stable.stderr
@@ -41,12 +41,12 @@ help: the trait `FromBytes` is not implemented for `DstA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:848:14
+   --> $WORKSPACE/src/util/macro_util.rs:870:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+870 |         Dst: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -75,12 +75,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:848:26
+   --> $WORKSPACE/src/util/macro_util.rs:870:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
 ...
-848 |         Dst: FromBytes + IntoBytes,
+870 |         Dst: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -151,12 +151,12 @@ help: the trait `FromBytes` is not implemented for `SrcC`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:847:14
+   --> $WORKSPACE/src/util/macro_util.rs:869:14
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+868 |     where
+869 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -185,12 +185,12 @@ help: the trait `IntoBytes` is not implemented for `SrcD`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:847:26
+   --> $WORKSPACE/src/util/macro_util.rs:869:26
     |
-845 |     pub fn transmute_mut(self) -> &'a mut Dst
+867 |     pub fn transmute_mut(self) -> &'a mut Dst
     |            ------------- required by a bound in this associated function
-846 |     where
-847 |         Src: FromBytes + IntoBytes,
+868 |     where
+869 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::transmute_mut`
     = note: this error originates in the macro `transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -200,9 +200,9 @@ error[E0599]: the method `transmute_mut` exists for struct `Wrap<&mut [u8], &mut
  87 | const SRC_UNSIZED: &mut [u8; 1] = transmute_mut!(&mut [0u8][..]);
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&mut [u8], &mut [u8; 1]>: TransmuteMutDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.msrv.stderr
+++ b/zerocopy/tests/ui/transmute_ref.msrv.stderr
@@ -188,9 +188,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
 84  | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Wrap<&[u8], &[u8; 1]>` due to unsatisfied trait bounds
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | --------------------------------------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/transmute_ref.nightly.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `zerocopy::util::macr
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: src/util/macro_util.rs:728:1
+   ::: src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `_: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/transmute_ref.stable.stderr
@@ -350,9 +350,9 @@ error[E0599]: the method `transmute_ref` exists for struct `Wrap<&[u8], &[u8; 1]
  84 | const SRC_UNSIZED: &[u8; 1] = transmute_ref!(&[0u8][..]);
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
-   ::: $WORKSPACE/src/util/macro_util.rs:728:1
+   ::: $WORKSPACE/src/util/macro_util.rs:750:1
     |
-728 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
+750 | pub struct Wrap<Src, Dst>(pub Src, pub PhantomData<Dst>);
     | ------------------------- doesn't satisfy `Wrap<&[u8], &[u8; 1]>: TransmuteRefDst<'_>`
     |
     = note: the following trait bounds were not satisfied:

--- a/zerocopy/tests/ui/try_transmute.msrv.stderr
+++ b/zerocopy/tests/ui/try_transmute.msrv.stderr
@@ -5,9 +5,9 @@ error[E0277]: the trait bound `NotZerocopy: TryFromBytes` is not satisfied
     |                                                          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `TryFromBytes` is not implemented for `NotZerocopy`
     |
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:528:10
+   --> $WORKSPACE/src/util/macro_util.rs:550:10
     |
-528 |     Dst: TryFromBytes,
+550 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -43,9 +43,9 @@ error[E0277]: the trait bound `NotZerocopy<AU16>: IntoBytes` is not satisfied
     |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
     |
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:527:10
+   --> $WORKSPACE/src/util/macro_util.rs:549:10
     |
-527 |     Src: IntoBytes,
+549 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute.nightly.stderr
@@ -51,12 +51,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
-   --> src/util/macro_util.rs:528:10
+   --> src/util/macro_util.rs:550:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+547 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
 ...
-528 |     Dst: TryFromBytes,
+550 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -116,12 +116,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::try_transmute`
-   --> src/util/macro_util.rs:527:10
+   --> src/util/macro_util.rs:549:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+547 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
-526 | where
-527 |     Src: IntoBytes,
+548 | where
+549 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute.stable.stderr
@@ -51,12 +51,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:528:10
+   --> $WORKSPACE/src/util/macro_util.rs:550:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+547 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
 ...
-528 |     Dst: TryFromBytes,
+550 |     Dst: TryFromBytes,
     |          ^^^^^^^^^^^^ required by this bound in `try_transmute`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -116,12 +116,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `try_transmute`
-   --> $WORKSPACE/src/util/macro_util.rs:527:10
+   --> $WORKSPACE/src/util/macro_util.rs:549:10
     |
-525 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
+547 | pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
     |        ------------- required by a bound in this function
-526 | where
-527 |     Src: IntoBytes,
+548 | where
+549 |     Src: IntoBytes,
     |          ^^^^^^^^^ required by this bound in `try_transmute`
     = note: this error originates in the macro `try_transmute` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.nightly.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:14
+   --> src/util/macro_util.rs:893:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:870:14
+   --> src/util/macro_util.rs:892:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+891 |     where
+892 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:870:26
+   --> src/util/macro_util.rs:892:26
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+891 |     where
+892 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> src/util/macro_util.rs:871:29
+   --> src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_mut.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_mut.stable.stderr
@@ -21,12 +21,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:14
+   --> $WORKSPACE/src/util/macro_util.rs:893:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -55,12 +55,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -148,12 +148,12 @@ help: the trait `FromBytes` is not implemented for `SrcA`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:870:14
+   --> $WORKSPACE/src/util/macro_util.rs:892:14
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+891 |     where
+892 |         Src: FromBytes + IntoBytes,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -182,12 +182,12 @@ help: the trait `IntoBytes` is not implemented for `DstA`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -214,12 +214,12 @@ help: the trait `IntoBytes` is not implemented for `SrcB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:870:26
+   --> $WORKSPACE/src/util/macro_util.rs:892:26
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
-869 |     where
-870 |         Src: FromBytes + IntoBytes,
+891 |     where
+892 |         Src: FromBytes + IntoBytes,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -246,12 +246,12 @@ help: the trait `IntoBytes` is not implemented for `DstB`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a mut Src, &'a mut Dst>::try_transmute_mut`
-   --> $WORKSPACE/src/util/macro_util.rs:871:29
+   --> $WORKSPACE/src/util/macro_util.rs:893:29
     |
-868 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
+890 |     pub fn try_transmute_mut(self) -> Result<&'a mut Dst, ValidityError<&'a mut Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-871 |         Dst: TryFromBytes + IntoBytes,
+893 |         Dst: TryFromBytes + IntoBytes,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&mut Src, &mut Dst>::try_transmute_mut`
     = note: this error originates in the macro `try_transmute_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.nightly.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:791:14
+   --> src/util/macro_util.rs:813:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+813 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:791:29
+   --> src/util/macro_util.rs:813:29
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+813 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:790:14
+   --> src/util/macro_util.rs:812:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+811 |     where
+812 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `zerocopy::util::macro_util::Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> src/util/macro_util.rs:790:26
+   --> src/util/macro_util.rs:812:26
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+811 |     where
+812 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console

--- a/zerocopy/tests/ui/try_transmute_ref.stable.stderr
+++ b/zerocopy/tests/ui/try_transmute_ref.stable.stderr
@@ -38,12 +38,12 @@ help: the trait `TryFromBytes` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F, G, H)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:791:14
+   --> $WORKSPACE/src/util/macro_util.rs:813:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+813 |         Dst: TryFromBytes + Immutable,
     |              ^^^^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -72,12 +72,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:791:29
+   --> $WORKSPACE/src/util/macro_util.rs:813:29
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
 ...
-791 |         Dst: TryFromBytes + Immutable,
+813 |         Dst: TryFromBytes + Immutable,
     |                             ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console
@@ -167,12 +167,12 @@ help: the trait `IntoBytes` is not implemented for `NotZerocopy<AU16>`
               AtomicIsize
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:790:14
+   --> $WORKSPACE/src/util/macro_util.rs:812:14
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+811 |     where
+812 |         Src: IntoBytes + Immutable,
     |              ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: this error originates in the macro `try_transmute_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -199,12 +199,12 @@ help: the trait `Immutable` is not implemented for `NotZerocopy<AU16>`
               (A, B, C, D, E, F)
             and $OTHER_TYPES others
 note: required by a bound in `Wrap::<&'a Src, &'a Dst>::try_transmute_ref`
-   --> $WORKSPACE/src/util/macro_util.rs:790:26
+   --> $WORKSPACE/src/util/macro_util.rs:812:26
     |
-788 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
+810 |     pub fn try_transmute_ref(self) -> Result<&'a Dst, ValidityError<&'a Src, Dst>>
     |            ----------------- required by a bound in this associated function
-789 |     where
-790 |         Src: IntoBytes + Immutable,
+811 |     where
+812 |         Src: IntoBytes + Immutable,
     |                          ^^^^^^^^^ required by this bound in `Wrap::<&Src, &Dst>::try_transmute_ref`
     = note: the full name for the type has been written to '/long-type-HASH.txt'
     = note: consider using `--verbose` to print the full type name to the console

--- a/zerocopy/zerocopy-derive/Cargo.toml
+++ b/zerocopy/zerocopy-derive/Cargo.toml
@@ -37,14 +37,14 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.1"
 quote = "1.0.40"
-syn = { version = "2.0.46", features = ["full"] }
+syn = { version = "=2.0.56", features = ["full", "visit"] }
 
 [dev-dependencies]
 dissimilar = "1.0.9"
 prettyplease = "0.2.17"
 rustversion = "1.0"
 static_assertions = "1.1"
-syn = { version = "2.0.46", features = ["visit"] }
+syn = { version = "=2.0.56", features = ["visit"] }
 testutil = { path = "../testutil" }
 # We import as `zerocopy-renamed` so that we can refer to the crate as
 # `zerocopy-renamed` in the generated code, which allows us to test that the

--- a/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/into_bytes.rs
@@ -7,8 +7,8 @@ use syn::{parse_quote, Data, DataEnum, DataStruct, DataUnion, Error, Ident, Type
 use crate::{
     repr::{EnumRepr, StructUnionRepr},
     util::{
-        generate_tag_enum, Ctx, DataExt, FieldBounds, ImplBlockBuilder, PaddingCheck, Trait,
-        TraitBound,
+        generate_tag_enum, reject_uninspectable_field_types, reject_uninspectable_impl_generics,
+        Ctx, DataExt, FieldBounds, ImplBlockBuilder, PaddingCheck, Trait, TraitBound,
     },
 };
 pub(crate) fn derive_into_bytes(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error> {
@@ -17,6 +17,11 @@ pub(crate) fn derive_into_bytes(ctx: &Ctx, _top_level: Trait) -> Result<TokenStr
         Data::Enum(enm) => derive_into_bytes_enum(ctx, enm),
         Data::Union(unn) => derive_into_bytes_union(ctx, unn),
     }
+}
+
+fn validate_input(ctx: &Ctx) -> Result<(), Error> {
+    reject_uninspectable_impl_generics(&ctx.ast.generics, "IntoBytes")?;
+    reject_uninspectable_field_types(&ctx.ast.data, "IntoBytes")
 }
 
 /// If every field is exactly `T`, `[T; _]`, or a final `[T]` for the same type
@@ -188,6 +193,10 @@ fn derive_into_bytes_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream
         FieldBounds::ALL_SELF
     };
 
+    if let Err(error) = validate_input(ctx) {
+        return ctx.error_or_skip(error);
+    }
+
     Ok(ImplBlockBuilder::new(ctx, strct, Trait::IntoBytes, field_bounds)
         .padding_check(padding_check)
         .build())
@@ -200,6 +209,10 @@ fn derive_into_bytes_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Erro
             Span::call_site(),
             "must have #[repr(C)] or #[repr(Int)] attribute in order to guarantee this type's memory layout",
         ));
+    }
+
+    if let Err(error) = validate_input(ctx) {
+        return ctx.error_or_skip(error);
     }
 
     let tag_type_definition = match generate_tag_enum(ctx, &repr, enm) {
@@ -253,6 +266,10 @@ please let us know you use this feature: https://github.com/google/zerocopy/disc
             Span::call_site(),
             "must be #[repr(C)], #[repr(packed)], or #[repr(transparent)]",
         ));
+    }
+
+    if let Err(error) = validate_input(ctx) {
+        return ctx.error_or_skip(error);
     }
 
     let impl_block = ImplBlockBuilder::new(ctx, unn, Trait::IntoBytes, FieldBounds::ALL_SELF)

--- a/zerocopy/zerocopy-derive/src/derive/known_layout.rs
+++ b/zerocopy/zerocopy-derive/src/derive/known_layout.rs
@@ -6,7 +6,11 @@ use syn::{parse_quote, Data, Error, Type};
 
 use crate::{
     repr::StructUnionRepr,
-    util::{Ctx, DataExt, FieldBounds, ImplBlockBuilder, SelfBounds, Trait},
+    util::{
+        reject_reserved_identifiers, reject_uninspectable_field_types,
+        reject_uninspectable_generics, Ctx, DataExt, FieldBounds, ImplBlockBuilder, SelfBounds,
+        Trait,
+    },
 };
 
 fn derive_known_layout_for_repr_c_struct<'a>(
@@ -265,6 +269,19 @@ pub(crate) fn derive(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error>
     };
 
     let fields = ctx.ast.data.fields();
+
+    if c_struct_repr.is_some() && !fields.is_empty() {
+        if let Err(error) = reject_uninspectable_generics(&ctx.ast.generics, "KnownLayout") {
+            return ctx.error_or_skip(error);
+        }
+        if let Err(error) = reject_uninspectable_field_types(&ctx.ast.data, "KnownLayout") {
+            return ctx.error_or_skip(error);
+        }
+
+        if let Err(error) = reject_reserved_identifiers(ctx, "KnownLayout", &["__Zerocopy"]) {
+            return ctx.error_or_skip(error);
+        }
+    }
 
     let (self_bounds, inner_extras, outer_extras) = c_struct_repr
         .as_ref()

--- a/zerocopy/zerocopy-derive/src/derive/mod.rs
+++ b/zerocopy/zerocopy-derive/src/derive/mod.rs
@@ -12,10 +12,20 @@ use syn::{Data, Error};
 
 use crate::{
     repr::StructUnionRepr,
-    util::{Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait},
+    util::{
+        reject_uninspectable_field_types, reject_uninspectable_impl_generics,
+        reject_uninspectable_types, Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait,
+    },
 };
 
 pub(crate) fn derive_immutable(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error> {
+    if let Err(error) = reject_uninspectable_impl_generics(&ctx.ast.generics, "Immutable") {
+        return ctx.error_or_skip(error);
+    }
+    if let Err(error) = reject_uninspectable_field_types(&ctx.ast.data, "Immutable") {
+        return ctx.error_or_skip(error);
+    }
+
     Ok(match &ctx.ast.data {
         Data::Struct(strct) => {
             ImplBlockBuilder::new(ctx, strct, Trait::Immutable, FieldBounds::ALL_SELF).build()
@@ -123,6 +133,13 @@ pub(crate) fn derive_split_at(ctx: &Ctx, _top_level: Trait) -> Result<TokenStrea
         return ctx.error_or_skip(Error::new(Span::call_site(), "must at least one field"));
     };
 
+    if let Err(error) = reject_uninspectable_types([*trailing_field], "SplitAt") {
+        return ctx.error_or_skip(error);
+    }
+    if let Err(error) = reject_uninspectable_impl_generics(&ctx.ast.generics, "SplitAt") {
+        return ctx.error_or_skip(error);
+    }
+
     let zerocopy_crate = &ctx.zerocopy_crate;
     // SAFETY: `#ty`, per the above checks, is `repr(C)` or `repr(transparent)`
     // and is not packed; its trailing field is guaranteed to be well-aligned
@@ -133,4 +150,19 @@ pub(crate) fn derive_split_at(ctx: &Ctx, _top_level: Trait) -> Result<TokenStrea
             type Elem = <#trailing_field as #zerocopy_crate::SplitAt>::Elem;
         })
         .build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_at_ignores_discarded_generic_defaults() {
+        let input = syn::parse_quote! {
+            #[repr(C)]
+            struct Slice<T = default_type!()>(T, [u8]);
+        };
+        let ctx = Ctx::try_from_derive_input(input).unwrap();
+        derive_split_at(&ctx, Trait::SplitAt).unwrap();
+    }
 }

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -10,8 +10,12 @@ use syn::{
 use crate::{
     repr::{EnumRepr, StructUnionRepr},
     util::{
-        const_block, enum_could_be_from_bytes, generate_tag_enum, validate_tag_enum_discriminants,
-        Ctx, DataExt, FieldBounds, ImplBlockBuilder, Trait, TraitBound,
+        const_block, enum_could_be_from_bytes, generate_tag_enum,
+        reject_contextual_self_in_generics, reject_contextual_self_in_types,
+        reject_reserved_identifiers, reject_reserved_identifiers_in_impl,
+        reject_uninspectable_field_types, reject_uninspectable_generics,
+        reject_uninspectable_impl_generics, validate_tag_enum_discriminants, Ctx, DataExt,
+        FieldBounds, ImplBlockBuilder, Trait, TraitBound,
     },
 };
 fn tag_ident(variant_ident: &Ident) -> Ident {
@@ -257,13 +261,14 @@ pub(crate) fn derive_is_bit_valid(
 
                 #[inline(always)]
                 fn project(slf: #zerocopy_crate::pointer::PtrInner<'_, Self>) -> *mut <Self as #has_field_path>::Type {
-                    use #zerocopy_crate::pointer::cast::{CastSized, Projection};
-
-                    slf.project::<___ZerocopyRawEnum #ty_generics, CastSized>()
-                        .project::<_, Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
-                        .project::<_, Projection<_, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>>()
-                        .project::<_, Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
-                        .project::<_, Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
+                    slf.project::<
+                            ___ZerocopyRawEnum #ty_generics,
+                            #zerocopy_crate::pointer::cast::CastSized,
+                        >()
+                        .project::<_, #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(variants) }>>()
+                        .project::<_, #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::REPR_C_UNION_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variants_union_field_ident) }>>()
+                        .project::<_, #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(value) }>>()
+                        .project::<_, #zerocopy_crate::pointer::cast::Projection<_, { #zerocopy_crate::STRUCT_VARIANT_ID }, { #zerocopy_crate::ident_id!(#variant_struct_field_index) }>>()
                         .as_ptr()
                 }
             })
@@ -443,22 +448,76 @@ pub(crate) fn derive_is_bit_valid(
         }
     })
 }
-/// Validates any input syntax that `TryFromBytes` code generation will copy
-/// into a helper definition.
+/// Validates input syntax whose meaning must be preserved in generated
+/// `TryFromBytes` code.
 ///
 /// Keep this separate from code generation so supertrait derives can reject
 /// the entire generated impl chain when `on_error = "skip"` is requested.
 pub(crate) fn validate_try_from_bytes_generation(ctx: &Ctx, top_level: Trait) -> Result<(), Error> {
+    let derive_name = match &top_level {
+        Trait::FromZeros => "FromZeros",
+        Trait::FromBytes => "FromBytes",
+        _ => "TryFromBytes",
+    };
+
+    reject_uninspectable_impl_generics(&ctx.ast.generics, derive_name)?;
+    reject_uninspectable_field_types(&ctx.ast.data, derive_name)?;
+
+    let uses_from_bytes_trivial_validator = try_gen_trivial_is_bit_valid(ctx, top_level).is_some();
+    let (copied_syntax_prefixes, target_name_prefixes): (&[&str], &[&str]) =
+        match (&ctx.ast.data, uses_from_bytes_trivial_validator) {
+            // `derive_has_field_struct_union` emits no field-marker helpers for
+            // a zero-field struct. A nontrivial validator still introduces its
+            // method type parameter, so that prefix remains reserved for
+            // retained target type parameters. The FromBytes trivial branch is
+            // reachable only when the target has no generic parameters, and
+            // copies no input syntax into the method scope.
+            (Data::Struct(strct), true) if strct.fields.is_empty() => (&[], &[]),
+            (Data::Struct(strct), false) if strct.fields.is_empty() => (&["___Zc"], &[]),
+            // The field-marker helpers are emitted even for a trivial
+            // validator. The FromBytes-only trivial branch has no target
+            // generics and its method body mentions only `Self`, so its method
+            // generic cannot capture user syntax. Struct and union target names
+            // are copied into the field-marker helper scope, but are referenced
+            // as `Self` inside either validator, so only the field-marker
+            // prefix applies to their names.
+            (Data::Struct(_) | Data::Union(_), true) => (&["ẕ"], &["ẕ"]),
+            (Data::Struct(_) | Data::Union(_), false) => (&["___Zc", "ẕ"], &["ẕ"]),
+            // A full enum validator copies its target name into the generated
+            // nested-helper scope validated below. Inside its validator, an
+            // exhaustive helperless enum refers to the target only as `Self`.
+            (Data::Enum(_), true) => (&[], &[]),
+            (Data::Enum(_), false) => (&["___Zc"], &[]),
+        };
+    reject_reserved_identifiers_in_impl(
+        ctx,
+        derive_name,
+        copied_syntax_prefixes,
+        target_name_prefixes,
+    )?;
+
     let enm = match &ctx.ast.data {
         Data::Enum(enm) => enm,
         Data::Struct(_) | Data::Union(_) => return Ok(()),
     };
     let repr = EnumRepr::from_attrs(&ctx.ast.attrs)?;
-    let generates_tag_enum = try_gen_trivial_is_bit_valid(ctx, top_level).is_none()
-        && !enum_could_be_from_bytes(&repr, enm);
-    if generates_tag_enum {
+    let generates_full_enum_validator =
+        !uses_from_bytes_trivial_validator && !enum_could_be_from_bytes(&repr, enm);
+    if generates_full_enum_validator {
+        reject_uninspectable_generics(&ctx.ast.generics, derive_name)?;
+        reject_reserved_identifiers(
+            ctx,
+            derive_name,
+            &["___Zc", "___Zerocopy", "___ZEROCOPY", "ẕ"],
+        )?;
+        reject_contextual_self_in_generics(&ctx.ast.generics, derive_name)?;
+        reject_contextual_self_in_types(
+            enm.variants.iter().flat_map(|variant| &variant.fields).map(|field| &field.ty),
+            derive_name,
+        )?;
         validate_tag_enum_discriminants(enm)?;
     }
+
     Ok(())
 }
 
@@ -820,6 +879,169 @@ mod tests {
             Trait::TryFromBytes,
         )
         .is_err());
+    }
+
+    #[test]
+    fn generic_defaults_are_validated_only_when_copied_into_helpers() {
+        let direct_impl = syn::parse_quote! {
+            struct Struct<T = default_type!()>(T);
+        };
+        let direct_impl = Ctx::try_from_derive_input(direct_impl).unwrap();
+        assert!(validate_try_from_bytes_generation(&direct_impl, Trait::TryFromBytes).is_ok());
+
+        let variants = (0usize..256).map(|index| format_ident!("V{}", index));
+        let helperless_enum = syn::parse2(quote! {
+            #[repr(u8)]
+            enum ___ZcAlignment<const N: usize = { default_value!() }> {
+                #(#variants,)*
+            }
+        })
+        .unwrap();
+        let helperless_enum = Ctx::try_from_derive_input(helperless_enum).unwrap();
+        assert!(validate_try_from_bytes_generation(&helperless_enum, Trait::TryFromBytes).is_ok());
+
+        let helper_definition = syn::parse_quote! {
+            #[repr(u8)]
+            enum Enum<T = default_type!()> {
+                Value(T),
+                End,
+            }
+        };
+        let helper_definition = Ctx::try_from_derive_input(helper_definition).unwrap();
+        assert!(
+            validate_try_from_bytes_generation(&helper_definition, Trait::TryFromBytes).is_err()
+        );
+
+        let helper_captures_method_generic = syn::parse_quote! {
+            #[repr(u8)]
+            enum Enum<T = ___ZcAlignment> {
+                Value(T),
+                End,
+            }
+        };
+        let helper_captures_method_generic =
+            Ctx::try_from_derive_input(helper_captures_method_generic).unwrap();
+        assert!(validate_try_from_bytes_generation(
+            &helper_captures_method_generic,
+            Trait::TryFromBytes,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn reserves_validator_names_only_when_generated_code_can_capture_them() {
+        let nongeneric = || {
+            let ast = syn::parse_quote! {
+                struct Struct(___ZcAlignment);
+            };
+            Ctx::try_from_derive_input(ast).unwrap()
+        };
+
+        assert!(validate_try_from_bytes_generation(&nongeneric(), Trait::FromBytes).is_ok());
+        assert!(validate_try_from_bytes_generation(&nongeneric(), Trait::TryFromBytes).is_err());
+        assert!(validate_try_from_bytes_generation(&nongeneric(), Trait::FromZeros).is_err());
+        assert!(validate_try_from_bytes_generation(
+            &nongeneric().skip_on_error(),
+            Trait::FromBytes,
+        )
+        .is_err());
+
+        let generic = syn::parse_quote! {
+            struct Struct<T>(___ZcAlignment, T);
+        };
+        let generic = Ctx::try_from_derive_input(generic).unwrap();
+        assert!(validate_try_from_bytes_generation(&generic, Trait::FromBytes).is_err());
+
+        let field_marker = format_ident!("ẕfield");
+        let field_marker = syn::parse2(quote! {
+            struct Struct(#field_marker);
+        })
+        .unwrap();
+        let field_marker = Ctx::try_from_derive_input(field_marker).unwrap();
+        assert!(validate_try_from_bytes_generation(&field_marker, Trait::FromBytes).is_err());
+
+        let struct_target = || {
+            let ast = syn::parse_quote! {
+                struct ___ZcAlignment(bool);
+            };
+            Ctx::try_from_derive_input(ast).unwrap()
+        };
+        assert!(validate_try_from_bytes_generation(&struct_target(), Trait::TryFromBytes).is_ok());
+        assert!(validate_try_from_bytes_generation(&struct_target(), Trait::FromZeros).is_ok());
+        assert!(validate_try_from_bytes_generation(
+            &struct_target().skip_on_error(),
+            Trait::FromBytes,
+        )
+        .is_ok());
+
+        let union_target = syn::parse_quote! {
+            union ___ZcAlignment {
+                value: bool,
+            }
+        };
+        let union_target = Ctx::try_from_derive_input(union_target).unwrap();
+        assert!(validate_try_from_bytes_generation(&union_target, Trait::TryFromBytes).is_ok());
+
+        let generic_target = syn::parse_quote! {
+            struct ___ZcAlignment<T>(T);
+        };
+        let generic_target = Ctx::try_from_derive_input(generic_target).unwrap();
+        assert!(validate_try_from_bytes_generation(&generic_target, Trait::FromBytes).is_ok());
+
+        let zero_field_target = format_ident!("ẕUnit");
+        let zero_field_marker_names = syn::parse2(quote! {
+            struct #zero_field_target<const N: usize>;
+        })
+        .unwrap();
+        let zero_field_marker_names = Ctx::try_from_derive_input(zero_field_marker_names).unwrap();
+        assert!(validate_try_from_bytes_generation(&zero_field_marker_names, Trait::TryFromBytes,)
+            .is_ok());
+        assert!(
+            validate_try_from_bytes_generation(&zero_field_marker_names, Trait::FromBytes,).is_ok()
+        );
+
+        let zero_field_trivial = syn::parse_quote! {
+            struct ___ZcAlignment;
+        };
+        let zero_field_trivial = Ctx::try_from_derive_input(zero_field_trivial).unwrap();
+        assert!(validate_try_from_bytes_generation(&zero_field_trivial, Trait::FromBytes).is_ok());
+
+        let field_marker_target_ident = format_ident!("ẕfield");
+        let field_marker_target = syn::parse2(quote! {
+            struct #field_marker_target_ident {
+                field: bool,
+            }
+        })
+        .unwrap();
+        let field_marker_target = Ctx::try_from_derive_input(field_marker_target).unwrap();
+        assert!(
+            validate_try_from_bytes_generation(&field_marker_target, Trait::TryFromBytes,).is_err()
+        );
+
+        let union_field_marker_target_ident = format_ident!("ẕvalue");
+        let union_field_marker_target = syn::parse2(quote! {
+            union #union_field_marker_target_ident {
+                value: bool,
+            }
+        })
+        .unwrap();
+        let union_field_marker_target =
+            Ctx::try_from_derive_input(union_field_marker_target).unwrap();
+        assert!(validate_try_from_bytes_generation(
+            &union_field_marker_target,
+            Trait::TryFromBytes,
+        )
+        .is_err());
+
+        let enum_target = syn::parse_quote! {
+            #[repr(u8)]
+            enum ___ZcAlignment {
+                Value(bool),
+                End,
+            }
+        };
+        let enum_target = Ctx::try_from_derive_input(enum_target).unwrap();
+        assert!(validate_try_from_bytes_generation(&enum_target, Trait::TryFromBytes).is_err());
     }
 
     fn derive_error(input: DeriveInput) -> String {

--- a/zerocopy/zerocopy-derive/src/derive/unaligned.rs
+++ b/zerocopy/zerocopy-derive/src/derive/unaligned.rs
@@ -5,7 +5,10 @@ use syn::{Data, DataEnum, DataStruct, DataUnion, Error};
 
 use crate::{
     repr::{EnumRepr, StructUnionRepr},
-    util::{Ctx, FieldBounds, ImplBlockBuilder, Trait},
+    util::{
+        reject_uninspectable_field_types, reject_uninspectable_impl_generics, Ctx, FieldBounds,
+        ImplBlockBuilder, Trait,
+    },
 };
 
 pub(crate) fn derive_unaligned(ctx: &Ctx, _top_level: Trait) -> Result<TokenStream, Error> {
@@ -28,6 +31,12 @@ fn derive_unaligned_struct(ctx: &Ctx, strct: &DataStruct) -> Result<TokenStream,
     let field_bounds = if repr.is_packed_1() {
         FieldBounds::None
     } else if repr.is_c() || repr.is_transparent() {
+        if let Err(error) = reject_uninspectable_impl_generics(&ctx.ast.generics, "Unaligned") {
+            return ctx.error_or_skip(error);
+        }
+        if let Err(error) = reject_uninspectable_field_types(strct, "Unaligned") {
+            return ctx.error_or_skip(error);
+        }
         FieldBounds::ALL_SELF
     } else {
         return ctx.error_or_skip(Error::new(
@@ -53,6 +62,13 @@ fn derive_unaligned_enum(ctx: &Ctx, enm: &DataEnum) -> Result<TokenStream, Error
         ));
     }
 
+    if let Err(error) = reject_uninspectable_impl_generics(&ctx.ast.generics, "Unaligned") {
+        return ctx.error_or_skip(error);
+    }
+    if let Err(error) = reject_uninspectable_field_types(enm, "Unaligned") {
+        return ctx.error_or_skip(error);
+    }
+
     Ok(ImplBlockBuilder::new(ctx, enm, Trait::Unaligned, FieldBounds::ALL_SELF).build())
 }
 
@@ -68,6 +84,12 @@ fn derive_unaligned_union(ctx: &Ctx, unn: &DataUnion) -> Result<TokenStream, Err
     let field_type_trait_bounds = if repr.is_packed_1() {
         FieldBounds::None
     } else if repr.is_c() || repr.is_transparent() {
+        if let Err(error) = reject_uninspectable_impl_generics(&ctx.ast.generics, "Unaligned") {
+            return ctx.error_or_skip(error);
+        }
+        if let Err(error) = reject_uninspectable_field_types(unn, "Unaligned") {
+            return ctx.error_or_skip(error);
+        }
         FieldBounds::ALL_SELF
     } else {
         return ctx.error_or_skip(Error::new(

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(C).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(C)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(C)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i128).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(i128)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(i128)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i16).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(i16)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(i16)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i32).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(i32)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(i32)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i64).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(i64)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(i64)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(i8).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(i8)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(i8)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(isize).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(isize)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(isize)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u128).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(u128)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(u128)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u16).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(u16)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(u16)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u32).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(u32)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(u32)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u64).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(u64)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(u64)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(u8).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(u8)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(u8)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/into_bytes_enum.repr(usize).expected.rs
@@ -16,21 +16,17 @@ const _: () = {
         (): ::zerocopy::util::macro_util::PaddingFree<
             Self,
             {
-                #[repr(usize)]
-                #[allow(dead_code)]
-                pub enum ___ZerocopyTag {
-                    Bar,
-                }
-                unsafe impl ::zerocopy::Immutable for ___ZerocopyTag {
-                    fn only_derive_is_allowed_to_implement_this_trait() {}
-                }
                 ::zerocopy::enum_padding!(
-                    Self,
+                    @ tag_size, Self,
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
                     (::zerocopy::util::macro_util::core_reexport::option::Option::None::
                     < ::zerocopy::util::macro_util::core_reexport::num::NonZeroUsize >),
-                    ___ZerocopyTag, []
+                    { #[repr(usize)] #[allow(dead_code)] pub enum ___ZerocopyTag { Bar, }
+                    unsafe impl ::zerocopy::Immutable for ___ZerocopyTag { fn
+                    only_derive_is_allowed_to_implement_this_trait() {} }
+                    ::zerocopy::util::macro_util::core_reexport::mem::size_of:: <
+                    ___ZerocopyTag > () }, []
                 )
             },
         >,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -1869,11 +1869,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(a) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1881,7 +1883,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -1889,7 +1891,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -1897,7 +1899,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -1981,11 +1983,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(b) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1993,7 +1997,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2001,7 +2005,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2009,7 +2013,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2093,11 +2097,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(c) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2105,7 +2111,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2113,7 +2119,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2121,7 +2127,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },
@@ -2205,11 +2211,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(d) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2217,7 +2225,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2225,7 +2233,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2233,7 +2241,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(4) },
@@ -2317,11 +2325,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(e) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2329,7 +2339,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2337,7 +2347,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2345,7 +2355,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(5) },
@@ -2429,11 +2439,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(0) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2441,7 +2453,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2449,7 +2461,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2457,7 +2469,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -2541,11 +2553,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(1) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2553,7 +2567,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2561,7 +2575,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2569,7 +2583,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2653,11 +2667,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(2) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2665,7 +2681,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2673,7 +2689,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2681,7 +2697,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -1869,11 +1869,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(a) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1881,7 +1883,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -1889,7 +1891,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -1897,7 +1899,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -1981,11 +1983,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(b) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1993,7 +1997,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2001,7 +2005,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2009,7 +2013,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2093,11 +2097,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(c) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2105,7 +2111,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2113,7 +2119,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2121,7 +2127,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },
@@ -2205,11 +2211,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(d) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2217,7 +2225,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2225,7 +2233,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2233,7 +2241,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(4) },
@@ -2317,11 +2325,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(e) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2329,7 +2339,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2337,7 +2347,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2345,7 +2355,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(5) },
@@ -2429,11 +2439,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(0) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2441,7 +2453,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2449,7 +2461,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2457,7 +2469,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -2541,11 +2553,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(1) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2553,7 +2567,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2561,7 +2575,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2569,7 +2583,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2653,11 +2667,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(2) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2665,7 +2681,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2673,7 +2689,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2681,7 +2697,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -1869,11 +1869,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(a) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1881,7 +1883,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -1889,7 +1891,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -1897,7 +1899,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -1981,11 +1983,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(b) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -1993,7 +1997,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2001,7 +2005,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2009,7 +2013,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2093,11 +2097,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(c) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2105,7 +2111,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2113,7 +2119,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2121,7 +2127,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },
@@ -2205,11 +2211,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(d) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2217,7 +2225,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2225,7 +2233,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2233,7 +2241,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(4) },
@@ -2317,11 +2325,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(StructLike) },
                         { ::zerocopy::ident_id!(e) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2329,7 +2339,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_StructLike) },
@@ -2337,7 +2347,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2345,7 +2355,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(5) },
@@ -2429,11 +2439,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(0) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2441,7 +2453,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2449,7 +2461,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2457,7 +2469,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(1) },
@@ -2541,11 +2553,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(1) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2553,7 +2567,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2561,7 +2575,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2569,7 +2583,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(2) },
@@ -2653,11 +2667,13 @@ const _: () = {
                         { ::zerocopy::ident_id!(TupleLike) },
                         { ::zerocopy::ident_id!(2) },
                     >>::Type {
-                        use ::zerocopy::pointer::cast::{CastSized, Projection};
-                        slf.project::<___ZerocopyRawEnum<'a, N, X, Y>, CastSized>()
+                        slf.project::<
+                                ___ZerocopyRawEnum<'a, N, X, Y>,
+                                ::zerocopy::pointer::cast::CastSized,
+                            >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(variants) },
@@ -2665,7 +2681,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::REPR_C_UNION_VARIANT_ID },
                                     { ::zerocopy::ident_id!(__field_TupleLike) },
@@ -2673,7 +2689,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(value) },
@@ -2681,7 +2697,7 @@ const _: () = {
                             >()
                             .project::<
                                 _,
-                                Projection<
+                                ::zerocopy::pointer::cast::Projection<
                                     _,
                                     { ::zerocopy::STRUCT_VARIANT_ID },
                                     { ::zerocopy::ident_id!(3) },

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -225,6 +225,505 @@ pub(crate) trait DataExt {
     fn tag(&self) -> Option<Ident>;
 }
 
+#[derive(Default)]
+struct UninspectableSyntaxFinder(Option<(Span, &'static str)>);
+
+impl UninspectableSyntaxFinder {
+    fn record(&mut self, span: Span, reason: &'static str) {
+        if self.0.is_none() {
+            self.0 = Some((span, reason));
+        }
+    }
+}
+
+impl<'ast> syn::visit::Visit<'ast> for UninspectableSyntaxFinder {
+    fn visit_attribute(&mut self, attr: &'ast syn::Attribute) {
+        self.record(attr.span(), "an attribute");
+    }
+
+    fn visit_expr(&mut self, expr: &'ast Expr) {
+        if matches!(expr, Expr::Verbatim(_)) {
+            self.record(expr.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_expr(self, expr);
+        }
+    }
+
+    fn visit_foreign_item(&mut self, item: &'ast syn::ForeignItem) {
+        if matches!(item, syn::ForeignItem::Verbatim(_)) {
+            self.record(item.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_foreign_item(self, item);
+        }
+    }
+
+    fn visit_impl_item(&mut self, item: &'ast syn::ImplItem) {
+        if matches!(item, syn::ImplItem::Verbatim(_)) {
+            self.record(item.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_impl_item(self, item);
+        }
+    }
+
+    fn visit_item(&mut self, item: &'ast syn::Item) {
+        if matches!(item, syn::Item::Verbatim(_)) {
+            self.record(item.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_item(self, item);
+        }
+    }
+
+    fn visit_lit(&mut self, lit: &'ast Lit) {
+        if matches!(lit, Lit::Verbatim(_)) {
+            self.record(lit.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_lit(self, lit);
+        }
+    }
+
+    fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+        self.record(mac.span(), "a macro invocation");
+    }
+
+    fn visit_pat(&mut self, pat: &'ast syn::Pat) {
+        if matches!(pat, syn::Pat::Verbatim(_)) {
+            self.record(pat.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_pat(self, pat);
+        }
+    }
+
+    fn visit_trait_item(&mut self, item: &'ast syn::TraitItem) {
+        if matches!(item, syn::TraitItem::Verbatim(_)) {
+            self.record(item.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_trait_item(self, item);
+        }
+    }
+
+    fn visit_type(&mut self, ty: &'ast Type) {
+        if matches!(ty, Type::Verbatim(_)) {
+            self.record(ty.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_type(self, ty);
+        }
+    }
+
+    fn visit_type_param_bound(&mut self, bound: &'ast syn::TypeParamBound) {
+        if matches!(bound, syn::TypeParamBound::Verbatim(_)) {
+            self.record(bound.span(), "unsupported unresolved syntax");
+        } else {
+            syn::visit::visit_type_param_bound(self, bound);
+        }
+    }
+}
+
+fn reject_uninspectable_syntax(
+    finder: UninspectableSyntaxFinder,
+    derive_name: &str,
+    location: &str,
+) -> Result<(), Error> {
+    if let Some((span, reason)) = finder.0 {
+        return Err(Error::new(
+            span,
+            format!(
+                "cannot derive `{}` for a type containing {} in {}; write the expanded syntax explicitly",
+                derive_name, reason, location,
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Rejects field types which contain macro invocations or uninspectable syntax.
+///
+/// A derive macro receives a field type macro before rustc expands it. If the
+/// derive copies that macro invocation into multiple generated locations, the
+/// expansions need not be identical (for example, a stateful procedural macro
+/// can emit a different type each time). Since a derive cannot inspect an
+/// expansion at proc-macro execution time, callers which rely on copied field
+/// types must reject the unresolved invocation itself.
+pub(crate) fn reject_uninspectable_types<'a>(
+    types: impl IntoIterator<Item = &'a Type>,
+    derive_name: &str,
+) -> Result<(), Error> {
+    use syn::visit::Visit as _;
+
+    for ty in types {
+        let mut finder = UninspectableSyntaxFinder::default();
+        finder.visit_type(ty);
+        reject_uninspectable_syntax(finder, derive_name, "a field type")?;
+    }
+
+    Ok(())
+}
+
+/// Returns the generic syntax copied into an `impl` declaration.
+///
+/// Type and const defaults belong to the type declaration and are not legal
+/// on an `impl`. [`ImplBlockBuilder`] therefore discards them before emitting
+/// its generic parameters. Keep validation in sync with that behavior so that
+/// syntax which is expanded only in the original item is not rejected.
+fn generics_without_defaults(generics: &syn::Generics) -> syn::Generics {
+    let mut generics = generics.clone();
+    for param in &mut generics.params {
+        match param {
+            GenericParam::Type(ty) => ty.default = None,
+            GenericParam::Const(cnst) => cnst.default = None,
+            GenericParam::Lifetime(_) => {}
+        }
+    }
+    generics
+}
+
+/// Rejects macro invocations or uninspectable syntax in copied generics.
+///
+/// A copied bound can change how an associated type shorthand in a field type
+/// resolves, so validating only the field type syntax is insufficient.
+pub(crate) fn reject_uninspectable_generics(
+    generics: &syn::Generics,
+    derive_name: &str,
+) -> Result<(), Error> {
+    use syn::visit::Visit as _;
+
+    let mut finder = UninspectableSyntaxFinder::default();
+    finder.visit_generics(generics);
+    reject_uninspectable_syntax(finder, derive_name, "generic parameters or predicates")
+}
+
+/// Rejects uninspectable syntax in generics copied into an `impl` declaration.
+pub(crate) fn reject_uninspectable_impl_generics(
+    generics: &syn::Generics,
+    derive_name: &str,
+) -> Result<(), Error> {
+    reject_uninspectable_generics(&generics_without_defaults(generics), derive_name)
+}
+
+pub(crate) fn reject_uninspectable_field_types(
+    data: &dyn DataExt,
+    derive_name: &str,
+) -> Result<(), Error> {
+    reject_uninspectable_types(data.fields().into_iter().map(|(_, _, ty)| ty), derive_name)
+}
+
+/// Rejects identifiers which can capture generated helper items.
+///
+/// Derive output is unhygienic and is emitted in a nested scope. A helper item
+/// in that scope can therefore change the meaning of copied syntax. Reserve
+/// implementation-specific prefixes in target type-parameter declarations and
+/// in unqualified paths and patterns whose resolution can change in the
+/// generated scope. The derive target itself is also checked because some
+/// generators copy its name into a helper scope. Qualified paths cannot be
+/// captured by these helpers and remain supported.
+///
+/// Every copied syntax position whose meaning is used in a safety proof must
+/// also reject unresolved syntax (or validate it by an equally strict
+/// grammar): an unexpanded macro could otherwise produce a name which is not
+/// visible in this token stream.
+pub(crate) fn reject_reserved_identifiers(
+    ctx: &Ctx,
+    derive_name: &str,
+    reserved_prefixes: &[&str],
+) -> Result<(), Error> {
+    reject_reserved_identifiers_with_target_prefixes(
+        ctx,
+        derive_name,
+        reserved_prefixes,
+        reserved_prefixes,
+    )
+}
+
+fn reject_reserved_identifiers_with_target_prefixes(
+    ctx: &Ctx,
+    derive_name: &str,
+    copied_syntax_prefixes: &[&str],
+    target_name_prefixes: &[&str],
+) -> Result<(), Error> {
+    use syn::visit::Visit as _;
+
+    fn is_reserved(ident: &Ident, reserved_prefixes: &[&str]) -> bool {
+        let normalized = to_ident_str(ident);
+        reserved_prefixes.iter().any(|prefix| normalized.starts_with(prefix))
+    }
+
+    struct ReservedIdentifierFinder<'a> {
+        reserved_prefixes: &'a [&'a str],
+        found: Option<Ident>,
+    }
+
+    impl ReservedIdentifierFinder<'_> {
+        fn record(&mut self, ident: &Ident) {
+            if self.found.is_none() && is_reserved(ident, self.reserved_prefixes) {
+                self.found = Some(ident.clone());
+            }
+        }
+
+        fn visit_use_root(&mut self, tree: &syn::UseTree) {
+            match tree {
+                syn::UseTree::Name(name) => self.record(&name.ident),
+                syn::UseTree::Rename(rename) => self.record(&rename.ident),
+                syn::UseTree::Path(path) => {
+                    // Only the first segment is unqualified. The remainder is
+                    // resolved through it and cannot be captured directly.
+                    self.record(&path.ident);
+                }
+                syn::UseTree::Group(group) => {
+                    for tree in &group.items {
+                        self.visit_use_root(tree);
+                    }
+                }
+                syn::UseTree::Glob(_) => {}
+            }
+        }
+
+        fn visit_maybe_qself_path(&mut self, qself: Option<&syn::QSelf>, path: &Path) {
+            if let Some(qself) = qself {
+                self.visit_qself(qself);
+
+                // In `<T as path::Trait>::Assoc`, only the part of `path`
+                // before the associated item is resolved lexically. The
+                // associated item and any following segments are resolved
+                // through `T` and cannot be captured by a generated helper.
+                if qself.position > 0 && path.leading_colon.is_none() {
+                    if let Some(first) = path.segments.first() {
+                        self.record(&first.ident);
+                    }
+                }
+            } else if path.leading_colon.is_none() {
+                if let Some(first) = path.segments.first() {
+                    self.record(&first.ident);
+                }
+            }
+
+            // Generic arguments can themselves contain unqualified paths,
+            // including on associated segments which are otherwise safe.
+            for segment in &path.segments {
+                self.visit_path_arguments(&segment.arguments);
+            }
+        }
+    }
+
+    impl<'ast> syn::visit::Visit<'ast> for ReservedIdentifierFinder<'_> {
+        fn visit_expr_path(&mut self, path: &'ast syn::ExprPath) {
+            for attr in &path.attrs {
+                self.visit_attribute(attr);
+            }
+            self.visit_maybe_qself_path(path.qself.as_ref(), &path.path);
+        }
+
+        fn visit_expr_struct(&mut self, expr: &'ast syn::ExprStruct) {
+            for attr in &expr.attrs {
+                self.visit_attribute(attr);
+            }
+            self.visit_maybe_qself_path(expr.qself.as_ref(), &expr.path);
+            for field in &expr.fields {
+                self.visit_field_value(field);
+            }
+            if let Some(rest) = &expr.rest {
+                self.visit_expr(rest);
+            }
+        }
+
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            if item.leading_colon.is_none() {
+                self.visit_use_root(&item.tree);
+            }
+        }
+
+        fn visit_path(&mut self, path: &'ast Path) {
+            self.visit_maybe_qself_path(None, path);
+        }
+
+        fn visit_pat_ident(&mut self, pat: &'ast syn::PatIdent) {
+            // A bare identifier in a pattern can resolve either as a binding
+            // or as an in-scope constant. A generated constant can therefore
+            // change the meaning of the copied pattern.
+            self.record(&pat.ident);
+            syn::visit::visit_pat_ident(self, pat);
+        }
+
+        fn visit_pat_struct(&mut self, pat: &'ast syn::PatStruct) {
+            for attr in &pat.attrs {
+                self.visit_attribute(attr);
+            }
+            self.visit_maybe_qself_path(pat.qself.as_ref(), &pat.path);
+            for field in &pat.fields {
+                self.visit_field_pat(field);
+            }
+            if let Some(rest) = &pat.rest {
+                self.visit_pat_rest(rest);
+            }
+        }
+
+        fn visit_pat_tuple_struct(&mut self, pat: &'ast syn::PatTupleStruct) {
+            for attr in &pat.attrs {
+                self.visit_attribute(attr);
+            }
+            self.visit_maybe_qself_path(pat.qself.as_ref(), &pat.path);
+            for elem in &pat.elems {
+                self.visit_pat(elem);
+            }
+        }
+
+        fn visit_type_path(&mut self, path: &'ast syn::TypePath) {
+            self.visit_maybe_qself_path(path.qself.as_ref(), &path.path);
+        }
+    }
+
+    let mut finder =
+        ReservedIdentifierFinder { reserved_prefixes: copied_syntax_prefixes, found: None };
+
+    // Some generators copy the derive target's name into a helper scope, while
+    // others refer to it only as `Self`. Reject the target only for prefixes
+    // which can capture that generator's copied target reference.
+    if is_reserved(&ctx.ast.ident, target_name_prefixes) {
+        finder.found = Some(ctx.ast.ident.clone());
+    }
+    // A target type parameter is also in scope in generated impl methods. Its
+    // only semantic use can be hidden behind `Self`, so scanning path
+    // references alone does not prove that it cannot capture a generated
+    // helper type. Const and lifetime parameters cannot resolve as helper
+    // types; exact cross-kind generic-name collisions are rejected by rustc.
+    for param in &ctx.ast.generics.params {
+        if let syn::GenericParam::Type(param) = param {
+            finder.record(&param.ident);
+        }
+    }
+    finder.visit_generics(&ctx.ast.generics);
+    for (_, _, ty) in ctx.ast.data.fields() {
+        finder.visit_type(ty);
+    }
+
+    if let Some(ident) = finder.found {
+        return Err(Error::new(
+            ident.span(),
+            format!(
+                "cannot derive `{}` because the unqualified identifier `{}` is reserved for generated code; qualify the path or rename the identifier",
+                derive_name,
+                to_ident_str(&ident),
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Rejects reserved identifiers in syntax copied into an `impl` declaration.
+///
+/// `copied_syntax_prefixes` applies to the retained impl generics and field
+/// types. `target_name_prefixes` applies independently when a generated helper
+/// copies the derive target's name into its scope.
+pub(crate) fn reject_reserved_identifiers_in_impl(
+    ctx: &Ctx,
+    derive_name: &str,
+    copied_syntax_prefixes: &[&str],
+    target_name_prefixes: &[&str],
+) -> Result<(), Error> {
+    let mut input = ctx.ast.clone();
+    input.generics = generics_without_defaults(&input.generics);
+    reject_reserved_identifiers_with_target_prefixes(
+        &ctx.with_input(&input),
+        derive_name,
+        copied_syntax_prefixes,
+        target_name_prefixes,
+    )
+}
+
+/// Rejects the contextual `Self` type in syntax which will be copied into a
+/// generated type.
+///
+/// `Self` resolves to the derive target in the input, but to the generated type
+/// in a copied field. That can change the field's layout or validity even when
+/// all generated helper names are fresh.
+#[derive(Default)]
+struct ContextualSelfFinder(Option<Span>);
+
+impl<'ast> syn::visit::Visit<'ast> for ContextualSelfFinder {
+    fn visit_path(&mut self, path: &'ast Path) {
+        if path.leading_colon.is_none()
+            && path
+                .segments
+                .first()
+                .map(|segment| to_ident_str(&segment.ident) == "Self")
+                .unwrap_or(false)
+        {
+            if self.0.is_none() {
+                self.0 = Some(path.span());
+            }
+            return;
+        }
+        syn::visit::visit_path(self, path);
+    }
+
+    fn visit_item_impl(&mut self, _item: &'ast syn::ItemImpl) {
+        // `Self` inside a nested impl denotes that impl's target, not the
+        // derive target whose syntax is being copied.
+    }
+
+    fn visit_item_enum(&mut self, _item: &'ast syn::ItemEnum) {
+        // `Self` inside a nested type definition denotes that nested type.
+    }
+
+    fn visit_item_struct(&mut self, _item: &'ast syn::ItemStruct) {
+        // `Self` inside a nested type definition denotes that nested type.
+    }
+
+    fn visit_item_trait(&mut self, _item: &'ast syn::ItemTrait) {
+        // `Self` inside a nested trait denotes that trait.
+    }
+
+    fn visit_item_trait_alias(&mut self, _item: &'ast syn::ItemTraitAlias) {
+        // `Self` inside a nested trait alias denotes that trait alias.
+    }
+
+    fn visit_item_union(&mut self, _item: &'ast syn::ItemUnion) {
+        // `Self` inside a nested type definition denotes that nested type.
+    }
+}
+
+fn reject_contextual_self(
+    finder: ContextualSelfFinder,
+    derive_name: &str,
+    location: &str,
+) -> Result<(), Error> {
+    if let Some(span) = finder.0 {
+        return Err(Error::new(
+            span,
+            format!(
+                "cannot derive `{}` with `Self` in {}; write the concrete type explicitly",
+                derive_name, location,
+            ),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn reject_contextual_self_in_types<'a>(
+    types: impl IntoIterator<Item = &'a Type>,
+    derive_name: &str,
+) -> Result<(), Error> {
+    use syn::visit::Visit as _;
+
+    for ty in types {
+        let mut finder = ContextualSelfFinder::default();
+        finder.visit_type(ty);
+        reject_contextual_self(finder, derive_name, "an enum field type")?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn reject_contextual_self_in_generics(
+    generics: &syn::Generics,
+    derive_name: &str,
+) -> Result<(), Error> {
+    use syn::visit::Visit as _;
+
+    let mut finder = ContextualSelfFinder::default();
+    finder.visit_generics(generics);
+    reject_contextual_self(finder, derive_name, "generic parameters or predicates")
+}
+
 impl DataExt for Data {
     fn fields(&self) -> Vec<(&Visibility, TokenStream, &Type)> {
         match self {
@@ -346,7 +845,7 @@ pub(crate) enum PaddingCheck {
     /// Check that every variant of the enum contains no padding.
     ///
     /// Because doing so requires a tag enum, this padding check requires an
-    /// additional `TokenStream` which defines the tag enum as `___ZerocopyTag`.
+    /// additional expression which computes the tag size in an isolated scope.
     Enum { tag_type_definition: TokenStream },
 }
 
@@ -364,15 +863,6 @@ impl PaddingCheck {
         let trt = Ident::new(trt, Span::call_site());
         let mcro = Ident::new(mcro, Span::call_site());
         (trt, mcro)
-    }
-
-    /// Sometimes performing the padding check requires some additional
-    /// "context" code. For enums, this is the definition of the tag enum.
-    pub(crate) fn validator_macro_context(&self) -> Option<&TokenStream> {
-        match self {
-            PaddingCheck::Struct | PaddingCheck::ReprCStruct | PaddingCheck::Union => None,
-            PaddingCheck::Enum { tag_type_definition } => Some(tag_type_definition),
-        }
     }
 }
 
@@ -648,46 +1138,71 @@ impl<'a> ImplBlockBuilder<'a> {
             (FieldBounds::Explicit(bounds), _) => bounds,
         };
 
-        let padding_check_bound = self
-            .padding_check
-            .map(|check| {
-                // Parse the repr for `align` and `packed` modifiers. Note that
-                // `Repr::<PrimitiveRepr, NonZeroU32>` is more permissive than
-                // what Rust supports for structs, enums, or unions, and thus
-                // reliably extracts these modifiers for any kind of type.
-                let repr =
-                    Repr::<PrimitiveRepr, NonZeroU32>::from_attrs(&self.ctx.ast.attrs).unwrap();
-                let core = self.ctx.core_path();
-                let option = quote! { #core::option::Option };
-                let nonzero = quote! { #core::num::NonZeroUsize };
-                let none = quote! { #option::None::<#nonzero> };
-                let repr_align =
-                    repr.get_align().map(|spanned| {
-                        let n = spanned.t.get();
-                        quote_spanned! { spanned.span => (#nonzero::new(#n as usize)) }
-                    }).unwrap_or(quote! { (#none) });
-                let repr_packed =
-                    repr.get_packed().map(|packed| {
-                        let n = packed.get();
-                        quote! { (#nonzero::new(#n as usize)) }
-                    }).unwrap_or(quote! { (#none) });
-                let variant_types = variants.iter().map(|(_, fields)| {
-                    let types = fields.iter().map(|(_vis, _name, ty)| ty);
-                    quote!([#((#types)),*])
-                });
-                let validator_context = check.validator_macro_context();
-                let (trt, validator_macro) = check.validator_trait_and_macro_idents();
-                let t = tag.iter();
-                parse_quote! {
-                    (): #zerocopy_crate::util::macro_util::#trt<
-                        Self,
-                        {
-                            #validator_context
-                            #zerocopy_crate::#validator_macro!(Self, #repr_align, #repr_packed, #(#t,)* #(#variant_types),*)
-                        }
-                    >
-                }
+        let padding_check_bound = self.padding_check.map(|check| {
+            // Parse the repr for `align` and `packed` modifiers. Note that
+            // `Repr::<PrimitiveRepr, NonZeroU32>` is more permissive than
+            // what Rust supports for structs, enums, or unions, and thus
+            // reliably extracts these modifiers for any kind of type.
+            let repr = Repr::<PrimitiveRepr, NonZeroU32>::from_attrs(&self.ctx.ast.attrs).unwrap();
+            let core = self.ctx.core_path();
+            let option = quote! { #core::option::Option };
+            let nonzero = quote! { #core::num::NonZeroUsize };
+            let none = quote! { #option::None::<#nonzero> };
+            let repr_align = repr
+                .get_align()
+                .map(|spanned| {
+                    let n = spanned.t.get();
+                    quote_spanned! { spanned.span => (#nonzero::new(#n as usize)) }
+                })
+                .unwrap_or(quote! { (#none) });
+            let repr_packed = repr
+                .get_packed()
+                .map(|packed| {
+                    let n = packed.get();
+                    quote! { (#nonzero::new(#n as usize)) }
+                })
+                .unwrap_or(quote! { (#none) });
+            let variant_types = variants.iter().map(|(_, fields)| {
+                let types = fields.iter().map(|(_vis, _name, ty)| ty);
+                quote!([#((#types)),*])
             });
+            let (trt, validator_macro) = check.validator_trait_and_macro_idents();
+            let check = match check {
+                PaddingCheck::Enum { tag_type_definition } => quote! {
+                    #zerocopy_crate::#validator_macro!(
+                        @tag_size,
+                        Self,
+                        #repr_align,
+                        #repr_packed,
+                        {
+                            #tag_type_definition
+                            #core::mem::size_of::<___ZerocopyTag>()
+                        },
+                        #(#variant_types),*
+                    )
+                },
+                _ => {
+                    let t = tag.iter();
+                    quote! {
+                        #zerocopy_crate::#validator_macro!(
+                            Self,
+                            #repr_align,
+                            #repr_packed,
+                            #(#t,)*
+                            #(#variant_types),*
+                        )
+                    }
+                }
+            };
+            parse_quote! {
+                (): #zerocopy_crate::util::macro_util::#trt<
+                    Self,
+                    {
+                        #check
+                    }
+                >
+            }
+        });
 
         let self_bounds: Option<WherePredicate> = match self.self_type_trait_bounds {
             SelfBounds::None => None,
@@ -722,21 +1237,10 @@ impl<'a> ImplBlockBuilder<'a> {
             .chain(zerocopy_bounds.iter());
 
         // The parameters with trait bounds, but without type defaults.
-        let mut params: Vec<_> = self
-            .ctx
-            .ast
-            .generics
+        let mut params: Vec<_> = generics_without_defaults(&self.ctx.ast.generics)
             .params
-            .clone()
             .into_iter()
-            .map(|mut param| {
-                match &mut param {
-                    GenericParam::Type(ty) => ty.default = None,
-                    GenericParam::Const(cnst) => cnst.default = None,
-                    GenericParam::Lifetime(_) => {}
-                }
-                parse_quote!(#param)
-            })
+            .map(|param| parse_quote!(#param))
             .chain(self.param_extras)
             .collect();
 
@@ -1191,6 +1695,202 @@ pub(crate) fn enum_size_from_repr(repr: &EnumRepr) -> Result<usize, Error> {
 pub(crate) mod testutil {
     use proc_macro2::TokenStream;
     use syn::visit::{self, Visit};
+
+    #[test]
+    fn rejects_opaque_syntax_nested_in_field_types() {
+        let attributed: syn::Type = syn::parse_quote!(
+            [u8; #[stateful]
+            1]
+        );
+        let error = super::reject_uninspectable_types([&attributed], "IntoBytes").unwrap_err();
+        assert!(error.to_string().contains("containing an attribute"));
+
+        let verbatim = syn::Type::Verbatim(quote::quote!(dyn* Trait));
+        let error = super::reject_uninspectable_types([&verbatim], "KnownLayout").unwrap_err();
+        assert!(error.to_string().contains("unsupported unresolved syntax"));
+
+        let generic: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T: Select<{ choose!() }>>(T);
+        };
+        let error =
+            super::reject_uninspectable_generics(&generic.generics, "TryFromBytes").unwrap_err();
+        assert!(error.to_string().contains("a macro invocation"));
+        assert!(error.to_string().contains("generic parameters or predicates"));
+
+        let defaults: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T = type_default!(), const N: usize = { const_default!() }>([T; N]);
+        };
+        super::reject_uninspectable_impl_generics(&defaults.generics, "TryFromBytes").unwrap();
+        super::reject_uninspectable_generics(&defaults.generics, "TryFromBytes").unwrap_err();
+    }
+
+    #[test]
+    fn rejects_reserved_unqualified_identifiers() {
+        let direct: syn::DeriveInput = syn::parse_quote! {
+            struct Packet {
+                field: __ZerocopyGeneratedHelper,
+            }
+        };
+        let direct = super::Ctx::try_from_derive_input(direct).unwrap();
+        let error = super::reject_reserved_identifiers(&direct, "KnownLayout", &["__Zerocopy"])
+            .unwrap_err();
+        assert!(error.to_string().contains("`__ZerocopyGeneratedHelper` is reserved"));
+
+        let qualified: syn::DeriveInput = syn::parse_quote! {
+            struct Packet {
+                field: crate::types::__ZerocopyGeneratedHelper,
+            }
+        };
+        let qualified = super::Ctx::try_from_derive_input(qualified).unwrap();
+        super::reject_reserved_identifiers(&qualified, "KnownLayout", &["__Zerocopy"]).unwrap();
+
+        let qself_terminal: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T>(<T>::__ZerocopyAssociated);
+        };
+        let qself_terminal = super::Ctx::try_from_derive_input(qself_terminal).unwrap();
+        super::reject_reserved_identifiers(&qself_terminal, "KnownLayout", &["__Zerocopy"])
+            .unwrap();
+
+        let qself_expr_terminal: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T>([u8; <T>::__ZerocopyAssociated]);
+        };
+        let qself_expr_terminal = super::Ctx::try_from_derive_input(qself_expr_terminal).unwrap();
+        super::reject_reserved_identifiers(&qself_expr_terminal, "KnownLayout", &["__Zerocopy"])
+            .unwrap();
+
+        let qself_struct_terminals: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T>([u8; {
+                let _ = <T>::__ZerocopyStruct { field: 0 };
+                match todo!() {
+                    <T>::__ZerocopyStruct { field: _ } => 0,
+                    <T>::__ZerocopyTuple(_) => 1,
+                }
+            }]);
+        };
+        let qself_struct_terminals =
+            super::Ctx::try_from_derive_input(qself_struct_terminals).unwrap();
+        super::reject_reserved_identifiers(&qself_struct_terminals, "KnownLayout", &["__Zerocopy"])
+            .unwrap();
+
+        let qself_trait_root: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T>(<T as __ZerocopyTrait>::Associated);
+        };
+        let qself_trait_root = super::Ctx::try_from_derive_input(qself_trait_root).unwrap();
+        super::reject_reserved_identifiers(&qself_trait_root, "KnownLayout", &["__Zerocopy"])
+            .unwrap_err();
+
+        let qself_argument: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T>(<T>::Associated<__ZerocopyArgument>);
+        };
+        let qself_argument = super::Ctx::try_from_derive_input(qself_argument).unwrap();
+        super::reject_reserved_identifiers(&qself_argument, "KnownLayout", &["__Zerocopy"])
+            .unwrap_err();
+
+        let target: syn::DeriveInput = syn::parse_quote! {
+            struct __ZerocopyGeneratedHelper;
+        };
+        let target = super::Ctx::try_from_derive_input(target).unwrap();
+        super::reject_reserved_identifiers(&target, "KnownLayout", &["__Zerocopy"]).unwrap_err();
+
+        // The type parameter's only use is through `Self`, so this exercises
+        // declaration scanning rather than an ordinary type-path reference.
+        let type_parameter: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<___ZerocopyType>(<Self as Assoc>::Type)
+            where
+                Self: Assoc;
+        };
+        let type_parameter = super::Ctx::try_from_derive_input(type_parameter).unwrap();
+        super::reject_reserved_identifiers(&type_parameter, "TryFromBytes", &["___Zerocopy"])
+            .unwrap_err();
+
+        let default_only: syn::DeriveInput = syn::parse_quote! {
+            struct Packet<T = ___ZcDefault>(T);
+        };
+        let default_only = super::Ctx::try_from_derive_input(default_only).unwrap();
+        super::reject_reserved_identifiers_in_impl(
+            &default_only,
+            "TryFromBytes",
+            &["___Zc"],
+            &["___Zc"],
+        )
+        .unwrap();
+        super::reject_reserved_identifiers(&default_only, "TryFromBytes", &["___Zc"]).unwrap_err();
+
+        let pattern: syn::DeriveInput = syn::parse_quote! {
+            enum Packet {
+                Variant([u8; match 0 { ___ZEROCOPY_TAG_Variant => 1, _ => 2 }]),
+            }
+        };
+        let pattern = super::Ctx::try_from_derive_input(pattern).unwrap();
+        super::reject_reserved_identifiers(&pattern, "TryFromBytes", &["___ZEROCOPY"]).unwrap_err();
+
+        let imported: syn::DeriveInput = syn::parse_quote! {
+            struct Packet([u8; {
+                use __ZerocopyGeneratedHelper as T;
+                core::mem::size_of::<T>()
+            }]);
+        };
+        let imported = super::Ctx::try_from_derive_input(imported).unwrap();
+        super::reject_reserved_identifiers(&imported, "KnownLayout", &["__Zerocopy"]).unwrap_err();
+
+        let qualified_import: syn::DeriveInput = syn::parse_quote! {
+            struct Packet([u8; {
+                use crate::types::__ZerocopyGeneratedHelper as T;
+                core::mem::size_of::<T>()
+            }]);
+        };
+        let qualified_import = super::Ctx::try_from_derive_input(qualified_import).unwrap();
+        super::reject_reserved_identifiers(&qualified_import, "KnownLayout", &["__Zerocopy"])
+            .unwrap();
+    }
+
+    #[test]
+    fn accepts_inspectable_blocks_but_rejects_nested_macros() {
+        let inspectable: syn::Type = syn::parse_quote!(
+            [u8; {
+                const N: usize = 4;
+                N
+            }]
+        );
+        super::reject_uninspectable_types([&inspectable], "IntoBytes").unwrap();
+
+        let macro_in_block: syn::Type = syn::parse_quote! {
+            [u8; { macro_rules! n { () => { 4 } } n!() }]
+        };
+        let error = super::reject_uninspectable_types([&macro_in_block], "IntoBytes").unwrap_err();
+        assert!(error.to_string().contains("a macro invocation"));
+    }
+
+    #[test]
+    fn rejects_contextual_self_recursively() {
+        let nested: syn::Type =
+            syn::parse_quote!([u8; core::mem::size_of::<core::mem::Discriminant<Self>>()]);
+        let error = super::reject_contextual_self_in_types([&nested], "TryFromBytes").unwrap_err();
+        assert!(error.to_string().contains("`Self` in an enum field type"));
+
+        let generic: syn::DeriveInput = syn::parse_quote! {
+            enum Packet<T: Select<Self>> {
+                Variant(T),
+            }
+        };
+        let error = super::reject_contextual_self_in_generics(&generic.generics, "TryFromBytes")
+            .unwrap_err();
+        assert!(error.to_string().contains("`Self` in generic parameters or predicates"));
+
+        let nested_items: syn::Type = syn::parse_quote! {
+            [u8; {
+                struct NestedStruct(core::marker::PhantomData<Self>);
+                enum NestedEnum {
+                    Variant(core::marker::PhantomData<Self>),
+                }
+                union NestedUnion {
+                    field: core::mem::ManuallyDrop<Self>,
+                }
+                0
+            }]
+        };
+        super::reject_contextual_self_in_types([&nested_items], "TryFromBytes").unwrap();
+    }
 
     /// Checks for hygiene violations in the generated code.
     ///

--- a/zerocopy/zerocopy-derive/tests/issue_3633.rs
+++ b/zerocopy/zerocopy-derive/tests/issue_3633.rs
@@ -1,0 +1,407 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![no_implicit_prelude]
+#![allow(dead_code)]
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+include!("include.rs");
+
+#[derive(imp::KnownLayout, imp::Immutable, imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct InspectableBlock(
+    [u8; {
+        const N: usize = 1;
+        N
+    }],
+);
+
+util_assert_impl_all!(
+    InspectableBlock:
+        imp::KnownLayout,
+        imp::Immutable,
+        imp::FromBytes,
+        imp::IntoBytes,
+        imp::Unaligned,
+);
+
+mod discarded_generic_defaults {
+    use super::*;
+
+    macro_rules! default_type {
+        () => {
+            u8
+        };
+    }
+
+    // These defaults are expanded only in the source declaration. The
+    // generated impls discard them while preserving the parameters, bounds,
+    // const parameter types, and where predicates.
+    #[derive(imp::Immutable, imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct ImplOnly<T = default_type!()>(T);
+
+    util_assert_impl_all!(
+        ImplOnly:
+            imp::Immutable,
+            imp::TryFromBytes,
+            imp::FromZeros,
+            imp::FromBytes,
+            imp::IntoBytes,
+            imp::Unaligned,
+    );
+}
+
+mod trivial_from_bytes_validator {
+    use super::*;
+
+    type ___ZcAlignment = u8;
+
+    // A trivial validator refers only to `Self`, so its method generic cannot
+    // capture this field type.
+    #[derive(imp::FromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(transparent)]
+    struct Packet(___ZcAlignment);
+
+    #[derive(imp::FromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    union UnionPacket {
+        value: ___ZcAlignment,
+    }
+
+    util_assert_impl_all!(Packet: imp::FromBytes);
+    util_assert_impl_all!(UnionPacket: imp::FromBytes);
+}
+
+mod target_named_like_method_generic {
+    use super::*;
+
+    mod try_from_bytes_struct {
+        use super::*;
+
+        #[derive(imp::TryFromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        struct ___ZcAlignment(bool);
+
+        util_assert_impl_all!(___ZcAlignment: imp::TryFromBytes);
+    }
+
+    mod try_from_bytes_union {
+        use super::*;
+
+        #[derive(imp::TryFromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        union ___ZcAlignment {
+            value: bool,
+        }
+
+        util_assert_impl_all!(___ZcAlignment: imp::TryFromBytes);
+    }
+
+    mod from_zeros_struct {
+        use super::*;
+
+        #[derive(imp::FromZeros)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        struct ___ZcAlignment(u8);
+
+        util_assert_impl_all!(___ZcAlignment: imp::FromZeros);
+    }
+
+    mod generic_from_bytes_struct {
+        use super::*;
+
+        #[derive(imp::FromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        struct ___ZcAlignment<T>(T);
+
+        util_assert_impl_all!(___ZcAlignment<u8>: imp::FromBytes);
+    }
+}
+
+mod zero_field_target_named_like_field_marker {
+    use super::*;
+
+    mod try_from_bytes {
+        use super::*;
+
+        #[allow(non_camel_case_types)]
+        #[derive(imp::TryFromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        struct ẕUnit<const N: usize>;
+
+        util_assert_impl_all!(ẕUnit<0>: imp::TryFromBytes);
+    }
+
+    mod trivial_from_bytes {
+        use super::*;
+
+        #[derive(imp::FromBytes)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        struct ___ZcAlignment;
+
+        util_assert_impl_all!(___ZcAlignment: imp::FromBytes);
+    }
+}
+
+mod known_layout {
+    use super::*;
+
+    pub mod types {
+        pub type __Zerocopy_Field_header = [u8; 8];
+    }
+
+    #[derive(imp::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: crate::known_layout::types::__Zerocopy_Field_header,
+        bytes: [u8],
+    }
+
+    #[test]
+    fn qualified_reserved_field_type_is_not_captured_by_a_generated_helper() {
+        imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(0), imp::Some(8));
+        imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(1), imp::Some(9));
+    }
+}
+
+mod known_layout_trailing_dst {
+    use super::*;
+
+    pub mod types {
+        pub type __ZerocopyKnownLayoutMaybeUninit = [u8];
+    }
+
+    #[derive(imp::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: u8,
+        bytes: crate::known_layout_trailing_dst::types::__ZerocopyKnownLayoutMaybeUninit,
+    }
+
+    #[test]
+    fn qualified_reserved_trailing_dst_is_not_captured_by_a_generated_helper() {
+        imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(0), imp::Some(1));
+        imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(1), imp::Some(2));
+    }
+}
+
+mod try_from_bytes {
+    use super::*;
+
+    pub mod types {
+        pub type ___ZerocopyTagPrimitive = bool;
+    }
+
+    #[derive(imp::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Flag(crate::try_from_bytes::types::___ZerocopyTagPrimitive),
+    }
+
+    #[derive(imp::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum NamedPacket {
+        Flag { value: crate::try_from_bytes::types::___ZerocopyTagPrimitive },
+    }
+
+    #[test]
+    fn qualified_reserved_field_type_is_not_captured_by_a_generated_helper() {
+        crate::util::test_is_bit_valid::<Packet, _>([0u8, 0], true);
+        crate::util::test_is_bit_valid::<Packet, _>([0u8, 2], false);
+        crate::util::test_is_bit_valid::<NamedPacket, _>([0u8, 0], true);
+        crate::util::test_is_bit_valid::<NamedPacket, _>([0u8, 2], false);
+    }
+}
+
+mod into_bytes {
+    use super::*;
+
+    const max_and_disc_size: usize = 0;
+
+    mod types {
+        pub type ___ZerocopyTag = [u16; 0];
+    }
+
+    use types::___ZerocopyTag;
+
+    #[derive(imp::IntoBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u16)]
+    enum PaddingFree {
+        Variant(___ZerocopyTag),
+    }
+
+    #[derive(imp::IntoBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum ExistingCallerName {
+        Variant([u8; max_and_disc_size]),
+    }
+
+    util_assert_impl_all!(PaddingFree: imp::IntoBytes);
+    util_assert_impl_all!(ExistingCallerName: imp::IntoBytes);
+
+    #[test]
+    fn field_type_is_not_captured_by_the_generated_tag() {
+        imp::assert_eq!(::core::mem::size_of::<PaddingFree>(), 2);
+    }
+}
+
+mod qualified_roots {
+    use super::*;
+
+    mod self_root {
+        use super::*;
+
+        type __Zerocopy_Field_header = [u8; 8];
+
+        #[derive(imp::KnownLayout)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(C)]
+        struct Packet {
+            header: self::__Zerocopy_Field_header,
+            bytes: [u8],
+        }
+
+        #[test]
+        fn self_qualified_reserved_name_is_not_captured() {
+            imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(1), imp::Some(9));
+        }
+    }
+
+    mod super_root {
+        use super::*;
+
+        type __Zerocopy_Field_header = [u8; 8];
+
+        mod nested {
+            use super::*;
+
+            #[derive(imp::KnownLayout)]
+            #[zerocopy(crate = "zerocopy_renamed")]
+            #[repr(C)]
+            struct Packet {
+                header: super::__Zerocopy_Field_header,
+                bytes: [u8],
+            }
+
+            #[test]
+            fn super_qualified_reserved_name_is_not_captured() {
+                imp::assert_eq!(<Packet as imp::KnownLayout>::size_for_metadata(1), imp::Some(9),);
+            }
+        }
+    }
+
+    mod qself {
+        use super::*;
+
+        trait Layout {
+            type __Zerocopy_Field_header;
+        }
+
+        impl Layout for () {
+            type __Zerocopy_Field_header = [u8; 8];
+        }
+
+        struct Length;
+
+        impl Length {
+            const __Zerocopy_Field_len: usize = 8;
+        }
+
+        #[derive(imp::KnownLayout)]
+        #[zerocopy(crate = "zerocopy_renamed")]
+        #[repr(C)]
+        struct Packet<T: Layout> {
+            header: <T as Layout>::__Zerocopy_Field_header,
+            prefix: [u8; <Length>::__Zerocopy_Field_len],
+            bytes: [u8],
+        }
+
+        #[test]
+        fn qself_qualified_reserved_names_are_not_captured() {
+            imp::assert_eq!(<Packet<()> as imp::KnownLayout>::size_for_metadata(1), imp::Some(17),);
+        }
+    }
+}
+
+mod nested_contextual_self {
+    use super::*;
+
+    #[derive(imp::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Empty(
+            [bool; {
+                struct Local(::core::marker::PhantomData<Self>);
+                ::core::mem::size_of::<Local>()
+            }],
+        ),
+        Other,
+    }
+
+    #[test]
+    fn self_in_a_nested_type_denotes_that_type() {
+        crate::util::test_is_bit_valid::<Packet, _>([0u8], true);
+        crate::util::test_is_bit_valid::<Packet, _>([2u8], false);
+    }
+}
+
+mod imported_helper_capture {
+    use super::*;
+
+    trait UserType {}
+
+    impl UserType for u8 {}
+
+    #[derive(imp::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet<CastSized: UserType, Projection: UserType> {
+        Variant(CastSized, Projection, bool),
+        Other,
+    }
+
+    util_assert_impl_all!(Packet<u8, u8>: imp::TryFromBytes);
+
+    #[test]
+    fn generic_parameters_are_not_captured_by_projection_helpers() {
+        crate::util::test_is_bit_valid::<Packet<u8, u8>, _>([0u8, 0, 0, 0], true);
+        crate::util::test_is_bit_valid::<Packet<u8, u8>, _>([0u8, 0, 0, 2], false);
+    }
+}
+
+mod const_parameter_shadowing {
+    use super::*;
+
+    #[derive(imp::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet<const ___ZEROCOPY_TAG_A: u8> {
+        A(u8),
+        B(bool),
+    }
+
+    util_assert_impl_all!(Packet<1>: imp::TryFromBytes);
+
+    #[test]
+    fn generated_tag_constant_shadows_the_const_parameter() {
+        crate::util::test_is_bit_valid::<Packet<1>, _>([0u8, 2], true);
+        crate::util::test_is_bit_valid::<Packet<1>, _>([1u8, 2], false);
+    }
+}

--- a/zerocopy/zerocopy-derive/tests/on_error.rs
+++ b/zerocopy/zerocopy-derive/tests/on_error.rs
@@ -20,6 +20,13 @@ struct LoudValid;
 
 util_assert_impl_all!(LoudValid: imp::FromBytes);
 
+#[derive(imp::FromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct ___ZcAlignment(u8);
+
+util_assert_impl_all!(___ZcAlignment: imp::FromBytes);
+
 // `derive(Unaligned)` fails without a repr.
 #[derive(imp::FromBytes, imp::IntoBytes, imp::Unaligned)]
 #[zerocopy(on_error = "skip")]
@@ -237,6 +244,68 @@ util_assert_not_impl_any!(BadIntoBytesUnionGeneric<u8>: imp::IntoBytes);
 struct TrivialBounds(bool);
 
 util_assert_not_impl_any!(TrivialBounds: imp::FromBytes);
+
+macro_rules! skipped_field_type {
+    () => {
+        u8
+    };
+}
+
+#[derive(imp::TryFromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct UninspectableTryFromBytes(skipped_field_type!());
+
+util_assert_not_impl_any!(UninspectableTryFromBytes: imp::TryFromBytes);
+
+#[derive(imp::FromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct UninspectableFromBytes(skipped_field_type!());
+
+util_assert_not_impl_any!(UninspectableFromBytes:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
+
+type ___ZerocopyTagPrimitive = bool;
+
+#[derive(imp::FromZeros)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum ReservedFromZeros {
+    Zero(___ZerocopyTagPrimitive),
+    One,
+}
+
+util_assert_not_impl_any!(ReservedFromZeros: imp::TryFromBytes, imp::FromZeros);
+
+trait Select<const N: usize> {
+    type Assoc;
+}
+
+impl Select<0> for () {
+    type Assoc = u8;
+}
+
+macro_rules! skipped_selection {
+    () => {
+        0
+    };
+}
+
+#[derive(imp::FromBytes)]
+#[zerocopy(on_error = "skip")]
+#[zerocopy(crate = "zerocopy_renamed")]
+struct UninspectableGeneric<T: Select<{ skipped_selection!() }>>(T::Assoc);
+
+util_assert_not_impl_any!(UninspectableGeneric<()>:
+    imp::TryFromBytes,
+    imp::FromZeros,
+    imp::FromBytes,
+);
 
 #[derive(imp::IntoBytes)]
 #[zerocopy(on_error = "skip")]

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633.msrv.stderr
@@ -1,0 +1,32 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:22:17
+   |
+22 |         header: __Zerocopy_Field_header,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:39:22
+   |
+39 |         header: [u8; len!()],
+   |                      ^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:58:17
+   |
+58 |         header: header!(),
+   |                 ^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:86:19
+   |
+86 |     struct Packet<__Zerocopy_Field_header>
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633.rs:104:17
+    |
+104 |             use __Zerocopy_Field_0 as T;
+    |                 ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633.nightly.stderr
@@ -1,0 +1,32 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:22:17
+   |
+22 |         header: __Zerocopy_Field_header,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:39:22
+   |
+39 |         header: [u8; len!()],
+   |                      ^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:58:17
+   |
+58 |         header: header!(),
+   |                 ^^^^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:86:19
+   |
+86 |     struct Packet<__Zerocopy_Field_header>
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633.rs:104:17
+    |
+104 |             use __Zerocopy_Field_0 as T;
+    |                 ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633.rs
@@ -1,0 +1,110 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(non_camel_case_types)]
+
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+mod known_layout_direct {
+    type __Zerocopy_Field_header = [u8; 8];
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: __Zerocopy_Field_header,
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code
+        bytes: [u8],
+    }
+}
+
+mod known_layout_nested_macro {
+    macro_rules! len {
+        () => {
+            8
+        };
+    }
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: [u8; len!()],
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` for a type containing a macro invocation in a field type
+        bytes: [u8],
+    }
+}
+
+mod known_layout_macro {
+    type __Zerocopy_Field_header = [u8; 8];
+
+    macro_rules! header {
+        () => {
+            __Zerocopy_Field_header
+        };
+    }
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: header!(),
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` for a type containing a macro invocation in a field type
+        bytes: [u8],
+    }
+}
+
+mod known_layout_qualified {
+    mod types {
+        pub type __Zerocopy_Field_header = [u8; 8];
+    }
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet {
+        header: crate::known_layout_qualified::types::__Zerocopy_Field_header,
+        bytes: [u8],
+    }
+}
+
+mod known_layout_generic_marker_capture {
+    trait Assoc {
+        type Type;
+    }
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet<__Zerocopy_Field_header>
+    //~^ ERROR: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code
+    where
+        Self: Assoc,
+    {
+        header: <Self as Assoc>::Type,
+        bytes: [u8],
+    }
+}
+
+mod known_layout_use_root {
+    type __Zerocopy_Field_0 = u8;
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Packet(
+        [u8; {
+            use __Zerocopy_Field_0 as T;
+            //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_0` is reserved for generated code
+            core::mem::size_of::<T>()
+        }],
+        [u8],
+    );
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633.stable.stderr
@@ -1,0 +1,32 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:22:17
+   |
+22 |         header: __Zerocopy_Field_header,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:39:22
+   |
+39 |         header: [u8; len!()],
+   |                      ^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633.rs:58:17
+   |
+58 |         header: header!(),
+   |                 ^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_header` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633.rs:86:19
+   |
+86 |     struct Packet<__Zerocopy_Field_header>
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633.rs:104:17
+    |
+104 |             use __Zerocopy_Field_0 as T;
+    |                 ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.msrv.stderr
@@ -1,0 +1,80 @@
+error: cannot derive `Immutable` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:34:18
+   |
+34 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:41:18
+   |
+41 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:48:18
+   |
+48 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:56:18
+   |
+56 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:70:22
+   |
+70 |     struct Value(u8, trailing_type!());
+   |                      ^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:80:36
+   |
+80 |     struct KnownLayout<T: Select<{ selection!() }>>(T::Assoc);
+   |                                    ^^^^^^^^^
+
+error: cannot derive `Immutable` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:85:34
+   |
+85 |     struct Immutable<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:90:37
+   |
+90 |     struct TryFromBytes<T: Select<{ selection!() }>>(T::Assoc);
+   |                                     ^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:95:34
+   |
+95 |     struct FromZeros<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:100:34
+    |
+100 |     struct FromBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:106:34
+    |
+106 |     struct IntoBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:112:34
+    |
+112 |     struct Unaligned<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:118:32
+    |
+118 |     struct SplitAt<T: Select<{ selection!() }>>(u8, [T::Assoc]);
+    |                                ^^^^^^^^^
+
+error: aborting due to 13 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.nightly.stderr
@@ -1,0 +1,80 @@
+error: cannot derive `Immutable` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:34:18
+   |
+34 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:41:18
+   |
+41 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:48:18
+   |
+48 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:56:18
+   |
+56 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:70:22
+   |
+70 |     struct Value(u8, trailing_type!());
+   |                      ^^^^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:80:36
+   |
+80 |     struct KnownLayout<T: Select<{ selection!() }>>(T::Assoc);
+   |                                    ^^^^^^^^^^^^
+
+error: cannot derive `Immutable` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:85:34
+   |
+85 |     struct Immutable<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:90:37
+   |
+90 |     struct TryFromBytes<T: Select<{ selection!() }>>(T::Assoc);
+   |                                     ^^^^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:95:34
+   |
+95 |     struct FromZeros<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:100:34
+    |
+100 |     struct FromBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:106:34
+    |
+106 |     struct IntoBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:112:34
+    |
+112 |     struct Unaligned<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:118:32
+    |
+118 |     struct SplitAt<T: Select<{ selection!() }>>(u8, [T::Assoc]);
+    |                                ^^^^^^^^^^^^
+
+error: aborting due to 13 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(dead_code, unused_braces)]
+
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+macro_rules! field_type {
+    () => {
+        u8
+    };
+}
+
+trait Select<const N: usize> {
+    type Assoc;
+}
+
+macro_rules! selection {
+    () => {
+        0
+    };
+}
+
+mod immutable {
+    #[derive(zerocopy_derive::Immutable)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Value(field_type!());
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `Immutable` for a type containing a macro invocation in a field type
+}
+
+mod from_zeros {
+    #[derive(zerocopy_derive::FromZeros)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Value(field_type!());
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `FromZeros` for a type containing a macro invocation in a field type
+}
+
+mod from_bytes {
+    #[derive(zerocopy_derive::FromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Value(field_type!());
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `FromBytes` for a type containing a macro invocation in a field type
+}
+
+mod unaligned {
+    #[derive(zerocopy_derive::Unaligned)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Value(field_type!());
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `Unaligned` for a type containing a macro invocation in a field type
+}
+
+mod split_at {
+    macro_rules! trailing_type {
+        () => {
+            [u8]
+        };
+    }
+
+    #[derive(zerocopy_derive::SplitAt)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Value(u8, trailing_type!());
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `SplitAt` for a type containing a macro invocation in a field type
+}
+
+mod generic_bounds {
+    use super::Select;
+
+    #[derive(zerocopy_derive::KnownLayout)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct KnownLayout<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::Immutable)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Immutable<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `Immutable` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct TryFromBytes<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::FromZeros)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct FromZeros<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `FromZeros` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::FromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct FromBytes<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `FromBytes` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::IntoBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(transparent)]
+    struct IntoBytes<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `IntoBytes` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::Unaligned)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct Unaligned<T: Select<{ selection!() }>>(T::Assoc);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `Unaligned` for a type containing a macro invocation in generic parameters or predicates
+
+    #[derive(zerocopy_derive::SplitAt)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(C)]
+    struct SplitAt<T: Select<{ selection!() }>>(u8, [T::Assoc]);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `SplitAt` for a type containing a macro invocation in generic parameters or predicates
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_field_type_macros.stable.stderr
@@ -1,0 +1,80 @@
+error: cannot derive `Immutable` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:34:18
+   |
+34 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:41:18
+   |
+41 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:48:18
+   |
+48 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:56:18
+   |
+56 |     struct Value(field_type!());
+   |                  ^^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:70:22
+   |
+70 |     struct Value(u8, trailing_type!());
+   |                      ^^^^^^^^^^^^^
+
+error: cannot derive `KnownLayout` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:80:36
+   |
+80 |     struct KnownLayout<T: Select<{ selection!() }>>(T::Assoc);
+   |                                    ^^^^^^^^^
+
+error: cannot derive `Immutable` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:85:34
+   |
+85 |     struct Immutable<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:90:37
+   |
+90 |     struct TryFromBytes<T: Select<{ selection!() }>>(T::Assoc);
+   |                                     ^^^^^^^^^
+
+error: cannot derive `FromZeros` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+  --> $DIR/issue_3633_field_type_macros.rs:95:34
+   |
+95 |     struct FromZeros<T: Select<{ selection!() }>>(T::Assoc);
+   |                                  ^^^^^^^^^
+
+error: cannot derive `FromBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:100:34
+    |
+100 |     struct FromBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:106:34
+    |
+106 |     struct IntoBytes<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `Unaligned` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:112:34
+    |
+112 |     struct Unaligned<T: Select<{ selection!() }>>(T::Assoc);
+    |                                  ^^^^^^^^^
+
+error: cannot derive `SplitAt` for a type containing a macro invocation in generic parameters or predicates; write the expanded syntax explicitly
+   --> $DIR/issue_3633_field_type_macros.rs:118:32
+    |
+118 |     struct SplitAt<T: Select<{ selection!() }>>(u8, [T::Assoc]);
+    |                                ^^^^^^^^^
+
+error: aborting due to 13 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.msrv.stderr
@@ -1,0 +1,26 @@
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:37:17
+   |
+37 |         Variant(field_type!()),
+   |                 ^^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:52:24
+   |
+52 |     struct Packet([u8; len!()]);
+   |                        ^^^
+
+error[E0277]: the trait bound `(): PaddingFree<Padded, 1_usize>` is not satisfied
+  --> $DIR/issue_3633_into_bytes.rs:17:10
+   |
+17 | #[derive(zerocopy_derive::IntoBytes)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PaddingFree<Padded, 1_usize>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as PaddingFree<T, 0_usize>>
+   = help: see issue #48214
+   = note: this error originates in the derive macro `zerocopy_derive::IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.nightly.stderr
@@ -1,0 +1,34 @@
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:37:17
+   |
+37 |         Variant(field_type!()),
+   |                 ^^^^^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:52:24
+   |
+52 |     struct Packet([u8; len!()]);
+   |                        ^^^^^^
+
+error[E0277]: `Padded` has 1 total byte(s) of padding
+  --> $DIR/issue_3633_into_bytes.rs:17:10
+   |
+17 | #[derive(zerocopy_derive::IntoBytes)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ types with padding cannot implement `IntoBytes`
+   |
+   = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+   = note: consider adding explicit fields where padding would be
+   = note: consider using `#[repr(packed)]` to remove padding
+help: the trait `PaddingFree<Padded, 1>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> src/util/macro_util.rs:64:0
+   = help: see issue #48214
+   = note: this error originates in the derive macro `zerocopy_derive::IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+   |
+11 + #![feature(trivial_bounds)]
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(non_camel_case_types)]
+
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+type ___ZerocopyTag = [u16; 0];
+
+#[derive(zerocopy_derive::IntoBytes)]
+//~[msrv]^ ERROR: PaddingFree
+//~[stable, nightly]^^ ERROR: has 1 total byte(s) of padding
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(u8)]
+enum Padded {
+    Variant(___ZerocopyTag),
+}
+
+mod top_level_macro {
+    macro_rules! field_type {
+        () => {
+            u8
+        };
+    }
+
+    #[derive(zerocopy_derive::IntoBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Variant(field_type!()),
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `IntoBytes` for a type containing a macro invocation in a field type
+    }
+}
+
+mod nested_macro {
+    macro_rules! len {
+        () => {
+            1
+        };
+    }
+
+    #[derive(zerocopy_derive::IntoBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(transparent)]
+    struct Packet([u8; len!()]);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `IntoBytes` for a type containing a macro invocation in a field type
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_into_bytes.stable.stderr
@@ -1,0 +1,33 @@
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:37:17
+   |
+37 |         Variant(field_type!()),
+   |                 ^^^^^^^^^^
+
+error: cannot derive `IntoBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_into_bytes.rs:52:24
+   |
+52 |     struct Packet([u8; len!()]);
+   |                        ^^^
+
+error[E0277]: `Padded` has 1 total byte(s) of padding
+  --> $DIR/issue_3633_into_bytes.rs:17:10
+   |
+17 | #[derive(zerocopy_derive::IntoBytes)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ types with padding cannot implement `IntoBytes`
+   |
+   = note: consider using `zerocopy::Unalign` to lower the alignment of individual fields
+   = note: consider adding explicit fields where padding would be
+   = note: consider using `#[repr(packed)]` to remove padding
+help: the trait `PaddingFree<Padded, 1>` is not implemented for `()`
+      but trait `PaddingFree<Padded, 0>` is implemented for it
+  --> $WORKSPACE/src/util/macro_util.rs:64:1
+   |
+64 | impl<T: ?Sized> PaddingFree<T, 0> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: see issue #48214
+   = note: this error originates in the derive macro `zerocopy_derive::IntoBytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.msrv.stderr
@@ -1,0 +1,8 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_trailer` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_known_layout_trailing.rs:22:14
+   |
+22 |     trailer: __Zerocopy_Field_trailer,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.nightly.stderr
@@ -1,0 +1,8 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_trailer` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_known_layout_trailing.rs:22:14
+   |
+22 |     trailer: __Zerocopy_Field_trailer,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.rs
@@ -1,0 +1,24 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(non_camel_case_types)]
+
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+type __Zerocopy_Field_trailer = [u8; 8];
+
+#[derive(zerocopy_derive::KnownLayout)]
+#[zerocopy(crate = "zerocopy_renamed")]
+#[repr(C)]
+struct Packet {
+    prefix: u8,
+    trailer: __Zerocopy_Field_trailer,
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_trailer` is reserved for generated code
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_known_layout_trailing.stable.stderr
@@ -1,0 +1,8 @@
+error: cannot derive `KnownLayout` because the unqualified identifier `__Zerocopy_Field_trailer` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_known_layout_trailing.rs:22:14
+   |
+22 |     trailer: __Zerocopy_Field_trailer,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.msrv.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.msrv.stderr
@@ -1,0 +1,68 @@
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTagPrimitive` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:22:14
+   |
+22 |         Flag(___ZerocopyTagPrimitive),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_try_from_bytes.rs:41:14
+   |
+41 |         Flag(flag!()),
+   |              ^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:66:19
+   |
+66 |     struct Packet(___ZcAlignment);
+   |                   ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:76:16
+   |
+76 |         field: ẕfield,
+   |                ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:84:12
+   |
+84 |     struct ẕfield {
+   |            ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:94:10
+   |
+94 |     enum ___ZcAlignment {
+   |          ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕ0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:109:19
+    |
+109 |     struct Packet<ẕ0>(<Self as Assoc>::Type)
+    |                   ^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTag` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:127:17
+    |
+127 |                 ___ZerocopyTag
+    |                 ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZEROCOPY_TAG_Variant` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:143:21
+    |
+143 |                     ___ZEROCOPY_TAG_Variant => 1,
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in an enum field type; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:166:21
+    |
+166 |         Flag([bool; Self::N]),
+    |                     ^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in generic parameters or predicates; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:184:27
+    |
+184 |     enum Packet<T: Select<Self>> {
+    |                           ^^^^
+
+error: aborting due to 11 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.nightly.stderr
@@ -1,0 +1,68 @@
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTagPrimitive` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:22:14
+   |
+22 |         Flag(___ZerocopyTagPrimitive),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_try_from_bytes.rs:41:14
+   |
+41 |         Flag(flag!()),
+   |              ^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:66:19
+   |
+66 |     struct Packet(___ZcAlignment);
+   |                   ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:76:16
+   |
+76 |         field: ẕfield,
+   |                ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:84:12
+   |
+84 |     struct ẕfield {
+   |            ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:94:10
+   |
+94 |     enum ___ZcAlignment {
+   |          ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕ0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:109:19
+    |
+109 |     struct Packet<ẕ0>(<Self as Assoc>::Type)
+    |                   ^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTag` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:127:17
+    |
+127 |                 ___ZerocopyTag
+    |                 ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZEROCOPY_TAG_Variant` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:143:21
+    |
+143 |                     ___ZEROCOPY_TAG_Variant => 1,
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in an enum field type; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:166:21
+    |
+166 |         Flag([bool; Self::N]),
+    |                     ^^^^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in generic parameters or predicates; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:184:27
+    |
+184 |     enum Packet<T: Select<Self>> {
+    |                           ^^^^
+
+error: aborting due to 11 previous errors
+

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.rs
@@ -1,0 +1,189 @@
+// Copyright 2026 The Fuchsia Authors
+//
+// Licensed under a BSD-style license <LICENSE-BSD>, Apache License, Version 2.0
+// <LICENSE-APACHE or https://www.apache.org/licenses/LICENSE-2.0>, or the MIT
+// license <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your option.
+// This file may not be copied, modified, or distributed except according to
+// those terms.
+
+#![allow(non_ascii_idents, non_camel_case_types, non_snake_case, unreachable_patterns)]
+
+extern crate zerocopy_renamed;
+
+fn main() {}
+
+mod direct {
+    type ___ZerocopyTagPrimitive = bool;
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Flag(___ZerocopyTagPrimitive),
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTagPrimitive` is reserved for generated code
+        Other,
+    }
+}
+
+mod field_type_macro {
+    type ___ZerocopyTagPrimitive = bool;
+
+    macro_rules! flag {
+        () => {
+            ___ZerocopyTagPrimitive
+        };
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Flag(flag!()),
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` for a type containing a macro invocation in a field type
+        Other,
+    }
+}
+
+mod qualified {
+    mod types {
+        pub type ___ZerocopyTagPrimitive = bool;
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Flag(crate::qualified::types::___ZerocopyTagPrimitive),
+        Other,
+    }
+}
+
+mod method_generic_prefix {
+    type ___ZcAlignment = bool;
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Packet(___ZcAlignment);
+    //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code
+}
+
+mod field_marker_prefix {
+    type ẕfield = bool;
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct Packet {
+        field: ẕfield,
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code
+    }
+}
+
+mod field_marker_target_prefix {
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    struct ẕfield {
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code
+        field: bool,
+    }
+}
+
+mod nontrivial_enum_target_prefix {
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum ___ZcAlignment {
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code
+        Flag(bool),
+        Other,
+    }
+}
+
+mod generic_field_marker_capture {
+    trait Assoc {
+        type Type;
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(transparent)]
+    struct Packet<ẕ0>(<Self as Assoc>::Type)
+    //~^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `ẕ0` is reserved for generated code
+    where
+        Self: Assoc;
+}
+
+mod use_tree_capture {
+    mod helpers {
+        pub const VARIANT: usize = 1;
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Variant(
+            [bool; {
+                use helpers::VARIANT as ___ZerocopyTag;
+                ___ZerocopyTag
+                //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTag` is reserved for generated code
+            }],
+        ),
+        Other,
+    }
+}
+
+mod pattern_capture {
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Variant(
+            [bool; {
+                match 1u8 {
+                    ___ZEROCOPY_TAG_Variant => 1,
+                    //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` because the unqualified identifier `___ZEROCOPY_TAG_Variant` is reserved for generated code
+                    _ => 2,
+                }
+            }],
+        ),
+        Other,
+    }
+}
+
+mod contextual_self {
+    trait N {
+        const N: usize;
+    }
+
+    impl<T> N for T {
+        const N: usize = 0;
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet {
+        Flag([bool; Self::N]),
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` with `Self` in an enum field type
+        Other,
+    }
+
+    impl Packet {
+        const N: usize = 1;
+    }
+}
+
+mod contextual_self_in_generics {
+    trait Select<T: ?Sized> {
+        type Assoc;
+    }
+
+    #[derive(zerocopy_derive::TryFromBytes)]
+    #[zerocopy(crate = "zerocopy_renamed")]
+    #[repr(u8)]
+    enum Packet<T: Select<Self>> {
+        //~[msrv, stable, nightly]^ ERROR: cannot derive `TryFromBytes` with `Self` in generic parameters or predicates
+        Flag(T::Assoc),
+        Other,
+    }
+}

--- a/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/issue_3633_try_from_bytes.stable.stderr
@@ -1,0 +1,68 @@
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTagPrimitive` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:22:14
+   |
+22 |         Flag(___ZerocopyTagPrimitive),
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` for a type containing a macro invocation in a field type; write the expanded syntax explicitly
+  --> $DIR/issue_3633_try_from_bytes.rs:41:14
+   |
+41 |         Flag(flag!()),
+   |              ^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:66:19
+   |
+66 |     struct Packet(___ZcAlignment);
+   |                   ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:76:16
+   |
+76 |         field: ẕfield,
+   |                ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕfield` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:84:12
+   |
+84 |     struct ẕfield {
+   |            ^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZcAlignment` is reserved for generated code; qualify the path or rename the identifier
+  --> $DIR/issue_3633_try_from_bytes.rs:94:10
+   |
+94 |     enum ___ZcAlignment {
+   |          ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `ẕ0` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:109:19
+    |
+109 |     struct Packet<ẕ0>(<Self as Assoc>::Type)
+    |                   ^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZerocopyTag` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:127:17
+    |
+127 |                 ___ZerocopyTag
+    |                 ^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` because the unqualified identifier `___ZEROCOPY_TAG_Variant` is reserved for generated code; qualify the path or rename the identifier
+   --> $DIR/issue_3633_try_from_bytes.rs:143:21
+    |
+143 |                     ___ZEROCOPY_TAG_Variant => 1,
+    |                     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in an enum field type; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:166:21
+    |
+166 |         Flag([bool; Self::N]),
+    |                     ^^^^
+
+error: cannot derive `TryFromBytes` with `Self` in generic parameters or predicates; write the concrete type explicitly
+   --> $DIR/issue_3633_try_from_bytes.rs:184:27
+    |
+184 |     enum Packet<T: Select<Self>> {
+    |                           ^^^^
+
+error: aborting due to 11 previous errors
+


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->

Derive expansions copy user syntax into generated scopes and refer to helper
items by unqualified names. Reject uninspectable syntax, contextual `Self`,
and identifiers that could change the meaning of copied fields or generated
safety checks.

Pin the Syn grammar used by this validation and add cross-toolchain
regressions for helper capture, copied macros, qualified paths, and enum tag
validation.

Closes #3633

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*




---

- 👉 #3635
- 　  #3631


**Latest Update:** v7 — [Compare vs v6](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|
|v7|[vs v6](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs v5](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs v4](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs v3](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs v2](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v7)|
|v6||[vs v5](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|[vs v4](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|[vs v3](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|[vs v2](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v6)|
|v5|||[vs v4](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5)|[vs v3](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5)|[vs v2](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5)|[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v5)|
|v4||||[vs v3](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4)|[vs v2](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4)|[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v4)|
|v3|||||[vs v2](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3)|[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v3)|
|v2||||||[vs v1](/google/zerocopy/compare/gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2)|[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v2)|
|v1|||||||[vs Base](/google/zerocopy/compare/Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck..gherrit/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn && git checkout -b pr-Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id":"Gkiogbp7b2w7nxwx27s7vk5wesojtk7bn","parent":"Gifjr6pbpu4fh6t7qbzuuqczj3odny3ck","child":null} -->