### PR TITLE
Strengthen byteorder and split tests

### DIFF
--- a/zerocopy/src/byte_slice.rs
+++ b/zerocopy/src/byte_slice.rs
@@ -280,7 +280,7 @@ unsafe impl SplitByteSlice for &mut [u8] {
         //   true for these two sub-slices of `self`.
         // - The memory referenced by the returned slice cannot be accessed
         //   through any other pointer (not derived from the return value) for
-        //   the duration of lifetime `'a`, because:
+        //   the duration of lifetime `'a``, because:
         //   - `split_at_unchecked` consumes `self` (which is not `Copy`),
         //   - `split_at_unchecked` does not exfiltrate any references to this
         //     memory, besides those references returned below,

--- a/zerocopy/src/byte_slice.rs
+++ b/zerocopy/src/byte_slice.rs
@@ -280,7 +280,7 @@ unsafe impl SplitByteSlice for &mut [u8] {
         //   true for these two sub-slices of `self`.
         // - The memory referenced by the returned slice cannot be accessed
         //   through any other pointer (not derived from the return value) for
-        //   the duration of lifetime `'a``, because:
+        //   the duration of lifetime `'a`, because:
         //   - `split_at_unchecked` consumes `self` (which is not `Copy`),
         //   - `split_at_unchecked` does not exfiltrate any references to this
         //     memory, besides those references returned below,
@@ -427,8 +427,12 @@ mod tests {
         let borrow_mut = cell.borrow_mut();
         let slice_ref_mut: cell::RefMut<'_, [u8]> = cell::RefMut::map(borrow_mut, |a| &mut a[..]);
         // SAFETY: 2 is within bounds of [1, 2, 3, 4]
-        let (l, r) = unsafe { slice_ref_mut.split_at_unchecked(2) };
+        let (mut l, mut r) = unsafe { slice_ref_mut.split_at_unchecked(2) };
         assert_eq!(*l, [1, 2]);
         assert_eq!(*r, [3, 4]);
+        l[0] = 5;
+        r[0] = 6;
+        drop((l, r));
+        assert_eq!(*cell.borrow(), [5, 2, 6, 4]);
     }
 }

--- a/zerocopy/src/byteorder.rs
+++ b/zerocopy/src/byteorder.rs
@@ -1236,7 +1236,7 @@ mod tests {
     impl_traits!(I32, i32, signed);
     impl_traits!(I64, i64, signed);
     impl_traits!(I128, i128, signed);
-    impl_traits!(Isize, isize, unsigned);
+    impl_traits!(Isize, isize, signed);
     impl_traits!(F32, f32, signed, @float);
     impl_traits!(F64, f64, signed, @float);
 
@@ -1382,6 +1382,18 @@ mod tests {
 
         call_for_all_types!(test_native, NativeEndian);
         call_for_all_types!(test_non_native, NonNativeEndian);
+    }
+
+    #[test]
+    fn test_float_bit_patterns() {
+        for bits in [0u32, 0x8000_0000, 0x7F80_0000, 0xFF80_0000, 0x7FC0_1234] {
+            let be = F32::<BE>::new(f32::from_bits(bits));
+            let le = F32::<LE>::new(f32::from_bits(bits));
+            assert_eq!(be.to_bytes(), bits.to_be_bytes());
+            assert_eq!(le.to_bytes(), bits.to_le_bytes());
+            assert_eq!(be.get().to_bits(), bits);
+            assert_eq!(le.get().to_bits(), bits);
+        }
     }
 
     #[test]
@@ -1552,6 +1564,17 @@ mod tests {
 
         test!(@unary Not, not, call_for_signed_types, call_for_unsigned_types);
         test!(@unary Neg, neg, call_for_signed_types, call_for_float_types);
+
+        for shift in [0u64, 1, 31, 63] {
+            let n = 0x0123_4567_89AB_CDEFu64;
+            let shift_u32: u32 = shift.try_into().unwrap();
+            let shl = n.checked_shl(shift_u32).unwrap();
+            let shr = n.checked_shr(shift_u32).unwrap();
+            assert_eq!(core::ops::Shl::shl(U64::<NativeEndian>::new(n), shift).get(), shl);
+            assert_eq!(core::ops::Shr::shr(U64::<NativeEndian>::new(n), shift).get(), shr);
+            assert_eq!(core::ops::Shl::shl(U64::<NonNativeEndian>::new(n), shift).get(), shl);
+            assert_eq!(core::ops::Shr::shr(U64::<NonNativeEndian>::new(n), shift).get(), shr);
+        }
     }
 
     #[test]
@@ -1579,6 +1602,13 @@ mod tests {
         assert!(val_be >= val_be);
         assert!(val_be <= val_be);
         assert_eq!(val_be.cmp(&val_be), core::cmp::Ordering::Equal);
+
+        let low = U16::<LE>::new(255);
+        let high = U16::<LE>::new(256);
+        assert!(low < high);
+        assert!(low < 256u16);
+        assert_eq!(low.cmp(&high), core::cmp::Ordering::Less);
+        assert!(I16::<LE>::new(-1) < I16::<LE>::new(0));
 
         // PartialOrd with native
         assert!(val_be == 1u16);


### PR DESCRIPTION
Classify `Isize` as signed in the byteorder test helpers so its test-only
traits match the production type. Add deterministic coverage for numeric
ordering, valid shift counts, and floating-point bit-pattern preservation.

Also make the mutable `RefMut<[u8]>` split test verify writes through both
returned halves reach the backing slice.

*Authored by an AI agent acting on Josh Liebow-Feeser's behalf.*