### PR TITLE
Rename `invariant::Valid` to `invariant::Safe`

### DIFF
--- a/zerocopy/src/impls.rs
+++ b/zerocopy/src/impls.rs
@@ -111,7 +111,7 @@ assert_unaligned!(bool);
 //   pattern 0x01.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for bool; |byte| {
-        let byte = byte.transmute_with::<u8, invariant::Valid, CastSizedExact, BecauseImmutable>();
+        let byte = byte.transmute_with::<u8, invariant::Safe, CastSizedExact, BecauseImmutable>();
         *byte.unaligned_as_ref() < 2
     })
 };
@@ -140,7 +140,7 @@ const _: () = unsafe { unsafe_impl!(char: Immutable, FromZeros, IntoBytes) };
 //   `char`.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for char; |c| {
-        let c = c.transmute_with::<Unalign<u32>, invariant::Valid, CastSizedExact, BecauseImmutable>();
+        let c = c.transmute_with::<Unalign<u32>, invariant::Safe, CastSizedExact, BecauseImmutable>();
         let c = c.read().into_inner();
         char::from_u32(c).is_some()
     });
@@ -173,7 +173,7 @@ const _: () = unsafe { unsafe_impl!(str: Immutable, FromZeros, IntoBytes, Unalig
 //   Returns `Err` if the slice is not UTF-8.
 const _: () = unsafe {
     unsafe_impl!(=> TryFromBytes for str; |c| {
-        let c = c.transmute_with::<[u8], invariant::Valid, CastUnsized, BecauseImmutable>();
+        let c = c.transmute_with::<[u8], invariant::Safe, CastUnsized, BecauseImmutable>();
         let c = c.unaligned_as_ref();
         core::str::from_utf8(c).is_ok()
     })
@@ -183,7 +183,7 @@ macro_rules! unsafe_impl_try_from_bytes_for_nonzero {
     ($($nonzero:ident[$prim:ty]),*) => {
         $(
             unsafe_impl!(=> TryFromBytes for $nonzero; |n| {
-                let n = n.transmute_with::<Unalign<$prim>, invariant::Valid, CastSizedExact, BecauseImmutable>();
+                let n = n.transmute_with::<Unalign<$prim>, invariant::Safe, CastSizedExact, BecauseImmutable>();
                 $nonzero::new(n.read().into_inner()).is_some()
             });
         )*
@@ -421,15 +421,15 @@ mod atomics {
         ($($($tyvar:ident)? => $atomic:ty [$prim:ty]),*) => {{
             crate::util::macros::__unsafe();
 
-            use crate::pointer::{SizeEq, TransmuteFrom, invariant::Valid};
+            use crate::pointer::{SizeEq, TransmuteFrom, invariant::Safe};
 
             $(
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
                 // the same size and bit validity.
-                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for $prim {}
+                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Safe, Safe> for $prim {}
                 // SAFETY: The caller promised that `$atomic` and `$prim` have
                 // the same size and bit validity.
-                unsafe impl<$($tyvar)?> TransmuteFrom<$prim, Valid, Valid> for $atomic {}
+                unsafe impl<$($tyvar)?> TransmuteFrom<$prim, Safe, Safe> for $atomic {}
 
                 impl<$($tyvar)?> SizeEq<ReadOnly<$atomic>> for ReadOnly<$prim> {
                     type CastFrom = $crate::pointer::cast::CastSizedExact;
@@ -444,9 +444,9 @@ mod atomics {
                 //   `UnsafeCell<T>` has the same in-memory representation as
                 //   its inner type `T`. A consequence of this guarantee is that
                 //   it is possible to convert between `T` and `UnsafeCell<T>`.
-                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Valid, Valid> for core::cell::UnsafeCell<$prim> {}
+                unsafe impl<$($tyvar)?> TransmuteFrom<$atomic, Safe, Safe> for core::cell::UnsafeCell<$prim> {}
                 // SAFETY: See previous safety comment.
-                unsafe impl<$($tyvar)?> TransmuteFrom<core::cell::UnsafeCell<$prim>, Valid, Valid> for $atomic {}
+                unsafe impl<$($tyvar)?> TransmuteFrom<core::cell::UnsafeCell<$prim>, Safe, Safe> for $atomic {}
             )*
         }};
     }
@@ -849,7 +849,7 @@ impl_for_transmute_from!(T: ?Sized + IntoBytes => IntoBytes for UnsafeCell<T>[T]
 const _: () = unsafe { unsafe_impl!(T: ?Sized + Unaligned => Unaligned for UnsafeCell<T>) };
 assert_unaligned!(UnsafeCell<()>, UnsafeCell<u8>);
 
-// SAFETY: See safety comment in `is_bit_valid` impl.
+// SAFETY: See safety comment in `is_safe` impl.
 unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
     #[allow(clippy::missing_inline_in_public_items)]
     fn only_derive_is_allowed_to_implement_this_trait()
@@ -859,11 +859,11 @@ unsafe impl<T: TryFromBytes + ?Sized> TryFromBytes for UnsafeCell<T> {
     }
 
     #[inline(always)]
-    fn is_bit_valid<A>(candidate: Maybe<'_, Self, A>) -> bool
+    fn is_safe<A>(candidate: Maybe<'_, Self, A>) -> bool
     where
         A: invariant::Alignment,
     {
-        T::is_bit_valid(candidate.transmute::<_, _, BecauseImmutable>())
+        T::is_safe(candidate.transmute::<_, _, BecauseImmutable>())
     }
 }
 
@@ -897,10 +897,10 @@ const _: () = unsafe {
         let c: Ptr<'_, ReadOnly<[T]>, _> = c.cast::<_, crate::pointer::cast::CastUnsized, _>();
 
         // Note that this call may panic, but it would still be sound even if it
-        // did. `is_bit_valid` does not promise that it will not panic (in fact,
-        // it explicitly warns that it's a possibility), and we have not
-        // violated any safety invariants that we must fix before returning.
-        <[T] as TryFromBytes>::is_bit_valid(c)
+        // did. `is_safe` does not promise that it will not panic (in fact, it
+        // explicitly warns that it's a possibility), and we have not violated
+        // any safety invariants that we must fix before returning.
+        <[T] as TryFromBytes>::is_safe(c)
     });
     unsafe_impl!(const N: usize, T: FromZeros => FromZeros for [T; N]);
     unsafe_impl!(const N: usize, T: FromBytes => FromBytes for [T; N]);
@@ -924,14 +924,14 @@ const _: () = unsafe {
         //
         // In other words, the layout of a `[T] is a sequence of `T`s laid out
         // back-to-back with no bytes in between. If all elements in `candidate`
-        // are `is_bit_valid`, so too is `candidate`.
+        // are `is_safe`, so too is `candidate`.
         //
         // Note that any of the below calls may panic, but it would still be
-        // sound even if it did. `is_bit_valid` does not promise that it will
-        // not panic (in fact, it explicitly warns that it's a possibility), and
-        // we have not violated any safety invariants that we must fix before
+        // sound even if it did. `is_safe` does not promise that it will not
+        // panic (in fact, it explicitly warns that it's a possibility), and we
+        // have not violated any safety invariants that we must fix before
         // returning.
-        c.iter().all(<T as TryFromBytes>::is_bit_valid)
+        c.iter().all(<T as TryFromBytes>::is_safe)
     });
     unsafe_impl!(T: FromZeros => FromZeros for [T]);
     unsafe_impl!(T: FromBytes => FromBytes for [T]);
@@ -946,7 +946,7 @@ const _: () = unsafe {
 //   null pointers, so this is not a footgun.
 // - `TryFromBytes`: By the same reasoning as for `FromZeroes`, we can implement
 //   `TryFromBytes` for thin pointers provided that
-//   [`TryFromByte::is_bit_valid`] only produces `true` for zeroed bytes.
+//   [`TryFromBytes::is_safe`] only produces `true` for zeroed bytes.
 //
 // NOTE(#170): Implementing `FromBytes` and `IntoBytes` for raw pointers would
 // be sound, but carries provenance footguns. We want to support `FromBytes` and
@@ -1012,11 +1012,11 @@ mod tuples {
             // SAFETY: If all fields of the tuple `Self` are `Immutable`, so too is `Self`.
             unsafe_impl!($($head_T: Immutable,)* $next_T: Immutable => Immutable for ($($head_T,)* $next_T,));
 
-            // SAFETY: If all fields in `c` are `is_bit_valid`, so too is `c`.
+            // SAFETY: If all fields in `c` are `is_safe`, so too is `c`.
             unsafe_impl!($($head_T: TryFromBytes,)* $next_T: TryFromBytes => TryFromBytes for ($($head_T,)* $next_T,); |c| {
                 let mut c = c;
-                $(TryFromBytes::is_bit_valid(into_inner!(c.reborrow().project::<crate::project_clients::TryFromBytesDerive, _, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!($head_I) }>())) &&)*
-                    TryFromBytes::is_bit_valid(into_inner!(c.reborrow().project::<crate::project_clients::TryFromBytesDerive, _, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!($next_I) }>()))
+                $(TryFromBytes::is_safe(into_inner!(c.reborrow().project::<crate::project_clients::TryFromBytesDerive, _, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!($head_I) }>())) &&)*
+                    TryFromBytes::is_safe(into_inner!(c.reborrow().project::<crate::project_clients::TryFromBytesDerive, _, { crate::STRUCT_VARIANT_ID }, { crate::ident_id!($next_I) }>()))
             });
 
             // SAFETY: If all fields in `Self` are `FromZeros`, so too is `Self`.
@@ -1163,7 +1163,7 @@ mod tuples {
             unsafe impl<Client, Aliasing, Alignment, $($AllT),+> crate::ProjectField<
                 Client,
                 (),
-                (Aliasing, Alignment, crate::invariant::Valid),
+                (Aliasing, Alignment, crate::invariant::Safe),
                 { crate::STRUCT_VARIANT_ID },
                 { crate::ident_id!($CurrI)}
             > for ($($AllT,)+)
@@ -1180,7 +1180,7 @@ mod tuples {
                 // SAFETY: Tuples are product types whose fields are
                 // well-aligned, so projection preserves both the alignment and
                 // validity invariants of the outer pointer.
-                type Invariants = (Aliasing, Alignment, crate::invariant::Valid);
+                type Invariants = (Aliasing, Alignment, crate::invariant::Safe);
 
                 // SAFETY: Tuples are product types and so projection is infallible;
                 type Error = core::convert::Infallible;
@@ -1395,10 +1395,9 @@ mod tests {
 
     #[test]
     fn test_impls() {
-        // A type that can supply test cases for testing
-        // `TryFromBytes::is_bit_valid`. All types passed to `assert_impls!`
-        // must implement this trait; that macro uses it to generate runtime
-        // tests for `TryFromBytes` impls.
+        // A type that can supply test cases for testing `TryFromBytes::is_safe`.
+        // All types passed to `assert_impls!` must implement this trait; that
+        // macro uses it to generate runtime tests for `TryFromBytes` impls.
         //
         // All `T: FromBytes` types are provided with a blanket impl. Other
         // types must implement `TryFromBytesTestable` directly (ie using
@@ -1580,19 +1579,15 @@ mod tests {
 
             pub(super) struct AutorefWrapper<T: ?Sized>(pub(super) PhantomData<T>);
 
-            pub(super) trait TestIsBitValidShared<T: ?Sized> {
+            pub(super) trait TestIsSafeShared<T: ?Sized> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<'ptr>(&self, candidate: Maybe<'ptr, T>)
-                    -> Option<bool>;
+                fn test_is_safe_shared<'ptr>(&self, candidate: Maybe<'ptr, T>) -> Option<bool>;
             }
 
-            impl<T: TryFromBytes + Immutable + ?Sized> TestIsBitValidShared<T> for AutorefWrapper<T> {
+            impl<T: TryFromBytes + Immutable + ?Sized> TestIsSafeShared<T> for AutorefWrapper<T> {
                 #[allow(clippy::needless_lifetimes)]
-                fn test_is_bit_valid_shared<'ptr>(
-                    &self,
-                    candidate: Maybe<'ptr, T>,
-                ) -> Option<bool> {
-                    Some(T::is_bit_valid(candidate))
+                fn test_is_safe_shared<'ptr>(&self, candidate: Maybe<'ptr, T>) -> Option<bool> {
+                    Some(T::is_safe(candidate))
                 }
             }
 
@@ -1696,12 +1691,12 @@ mod tests {
                 #[allow(unused, non_local_definitions)]
                 impl AutorefWrapper<$ty> {
                     #[allow(clippy::needless_lifetimes)]
-                    fn test_is_bit_valid_shared<'ptr>(
+                    fn test_is_safe_shared<'ptr>(
                         &mut self,
                         candidate: Maybe<'ptr, $ty>,
                     ) -> Option<bool> {
                         assert_on_allowlist!(
-                            test_is_bit_valid_shared($ty):
+                            test_is_safe_shared($ty):
                             ManuallyDrop<UnsafeCell<()>>,
                             ManuallyDrop<[UnsafeCell<u8>]>,
                             ManuallyDrop<[UnsafeCell<bool>]>,
@@ -1805,9 +1800,9 @@ mod tests {
                     // necessarily `IntoBytes`, but that's the corner we've
                     // backed ourselves into by using `Ptr::from_ref`.
                     let c = unsafe { c.assume_initialized() };
-                    let res = w.test_is_bit_valid_shared(c);
+                    let res = w.test_is_safe_shared(c);
                     if let Some(res) = res {
-                        assert!(res, "{}::is_bit_valid (shared `Ptr`): got false, expected true", stringify!($ty));
+                        assert!(res, "{}::is_safe (shared `Ptr`): got false, expected true", stringify!($ty));
                     }
 
                     let c = Ptr::from_mut(&mut *val);
@@ -1816,8 +1811,8 @@ mod tests {
                     // necessarily `IntoBytes`, but that's the corner we've
                     // backed ourselves into by using `Ptr::from_ref`.
                     let mut c = unsafe { c.assume_initialized() };
-                    let res = <$ty as TryFromBytes>::is_bit_valid(c.reborrow_shared());
-                    assert!(res, "{}::is_bit_valid (exclusive `Ptr`): got false, expected true", stringify!($ty));
+                    let res = <$ty as TryFromBytes>::is_safe(c.reborrow_shared());
+                    assert!(res, "{}::is_safe (exclusive `Ptr`): got false, expected true", stringify!($ty));
 
                     // `bytes` is `Some(val.as_bytes())` if `$ty: IntoBytes +
                     // Immutable` and `None` otherwise.
@@ -2243,11 +2238,11 @@ mod tests {
 
         assert_impls!(ManuallyDrop<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
-        // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_bit_valid`.
+        // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_safe`.
         assert_impls!(ManuallyDrop<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
         assert_impls!(ManuallyDrop<[u8]>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
-        // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_bit_valid`.
+        // implementation of `<ManuallyDrop<T> as TryFromBytes>::is_safe`.
         assert_impls!(ManuallyDrop<[bool]>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
         assert_impls!(ManuallyDrop<NotZerocopy>: !Immutable, !TryFromBytes, !KnownLayout, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
         assert_impls!(ManuallyDrop<[NotZerocopy]>: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
@@ -2261,14 +2256,14 @@ mod tests {
 
         assert_impls!(Wrapping<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
-        // implementation of `<Wrapping<T> as TryFromBytes>::is_bit_valid`.
+        // implementation of `<Wrapping<T> as TryFromBytes>::is_safe`.
         assert_impls!(Wrapping<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
         assert_impls!(Wrapping<NotZerocopy>: KnownLayout, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes, !Unaligned);
         assert_impls!(Wrapping<UnsafeCell<()>>: KnownLayout, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned, !Immutable);
 
         assert_impls!(Unalign<u8>: KnownLayout, Immutable, TryFromBytes, FromZeros, FromBytes, IntoBytes, Unaligned);
         // This test is important because it allows us to test our hand-rolled
-        // implementation of `<Unalign<T> as TryFromBytes>::is_bit_valid`.
+        // implementation of `<Unalign<T> as TryFromBytes>::is_safe`.
         assert_impls!(Unalign<bool>: KnownLayout, Immutable, TryFromBytes, FromZeros, IntoBytes, Unaligned, !FromBytes);
         assert_impls!(Unalign<NotZerocopy>: KnownLayout, Unaligned, !Immutable, !TryFromBytes, !FromZeros, !FromBytes, !IntoBytes);
 

--- a/zerocopy/src/lib.rs
+++ b/zerocopy/src/lib.rs
@@ -411,7 +411,7 @@ use core::alloc::Layout;
 // Used by `KnownLayout`.
 #[doc(hidden)]
 pub use crate::layout::*;
-// Used by `TryFromBytes::is_bit_valid`.
+// Used by `TryFromBytes::is_safe`.
 #[doc(hidden)]
 pub use crate::pointer::{invariant::BecauseImmutable, Maybe, Ptr};
 // For each trait polyfill, as soon as the corresponding feature is stable, the
@@ -1430,9 +1430,9 @@ where
                             // type – the type itself is irrelevant.
                             ValidityKind::Uninit | ValidityKind::Initialized => true,
                             // The projectability of an enum field from an
-                            // `AsInitialized` or `Valid` state is a dynamic
+                            // `AsInitialized` or `Safe` state is a dynamic
                             // property of its tag.
-                            ValidityKind::AsInitialized | ValidityKind::Valid => false,
+                            ValidityKind::AsInitialized | ValidityKind::Safe => false,
                         }
                     }
                 };
@@ -1848,25 +1848,25 @@ pub unsafe trait TryFromBytes {
     ///
     /// # Safety
     ///
-    /// Unsafe code may assume that, if `is_bit_valid(candidate)` returns true,
+    /// Unsafe code may assume that, if `is_safe(candidate)` returns true,
     /// `*candidate` contains a valid `Self`.
     ///
     /// # Panics
     ///
-    /// `is_bit_valid` may panic. Callers are responsible for ensuring that any
-    /// `unsafe` code remains sound even in the face of `is_bit_valid`
-    /// panicking. (We support user-defined validation routines; so long as
-    /// these routines are not required to be `unsafe`, there is no way to
-    /// ensure that these do not generate panics.)
+    /// `is_safe` may panic. Callers are responsible for ensuring that any
+    /// `unsafe` code remains sound even in the face of `is_safe` panicking. (We
+    /// support user-defined validation routines; so long as these routines are
+    /// not required to be `unsafe`, there is no way to ensure that these do not
+    /// generate panics.)
     ///
-    /// Besides user-defined validation routines panicking, `is_bit_valid` will
-    /// either panic or fail to compile if called on a pointer with [`Shared`]
-    /// aliasing when `Self: !Immutable`.
+    /// Besides user-defined validation routines panicking, `is_safe` will either
+    /// panic or fail to compile if called on a pointer with [`Shared`] aliasing
+    /// when `Self: !Immutable`.
     ///
     /// [`UnsafeCell`]: core::cell::UnsafeCell
     /// [`Shared`]: invariant::Shared
     #[doc(hidden)]
-    fn is_bit_valid<A>(candidate: Maybe<'_, Self, A>) -> bool
+    fn is_safe<A>(candidate: Maybe<'_, Self, A>) -> bool
     where
         A: invariant::Alignment;
 
@@ -3460,14 +3460,14 @@ unsafe fn try_read_from<S, T: TryFromBytes>(
     // This call may panic. If that happens, it doesn't cause any soundness
     // issues, as we have not generated any invalid state which we need to fix
     // before returning.
-    if !Wrapping::<T>::is_bit_valid(c_ptr.reborrow_shared().forget_aligned()) {
+    if !Wrapping::<T>::is_safe(c_ptr.reborrow_shared().forget_aligned()) {
         return Err(ValidityError::new(source).into());
     }
 
     fn _assert_same_size_and_validity<T>()
     where
-        Wrapping<T>: pointer::TransmuteFrom<T, invariant::Valid, invariant::Valid>,
-        T: pointer::TransmuteFrom<Wrapping<T>, invariant::Valid, invariant::Valid>,
+        Wrapping<T>: pointer::TransmuteFrom<T, invariant::Safe, invariant::Safe>,
+        T: pointer::TransmuteFrom<Wrapping<T>, invariant::Safe, invariant::Safe>,
     {
     }
 

--- a/zerocopy/src/macros.rs
+++ b/zerocopy/src/macros.rs
@@ -1033,7 +1033,7 @@ macro_rules! cryptocorrosion_derive_traits {
             )?
         {
             #[inline(always)]
-            fn is_bit_valid<A>(_: $crate::Maybe<'_, Self, A>) -> bool
+            fn is_safe<A>(_: $crate::Maybe<'_, Self, A>) -> bool
             where
                 A: $crate::invariant::Alignment,
             {
@@ -1179,7 +1179,7 @@ macro_rules! cryptocorrosion_derive_traits {
             )*
         {
             #[inline(always)]
-            fn is_bit_valid<A>(_: $crate::Maybe<'_, Self, A>) -> bool
+            fn is_safe<A>(_: $crate::Maybe<'_, Self, A>) -> bool
             where
                 A: $crate::invariant::Alignment,
             {

--- a/zerocopy/src/pointer/invariant.rs
+++ b/zerocopy/src/pointer/invariant.rs
@@ -47,7 +47,7 @@ pub trait Alignment: Sealed {
     fn read<T, I, R>(ptr: crate::Ptr<'_, T, I>) -> T
     where
         T: Copy + Read<I::Aliasing, R>,
-        I: Invariants<Alignment = Self, Validity = Valid>,
+        I: Invariants<Alignment = Self, Validity = Safe>,
         I::Aliasing: Reference;
 }
 
@@ -101,7 +101,7 @@ pub enum ValidityKind {
     Uninit,
     AsInitialized,
     Initialized,
-    Valid,
+    Safe,
 }
 
 /// An [`Aliasing`] invariant which is either [`Shared`] or [`Exclusive`].
@@ -147,7 +147,7 @@ impl Alignment for Unaligned {
     fn read<T, I, R>(ptr: crate::Ptr<'_, T, I>) -> T
     where
         T: Copy + Read<I::Aliasing, R>,
-        I: Invariants<Alignment = Self, Validity = Valid>,
+        I: Invariants<Alignment = Self, Validity = Safe>,
         I::Aliasing: Reference,
     {
         (*ptr.into_unalign().as_ref()).into_inner()
@@ -162,7 +162,7 @@ impl Alignment for Aligned {
     fn read<T, I, R>(ptr: crate::Ptr<'_, T, I>) -> T
     where
         T: Copy + Read<I::Aliasing, R>,
-        I: Invariants<Alignment = Self, Validity = Valid>,
+        I: Invariants<Alignment = Self, Validity = Safe>,
         I::Aliasing: Reference,
     {
         *ptr.as_ref()
@@ -227,11 +227,11 @@ unsafe impl Validity for Initialized {
 
 /// The referent of a `Ptr<T>` is valid for `T`, upholding bit validity and any
 /// library safety invariants.
-pub enum Valid {}
-// SAFETY: `Valid`'s validity is well-defined for all `T: ?Sized`, and is not a
+pub enum Safe {}
+// SAFETY: `Safe`'s validity is well-defined for all `T: ?Sized`, and is not a
 // function of any property of `T` other than its bit validity.
-unsafe impl Validity for Valid {
-    const KIND: ValidityKind = ValidityKind::Valid;
+unsafe impl Validity for Safe {
+    const KIND: ValidityKind = ValidityKind::Safe;
 }
 
 /// # Safety
@@ -289,7 +289,7 @@ mod sealed {
     impl Sealed for Uninit {}
     impl Sealed for AsInitialized {}
     impl Sealed for Initialized {}
-    impl Sealed for Valid {}
+    impl Sealed for Safe {}
 
     impl<A: Sealed, AA: Sealed, V: Sealed> Sealed for (A, AA, V) {}
 

--- a/zerocopy/src/pointer/mod.rs
+++ b/zerocopy/src/pointer/mod.rs
@@ -25,9 +25,9 @@ pub use transmute::*;
 use crate::wrappers::ReadOnly;
 
 /// A shorthand for a maybe-valid, maybe-aligned reference. Used as the argument
-/// to [`TryFromBytes::is_bit_valid`].
+/// to [`TryFromBytes::is_safe`].
 ///
-/// [`TryFromBytes::is_bit_valid`]: crate::TryFromBytes::is_bit_valid
+/// [`TryFromBytes::is_safe`]: crate::TryFromBytes::is_safe
 pub type Maybe<'a, T, Alignment = invariant::Unaligned> =
     Ptr<'a, ReadOnly<T>, (invariant::Shared, Alignment, invariant::Initialized)>;
 

--- a/zerocopy/src/pointer/ptr.rs
+++ b/zerocopy/src/pointer/ptr.rs
@@ -169,7 +169,7 @@ mod _conversions {
     use crate::pointer::cast::{CastExact, CastSized, IdCast};
 
     /// `&'a T` → `Ptr<'a, T>`
-    impl<'a, T> Ptr<'a, T, (Shared, Aligned, Valid)>
+    impl<'a, T> Ptr<'a, T, (Shared, Aligned, Safe)>
     where
         T: 'a + ?Sized,
     {
@@ -183,20 +183,19 @@ mod _conversions {
             // 1. `ptr`, by invariant on `&'a T`, conforms to the alignment
             //    invariant of `Aligned`.
             // 2. `ptr`'s referent, by invariant on `&'a T`, is a bit-valid `T`.
-            //    This satisfies the requirement that a `Ptr<T, (_, _, Valid)>`
+            //    This satisfies the requirement that a `Ptr<T, (_, _, Safe)>`
             //    point to a bit-valid `T`. Even if `T` permits interior
-            //    mutation, this invariant guarantees that the returned `Ptr`
-            //    can only ever be used to modify the referent to store
-            //    bit-valid `T`s, which ensures that the returned `Ptr` cannot
-            //    be used to violate the soundness of the original `ptr: &'a T`
-            //    or of any other references that may exist to the same
-            //    referent.
+            //    mutation, this invariant guarantees that the returned `Ptr` can
+            //    only ever be used to modify the referent to store bit-valid
+            //    `T`s, which ensures that the returned `Ptr` cannot be used to
+            //    violate the soundness of the original `ptr: &'a T` or of any
+            //    other references that may exist to the same referent.
             unsafe { Self::from_inner(inner) }
         }
     }
 
     /// `&'a mut T` → `Ptr<'a, T>`
-    impl<'a, T> Ptr<'a, T, (Exclusive, Aligned, Valid)>
+    impl<'a, T> Ptr<'a, T, (Exclusive, Aligned, Safe)>
     where
         T: 'a + ?Sized,
     {
@@ -211,7 +210,7 @@ mod _conversions {
             //    invariant of `Aligned`.
             // 2. `ptr`'s referent, by invariant on `&'a mut T`, is a bit-valid
             //    `T`. This satisfies the requirement that a `Ptr<T, (_, _,
-            //    Valid)>` point to a bit-valid `T`. This invariant guarantees
+            //    Safe)>` point to a bit-valid `T`. This invariant guarantees
             //    that the returned `Ptr` can only ever be used to modify the
             //    referent to store bit-valid `T`s, which ensures that the
             //    returned `Ptr` cannot be used to violate the soundness of the
@@ -224,7 +223,7 @@ mod _conversions {
     impl<'a, T, I> Ptr<'a, T, I>
     where
         T: 'a + ?Sized,
-        I: Invariants<Alignment = Aligned, Validity = Valid>,
+        I: Invariants<Alignment = Aligned, Validity = Safe>,
         I::Aliasing: Reference,
     {
         /// Converts `self` to a shared reference.
@@ -264,7 +263,7 @@ mod _conversions {
             //
             // 3. The pointer must point to a validly-initialized instance of
             //    `T`. This is ensured by-contract on `Ptr`, because the
-            //    `I::Validity` is `Valid`.
+            //    `I::Validity` is `Safe`.
             //
             // 4. You must enforce Rust’s aliasing rules. This is ensured by
             //    contract on `Ptr`, because `I::Aliasing: Reference`. Either it
@@ -377,7 +376,7 @@ mod _conversions {
     }
 
     /// `Ptr<'a, T>` → `&'a mut T`
-    impl<'a, T> Ptr<'a, T, (Exclusive, Aligned, Valid)>
+    impl<'a, T> Ptr<'a, T, (Exclusive, Aligned, Safe)>
     where
         T: 'a + ?Sized,
     {
@@ -413,8 +412,8 @@ mod _conversions {
             //   This is ensured by contract on all `PtrInner`s.
             //
             // 3. The pointer must point to a validly-initialized instance of
-            //    `T`. This is ensured by-contract on `Ptr`, because the
-            //    validity invariant is `Valid`.
+            //    `T`. This is ensured by-contract on `Ptr`, because the validity
+            //    invariant is `Safe`.
             //
             // 4. You must enforce Rust’s aliasing rules. This is ensured by
             //    contract on `Ptr`, because the `ALIASING_INVARIANT` is
@@ -562,7 +561,7 @@ mod _conversions {
             // FIXME(#1359): This should be a `transmute_with` call.
             // Unfortunately, to avoid blanket impl conflicts, we only implement
             // `TransmuteFrom<T>` for `Unalign<T>` (and vice versa) specifically
-            // for `Valid` validity, not for all validity types.
+            // for `Safe` validity, not for all validity types.
 
             // SAFETY:
             // - By `CastSized: Cast`, `CastSized` preserves referent address,
@@ -589,7 +588,7 @@ mod _conversions {
     impl<'a, T, I> Ptr<'a, T, I>
     where
         T: ?Sized,
-        I: Invariants<Validity = Valid>,
+        I: Invariants<Validity = Safe>,
         I::Aliasing: Reference,
     {
         /// Reads the referent.
@@ -754,27 +753,27 @@ mod _transitions {
             unsafe { self.assume_validity::<Initialized>() }
         }
 
-        /// A shorthand for `self.assume_validity<Valid>()`.
+        /// A shorthand for `self.assume_validity<Safe>()`.
         ///
         /// # Safety
         ///
         /// The caller promises to uphold the safety preconditions of
-        /// `self.assume_validity<Valid>()`.
+        /// `self.assume_validity<Safe>()`.
         #[must_use]
         #[inline]
-        pub unsafe fn assume_valid(self) -> Ptr<'a, T, (I::Aliasing, I::Alignment, Valid)> {
+        pub unsafe fn assume_safe(self) -> Ptr<'a, T, (I::Aliasing, I::Alignment, Safe)> {
             // SAFETY: The caller has promised to uphold the safety
             // preconditions.
-            unsafe { self.assume_validity::<Valid>() }
+            unsafe { self.assume_validity::<Safe>() }
         }
 
         /// Checks that `self`'s referent is validly initialized for `T`,
-        /// returning a `Ptr` with `Valid` on success.
+        /// returning a `Ptr` with `Safe` on success.
         ///
         /// # Panics
         ///
         /// This method will panic if
-        /// [`T::is_bit_valid`][TryFromBytes::is_bit_valid] panics.
+        /// [`T::is_safe`][TryFromBytes::is_safe] panics.
         ///
         /// # Safety
         ///
@@ -783,11 +782,11 @@ mod _transitions {
         #[inline]
         pub fn try_into_valid<R, S>(
             mut self,
-        ) -> Result<Ptr<'a, T, (I::Aliasing, I::Alignment, Valid)>, ValidityError<Self, T>>
+        ) -> Result<Ptr<'a, T, (I::Aliasing, I::Alignment, Safe)>, ValidityError<Self, T>>
         where
             T: TryFromBytes
                 + Read<I::Aliasing, R>
-                + TryTransmuteFromPtr<T, I::Aliasing, I::Validity, Valid, IdCast, S>,
+                + TryTransmuteFromPtr<T, I::Aliasing, I::Validity, Safe, IdCast, S>,
             ReadOnly<T>: Read<I::Aliasing, R>,
             I::Aliasing: Reference,
             I: Invariants<Validity = Initialized>,
@@ -795,14 +794,13 @@ mod _transitions {
             // This call may panic. If that happens, it doesn't cause any
             // soundness issues, as we have not generated any invalid state
             // which we need to fix before returning.
-            if T::is_bit_valid(self.reborrow().transmute::<_, _, _>().reborrow_shared()) {
-                // SAFETY: If `T::is_bit_valid`, code may assume that `self`
-                // contains a bit-valid instance of `T`. By `T:
-                // TryTransmuteFromPtr<T, I::Aliasing, I::Validity, Valid>`, so
-                // long as `self`'s referent conforms to the `Valid` validity
-                // for `T` (which we just confirmed), then this transmute is
-                // sound.
-                Ok(unsafe { self.assume_valid() })
+            if T::is_safe(self.reborrow().transmute::<_, _, _>().reborrow_shared()) {
+                // SAFETY: If `T::is_safe`, code may assume that `self` contains
+                // a bit-valid instance of `T`. By `T: TryTransmuteFromPtr<T,
+                // I::Aliasing, I::Validity, Safe>`, so long as `self`'s referent
+                // conforms to the `Safe` validity for `T` (which we just
+                // confirmed), then this transmute is sound.
+                Ok(unsafe { self.assume_safe() })
             } else {
                 Err(ValidityError::new(self))
             }
@@ -1039,11 +1037,11 @@ mod _casts {
         #[allow(clippy::wrong_self_convention)]
         #[must_use]
         #[inline]
-        pub fn as_bytes<R>(self) -> Ptr<'a, [u8], (I::Aliasing, Aligned, Valid)>
+        pub fn as_bytes<R>(self) -> Ptr<'a, [u8], (I::Aliasing, Aligned, Safe)>
         where
-            [u8]: TransmuteFromPtr<T, I::Aliasing, I::Validity, Valid, AsBytesCast, R>,
+            [u8]: TransmuteFromPtr<T, I::Aliasing, I::Validity, Safe, AsBytesCast, R>,
         {
-            self.transmute_with::<[u8], Valid, AsBytesCast, _>().bikeshed_recall_aligned()
+            self.transmute_with::<[u8], Safe, AsBytesCast, _>().bikeshed_recall_aligned()
         }
     }
 
@@ -1095,7 +1093,7 @@ mod _casts {
     /// alignment of `[u8]` is 1.
     impl<'a, I> Ptr<'a, [u8], I>
     where
-        I: Invariants<Validity = Valid>,
+        I: Invariants<Validity = Safe>,
     {
         /// Attempts to cast `self` to a `U` using the given cast type.
         ///
@@ -1159,7 +1157,7 @@ mod _casts {
             //    it is derived from `try_cast_into`, which promises that the
             //    object described by `target` is validly aligned for `U`.
             // 2. By trait bound, `self` - and thus `target` - is a bit-valid
-            //    `[u8]`. `Ptr<[u8], (_, _, Valid)>` and `Ptr<_, (_, _,
+            //    `[u8]`. `Ptr<[u8], (_, _, Safe)>` and `Ptr<_, (_, _,
             //    Initialized)>` have the same bit validity, and so neither
             //    `self` nor `res` can be used to write a value to the referent
             //    which violates the other's validity invariant.
@@ -1167,14 +1165,14 @@ mod _casts {
 
             // SAFETY:
             // 0. `self` and `remainder` both have the type `[u8]`. Thus, they
-            //    have `UnsafeCell`s at the same locations. Type casting does
-            //    not affect aliasing.
+            //    have `UnsafeCell`s at the same locations. Type casting does not
+            //    affect aliasing.
             // 1. `[u8]` has no alignment requirement.
-            // 2. `self` has validity `Valid` and has type `[u8]`. Since
+            // 2. `self` has validity `Safe` and has type `[u8]`. Since
             //    `remainder` references a subset of `self`'s referent, it is
             //    also a bit-valid `[u8]`. Thus, neither `self` nor `remainder`
-            //    can be used to write a value to the referent which violates
-            //    the other's validity invariant.
+            //    can be used to write a value to the referent which violates the
+            //    other's validity invariant.
             let remainder = unsafe { Ptr::from_inner(remainder) };
 
             Ok((res, remainder))
@@ -1370,7 +1368,7 @@ mod tests {
         let _: Ptr<
             '_,
             <Enum as crate::HasTag<crate::project_clients::ProjectDerive>>::Tag,
-            (Shared, Aligned, Valid),
+            (Shared, Aligned, Safe),
         > = Ptr::from_mut(&mut value).project_tag::<crate::project_clients::ProjectDerive>();
     }
 

--- a/zerocopy/src/pointer/transmute.rs
+++ b/zerocopy/src/pointer/transmute.rs
@@ -333,7 +333,7 @@ impl<T: ?Sized> SizeEq<T> for T {
 // SAFETY: Since `Src: IntoBytes`, the set of valid `Src`'s is the set of
 // initialized bit patterns, which is exactly the set allowed in the referent of
 // any `Initialized` `Ptr`.
-unsafe impl<Src, Dst> TransmuteFrom<Src, Valid, Initialized> for Dst
+unsafe impl<Src, Dst> TransmuteFrom<Src, Safe, Initialized> for Dst
 where
     Src: IntoBytes + ?Sized,
     Dst: ?Sized,
@@ -341,9 +341,9 @@ where
 }
 
 // SAFETY: Since `Dst: FromBytes`, any initialized bit pattern may appear in the
-// referent of a `Ptr<Dst, (_, _, Valid)>`. This is exactly equal to the set of
+// referent of a `Ptr<Dst, (_, _, Safe)>`. This is exactly equal to the set of
 // bit patterns which may appear in the referent of any `Initialized` `Ptr`.
-unsafe impl<Src, Dst> TransmuteFrom<Src, Initialized, Valid> for Dst
+unsafe impl<Src, Dst> TransmuteFrom<Src, Initialized, Safe> for Dst
 where
     Src: ?Sized,
     Dst: FromBytes + ?Sized,
@@ -478,7 +478,7 @@ impl_transitive_transmute_from!(T: ?Sized => UnsafeCell<T> => T => Cell<T>);
 // explicitly guaranteed, but it's obvious from `MaybeUninit`'s documentation
 // that this is the intention:
 // https://doc.rust-lang.org/1.85.0/core/mem/union.MaybeUninit.html
-unsafe impl<T> TransmuteFrom<T, Uninit, Valid> for MaybeUninit<T> {}
+unsafe impl<T> TransmuteFrom<T, Uninit, Safe> for MaybeUninit<T> {}
 
 impl<T> SizeEq<T> for MaybeUninit<T> {
     type CastFrom = CastSizedExact;

--- a/zerocopy/src/ref.rs
+++ b/zerocopy/src/ref.rs
@@ -198,7 +198,7 @@ mod def {
 pub use def::Ref;
 
 use crate::pointer::{
-    invariant::{Aligned, BecauseExclusive, Initialized, Unaligned, Valid},
+    invariant::{Aligned, BecauseExclusive, Initialized, Safe, Unaligned},
     BecauseRead, PtrInner,
 };
 
@@ -958,13 +958,13 @@ where
 /// `T: Sized` and `ptr`'s referent must have size `size_of::<T>()`.
 #[inline(always)]
 unsafe fn cast_for_sized<'a, T, A, R, S>(
-    ptr: Ptr<'a, [u8], (A, Aligned, Valid)>,
-) -> Ptr<'a, T, (A, Unaligned, Valid)>
+    ptr: Ptr<'a, [u8], (A, Aligned, Safe)>,
+) -> Ptr<'a, T, (A, Unaligned, Safe)>
 where
     T: FromBytes + KnownLayout + ?Sized,
     A: crate::invariant::Aliasing,
     [u8]: MutationCompatible<T, A, Initialized, Initialized, R>,
-    T: TransmuteFromPtr<T, A, Initialized, Valid, crate::pointer::cast::IdCast, S>,
+    T: TransmuteFromPtr<T, A, Initialized, Safe, crate::pointer::cast::IdCast, S>,
 {
     use crate::pointer::cast::{Cast, Project};
 
@@ -990,7 +990,7 @@ where
 
     ptr.recall_validity::<Initialized, (_, (_, _))>()
         .cast::<_, CastForSized, _>()
-        .recall_validity::<Valid, _>()
+        .recall_validity::<Safe, _>()
 }
 
 #[cfg(test)]

--- a/zerocopy/src/split_at.rs
+++ b/zerocopy/src/split_at.rs
@@ -10,7 +10,7 @@
 // those terms.
 
 use super::*;
-use crate::pointer::invariant::{Aligned, Exclusive, Invariants, Shared, Valid};
+use crate::pointer::invariant::{Aligned, Exclusive, Invariants, Safe, Shared};
 
 /// Types that can be split in two.
 ///
@@ -304,7 +304,7 @@ where
     T: ?Sized + SplitAt,
 {
     #[inline(always)]
-    fn into_ptr(self) -> Split<Ptr<'a, T, (Shared, Aligned, Valid)>> {
+    fn into_ptr(self) -> Split<Ptr<'a, T, (Shared, Aligned, Safe)>> {
         let source = Ptr::from_ref(self.source);
         // SAFETY: `Ptr::from_ref(self.source)` points to exactly `self.source`
         // and thus maintains the invariants of `self` with respect to `l_len`.
@@ -602,7 +602,7 @@ where
     T: ?Sized + SplitAt,
 {
     #[inline(always)]
-    fn into_ptr(self) -> Split<Ptr<'a, T, (Exclusive, Aligned, Valid)>> {
+    fn into_ptr(self) -> Split<Ptr<'a, T, (Exclusive, Aligned, Safe)>> {
         let source = Ptr::from_mut(self.source);
         // SAFETY: `Ptr::from_mut(self.source)` points to exactly `self.source`,
         // and thus maintains the invariants of `self` with respect to `l_len`.
@@ -805,7 +805,7 @@ where
 impl<'a, T, I> Split<Ptr<'a, T, I>>
 where
     T: ?Sized + SplitAt,
-    I: Invariants<Alignment = Aligned, Validity = Valid>,
+    I: Invariants<Alignment = Aligned, Validity = Safe>,
 {
     fn into_ref(self) -> Split<&'a T>
     where

--- a/zerocopy/src/util/macro_util.rs
+++ b/zerocopy/src/util/macro_util.rs
@@ -29,7 +29,7 @@ use core::{marker::PhantomData, mem, num::Wrapping};
 use crate::{
     pointer::{
         cast::CastSizedExact,
-        invariant::{Aligned, Initialized, Valid},
+        invariant::{Aligned, Initialized, Safe},
         BecauseImmutable,
     },
     FromBytes, Immutable, IntoBytes, KnownLayout, Ptr, ReadOnly, TryFromBytes, ValidityError,
@@ -518,9 +518,9 @@ pub const fn hash_name(name: &str) -> i128 {
 ///
 /// `try_transmute` may either produce a post-monomorphization error or a panic
 /// if `Dst` is bigger than `Src`. Otherwise, `try_transmute` panics under the
-/// same circumstances as [`is_bit_valid`].
+/// same circumstances as [`is_safe`].
 ///
-/// [`is_bit_valid`]: TryFromBytes::is_bit_valid
+/// [`is_safe`]: TryFromBytes::is_safe
 #[inline(always)]
 pub fn try_transmute<Src, Dst>(src: Src) -> Result<Dst, ValidityError<Src, Dst>>
 where
@@ -532,7 +532,7 @@ where
     let src = mem::ManuallyDrop::new(ReadOnly::new(src));
     let mut ptr =
         Ptr::from_ref(&*src).transmute_with::<ReadOnly<Dst>, Initialized, CastSizedExact, _>();
-    if Dst::is_bit_valid(ptr.reborrow_shared()) {
+    if Dst::is_safe(ptr.reborrow_shared()) {
         // SAFETY: `read_unaligned` requires that `ptr` be valid for reads and
         // point to a properly initialized `ReadOnly<Dst>` [1]. `ptr` was
         // derived from a live reference to `src`; `CastSizedExact` preserves
@@ -543,12 +543,12 @@ where
         //
         // `Src: IntoBytes` and the `ReadOnly<Src>` bridge let `transmute_with`
         // establish that every byte in that exact range is initialized.
-        // `Dst::is_bit_valid` then established that the same bytes are
-        // bit-valid for `Dst`, and thus for `ReadOnly<Dst>`. The candidate was
-        // a shared `ReadOnly` pointer, so it could not mutate the bytes; no
-        // operation occurs between validation and this read which could do so.
-        // Alignment is not an additional precondition because [1] expressly
-        // permits unaligned pointers.
+        // `Dst::is_safe` then established that the same bytes are bit-valid for
+        // `Dst`, and thus for `ReadOnly<Dst>`. The candidate was a shared
+        // `ReadOnly` pointer, so it could not mutate the bytes; no operation
+        // occurs between validation and this read which could do so. Alignment
+        // is not an additional precondition because [1] expressly permits
+        // unaligned pointers.
         //
         // `read_unaligned` leaves the source memory unchanged and makes a
         // bitwise copy [1]. The source is wrapped in `ManuallyDrop`, which
@@ -912,7 +912,7 @@ where
         let ptr = Ptr::from_ref(self.0)
             .recall_validity::<Initialized, _>()
             .transmute_with::<Dst, Initialized, crate::layout::CastFrom<Dst>, (crate::pointer::BecauseMutationCompatible, _)>()
-            .recall_validity::<Valid, _>();
+            .recall_validity::<Safe, _>();
 
         static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {
             Src::LAYOUT.align.get() >= Dst::LAYOUT.align.get()
@@ -945,7 +945,7 @@ where
         let ptr = Ptr::from_mut(self.0)
             .recall_validity::<Initialized, (_, (_, _))>()
             .transmute_with::<Dst, Initialized, crate::layout::CastFrom<Dst>, _>()
-            .recall_validity::<Valid, (_, (_, _))>();
+            .recall_validity::<Safe, (_, (_, _))>();
 
         static_assert!(Src: ?Sized + KnownLayout, Dst: ?Sized + KnownLayout => {
             Src::LAYOUT.align.get() >= Dst::LAYOUT.align.get()

--- a/zerocopy/src/util/macros.rs
+++ b/zerocopy/src/util/macros.rs
@@ -15,21 +15,20 @@
 /// The trait impl must be sound.
 ///
 /// When implementing `TryFromBytes`:
-/// - If no `is_bit_valid` impl is provided, then it must be valid for
-///   `is_bit_valid` to unconditionally return `true`. In other words, it must
-///   be the case that any initialized sequence of bytes constitutes a valid
-///   instance of `$ty`.
-/// - If an `is_bit_valid` impl is provided, then the impl of `is_bit_valid`
-///   must only return `true` if its argument refers to a valid `$ty`.
+/// - If no `is_safe` impl is provided, then it must be valid for `is_safe` to
+///   unconditionally return `true`. In other words, it must be the case that any
+///   initialized sequence of bytes constitutes a valid instance of `$ty`.
+/// - If an `is_safe` impl is provided, then the impl of `is_safe` must only
+///   return `true` if its argument refers to a valid `$ty`.
 macro_rules! unsafe_impl {
     // Implement `$trait` for `$ty` with no bounds.
-    ($(#[$attr:meta])* $ty:ty: $trait:ident $(; |$candidate:ident| $is_bit_valid:expr)?) => {{
+    ($(#[$attr:meta])* $ty:ty: $trait:ident $(; |$candidate:ident| $is_safe:expr)?) => {{
         crate::util::macros::__unsafe();
 
         $(#[$attr])*
         // SAFETY: The caller promises that this is sound.
         unsafe impl $trait for $ty {
-            unsafe_impl!(@method $trait $(; |$candidate| $is_bit_valid)?);
+            unsafe_impl!(@method $trait $(; |$candidate| $is_safe)?);
         }
     }};
 
@@ -92,26 +91,26 @@ macro_rules! unsafe_impl {
         $(#[$attr:meta])*
         const $constname:ident : $constty:ident $(,)?
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_bit_valid:expr)?
+        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_safe:expr)?
     ) => {
         unsafe_impl!(
             @inner
             $(#[$attr])*
             @const $constname: $constty,
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty $(; |$candidate| $is_bit_valid)?
+            => $trait for $ty $(; |$candidate| $is_safe)?
         );
     };
     (
         $(#[$attr:meta])*
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_bit_valid:expr)?
+        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_safe:expr)?
     ) => {{
         unsafe_impl!(
             @inner
             $(#[$attr])*
             $($tyvar $(: $(? $optbound +)* + $($bound +)*)?,)*
-            => $trait for $ty $(; |$candidate| $is_bit_valid)?
+            => $trait for $ty $(; |$candidate| $is_safe)?
         );
     }};
     (
@@ -119,7 +118,7 @@ macro_rules! unsafe_impl {
         $(#[$attr:meta])*
         $(@const $constname:ident : $constty:ident,)*
         $($tyvar:ident $(: $(? $optbound:ident +)* + $($bound:ident +)* )?,)*
-        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_bit_valid:expr)?
+        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_safe:expr)?
     ) => {{
         crate::util::macros::__unsafe();
 
@@ -127,21 +126,21 @@ macro_rules! unsafe_impl {
         #[allow(non_local_definitions)]
         // SAFETY: The caller promises that this is sound.
         unsafe impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),* $(, const $constname: $constty,)*> $trait for $ty {
-            unsafe_impl!(@method $trait $(; |$candidate| $is_bit_valid)?);
+            unsafe_impl!(@method $trait $(; |$candidate| $is_safe)?);
         }
     }};
 
-    (@method TryFromBytes ; |$candidate:ident| $is_bit_valid:expr) => {
+    (@method TryFromBytes ; |$candidate:ident| $is_safe:expr) => {
         #[allow(clippy::missing_inline_in_public_items, dead_code)]
         #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
 
         #[inline]
-        fn is_bit_valid<Alignment>($candidate: Maybe<'_, Self, Alignment>) -> bool
+        fn is_safe<Alignment>($candidate: Maybe<'_, Self, Alignment>) -> bool
         where
             Alignment: crate::invariant::Alignment,
         {
-            $is_bit_valid
+            $is_safe
         }
     };
     (@method TryFromBytes) => {
@@ -149,7 +148,7 @@ macro_rules! unsafe_impl {
         #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)]
-        fn is_bit_valid<Alignment>(_candidate: Maybe<'_, Self, Alignment>) -> bool
+        fn is_safe<Alignment>(_candidate: Maybe<'_, Self, Alignment>) -> bool
         where
             Alignment: crate::invariant::Alignment,
         {
@@ -161,8 +160,8 @@ macro_rules! unsafe_impl {
         #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
         fn only_derive_is_allowed_to_implement_this_trait() {}
     };
-    (@method $trait:ident; |$_candidate:ident| $_is_bit_valid:expr) => {
-        compile_error!("Can't provide `is_bit_valid` impl for trait other than `TryFromBytes`");
+    (@method $trait:ident; |$_candidate:ident| $_is_safe:expr) => {
+        compile_error!("Can't provide `is_safe` impl for trait other than `TryFromBytes`");
     };
 }
 
@@ -193,14 +192,14 @@ macro_rules! impl_for_transmute_from {
                 #[allow(dead_code, clippy::missing_inline_in_public_items)]
                 #[cfg_attr(all(coverage_nightly, __ZEROCOPY_INTERNAL_USE_ONLY_NIGHTLY_FEATURES_IN_TESTS), coverage(off))]
                 fn only_derive_is_allowed_to_implement_this_trait() {
-                    use crate::pointer::{*, invariant::Valid};
+                    use crate::pointer::{*, invariant::Safe};
 
                     impl_for_transmute_from!(@assert_is_supported_trait $trait);
 
                     fn is_trait<T, R>()
                     where
-                        T: TransmuteFrom<R, Valid, Valid> + ?Sized,
-                        R: TransmuteFrom<T, Valid, Valid> + ?Sized,
+                        T: TransmuteFrom<R, Safe, Safe> + ?Sized,
+                        R: TransmuteFrom<T, Safe, Safe> + ?Sized,
                         R: $trait,
                     {
                     }
@@ -212,7 +211,7 @@ macro_rules! impl_for_transmute_from {
                 }
 
                 impl_for_transmute_from!(
-                    @is_bit_valid
+                    @is_safe
                     $(<$tyvar $(: $(? $optbound +)* $($bound +)*)?>)?
                     $trait for $ty [$repr]
                 );
@@ -224,27 +223,27 @@ macro_rules! impl_for_transmute_from {
     (@assert_is_supported_trait FromBytes) => {};
     (@assert_is_supported_trait IntoBytes) => {};
     (
-        @is_bit_valid
+        @is_safe
         $(<$tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?>)?
         TryFromBytes for $ty:ty [$repr:ty]
     ) => {
         #[inline(always)]
-        fn is_bit_valid<Alignment>(candidate: $crate::Maybe<'_, Self, Alignment>) -> bool
+        fn is_safe<Alignment>(candidate: $crate::Maybe<'_, Self, Alignment>) -> bool
         where
             Alignment: $crate::invariant::Alignment,
         {
             // SAFETY: This macro ensures that `$repr` and `Self` have the same
             // size and bit validity. Thus, a bit-valid instance of `$repr` is
             // also a bit-valid instance of `Self`.
-            <$repr as TryFromBytes>::is_bit_valid(candidate.transmute::<_, _, BecauseImmutable>())
+            <$repr as TryFromBytes>::is_safe(candidate.transmute::<_, _, BecauseImmutable>())
         }
     };
     (
-        @is_bit_valid
+        @is_safe
         $(<$tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?>)?
         $trait:ident for $ty:ty [$repr:ty]
     ) => {
-        // Trait other than `TryFromBytes`; no `is_bit_valid` impl.
+        // Trait other than `TryFromBytes`; no `is_safe` impl.
     };
 }
 
@@ -269,33 +268,33 @@ macro_rules! impl_for_transmute_from {
 macro_rules! unsafe_impl_for_power_set {
     (
         $first:ident $(, $rest:ident)* $(-> $ret:ident)? => $trait:ident for $macro:ident!(...)
-        $(; |$candidate:ident| $is_bit_valid:expr)?
+        $(; |$candidate:ident| $is_safe:expr)?
     ) => {
         unsafe_impl_for_power_set!(
             $($rest),* $(-> $ret)? => $trait for $macro!(...)
-            $(; |$candidate| $is_bit_valid)?
+            $(; |$candidate| $is_safe)?
         );
         unsafe_impl_for_power_set!(
             @impl $first $(, $rest)* $(-> $ret)? => $trait for $macro!(...)
-            $(; |$candidate| $is_bit_valid)?
+            $(; |$candidate| $is_safe)?
         );
     };
     (
         $(-> $ret:ident)? => $trait:ident for $macro:ident!(...)
-        $(; |$candidate:ident| $is_bit_valid:expr)?
+        $(; |$candidate:ident| $is_safe:expr)?
     ) => {
         unsafe_impl_for_power_set!(
             @impl $(-> $ret)? => $trait for $macro!(...)
-            $(; |$candidate| $is_bit_valid)?
+            $(; |$candidate| $is_safe)?
         );
     };
     (
         @impl $($vars:ident),* $(-> $ret:ident)? => $trait:ident for $macro:ident!(...)
-        $(; |$candidate:ident| $is_bit_valid:expr)?
+        $(; |$candidate:ident| $is_safe:expr)?
     ) => {
         unsafe_impl!(
             $($vars,)* $($ret)? => $trait for $macro!($($vars),* $(-> $ret)?)
-            $(; |$candidate| $is_bit_valid)?
+            $(; |$candidate| $is_safe)?
         );
     };
 }
@@ -355,8 +354,8 @@ macro_rules! opt_unsafe_fn {
 /// impl in this case, and also provides useful documentation for readers of the
 /// code.
 ///
-/// Finally, if a `TryFromBytes::is_bit_valid` impl is provided, it must adhere
-/// to the safety preconditions of [`unsafe_impl!`].
+/// Finally, if a `TryFromBytes::is_safe` impl is provided, it must adhere to the
+/// safety preconditions of [`unsafe_impl!`].
 ///
 /// ## Example
 ///
@@ -396,11 +395,11 @@ macro_rules! impl_or_verify {
     };
     (
         $($tyvar:ident $(: $(? $optbound:ident $(+)?)* $($bound:ident $(+)?)* )?),*
-        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_bit_valid:expr)?
+        => $trait:ident for $ty:ty $(; |$candidate:ident| $is_safe:expr)?
     ) => {
         impl_or_verify!(@impl { unsafe_impl!(
             $($tyvar $(: $(? $optbound +)* $($bound +)*)?),* => $trait for $ty
-            $(; |$candidate| $is_bit_valid)?
+            $(; |$candidate| $is_safe)?
         ); });
         impl_or_verify!(@verify $trait, {
             impl<$($tyvar $(: $(? $optbound +)* $($bound +)*)?),*> Subtrait for $ty {}
@@ -742,14 +741,14 @@ macro_rules! unsafe_impl_for_transparent_wrapper {
     ($vis:vis T $(: ?$optbound:ident)? => $wrapper:ident<T>) => {{
         crate::util::macros::__unsafe();
 
-        use crate::pointer::{TransmuteFrom, cast::{CastExact, TransitiveProject}, SizeEq, invariant::Valid};
+        use crate::pointer::{TransmuteFrom, cast::{CastExact, TransitiveProject}, SizeEq, invariant::Safe};
         use crate::wrappers::ReadOnly;
 
         // SAFETY: The caller promises that `T` and `$wrapper<T>` have the same
         // bit validity.
-        unsafe impl<T $(: ?$optbound)?> TransmuteFrom<T, Valid, Valid> for $wrapper<T> {}
+        unsafe impl<T $(: ?$optbound)?> TransmuteFrom<T, Safe, Safe> for $wrapper<T> {}
         // SAFETY: See previous safety comment.
-        unsafe impl<T $(: ?$optbound)?> TransmuteFrom<$wrapper<T>, Valid, Valid> for T {}
+        unsafe impl<T $(: ?$optbound)?> TransmuteFrom<$wrapper<T>, Safe, Safe> for T {}
         // SAFETY: The caller promises that a `T` to `$wrapper<T>` cast is
         // size-preserving.
         define_cast!(unsafe { $vis CastToWrapper<T $(: ?$optbound)? > = T => $wrapper<T> });
@@ -805,7 +804,7 @@ macro_rules! unsafe_impl_for_transparent_wrapper {
 macro_rules! impl_transitive_transmute_from {
     ($($tyvar:ident $(: ?$optbound:ident)?)? => $t:ty => $u:ty => $v:ty) => {
         const _: () = {
-            use crate::pointer::{TransmuteFrom, SizeEq, invariant::Valid};
+            use crate::pointer::{TransmuteFrom, SizeEq, invariant::Safe};
 
             impl<$($tyvar $(: ?$optbound)?)?> SizeEq<$t> for $v
             where
@@ -819,14 +818,14 @@ macro_rules! impl_transitive_transmute_from {
                 >;
             }
 
-            // SAFETY: Since `$u: TransmuteFrom<$t, Valid, Valid>`, it is sound
-            // to transmute a bit-valid `$t` to a bit-valid `$u`. Since `$v:
-            // TransmuteFrom<$u, Valid, Valid>`, it is sound to transmute that
+            // SAFETY: Since `$u: TransmuteFrom<$t, Safe, Safe>`, it is sound to
+            // transmute a bit-valid `$t` to a bit-valid `$u`. Since `$v:
+            // TransmuteFrom<$u, Safe, Safe>`, it is sound to transmute that
             // bit-valid `$u` to a bit-valid `$v`.
-            unsafe impl<$($tyvar $(: ?$optbound)?)?> TransmuteFrom<$t, Valid, Valid> for $v
+            unsafe impl<$($tyvar $(: ?$optbound)?)?> TransmuteFrom<$t, Safe, Safe> for $v
             where
-                $u: TransmuteFrom<$t, Valid, Valid>,
-                $v: TransmuteFrom<$u, Valid, Valid>,
+                $u: TransmuteFrom<$t, Safe, Safe>,
+                $v: TransmuteFrom<$u, Safe, Safe>,
             {}
         };
     };

--- a/zerocopy/src/util/mod.rs
+++ b/zerocopy/src/util/mod.rs
@@ -23,7 +23,7 @@ use core::{
 
 use super::*;
 use crate::pointer::{
-    invariant::{Exclusive, Shared, Valid},
+    invariant::{Exclusive, Safe, Shared},
     SizeEq, TransmuteFromPtr,
 };
 
@@ -340,7 +340,7 @@ pub(crate) unsafe fn transmute_ref<Src, Dst, R>(src: &Src) -> &Dst
 where
     Src: ?Sized,
     Dst: SizeEq<Src>
-        + TransmuteFromPtr<Src, Shared, Valid, Valid, <Dst as SizeEq<Src>>::CastFrom, R>
+        + TransmuteFromPtr<Src, Shared, Safe, Safe, <Dst as SizeEq<Src>>::CastFrom, R>
         + ?Sized,
 {
     let dst = Ptr::from_ref(src).transmute();
@@ -357,7 +357,7 @@ pub(crate) unsafe fn transmute_mut<Src, Dst, R>(src: &mut Src) -> &mut Dst
 where
     Src: ?Sized,
     Dst: SizeEq<Src>
-        + TransmuteFromPtr<Src, Exclusive, Valid, Valid, <Dst as SizeEq<Src>>::CastFrom, R>
+        + TransmuteFromPtr<Src, Exclusive, Safe, Safe, <Dst as SizeEq<Src>>::CastFrom, R>
         + ?Sized,
 {
     let dst = Ptr::from_mut(src).transmute();

--- a/zerocopy/src/wrappers.rs
+++ b/zerocopy/src/wrappers.rs
@@ -11,7 +11,7 @@
 use core::{fmt, hash::Hash};
 
 use super::*;
-use crate::pointer::{invariant::Valid, SizeEq, TransmuteFrom};
+use crate::pointer::{invariant::Safe, SizeEq, TransmuteFrom};
 
 /// A type with no alignment requirement.
 ///
@@ -140,10 +140,10 @@ impl_known_layout!(T => Unalign<T>);
 //   Unaligned`.
 // - `Unalign<T>` has the same bit validity as `T`, and so it is `FromZeros`,
 //   `FromBytes`, or `IntoBytes` exactly when `T` is as well.
-// - `Immutable`: `Unalign<T>` has the same fields as `T`, so it permits
-//   interior mutation exactly when `T` does.
+// - `Immutable`: `Unalign<T>` has the same fields as `T`, so it permits interior
+//   mutation exactly when `T` does.
 // - `TryFromBytes`: `Unalign<T>` has the same the same bit validity as `T`, so
-//   `T::is_bit_valid` is a sound implementation of `is_bit_valid`.
+//   `T::is_safe` is a sound implementation of `is_safe`.
 //
 #[allow(clippy::multiple_unsafe_ops_per_block)]
 const _: () = unsafe {
@@ -151,7 +151,7 @@ const _: () = unsafe {
     impl_or_verify!(T: Immutable => Immutable for Unalign<T>);
     impl_or_verify!(
         T: TryFromBytes => TryFromBytes for Unalign<T>;
-        |c| T::is_bit_valid(c.transmute::<_, _, BecauseImmutable>())
+        |c| T::is_safe(c.transmute::<_, _, BecauseImmutable>())
     );
     impl_or_verify!(T: FromZeros => FromZeros for Unalign<T>);
     impl_or_verify!(T: FromBytes => FromBytes for Unalign<T>);
@@ -665,7 +665,7 @@ const _: () = unsafe {
 // SAFETY:
 // - `ReadOnly<T>` has the same alignment as `T`, and so it is `Unaligned`
 //   exactly when `T` is as well.
-// - `ReadOnly<T>` has the same bit validity as `T`, and so this `is_bit_valid`
+// - `ReadOnly<T>` has the same bit validity as `T`, and so this `is_safe`
 //   implementation is correct, and thus the `TryFromBytes` impl is sound.
 // - `ReadOnly<T>` has the same bit validity as `T`, and so it is `FromZeros`,
 //   `FromBytes`, and `IntoBytes` exactly when `T` is as well.
@@ -673,7 +673,7 @@ const _: () = unsafe {
     unsafe_impl!(T: ?Sized + Unaligned => Unaligned for ReadOnly<T>);
     unsafe_impl!(
         T: ?Sized + TryFromBytes => TryFromBytes for ReadOnly<T>;
-        |c| T::is_bit_valid(c.cast::<_, <ReadOnly<T> as SizeEq<ReadOnly<ReadOnly<T>>>>::CastFrom, _>())
+        |c| T::is_safe(c.cast::<_, <ReadOnly<T> as SizeEq<ReadOnly<ReadOnly<T>>>>::CastFrom, _>())
     );
     unsafe_impl!(T: ?Sized + FromZeros => FromZeros for ReadOnly<T>);
     unsafe_impl!(T: ?Sized + FromBytes => FromBytes for ReadOnly<T>);
@@ -709,11 +709,11 @@ const _: () = {
 
 // SAFETY: `ReadOnly<T>` is a `#[repr(transparent)]` wrapper around `T`, and so
 // it has the same bit validity as `T`.
-unsafe impl<T: ?Sized> TransmuteFrom<T, Valid, Valid> for ReadOnly<T> {}
+unsafe impl<T: ?Sized> TransmuteFrom<T, Safe, Safe> for ReadOnly<T> {}
 
 // SAFETY: `ReadOnly<T>` is a `#[repr(transparent)]` wrapper around `T`, and so
 // it has the same bit validity as `T`.
-unsafe impl<T: ?Sized> TransmuteFrom<ReadOnly<T>, Valid, Valid> for T {}
+unsafe impl<T: ?Sized> TransmuteFrom<ReadOnly<T>, Safe, Safe> for T {}
 
 impl<'a, T: ?Sized + Immutable> From<&'a T> for &'a ReadOnly<T> {
     #[inline(always)]

--- a/zerocopy/tests/include.rs
+++ b/zerocopy/tests/include.rs
@@ -56,11 +56,11 @@ mod util {
     }
 
     #[macro_export]
-    macro_rules! test_trivial_is_bit_valid {
+    macro_rules! test_trivial_is_safe {
         ($x:ty => $name:ident) => {
             #[test]
             fn $name() {
-                util::test_trivial_is_bit_valid::<$x>();
+                util::test_trivial_is_safe::<$x>();
             }
         };
     }

--- a/zerocopy/tests/ui/ptr-is-invariant-over-v.msrv.stderr
+++ b/zerocopy/tests/ui/ptr-is-invariant-over-v.msrv.stderr
@@ -1,8 +1,8 @@
 error[E0623]: lifetime mismatch
   --> $DIR/ptr-is-invariant-over-v.rs:21:14
    |
-18 |     big: Ptr<'small, &'big u32, (Exclusive, Aligned, Valid)>,
-   |          --------------------------------------------------- these two types are declared with different lifetimes...
+18 |     big: Ptr<'small, &'big u32, (Exclusive, Aligned, Safe)>,
+   |          -------------------------------------------------- these two types are declared with different lifetimes...
 ...
 21 |     _small = big;
    |              ^^^ ...but data from `big` flows into `big` here
@@ -10,8 +10,8 @@ error[E0623]: lifetime mismatch
 error[E0623]: lifetime mismatch
   --> $DIR/ptr-is-invariant-over-v.rs:30:14
    |
-27 |     big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
-   |          ------------------------------------------------ these two types are declared with different lifetimes...
+27 |     big: Ptr<'small, &'big u32, (Shared, Aligned, Safe)>,
+   |          ----------------------------------------------- these two types are declared with different lifetimes...
 ...
 30 |     _small = big;
    |              ^^^ ...but data from `big` flows into `big` here

--- a/zerocopy/tests/ui/ptr-is-invariant-over-v.nightly.stderr
+++ b/zerocopy/tests/ui/ptr-is-invariant-over-v.nightly.stderr
@@ -10,7 +10,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, Aligned, zerocopy::invariant::Safe)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -26,7 +26,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, zerocopy::invariant::Safe)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/zerocopy/tests/ui/ptr-is-invariant-over-v.rs
+++ b/zerocopy/tests/ui/ptr-is-invariant-over-v.rs
@@ -10,13 +10,13 @@
 include!("../include.rs");
 
 use zerocopy::pointer::{
-    invariant::{Aligned, Exclusive, Shared, Valid},
+    invariant::{Aligned, Exclusive, Safe, Shared},
     Ptr,
 };
 
 fn _when_exclusive<'big: 'small, 'small>(
-    big: Ptr<'small, &'big u32, (Exclusive, Aligned, Valid)>,
-    mut _small: Ptr<'small, &'small u32, (Exclusive, Aligned, Valid)>,
+    big: Ptr<'small, &'big u32, (Exclusive, Aligned, Safe)>,
+    mut _small: Ptr<'small, &'small u32, (Exclusive, Aligned, Safe)>,
 ) {
     _small = big;
     //~[msrv]^ ERROR: lifetime mismatch
@@ -24,8 +24,8 @@ fn _when_exclusive<'big: 'small, 'small>(
 }
 
 fn _when_shared<'big: 'small, 'small>(
-    big: Ptr<'small, &'big u32, (Shared, Aligned, Valid)>,
-    mut _small: Ptr<'small, &'small u32, (Shared, Aligned, Valid)>,
+    big: Ptr<'small, &'big u32, (Shared, Aligned, Safe)>,
+    mut _small: Ptr<'small, &'small u32, (Shared, Aligned, Safe)>,
 ) {
     _small = big;
     //~[msrv]^ ERROR: lifetime mismatch

--- a/zerocopy/tests/ui/ptr-is-invariant-over-v.stable.stderr
+++ b/zerocopy/tests/ui/ptr-is-invariant-over-v.stable.stderr
@@ -10,7 +10,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (zerocopy::invariant::Exclusive, Aligned, zerocopy::invariant::Safe)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -26,7 +26,7 @@ error: lifetime may not live long enough
    |     ^^^^^^^^^^^^ assignment requires that `'small` must outlive `'big`
    |
    = help: consider adding the following bound: `'small: 'big`
-   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, zerocopy::invariant::Valid)>`, which makes the generic argument `&u32` invariant
+   = note: requirement occurs because of the type `Ptr<'_, &u32, (Shared, Aligned, zerocopy::invariant::Safe)>`, which makes the generic argument `&u32` invariant
    = note: the struct `Ptr<'a, T, I>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/zerocopy/tests/ui/transmute-ptr-to-usize.nightly.stderr
+++ b/zerocopy/tests/ui/transmute-ptr-to-usize.nightly.stderr
@@ -9,9 +9,9 @@ error[E0277]: the trait bound `*const usize: IntoBytes` is not satisfied
    |
    = note: Consider adding `#[derive(IntoBytes)]` to `*const usize`
 help: the trait `IntoBytes` is implemented for `usize`
-  --> src/util/macros.rs:31:9
+  --> src/util/macros.rs:30:9
    |
-31 |         unsafe impl $trait for $ty {
+30 |         unsafe impl $trait for $ty {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: src/impls.rs:79:5

--- a/zerocopy/zerocopy-derive/src/derive/project.rs
+++ b/zerocopy/zerocopy-derive/src/derive/project.rs
@@ -81,7 +81,7 @@ pub(crate) fn generate_tag_consts(data: &DataEnum) -> TokenStream {
 enum Validity {
     Uninit,
     Initialized,
-    Valid,
+    Safe,
 }
 
 impl Validity {
@@ -92,7 +92,7 @@ impl Validity {
             Validity::Initialized => {
                 parse_quote!(#zerocopy_crate::invariant::Initialized)
             }
-            Validity::Valid => parse_quote!(#zerocopy_crate::invariant::Valid),
+            Validity::Safe => parse_quote!(#zerocopy_crate::invariant::Safe),
         }
     }
 
@@ -101,14 +101,14 @@ impl Validity {
     ///
     /// Struct fields preserve all three validity invariants. Union fields
     /// preserve `Uninit` and `Initialized`. No projection is generated from a
-    /// `Valid` union.
+    /// `Safe` union.
     fn output_validity_for_struct_or_union(self, data: &Data) -> Option<Self> {
         match (data, self) {
             (Data::Struct(_), validity) => Some(validity),
             (Data::Union(_), validity @ (Validity::Uninit | Validity::Initialized)) => {
                 Some(validity)
             }
-            (Data::Union(_), Validity::Valid) => None,
+            (Data::Union(_), Validity::Safe) => None,
             (Data::Enum(_), _) => unreachable!(),
         }
     }
@@ -231,11 +231,12 @@ pub(crate) fn derive_projection_struct_union(
                 // the referent, and are therefore infallible.
                 type Error = #zerocopy_crate::util::macro_util::core_reexport::convert::Infallible;
 
-                // SAFETY: Projection preserves aliasing. It also preserves alignment
-                // unless the containing type is packed. `Validity` determines whether
-                // a projection is emitted and, if so, computes its output validity:
-                // struct fields preserve validity; union fields preserve `Uninit` and
-                // `Initialized`, and no projection is emitted for `Valid` union input.
+                // SAFETY: Projection preserves aliasing. It also preserves
+                // alignment unless the containing type is packed. `Validity`
+                // determines whether a projection is emitted and, if so,
+                // computes its output validity: struct fields preserve validity;
+                // union fields preserve `Uninit` and `Initialized`, and no
+                // projection is emitted for `Safe` union input.
                 type Invariants = (___ZcAliasing, #output_alignment, #output_validity);
             })
             .build()
@@ -243,13 +244,13 @@ pub(crate) fn derive_projection_struct_union(
 
         let project_uninit = derive_project_field(Validity::Uninit);
         let project_initialized = derive_project_field(Validity::Initialized);
-        let project_valid = derive_project_field(Validity::Valid);
+        let project_safe = derive_project_field(Validity::Safe);
 
         quote! {
             #has_field
             #project_uninit
             #project_initialized
-            #project_valid
+            #project_safe
         }
     });
 
@@ -438,14 +439,13 @@ pub(crate) fn derive_enum(
             // prepends its inner tag before reproducing the enum fields in
             // source order, so `idx + 1` selects that same field. The assertion
             // above enforces that `repr` is `repr(C)` or a primitive
-            // representation;
-            // `___ZerocopyRawEnum` and its nested types model exactly the
-            // representations specified by [1] and [2]. Those representations
-            // use `repr(C)` structs for variant fields, so field projection
-            // preserves alignment. Each `ProjectField` impl preserves the input
-            // validity. The `Uninit` and `Initialized` projections are
+            // representation; `___ZerocopyRawEnum` and its nested types model
+            // exactly the representations specified by [1] and [2]. Those
+            // representations use `repr(C)` structs for variant fields, so field
+            // projection preserves alignment. Each `ProjectField` impl preserves
+            // the input validity. The `Uninit` and `Initialized` projections are
             // infallible because those validity invariants do not depend on the
-            // enum's tag. The `Valid` projection first checks that the tag
+            // enum's tag. The `Safe` projection first checks that the tag
             // selects `variant_ident`; its `Reference` aliasing bound prevents
             // mutation of the tag between that check and field projection. The
             // corresponding `HasTag` impl projects to the raw representation's
@@ -465,7 +465,7 @@ pub(crate) fn derive_enum(
             //   field. The first field of each struct in the union is [...] the
             //   tag and the remaining fields are the fields of that variant.
             let derive_enum_project_field = |validity| {
-                let (error, is_projectable, aliasing_bound) = if validity == Validity::Valid {
+                let (error, is_projectable, aliasing_bound) = if validity == Validity::Safe {
                     assert!(!matches!(validity, Validity::Uninit | Validity::Initialized));
                     (
                         quote! { () },
@@ -478,7 +478,7 @@ pub(crate) fn derive_enum(
                                     (
                                         #zerocopy_crate::invariant::Shared,
                                         ___ZcAlignment,
-                                        #zerocopy_crate::invariant::Valid,
+                                        #zerocopy_crate::invariant::Safe,
                                     ),
                                 >,
                             ) -> #core::result::Result<(), ()> {
@@ -517,7 +517,7 @@ pub(crate) fn derive_enum(
 
             let project_uninit = derive_enum_project_field(Validity::Uninit);
             let project_initialized = derive_enum_project_field(Validity::Initialized);
-            let project_valid = derive_enum_project_field(Validity::Valid);
+            let project_valid = derive_enum_project_field(Validity::Safe);
 
             quote! {
                 #has_field

--- a/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/src/derive/try_from_bytes.rs
@@ -16,14 +16,14 @@ use crate::{
     },
 };
 
-/// Generates an implementation of `is_bit_valid` for an arbitrary enum.
+/// Generates an implementation of `is_safe` for an arbitrary enum.
 ///
 /// For an enum with fields, [`derive_enum`] generates the representation model
 /// and projection impls. This function reads the tag, matches it against the
 /// enum's discriminants, and validates each field of the selected variant
 /// through those projections. A fieldless enum needs only the generated tag
 /// enum and discriminant constants.
-pub(crate) fn derive_is_bit_valid(
+pub(crate) fn derive_is_safe(
     ctx: &Ctx,
     data: &DataEnum,
     repr: &EnumRepr,
@@ -69,18 +69,18 @@ pub(crate) fn derive_is_bit_valid(
                         { #zerocopy_crate::ident_id!(#field_names) },
                     >()
                 );
-                <#field_tys as #trait_path>::is_bit_valid(field_candidate)
+                <#field_tys as #trait_path>::is_safe(field_candidate)
             })*
         }
     });
 
     Ok(quote! {
-        // SAFETY: We use `is_bit_valid` to validate that the bit pattern of the
+        // SAFETY: We use `is_safe` to validate that the bit pattern of the
         // enum's tag corresponds to one of the enum's discriminants. Then, we
         // check the bit validity of each field of the corresponding variant.
-        // Thus, this is a sound implementation of `is_bit_valid`.
+        // Thus, this is a sound implementation of `is_safe`.
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
         ) -> #core::primitive::bool
         where
@@ -117,20 +117,19 @@ fn derive_try_from_bytes_struct(
     strct: &DataStruct,
     top_level: Trait,
 ) -> Result<TokenStream, Error> {
-    let extras = try_gen_trivial_is_bit_valid(ctx, top_level).unwrap_or_else(|| {
+    let extras = try_gen_trivial_is_safe(ctx, top_level).unwrap_or_else(|| {
         let zerocopy_crate = &ctx.zerocopy_crate;
         let fields = strct.fields();
         let field_names = fields.iter().map(|(_vis, name, _ty)| name);
         let field_tys = fields.iter().map(|(_vis, _name, ty)| ty);
         let core = ctx.core_path();
         quote!(
-            // SAFETY: We use `is_bit_valid` to validate that each field is
-            // bit-valid, and only return `true` if all of them are. The bit
-            // validity of a struct is just the composition of the bit
-            // validities of its fields, so this is a sound implementation
-            // of `is_bit_valid`.
+            // SAFETY: We use `is_safe` to validate that each field is bit-valid,
+            // and only return `true` if all of them are. The bit validity of a
+            // struct is just the composition of the bit validities of its
+            // fields, so this is a sound implementation of `is_safe`.
             #[inline]
-            fn is_bit_valid<___ZcAlignment>(
+            fn is_safe<___ZcAlignment>(
                 mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
             ) -> #core::primitive::bool
             where
@@ -143,7 +142,7 @@ fn derive_try_from_bytes_struct(
                         { #zerocopy_crate::STRUCT_VARIANT_ID },
                         { #zerocopy_crate::ident_id!(#field_names) }
                     >());
-                    <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
+                    <#field_tys as #zerocopy_crate::TryFromBytes>::is_safe(field_candidate)
                 })*
             }
         )
@@ -158,19 +157,19 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
 
     let zerocopy_crate = &ctx.zerocopy_crate;
     let union_variant_id = struct_union_variant_id(ctx);
-    let extras = try_gen_trivial_is_bit_valid(ctx, top_level).unwrap_or_else(|| {
+    let extras = try_gen_trivial_is_safe(ctx, top_level).unwrap_or_else(|| {
         let fields = unn.fields();
         let field_names = fields.iter().map(|(_vis, name, _ty)| name);
         let field_tys = fields.iter().map(|(_vis, _name, ty)| ty);
         let core = ctx.core_path();
         quote!(
-            // SAFETY: We use `is_bit_valid` to validate that any field is
-            // bit-valid; we only return `true` if at least one of them is.
-            // The bit validity of a union is not yet well defined in Rust,
-            // but it is guaranteed to be no more strict than this
-            // definition. See #696 for a more in-depth discussion.
+            // SAFETY: We use `is_safe` to validate that any field is bit-valid;
+            // we only return `true` if at least one of them is. The bit validity
+            // of a union is not yet well defined in Rust, but it is guaranteed
+            // to be no more strict than this definition. See #696 for a more
+            // in-depth discussion.
             #[inline]
-            fn is_bit_valid<___ZcAlignment>(
+            fn is_safe<___ZcAlignment>(
                 mut candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
             ) -> #core::primitive::bool
             where
@@ -186,7 +185,7 @@ fn derive_try_from_bytes_union(ctx: &Ctx, unn: &DataUnion, top_level: Trait) -> 
                         >()
                     );
 
-                    <#field_tys as #zerocopy_crate::TryFromBytes>::is_bit_valid(field_candidate)
+                    <#field_tys as #zerocopy_crate::TryFromBytes>::is_safe(field_candidate)
                 })*
             }
         )
@@ -212,13 +211,13 @@ fn derive_try_from_bytes_enum(
         .map(|size| enm.fields().is_empty() && enm.variants.len() == 1usize << size)
         .unwrap_or(false);
 
-    let trivial_is_bit_valid = try_gen_trivial_is_bit_valid(ctx, top_level);
-    let extra = match (trivial_is_bit_valid, could_be_from_bytes) {
-        (Some(is_bit_valid), _) => is_bit_valid,
+    let trivial_is_safe = try_gen_trivial_is_safe(ctx, top_level);
+    let extra = match (trivial_is_safe, could_be_from_bytes) {
+        (Some(is_safe), _) => is_safe,
         // SAFETY: It would be sound for the enum to implement `FromBytes`, as
-        // required by `gen_trivial_is_bit_valid_unchecked`.
-        (None, true) => unsafe { gen_trivial_is_bit_valid_unchecked(ctx) },
-        (None, false) => match derive_is_bit_valid(ctx, enm, &repr) {
+        // required by `gen_trivial_is_safe_unchecked`.
+        (None, true) => unsafe { gen_trivial_is_safe_unchecked(ctx) },
+        (None, false) => match derive_is_safe(ctx, enm, &repr) {
             Ok(extra) => extra,
             Err(_) if ctx.skip_on_error => return Ok(TokenStream::new()),
             Err(e) => return Err(e),
@@ -229,15 +228,14 @@ fn derive_try_from_bytes_enum(
         .inner_extras(extra)
         .build())
 }
-fn try_gen_trivial_is_bit_valid(ctx: &Ctx, top_level: Trait) -> Option<proc_macro2::TokenStream> {
+fn try_gen_trivial_is_safe(ctx: &Ctx, top_level: Trait) -> Option<proc_macro2::TokenStream> {
     // If the top-level trait is `FromBytes` and `Self` has no type parameters,
     // then the `FromBytes` derive will fail compilation if `Self` is not
-    // actually soundly `FromBytes`, and so we can rely on that for our
-    // `is_bit_valid` impl. It's plausible that we could make changes - or Rust
-    // could make changes (such as the "trivial bounds" language feature) - that
-    // make this no longer true. To hedge against these, we include an explicit
-    // `Self: FromBytes` check in the generated `is_bit_valid`, which is
-    // bulletproof.
+    // actually soundly `FromBytes`, and so we can rely on that for our `is_safe`
+    // impl. It's plausible that we could make changes - or Rust could make
+    // changes (such as the "trivial bounds" language feature) - that make this
+    // no longer true. To hedge against these, we include an explicit `Self:
+    // FromBytes` check in the generated `is_safe`, which is bulletproof.
     //
     // If `ctx.skip_on_error` is true, we can't rely on the `FromBytes` derive
     // to fail compilation if `Self` is not actually soundly `FromBytes`.
@@ -250,7 +248,7 @@ fn try_gen_trivial_is_bit_valid(ctx: &Ctx, top_level: Trait) -> Option<proc_macr
         Some(quote!(
             // SAFETY: See inline.
             #[inline(always)]
-            fn is_bit_valid<___ZcAlignment>(
+            fn is_safe<___ZcAlignment>(
                 _candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
             ) -> #core::primitive::bool
             where
@@ -281,14 +279,14 @@ fn try_gen_trivial_is_bit_valid(ctx: &Ctx, top_level: Trait) -> Option<proc_macr
 /// # Safety
 ///
 /// All initialized bit patterns must be valid for `Self`.
-unsafe fn gen_trivial_is_bit_valid_unchecked(ctx: &Ctx) -> proc_macro2::TokenStream {
+unsafe fn gen_trivial_is_safe_unchecked(ctx: &Ctx) -> proc_macro2::TokenStream {
     let zerocopy_crate = &ctx.zerocopy_crate;
     let core = ctx.core_path();
     quote!(
-        // SAFETY: The caller of `gen_trivial_is_bit_valid_unchecked` has
-        // promised that all initialized bit patterns are valid for `Self`.
+        // SAFETY: The caller of `gen_trivial_is_safe_unchecked` has promised
+        // that all initialized bit patterns are valid for `Self`.
         #[inline(always)]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             _candidate: #zerocopy_crate::Maybe<'_, Self, ___ZcAlignment>,
         ) -> #core::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_enum.expected.rs
@@ -14,7 +14,7 @@ const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_struct.expected.rs
@@ -14,7 +14,7 @@ const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_bytes_union.expected.rs
@@ -17,7 +17,7 @@ const _: () = {
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/from_zeros.expected.rs
@@ -14,7 +14,7 @@ const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_1.expected.rs
@@ -247,7 +247,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -259,7 +259,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -411,7 +411,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -423,7 +423,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -575,7 +575,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -587,7 +587,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -739,7 +739,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -751,7 +751,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -903,7 +903,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -915,7 +915,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1067,7 +1067,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ5,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(5) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1079,7 +1079,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1233,7 +1233,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ6,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(6) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1245,7 +1245,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1460,7 +1460,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1472,7 +1472,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1624,7 +1624,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1636,7 +1636,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1788,7 +1788,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1800,7 +1800,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1952,7 +1952,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1964,7 +1964,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2118,7 +2118,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2130,7 +2130,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2723,7 +2723,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕtag,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(tag) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2732,7 +2732,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2875,7 +2875,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕvariants,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(variants) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2884,7 +2884,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -3098,7 +3098,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(a) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3110,7 +3110,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3122,7 +3122,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3316,7 +3316,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(b) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3328,7 +3328,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3340,7 +3340,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3534,7 +3534,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(c) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3546,7 +3546,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3558,7 +3558,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3752,7 +3752,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(d) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3764,7 +3764,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3776,7 +3776,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3970,7 +3970,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(e) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3982,7 +3982,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3994,7 +3994,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4188,7 +4188,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(0) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4200,7 +4200,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4212,7 +4212,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4406,7 +4406,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(1) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4418,7 +4418,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4430,7 +4430,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4624,7 +4624,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(2) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4636,7 +4636,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4648,7 +4648,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_2.expected.rs
@@ -247,7 +247,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -259,7 +259,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -411,7 +411,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -423,7 +423,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -575,7 +575,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -587,7 +587,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -739,7 +739,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -751,7 +751,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -903,7 +903,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -915,7 +915,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1067,7 +1067,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ5,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(5) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1079,7 +1079,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1233,7 +1233,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ6,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(6) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1245,7 +1245,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1460,7 +1460,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1472,7 +1472,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1624,7 +1624,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1636,7 +1636,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1788,7 +1788,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1800,7 +1800,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1952,7 +1952,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1964,7 +1964,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2118,7 +2118,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2130,7 +2130,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2723,7 +2723,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕtag,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(tag) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2732,7 +2732,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2875,7 +2875,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕvariants,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(variants) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2884,7 +2884,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -3098,7 +3098,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(a) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3110,7 +3110,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3122,7 +3122,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3316,7 +3316,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(b) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3328,7 +3328,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3340,7 +3340,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3534,7 +3534,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(c) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3546,7 +3546,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3558,7 +3558,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3752,7 +3752,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(d) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3764,7 +3764,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3776,7 +3776,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3970,7 +3970,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(e) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3982,7 +3982,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3994,7 +3994,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4188,7 +4188,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(0) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4200,7 +4200,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4212,7 +4212,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4406,7 +4406,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(1) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4418,7 +4418,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4430,7 +4430,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4624,7 +4624,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(2) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4636,7 +4636,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4648,7 +4648,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_enum_3.expected.rs
@@ -247,7 +247,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -259,7 +259,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -411,7 +411,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -423,7 +423,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -575,7 +575,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -587,7 +587,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -739,7 +739,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -751,7 +751,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -903,7 +903,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -915,7 +915,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1067,7 +1067,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ5,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(5) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1079,7 +1079,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1233,7 +1233,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ6,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(6) },
             > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1245,7 +1245,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1460,7 +1460,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ0,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(0) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1472,7 +1472,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1624,7 +1624,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ1,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(1) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1636,7 +1636,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1788,7 +1788,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ2,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(2) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1800,7 +1800,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -1952,7 +1952,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ3,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(3) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1964,7 +1964,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2118,7 +2118,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕ4,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(4) },
             > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2130,7 +2130,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2723,7 +2723,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕtag,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(tag) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2732,7 +2732,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -2875,7 +2875,7 @@ const _: () = {
             > ::zerocopy::ProjectField<
                 ::zerocopy::project_clients::ProjectDerive,
                 ẕvariants,
-                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                 { ::zerocopy::STRUCT_VARIANT_ID },
                 { ::zerocopy::ident_id!(variants) },
             > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2884,7 +2884,7 @@ const _: () = {
                 type Invariants = (
                     ___ZcAliasing,
                     ___ZcAlignment,
-                    ::zerocopy::invariant::Valid,
+                    ::zerocopy::invariant::Safe,
                 );
             }
         };
@@ -3098,7 +3098,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(a) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3110,7 +3110,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3122,7 +3122,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3316,7 +3316,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(b) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3328,7 +3328,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3340,7 +3340,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3534,7 +3534,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(c) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3546,7 +3546,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3558,7 +3558,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3752,7 +3752,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(d) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3764,7 +3764,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3776,7 +3776,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -3970,7 +3970,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(StructLike) },
             { ::zerocopy::ident_id!(e) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3982,7 +3982,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -3994,7 +3994,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4188,7 +4188,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(0) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4200,7 +4200,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4212,7 +4212,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4406,7 +4406,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(1) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4418,7 +4418,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4430,7 +4430,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {
@@ -4624,7 +4624,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             (),
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::ident_id!(TupleLike) },
             { ::zerocopy::ident_id!(2) },
         > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4636,7 +4636,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
             #[inline(always)]
             fn is_projectable(
@@ -4648,7 +4648,7 @@ const _: () = {
                     (
                         ::zerocopy::invariant::Shared,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     ),
                 >,
             ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<(), ()> {

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/project_struct.expected.rs
@@ -154,7 +154,7 @@ const _: () = {
         > ::zerocopy::ProjectField<
             ::zerocopy::project_clients::ProjectDerive,
             ẕfield,
-            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+            (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
             { ::zerocopy::STRUCT_VARIANT_ID },
             { ::zerocopy::ident_id!(field) },
         > for Foo {
@@ -163,7 +163,7 @@ const _: () = {
             type Invariants = (
                 ___ZcAliasing,
                 ___ZcAlignment,
-                ::zerocopy::invariant::Valid,
+                ::zerocopy::invariant::Safe,
             );
         }
     };

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes.expected.rs
@@ -14,7 +14,7 @@ const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_1.expected.rs
@@ -26,7 +26,7 @@ const _: () = {
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
@@ -281,7 +281,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -293,7 +293,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -449,7 +449,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -461,7 +461,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -617,7 +617,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -629,7 +629,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -785,7 +785,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -797,7 +797,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -953,7 +953,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -965,7 +965,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1121,7 +1121,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ5,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(5) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1133,7 +1133,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1291,7 +1291,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ6,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(6) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1303,7 +1303,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1527,7 +1527,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1539,7 +1539,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1695,7 +1695,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1707,7 +1707,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1863,7 +1863,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1875,7 +1875,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2031,7 +2031,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2043,7 +2043,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2201,7 +2201,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2213,7 +2213,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2822,7 +2822,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕtag,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(tag) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2831,7 +2831,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2978,7 +2978,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕvariants,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2987,7 +2987,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -3201,7 +3201,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3213,7 +3213,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3225,7 +3225,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3422,7 +3422,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3434,7 +3434,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3446,7 +3446,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3643,7 +3643,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3655,7 +3655,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3667,7 +3667,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3864,7 +3864,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3876,7 +3876,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3888,7 +3888,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4085,7 +4085,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4097,7 +4097,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4109,7 +4109,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4306,7 +4306,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4318,7 +4318,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4330,7 +4330,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4527,7 +4527,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4539,7 +4539,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4551,7 +4551,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4748,7 +4748,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4760,7 +4760,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4772,7 +4772,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4808,9 +4808,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(a) }, > ()
                             );
-                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <u8 as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4819,9 +4817,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(b) }, > ()
                             );
-                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <X as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4830,7 +4826,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(c) }, > ()
                             );
-                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <X::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4841,7 +4837,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(d) }, > ()
                             );
-                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4855,9 +4851,7 @@ const _: () = {
                             <[(
                                 X,
                                 Y,
-                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            ); N] as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
@@ -4869,9 +4863,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(0) }, > ()
                             );
-                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <bool as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4880,9 +4872,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(1) }, > ()
                             );
-                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <Y as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4893,7 +4883,7 @@ const _: () = {
                             );
                             <PhantomData<
                                 &'a [(X, Y); N],
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            > as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 _ => false,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_2.expected.rs
@@ -26,7 +26,7 @@ const _: () = {
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
@@ -281,7 +281,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -293,7 +293,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -449,7 +449,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -461,7 +461,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -617,7 +617,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -629,7 +629,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -785,7 +785,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -797,7 +797,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -953,7 +953,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -965,7 +965,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1121,7 +1121,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ5,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(5) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1133,7 +1133,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1291,7 +1291,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ6,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(6) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1303,7 +1303,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1527,7 +1527,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1539,7 +1539,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1695,7 +1695,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1707,7 +1707,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1863,7 +1863,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1875,7 +1875,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2031,7 +2031,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2043,7 +2043,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2201,7 +2201,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2213,7 +2213,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2822,7 +2822,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕtag,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(tag) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2831,7 +2831,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2978,7 +2978,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕvariants,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2987,7 +2987,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -3201,7 +3201,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3213,7 +3213,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3225,7 +3225,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3422,7 +3422,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3434,7 +3434,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3446,7 +3446,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3643,7 +3643,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3655,7 +3655,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3667,7 +3667,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3864,7 +3864,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3876,7 +3876,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3888,7 +3888,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4085,7 +4085,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4097,7 +4097,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4109,7 +4109,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4306,7 +4306,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4318,7 +4318,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4330,7 +4330,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4527,7 +4527,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4539,7 +4539,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4551,7 +4551,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4748,7 +4748,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4760,7 +4760,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4772,7 +4772,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4808,9 +4808,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(a) }, > ()
                             );
-                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <u8 as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4819,9 +4817,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(b) }, > ()
                             );
-                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <X as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4830,7 +4826,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(c) }, > ()
                             );
-                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <X::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4841,7 +4837,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(d) }, > ()
                             );
-                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4855,9 +4851,7 @@ const _: () = {
                             <[(
                                 X,
                                 Y,
-                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            ); N] as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
@@ -4869,9 +4863,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(0) }, > ()
                             );
-                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <bool as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4880,9 +4872,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(1) }, > ()
                             );
-                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <Y as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4893,7 +4883,7 @@ const _: () = {
                             );
                             <PhantomData<
                                 &'a [(X, Y); N],
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            > as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 _ => false,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_enum_3.expected.rs
@@ -26,7 +26,7 @@ const _: () = {
     {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             mut candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where
@@ -281,7 +281,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -293,7 +293,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -449,7 +449,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -461,7 +461,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -617,7 +617,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -629,7 +629,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -785,7 +785,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -797,7 +797,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -953,7 +953,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -965,7 +965,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1121,7 +1121,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ5,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(5) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1133,7 +1133,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1291,7 +1291,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ6,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(6) },
                     > for ___ZerocopyVariantStruct_StructLike<'a, { N }, X, Y>
@@ -1303,7 +1303,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1527,7 +1527,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ0,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(0) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1539,7 +1539,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1695,7 +1695,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ1,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(1) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1707,7 +1707,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -1863,7 +1863,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ2,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(2) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -1875,7 +1875,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2031,7 +2031,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ3,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(3) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2043,7 +2043,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2201,7 +2201,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕ4,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(4) },
                     > for ___ZerocopyVariantStruct_TupleLike<'a, { N }, X, Y>
@@ -2213,7 +2213,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2822,7 +2822,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕtag,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(tag) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2831,7 +2831,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -2978,7 +2978,7 @@ const _: () = {
                     > ::zerocopy::ProjectField<
                         ::zerocopy::project_clients::TryFromBytesDerive,
                         ẕvariants,
-                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                        (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                         { ::zerocopy::STRUCT_VARIANT_ID },
                         { ::zerocopy::ident_id!(variants) },
                     > for ___ZerocopyRawEnum<'a, { N }, X, Y> {
@@ -2987,7 +2987,7 @@ const _: () = {
                         type Invariants = (
                             ___ZcAliasing,
                             ___ZcAlignment,
-                            ::zerocopy::invariant::Valid,
+                            ::zerocopy::invariant::Safe,
                         );
                     }
                 };
@@ -3201,7 +3201,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(a) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3213,7 +3213,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3225,7 +3225,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3422,7 +3422,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(b) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3434,7 +3434,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3446,7 +3446,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3643,7 +3643,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(c) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3655,7 +3655,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3667,7 +3667,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -3864,7 +3864,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(d) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -3876,7 +3876,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -3888,7 +3888,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4085,7 +4085,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(StructLike) },
                     { ::zerocopy::ident_id!(e) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4097,7 +4097,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4109,7 +4109,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4306,7 +4306,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(0) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4318,7 +4318,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4330,7 +4330,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4527,7 +4527,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(1) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4539,7 +4539,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4551,7 +4551,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4748,7 +4748,7 @@ const _: () = {
                 > ::zerocopy::ProjectField<
                     ::zerocopy::project_clients::TryFromBytesDerive,
                     (),
-                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Valid),
+                    (___ZcAliasing, ___ZcAlignment, ::zerocopy::invariant::Safe),
                     { ::zerocopy::ident_id!(TupleLike) },
                     { ::zerocopy::ident_id!(2) },
                 > for ComplexWithGenerics<'a, { N }, X, Y>
@@ -4760,7 +4760,7 @@ const _: () = {
                     type Invariants = (
                         ___ZcAliasing,
                         ___ZcAlignment,
-                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::invariant::Safe,
                     );
                     #[inline(always)]
                     fn is_projectable(
@@ -4772,7 +4772,7 @@ const _: () = {
                             (
                                 ::zerocopy::invariant::Shared,
                                 ___ZcAlignment,
-                                ::zerocopy::invariant::Valid,
+                                ::zerocopy::invariant::Safe,
                             ),
                         >,
                     ) -> ::zerocopy::util::macro_util::core_reexport::result::Result<
@@ -4808,9 +4808,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(a) }, > ()
                             );
-                            <u8 as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <u8 as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4819,9 +4817,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(b) }, > ()
                             );
-                            <X as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <X as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4830,7 +4826,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(c) }, > ()
                             );
-                            <X::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <X::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4841,7 +4837,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(StructLike) }, {
                                 ::zerocopy::ident_id!(d) }, > ()
                             );
-                            <Y::Target as ::zerocopy::TryFromBytes>::is_bit_valid(
+                            <Y::Target as ::zerocopy::TryFromBytes>::is_safe(
                                 field_candidate,
                             )
                         }
@@ -4855,9 +4851,7 @@ const _: () = {
                             <[(
                                 X,
                                 Y,
-                            ); N] as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            ); N] as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 ___ZEROCOPY_TAG_TupleLike => {
@@ -4869,9 +4863,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(0) }, > ()
                             );
-                            <bool as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <bool as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4880,9 +4872,7 @@ const _: () = {
                                 ::zerocopy::ident_id!(TupleLike) }, {
                                 ::zerocopy::ident_id!(1) }, > ()
                             );
-                            <Y as ::zerocopy::TryFromBytes>::is_bit_valid(
-                                field_candidate,
-                            )
+                            <Y as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                         && {
                             let field_candidate = ::zerocopy::into_inner!(
@@ -4893,7 +4883,7 @@ const _: () = {
                             );
                             <PhantomData<
                                 &'a [(X, Y); N],
-                            > as ::zerocopy::TryFromBytes>::is_bit_valid(field_candidate)
+                            > as ::zerocopy::TryFromBytes>::is_safe(field_candidate)
                         }
                 }
                 _ => false,

--- a/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_safe_enum.expected.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/expected/try_from_bytes_trivial_is_safe_enum.expected.rs
@@ -14,7 +14,7 @@ const _: () = {
     unsafe impl ::zerocopy::TryFromBytes for Foo {
         fn only_derive_is_allowed_to_implement_this_trait() {}
         #[inline(always)]
-        fn is_bit_valid<___ZcAlignment>(
+        fn is_safe<___ZcAlignment>(
             _candidate: ::zerocopy::Maybe<'_, Self, ___ZcAlignment>,
         ) -> ::zerocopy::util::macro_util::core_reexport::primitive::bool
         where

--- a/zerocopy/zerocopy-derive/src/output_tests/mod.rs
+++ b/zerocopy/zerocopy-derive/src/output_tests/mod.rs
@@ -700,10 +700,10 @@ fn test_from_bytes_enum() {
 }
 
 #[test]
-fn test_try_from_bytes_trivial_is_bit_valid_enum() {
+fn test_try_from_bytes_trivial_is_safe_enum() {
     // Even when we aren't deriving `FromBytes` as the top-level trait,
     // `TryFromBytes` on enums still detects whether we *could* derive
-    // `FromBytes`, and if so, performs the same "trivial `is_bit_valid`"
+    // `FromBytes`, and if so, performs the same "trivial `is_safe`"
     // optimization.
     test! {
         TryFromBytes {
@@ -966,7 +966,7 @@ fn test_try_from_bytes_trivial_is_bit_valid_enum() {
                 Variant254,
                 Variant255,
             }
-        } expands to "expected/try_from_bytes_trivial_is_bit_valid_enum.expected.rs"
+        } expands to "expected/try_from_bytes_trivial_is_safe_enum.expected.rs"
     }
 }
 

--- a/zerocopy/zerocopy-derive/src/util.rs
+++ b/zerocopy/zerocopy-derive/src/util.rs
@@ -217,7 +217,7 @@ pub(crate) trait DataExt {
     /// FIXME: Extracting field names for enums doesn't really make sense. Types
     /// makes sense because we don't care about where they live - we just care
     /// about transitive ownership. But for field names, we'd only use them when
-    /// generating is_bit_valid, which cares about where they live.
+    /// generating is_safe, which cares about where they live.
     fn fields(&self) -> Vec<(&Visibility, TokenStream, &Type)>;
 
     fn variants(&self) -> Vec<(Option<&Variant>, Vec<(&Visibility, TokenStream, &Type)>)>;

--- a/zerocopy/zerocopy-derive/tests/enum_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/enum_from_bytes.rs
@@ -34,15 +34,15 @@ include!("include.rs");
 
 #[test]
 #[allow(deprecated)]
-fn test_trivial_is_bit_valid() {
-    // Since we derive `FromBytes`, the implied `TryFromBytes` derive's
-    // `is_bit_valid` impl is trivial - it unconditionally returns `true`.
-    util::test_trivial_is_bit_valid::<FooU8>();
-    util::test_trivial_is_bit_valid::<FooI8>();
-    util::test_trivial_is_bit_valid::<FooU8Align>();
-    util::test_trivial_is_bit_valid::<FooI8Align>();
-    util::test_trivial_is_bit_valid::<FooU16>();
-    util::test_trivial_is_bit_valid::<FooI16>();
+fn test_trivial_is_safe() {
+    // Since we derive `FromBytes`, the implied `TryFromBytes` derive's `is_safe`
+    // impl is trivial - it unconditionally returns `true`.
+    util::test_trivial_is_safe::<FooU8>();
+    util::test_trivial_is_safe::<FooI8>();
+    util::test_trivial_is_safe::<FooU8Align>();
+    util::test_trivial_is_safe::<FooI8Align>();
+    util::test_trivial_is_safe::<FooU16>();
+    util::test_trivial_is_safe::<FooI16>();
 }
 
 // Make sure no deprecation warning is generated from our derive (see #553).

--- a/zerocopy/zerocopy-derive/tests/enum_try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/enum_try_from_bytes.rs
@@ -639,12 +639,12 @@ enum FooU8 {
 }
 
 #[test]
-fn test_trivial_is_bit_valid() {
+fn test_trivial_is_safe() {
     // Though we don't derive `FromBytes`, `FooU8` *could* soundly implement
-    // `FromBytes`. Therefore, `TryFromBytes` derive's `is_bit_valid` impl is
-    // trivial - it unconditionally returns `true`.
+    // `FromBytes`. Therefore, `TryFromBytes` derive's `is_safe` impl is trivial
+    // - it unconditionally returns `true`.
     util_assert_not_impl_any!(FooU8: imp::FromBytes);
-    util::test_trivial_is_bit_valid::<FooU8>();
+    util::test_trivial_is_safe::<FooU8>();
 }
 
 #[deny(non_camel_case_types)]

--- a/zerocopy/zerocopy-derive/tests/include.rs
+++ b/zerocopy/zerocopy-derive/tests/include.rs
@@ -90,34 +90,32 @@ pub mod util {
     }
 
     #[macro_export]
-    macro_rules! test_trivial_is_bit_valid {
+    macro_rules! test_trivial_is_safe {
         ($x:ty => $name:ident) => {
             #[test]
             fn $name() {
-                util::test_trivial_is_bit_valid::<$x>();
+                util::test_trivial_is_safe::<$x>();
             }
         };
     }
 
     // Under some circumstances, our `TryFromBytes` derive generates a trivial
-    // `is_bit_valid` impl that unconditionally returns `true`. This test
-    // attempts to validate that this is, indeed, the behavior of our
-    // `TryFromBytes` derive. It is not foolproof, but is likely to catch some
-    // mistakes.
+    // `is_safe` impl that unconditionally returns `true`. This test attempts to
+    // validate that this is, indeed, the behavior of our `TryFromBytes` derive.
+    // It is not foolproof, but is likely to catch some mistakes.
     //
     // As of this writing, this happens when deriving `TryFromBytes` thanks to a
     // top-level `#[derive(FromBytes)]`.
-    pub fn test_trivial_is_bit_valid<T: super::imp::TryFromBytes>() {
+    pub fn test_trivial_is_safe<T: super::imp::TryFromBytes>() {
         use super::imp::{MaybeUninit, Ptr, ReadOnly};
 
-        // This test works based on the insight that a trivial `is_bit_valid`
-        // impl should never load any bytes from memory. Thus, while it is
-        // technically a violation of `is_bit_valid`'s safety precondition to
-        // pass a pointer to uninitialized memory, the `is_bit_valid` impl we
-        // expect our derives to generate should never touch this memory, and
-        // thus should never exhibit UB. By contrast, if our derives are
-        // spuriously generating non-trivial `is_bit_valid` impls, this should
-        // cause UB which may be caught by Miri.
+        // This test works based on the insight that a trivial `is_safe` impl
+        // should never load any bytes from memory. Thus, while it is technically
+        // a violation of `is_safe`'s safety precondition to pass a pointer to
+        // uninitialized memory, the `is_safe` impl we expect our derives to
+        // generate should never touch this memory, and thus should never exhibit
+        // UB. By contrast, if our derives are spuriously generating non-trivial
+        // `is_safe` impls, this should cause UB which may be caught by Miri.
 
         let mut buf = MaybeUninit::<T>::uninit();
         let ptr = Ptr::from_mut(&mut buf);
@@ -127,12 +125,12 @@ pub mod util {
         let ptr = ptr.reborrow_shared();
 
         let ptr = ptr.cast::<_, ::zerocopy_renamed::pointer::cast::CastSized, _>();
-        assert!(<T as super::imp::TryFromBytes>::is_bit_valid(ptr));
+        assert!(<T as super::imp::TryFromBytes>::is_safe(ptr));
     }
 
-    pub fn test_is_bit_valid<T: super::imp::TryFromBytes, V: super::imp::IntoBytes>(
+    pub fn test_is_safe<T: super::imp::TryFromBytes, V: super::imp::IntoBytes>(
         val: V,
-        is_bit_valid: bool,
+        is_safe: bool,
     ) {
         use super::imp::{
             pointer::{cast::CastSized, BecauseImmutable},
@@ -144,6 +142,6 @@ pub mod util {
         let candidate = candidate.recall_validity();
         let candidate = candidate.cast::<ReadOnly<T>, CastSized, (_, BecauseImmutable)>();
 
-        super::imp::assert_eq!(T::is_bit_valid(candidate), is_bit_valid);
+        super::imp::assert_eq!(T::is_safe(candidate), is_safe);
     }
 }

--- a/zerocopy/zerocopy-derive/tests/project.rs
+++ b/zerocopy/zerocopy-derive/tests/project.rs
@@ -30,7 +30,7 @@ struct Tuple(u8, u16);
 fn struct_fields() {
     let named = Named { byte: 1, word: 0x0203 };
     let word: imp::core::result::Result<
-        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&named)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
@@ -38,7 +38,7 @@ fn struct_fields() {
 
     let tuple = Tuple(4, 0x0506);
     let field: imp::core::result::Result<
-        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&tuple)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(1) }>();
@@ -77,7 +77,7 @@ fn struct_validity_is_preserved() {
     imp::assert!(projected.is_ok());
 
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
@@ -96,7 +96,7 @@ struct Packed {
 fn packed_struct_loses_alignment() {
     let value = Packed { byte: 1, word: 0x0203_0405 };
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u32, SharedUnaligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u32, SharedUnaligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(word) }>();
@@ -112,9 +112,9 @@ struct Unsized<T: ?imp::Sized> {
 }
 
 fn project_unsized_tail(
-    value: imp::Ptr<'_, Unsized<[u8]>, SharedAligned<imp::invariant::Valid>>,
+    value: imp::Ptr<'_, Unsized<[u8]>, SharedAligned<imp::invariant::Safe>>,
 ) -> imp::core::result::Result<
-    imp::Ptr<'_, [u8], SharedAligned<imp::invariant::Valid>>,
+    imp::Ptr<'_, [u8], SharedAligned<imp::invariant::Safe>>,
     imp::core::convert::Infallible,
 > {
     value.project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(tail) }>()
@@ -171,14 +171,14 @@ enum CEnum {
 fn repr_c_enum_checks_its_tag() {
     let value = CEnum::Flag { value: 0x1234 };
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Flag) }, { imp::ident_id!(value) }>();
     imp::assert_eq!(*projected.unwrap().as_ref(), 0x1234);
 
     let wrong_variant: imp::core::result::Result<
-        imp::Ptr<'_, u32, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u32, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Number) }, { imp::ident_id!(0) }>();
@@ -198,21 +198,21 @@ fn repr_u8_enum_validity_and_tag_checks() {
     let value = U8Enum::A(11);
 
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(A) }, { imp::ident_id!(0) }>();
     imp::assert_eq!(*projected.unwrap().as_ref(), 11);
 
     let wrong_variant: imp::core::result::Result<
-        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(0) }>();
     imp::assert!(wrong_variant.is_err());
 
-    // SAFETY: `Uninit` permits every bit pattern. Unlike a `Valid`
-    // projection, this projection must not inspect the tag.
+    // SAFETY: `Uninit` permits every bit pattern. Unlike a `Safe` projection,
+    // this projection must not inspect the tag.
     let uninit = unsafe { imp::Ptr::from_ref(&value).assume_validity::<imp::invariant::Uninit>() };
     let wrong_variant: imp::core::result::Result<
         imp::Ptr<'_, u8, SharedAligned<imp::invariant::Uninit>>,
@@ -244,7 +244,7 @@ struct Generic<T, U> {
 fn generic_fields_need_no_zerocopy_bounds() {
     let value = Generic { first: util::NotZerocopy(1u8), second: util::NotZerocopy(0x0203u16) };
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, util::NotZerocopy<u16>, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(second) }>();
@@ -264,7 +264,7 @@ fn generic_enum_fields_need_no_zerocopy_bounds() {
     let inner = util::NotZerocopy(0x1234u16);
     let value: GenericEnum<'_, util::NotZerocopy<u16>, 2> = GenericEnum::Borrowed(&inner);
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, &util::NotZerocopy<u16>, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, &util::NotZerocopy<u16>, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(Borrowed) }, { imp::ident_id!(0) }>();
@@ -288,7 +288,7 @@ mod visibility {
 fn public_marker_is_inferred_across_module_boundary() {
     let value = visibility::new();
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u16, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
@@ -326,7 +326,7 @@ fn project_and_try_from_bytes_impls_coexist() {
 
     let value = ProjectThenTryFromBytes { field: 42 };
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, u8, SharedAligned<imp::invariant::Safe>>,
         imp::core::convert::Infallible,
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::STRUCT_VARIANT_ID }, { imp::ident_id!(field) }>();
@@ -344,7 +344,7 @@ fn project_and_try_from_bytes_impls_coexist() {
 
     let value = ProjectAndTryFromBytes::B { field: true };
     let projected: imp::core::result::Result<
-        imp::Ptr<'_, bool, SharedAligned<imp::invariant::Valid>>,
+        imp::Ptr<'_, bool, SharedAligned<imp::invariant::Safe>>,
         (),
     > = imp::Ptr::from_ref(&value)
         .project::<imp::project_clients::ProjectDerive, _, { imp::ident_id!(B) }, { imp::ident_id!(field) }>();

--- a/zerocopy/zerocopy-derive/tests/project_enum.rs
+++ b/zerocopy/zerocopy-derive/tests/project_enum.rs
@@ -85,7 +85,7 @@ macro_rules! test_enum {
                     .unwrap()
                     .transmute::<
                         imp::MaybeUninit<u8>,
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .bikeshed_recall_aligned()
@@ -104,7 +104,7 @@ macro_rules! test_enum {
                     .unwrap()
                     .transmute::<
                         imp::MaybeUninit<u16>,
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .try_into_aligned()
@@ -124,7 +124,7 @@ macro_rules! test_enum {
                     .unwrap()
                     .transmute::<
                         imp::MaybeUninit<u8>,
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .bikeshed_recall_aligned()
@@ -143,7 +143,7 @@ macro_rules! test_enum {
                     .unwrap()
                     .transmute::<
                         imp::MaybeUninit<u16>,
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .try_into_aligned()
@@ -157,7 +157,7 @@ macro_rules! test_enum {
                 let _: imp::MaybeUninit<Enum> = *ptr
                     .transmute::<
                         imp::MaybeUninit<Enum>,
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .try_into_aligned()
@@ -188,7 +188,7 @@ macro_rules! test_enum {
                     >()
                     .unwrap()
                     .recall_validity::<
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .as_mut();
@@ -205,7 +205,7 @@ macro_rules! test_enum {
                     >()
                     .unwrap()
                     .recall_validity::<
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .as_mut();
@@ -222,7 +222,7 @@ macro_rules! test_enum {
                     >()
                     .unwrap()
                     .recall_validity::<
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .as_mut();
@@ -239,7 +239,7 @@ macro_rules! test_enum {
                     >()
                     .unwrap()
                     .recall_validity::<
-                        imp::invariant::Valid,
+                        imp::invariant::Safe,
                         (_, (_, imp::BecauseExclusive)),
                     >()
                     .as_mut();

--- a/zerocopy/zerocopy-derive/tests/project_struct.rs
+++ b/zerocopy/zerocopy-derive/tests/project_struct.rs
@@ -49,7 +49,7 @@ fn uninit() {
         .unwrap()
         .transmute::<
             imp::MaybeUninit<u8>,
-            imp::invariant::Valid,
+            imp::invariant::Safe,
             (_, (_, imp::BecauseExclusive)),
         >()
         .bikeshed_recall_aligned()
@@ -68,7 +68,7 @@ fn uninit() {
         .unwrap()
         .transmute::<
             imp::MaybeUninit<Align2>,
-            imp::invariant::Valid,
+            imp::invariant::Safe,
             (_, (_, imp::BecauseExclusive)),
         >()
         .try_into_aligned()
@@ -82,7 +82,7 @@ fn uninit() {
     let _: imp::MaybeUninit<Padded> = *ptr
         .transmute::<
             imp::MaybeUninit<Padded>,
-            imp::invariant::Valid,
+            imp::invariant::Safe,
             (_, (_, imp::BecauseExclusive)),
         >()
         .try_into_aligned()
@@ -108,7 +108,7 @@ fn initialized() {
             { imp::ident_id!(first) },
         >()
         .unwrap()
-        .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>();
+        .recall_validity::<imp::invariant::Safe, (_, (_, imp::BecauseExclusive))>();
     *first.as_mut() = FIRST;
     imp::assert_eq!(
         *ptr.reborrow()
@@ -119,7 +119,7 @@ fn initialized() {
                 { imp::ident_id!(first) },
             >()
             .unwrap()
-            .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>()
+            .recall_validity::<imp::invariant::Safe, (_, (_, imp::BecauseExclusive))>()
             .as_ref(),
         FIRST,
     );
@@ -133,7 +133,7 @@ fn initialized() {
             { imp::ident_id!(second) },
         >()
         .unwrap()
-        .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>();
+        .recall_validity::<imp::invariant::Safe, (_, (_, imp::BecauseExclusive))>();
     *second.as_mut() = SECOND;
     imp::assert_eq!(
         ptr.reborrow()
@@ -144,7 +144,7 @@ fn initialized() {
                 { imp::ident_id!(second) },
             >()
             .unwrap()
-            .recall_validity::<imp::invariant::Valid, (_, (_, imp::BecauseExclusive))>()
+            .recall_validity::<imp::invariant::Safe, (_, (_, imp::BecauseExclusive))>()
             .as_ref()
             .0,
         SECOND.0,
@@ -206,7 +206,7 @@ fn valid() {
         SECOND.0,
     );
 
-    // A valid `Padded` is the strictest form through which a `Valid`
+    // A valid `Padded` is the strictest form through which a `Safe`
     // `Ptr<Padded>` may be read.
     let value = ptr.as_ref();
     imp::assert_eq!(value.first, FIRST);

--- a/zerocopy/zerocopy-derive/tests/raw_identifiers.rs
+++ b/zerocopy/zerocopy-derive/tests/raw_identifiers.rs
@@ -61,8 +61,8 @@ fn test_enum_try_from_bytes() {
     // The `Value` payload is at byte offset one and is zero, so the candidate
     // is invalid. Both spellings must generate the same field validator.
     let bytes = [0, 0];
-    util::test_is_bit_valid::<OrdinaryPacket, _>(Wire(bytes), false);
-    util::test_is_bit_valid::<RawPacket, _>(Wire(bytes), false);
+    util::test_is_safe::<OrdinaryPacket, _>(Wire(bytes), false);
+    util::test_is_safe::<RawPacket, _>(Wire(bytes), false);
 }
 
 #[derive(imp::KnownLayout)]

--- a/zerocopy/zerocopy-derive/tests/struct_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/struct_from_bytes.rs
@@ -20,7 +20,7 @@ include!("include.rs");
 struct Zst;
 
 util_assert_impl_all!(Zst: imp::FromBytes);
-test_trivial_is_bit_valid!(Zst => test_zst_trivial_is_bit_valid);
+test_trivial_is_safe!(Zst => test_zst_trivial_is_safe);
 
 #[derive(imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -29,7 +29,7 @@ struct One {
 }
 
 util_assert_impl_all!(One: imp::FromBytes);
-test_trivial_is_bit_valid!(One => test_one_trivial_is_bit_valid);
+test_trivial_is_safe!(One => test_one_trivial_is_safe);
 
 #[derive(imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -39,7 +39,7 @@ struct Two {
 }
 
 util_assert_impl_all!(Two: imp::FromBytes);
-test_trivial_is_bit_valid!(Two => test_two_trivial_is_bit_valid);
+test_trivial_is_safe!(Two => test_two_trivial_is_safe);
 
 #[derive(imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -63,7 +63,7 @@ struct TypeParams<'a, T: ?imp::Sized, I: imp::Iterator> {
 util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::FromBytes);
 util_assert_impl_all!(TypeParams<'static, util::AU16, imp::IntoIter<()>>: imp::FromBytes);
 util_assert_impl_all!(TypeParams<'static, [util::AU16], imp::IntoIter<()>>: imp::FromBytes);
-test_trivial_is_bit_valid!(TypeParams<'static, (), imp::IntoIter<()>> => test_type_params_trivial_is_bit_valid);
+test_trivial_is_safe!(TypeParams<'static, (), imp::IntoIter<()>> => test_type_params_trivial_is_safe);
 
 // Deriving `FromBytes` should work if the struct has bounded parameters.
 
@@ -80,4 +80,4 @@ where
     T: 'a + 'b + imp::FromBytes;
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::FromBytes);
-test_trivial_is_bit_valid!(WithParams<'static, 'static, u8, 42> => test_with_params_trivial_is_bit_valid);
+test_trivial_is_safe!(WithParams<'static, 'static, u8, 42> => test_with_params_trivial_is_safe);

--- a/zerocopy/zerocopy-derive/tests/struct_try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/struct_try_from_bytes.rs
@@ -17,7 +17,7 @@ include!("include.rs");
 
 #[test]
 fn zst() {
-    crate::util::test_is_bit_valid::<(), _>((), true);
+    crate::util::test_is_safe::<(), _>((), true);
 }
 
 #[derive(imp::TryFromBytes, imp::Immutable, imp::IntoBytes)]
@@ -31,8 +31,8 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    crate::util::test_is_bit_valid::<One, _>(One { a: 42 }, true);
-    crate::util::test_is_bit_valid::<One, _>(One { a: 43 }, true);
+    crate::util::test_is_safe::<One, _>(One { a: 42 }, true);
+    crate::util::test_is_safe::<One, _>(One { a: 43 }, true);
 }
 
 #[derive(imp::TryFromBytes, imp::Immutable, imp::IntoBytes)]
@@ -47,9 +47,9 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    crate::util::test_is_bit_valid::<Two, _>(Two { a: false, b: () }, true);
-    crate::util::test_is_bit_valid::<Two, _>(Two { a: true, b: () }, true);
-    crate::util::test_is_bit_valid::<Two, _>([2u8], false);
+    crate::util::test_is_safe::<Two, _>(Two { a: false, b: () }, true);
+    crate::util::test_is_safe::<Two, _>(Two { a: true, b: () }, true);
+    crate::util::test_is_safe::<Two, _>([2u8], false);
 }
 
 #[derive(imp::KnownLayout, imp::TryFromBytes)]
@@ -76,8 +76,8 @@ fn un_sized() {
 
     // SAFETY: `candidate`'s referent is as-initialized as `Two`.
     let mut candidate = unsafe { candidate.assume_initialized() };
-    let is_bit_valid = <Unsized as imp::TryFromBytes>::is_bit_valid(candidate.reborrow_shared());
-    imp::assert!(is_bit_valid);
+    let is_safe = <Unsized as imp::TryFromBytes>::is_safe(candidate.reborrow_shared());
+    imp::assert!(is_safe);
 }
 
 #[derive(imp::TryFromBytes)]
@@ -121,12 +121,12 @@ struct MaybeFromBytes<T>(T);
 #[test]
 fn test_maybe_from_bytes() {
     // When deriving `FromBytes` on a type with no generic parameters, we emit a
-    // trivial `is_bit_valid` impl that always returns true. This test confirms
-    // that we *don't* spuriously do that when generic parameters are present.
+    // trivial `is_safe` impl that always returns true. This test confirms that
+    // we *don't* spuriously do that when generic parameters are present.
 
-    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>(MaybeFromBytes(false), true);
-    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>(MaybeFromBytes(true), true);
-    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>([2u8], false);
+    crate::util::test_is_safe::<MaybeFromBytes<bool>, _>(MaybeFromBytes(false), true);
+    crate::util::test_is_safe::<MaybeFromBytes<bool>, _>(MaybeFromBytes(true), true);
+    crate::util::test_is_safe::<MaybeFromBytes<bool>, _>([2u8], false);
 }
 
 #[derive(Debug, PartialEq, Eq, imp::TryFromBytes, imp::Immutable, imp::KnownLayout)]

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.nightly.stderr
@@ -335,7 +335,7 @@ note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
    |
 54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_bit_valid::assert_is_from_bytes`
+note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_safe::assert_is_from_bytes`
   --> $DIR/late_compile_pass.rs:54:10
    |
 54 | #[derive(FromBytes)]

--- a/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
+++ b/zerocopy/zerocopy-derive/tests/ui/late_compile_pass.stable.stderr
@@ -295,7 +295,7 @@ note: required for `FromBytes1` to implement `zerocopy_renamed::FromBytes`
    |
 54 | #[derive(FromBytes)]
    |          ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_bit_valid::assert_is_from_bytes`
+note: required by a bound in `_::_::<impl zerocopy_renamed::TryFromBytes for FromBytes1>::is_safe::assert_is_from_bytes`
   --> $DIR/late_compile_pass.rs:54:10
    |
 54 | #[derive(FromBytes)]

--- a/zerocopy/zerocopy-derive/tests/union_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/union_from_bytes.rs
@@ -22,7 +22,7 @@ union Zst {
 }
 
 util_assert_impl_all!(Zst: imp::FromBytes);
-test_trivial_is_bit_valid!(Zst => test_zst_trivial_is_bit_valid);
+test_trivial_is_safe!(Zst => test_zst_trivial_is_safe);
 
 #[derive(imp::Immutable, imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -31,7 +31,7 @@ union One {
 }
 
 util_assert_impl_all!(One: imp::FromBytes);
-test_trivial_is_bit_valid!(One => test_one_trivial_is_bit_valid);
+test_trivial_is_safe!(One => test_one_trivial_is_safe);
 
 #[derive(imp::Immutable, imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -41,7 +41,7 @@ union Two {
 }
 
 util_assert_impl_all!(Two: imp::FromBytes);
-test_trivial_is_bit_valid!(Two => test_two_trivial_is_bit_valid);
+test_trivial_is_safe!(Two => test_two_trivial_is_safe);
 
 #[derive(imp::Immutable, imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -58,7 +58,7 @@ where
 }
 
 util_assert_impl_all!(TypeParams<'static, (), imp::IntoIter<()>>: imp::FromBytes);
-test_trivial_is_bit_valid!(TypeParams<'static, (), imp::IntoIter<()>> => test_type_params_trivial_is_bit_valid);
+test_trivial_is_safe!(TypeParams<'static, (), imp::IntoIter<()>> => test_type_params_trivial_is_safe);
 
 // Deriving `imp::FromBytes` should work if the union has bounded parameters.
 
@@ -76,7 +76,7 @@ where
 }
 
 util_assert_impl_all!(WithParams<'static, 'static, u8, 42>: imp::FromBytes);
-test_trivial_is_bit_valid!(WithParams<'static, 'static, u8, 42> => test_with_params_trivial_is_bit_valid);
+test_trivial_is_safe!(WithParams<'static, 'static, u8, 42> => test_with_params_trivial_is_safe);
 
 #[derive(imp::FromBytes)]
 #[zerocopy(crate = "zerocopy_renamed")]
@@ -86,4 +86,4 @@ union UnsafeCellUnion {
 }
 
 util_assert_impl_all!(UnsafeCellUnion: imp::FromBytes);
-test_trivial_is_bit_valid!(UnsafeCellUnion => test_unsafe_cell_union_trivial_is_bit_valid);
+test_trivial_is_safe!(UnsafeCellUnion => test_unsafe_cell_union_trivial_is_safe);

--- a/zerocopy/zerocopy-derive/tests/union_try_from_bytes.rs
+++ b/zerocopy/zerocopy-derive/tests/union_try_from_bytes.rs
@@ -25,8 +25,8 @@ util_assert_impl_all!(One: imp::TryFromBytes);
 
 #[test]
 fn one() {
-    crate::util::test_is_bit_valid::<One, _>([42u8], true);
-    crate::util::test_is_bit_valid::<One, _>([43u8], true);
+    crate::util::test_is_safe::<One, _>([42u8], true);
+    crate::util::test_is_safe::<One, _>([43u8], true);
 }
 
 #[derive(imp::Immutable, imp::TryFromBytes, imp::IntoBytes)]
@@ -41,9 +41,9 @@ util_assert_impl_all!(Two: imp::TryFromBytes);
 
 #[test]
 fn two() {
-    crate::util::test_is_bit_valid::<Two, _>(Two { a: false }, true);
-    crate::util::test_is_bit_valid::<Two, _>(Two { b: true }, true);
-    crate::util::test_is_bit_valid::<Two, _>([2u8], false);
+    crate::util::test_is_safe::<Two, _>(Two { a: false }, true);
+    crate::util::test_is_safe::<Two, _>(Two { b: true }, true);
+    crate::util::test_is_safe::<Two, _>([2u8], false);
 }
 
 #[derive(imp::Immutable, imp::TryFromBytes)]
@@ -56,9 +56,9 @@ union BoolAndZst {
 
 #[test]
 fn bool_and_zst() {
-    crate::util::test_is_bit_valid::<BoolAndZst, _>([0u8], true);
-    crate::util::test_is_bit_valid::<BoolAndZst, _>([1u8], true);
-    crate::util::test_is_bit_valid::<BoolAndZst, _>([2u8], true);
+    crate::util::test_is_safe::<BoolAndZst, _>([0u8], true);
+    crate::util::test_is_safe::<BoolAndZst, _>([1u8], true);
+    crate::util::test_is_safe::<BoolAndZst, _>([2u8], true);
 }
 
 #[derive(imp::FromBytes)]
@@ -71,10 +71,10 @@ union MaybeFromBytes<T: imp::Copy> {
 #[test]
 fn test_maybe_from_bytes() {
     // When deriving `FromBytes` on a type with no generic parameters, we emit a
-    // trivial `is_bit_valid` impl that always returns true. This test confirms
-    // that we *don't* spuriously do that when generic parameters are present.
+    // trivial `is_safe` impl that always returns true. This test confirms that
+    // we *don't* spuriously do that when generic parameters are present.
 
-    crate::util::test_is_bit_valid::<MaybeFromBytes<bool>, _>([2u8], false);
+    crate::util::test_is_safe::<MaybeFromBytes<bool>, _>([2u8], false);
 }
 
 #[derive(imp::Immutable, imp::TryFromBytes)]
@@ -134,7 +134,7 @@ util_assert_impl_all!(UnsafeCellUnion: imp::TryFromBytes);
 
 #[test]
 fn unsafe_cell_union() {
-    crate::util::test_is_bit_valid::<UnsafeCellUnion, _>([0u8], true);
-    crate::util::test_is_bit_valid::<UnsafeCellUnion, _>([1u8], true);
-    crate::util::test_is_bit_valid::<UnsafeCellUnion, _>([2u8], false);
+    crate::util::test_is_safe::<UnsafeCellUnion, _>([0u8], true);
+    crate::util::test_is_safe::<UnsafeCellUnion, _>([1u8], true);
+    crate::util::test_is_safe::<UnsafeCellUnion, _>([2u8], false);
 }

--- a/zerocopy/zerocopy-derive/tests/unsafe_cell.rs
+++ b/zerocopy/zerocopy-derive/tests/unsafe_cell.rs
@@ -14,8 +14,8 @@ include!("include.rs");
 
 // Test to make sure that all of our derives are compatible with `UnsafeCell`s.
 //
-// We test both `FromBytes` and `FromZeros`, as the `FromBytes` implied derive
-// of `TryFromBytes` emits a trivial `is_bit_valid` impl - we want to test the
+// We test both `FromBytes` and `FromZeros`, as the `FromBytes` implied derive of
+// `TryFromBytes` emits a trivial `is_safe` impl - we want to test the
 // non-trivial impl, which deriving `FromZeros` accomplishes.
 
 #[derive(imp::FromBytes, imp::IntoBytes, imp::KnownLayout, imp::Unaligned)]


### PR DESCRIPTION
<!-- WARNING: This PR description is automatically generated by GHerrit. Any manual edits will be overwritten on the next push. -->




---

- 👉 #3665


**Latest Update:** v8 — [Compare vs v7](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)

<details>
<summary><strong>📚 Full Patch History</strong></summary>

*Links show the diff between the row version and the column version.*

|Version| v7 | v6 | v5 | v4 | v3 | v2 | v1 |Base|
|:---|:---|:---|:---|:---|:---|:---|:---|:---|
|v8|[vs v7](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v6](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v5](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v4](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v3](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v8)|
|v7||[vs v6](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs v5](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs v4](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs v3](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v7)|
|v6|||[vs v5](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|[vs v4](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|[vs v3](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v6)|
|v5||||[vs v4](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5)|[vs v3](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5)|[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v5)|
|v4|||||[vs v3](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4)|[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v4)|
|v3||||||[vs v2](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3)|[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v3)|
|v2|||||||[vs v1](/google/zerocopy/compare/gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2)|[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v2)|
|v1||||||||[vs Base](/google/zerocopy/compare/main..gherrit/G5fa632801df03c070c991b72a15721a1f2d66490/v1)|

</details>
<details>
<summary><strong>⬇️ Download this PR</strong></summary>

######

**Branch**
```bash
git fetch origin refs/heads/G5fa632801df03c070c991b72a15721a1f2d66490 && git checkout -b pr-G5fa632801df03c070c991b72a15721a1f2d66490 FETCH_HEAD
```

**Checkout**
```bash
git fetch origin refs/heads/G5fa632801df03c070c991b72a15721a1f2d66490 && git checkout FETCH_HEAD
```

**Cherry Pick**
```bash
git fetch origin refs/heads/G5fa632801df03c070c991b72a15721a1f2d66490 && git cherry-pick FETCH_HEAD
```

**Pull**
```bash
git pull origin refs/heads/G5fa632801df03c070c991b72a15721a1f2d66490
```

</details>

*Stacked PRs enabled by [GHerrit](https://github.com/joshlf/gherrit).*

<!-- WARNING: GHerrit relies on the following metadata to work properly. DO NOT EDIT OR REMOVE. --><!-- gherrit-meta: {"id": "G5fa632801df03c070c991b72a15721a1f2d66490", "parent": null, "child": null}" -->